### PR TITLE
Let instant execution report more unsupported types

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -17,11 +17,13 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.hamcrest.CoreMatchers
 import spock.lang.Issue
 
 class DependencyNotationIntegrationSpec extends AbstractIntegrationSpec {
 
+    @ToBeFixedForInstantExecution(because = "unsupported type Dependency")
     def "understands dependency notations"() {
         when:
         buildFile <<  """

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(project(":fileCollections"))
     implementation(project(":dependencyManagement"))
     implementation(project(":persistentCache"))
+    implementation(project(":plugins"))
     implementation(project(":kotlinDsl"))
     // TODO - move the isolatable serializer to model-core to live with the isolatable infrastructure
     implementation(project(":workers"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -1003,7 +1003,12 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         instantRun "broken"
 
         then:
-        outputContains("instant-execution > cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.")
+        outputContains("""
+            2 instant execution problems were found, 2 of which seem unique:
+              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
+              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
+            See the complete report at
+        """.stripIndent())
 
         when:
         instantRun "broken"

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -19,68 +19,11 @@ package org.gradle.instantexecution
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
-import org.gradle.api.DefaultTask
-import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.DependencyConstraintSet
-import org.gradle.api.artifacts.DependencySet
-import org.gradle.api.artifacts.LenientConfiguration
-import org.gradle.api.artifacts.ResolutionStrategy
-import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
-import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
-import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
-import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.artifacts.dsl.DependencyLockingHandler
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.artifacts.query.ArtifactResolutionQuery
-import org.gradle.api.artifacts.repositories.ArtifactRepository
-import org.gradle.api.artifacts.type.ArtifactTypeContainer
-import org.gradle.api.attributes.AttributeMatchingStrategy
-import org.gradle.api.attributes.AttributesSchema
-import org.gradle.api.attributes.CompatibilityRuleChain
-import org.gradle.api.attributes.DisambiguationRuleChain
 import org.gradle.api.file.FileSystemOperations
-import org.gradle.api.initialization.Settings
-import org.gradle.api.internal.artifacts.DefaultDependencyConstraintSet
-import org.gradle.api.internal.artifacts.DefaultDependencySet
-import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
-import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
-import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler
-import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler
-import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
-import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler
-import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler
-import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingLenientConfiguration
-import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingResolvedConfiguration
-import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
-import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
-import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
-import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
-import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
-import org.gradle.api.internal.attributes.DefaultAttributesSchema
-import org.gradle.api.internal.attributes.DefaultCompatibilityRuleChain
-import org.gradle.api.internal.attributes.DefaultDisambiguationRuleChain
-import org.gradle.api.internal.project.DefaultProject
-import org.gradle.api.internal.tasks.DefaultSourceSet
-import org.gradle.api.internal.tasks.DefaultSourceSetContainer
-import org.gradle.api.internal.tasks.DefaultTaskContainer
-import org.gradle.api.internal.tasks.DefaultTaskDependency
-import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskDependency
-import org.gradle.groovy.scripts.internal.DefaultScriptCompilationHandler.ScriptClassLoader
-import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.locking.DefaultDependencyLockingHandler
-import org.gradle.invocation.DefaultGradle
 import org.gradle.jvm.toolchain.JavaInstallationRegistry
 import org.gradle.process.ExecOperations
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
@@ -89,10 +32,7 @@ import org.slf4j.Logger
 import spock.lang.Unroll
 
 import javax.inject.Inject
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors.FinalizableDelegatedExecutorService
-import java.util.concurrent.Executors.DefaultThreadFactory
-import java.util.concurrent.ThreadFactory
+
 
 class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
@@ -968,99 +908,6 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         'an uri'           | 'fromUri(project.uri(project.file("resource.txt")))'
         'an insecure uri'  | 'fromInsecureUri(project.uri(project.file("resource.txt")))'
         'an archive entry' | 'fromArchiveEntry("resource.zip", "resource.txt")'
-    }
-
-    @Unroll
-    def "warns when task field references an object of type #baseType"() {
-        buildFile << """
-            plugins { id "java" }
-
-            class SomeBean {
-                private ${baseType} badReference
-            }
-
-            class SomeTask extends DefaultTask {
-                private final ${baseType} badReference
-                private final bean = new SomeBean()
-
-                SomeTask() {
-                    badReference = ${reference}
-                    bean.badReference = ${reference}
-                }
-
-                @TaskAction
-                void run() {
-                    println "this.reference = " + badReference
-                    println "bean.reference = " + bean.badReference
-                }
-            }
-
-            task other
-            task broken(type: SomeTask)
-        """
-
-        when:
-        instantRun "broken"
-
-        then:
-        outputContains("""
-            2 instant execution problems were found, 2 of which seem unique:
-              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
-              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
-            See the complete report at
-        """.stripIndent())
-
-        when:
-        instantRun "broken"
-
-        then:
-        outputContains("this.reference = null")
-        outputContains("bean.reference = null")
-
-        where:
-        concreteType                               | baseType                            | reference
-        // Live JVM state
-        ScriptClassLoader.name                     | ClassLoader.name                    | "getClass().classLoader"
-        Thread.name                                | Thread.name                         | "Thread.currentThread()"
-        DefaultThreadFactory.name                  | ThreadFactory.name                  | "java.util.concurrent.Executors.defaultThreadFactory()"
-        FinalizableDelegatedExecutorService.name   | Executor.name                       | "java.util.concurrent.Executors.newSingleThreadExecutor().tap { shutdown() }"
-        ByteArrayInputStream.name                  | InputStream.name                    | "new java.io.ByteArrayInputStream([] as byte[])"
-        ByteArrayOutputStream.name                 | OutputStream.name                   | "new java.io.ByteArrayOutputStream()"
-        FileDescriptor.name                        | FileDescriptor.name                 | "FileDescriptor.in"
-        RandomAccessFile.name                      | RandomAccessFile.name               | "new RandomAccessFile(project.file('some').tap { text = '' }, 'r').tap { close() }"
-        Socket.name                                | Socket.name                         | "new java.net.Socket()"
-        ServerSocket.name                          | ServerSocket.name                   | "new java.net.ServerSocket(0).tap { close() }"
-        // Gradle Build Model
-        DefaultGradle.name                         | Gradle.name                         | "project.gradle"
-        DefaultSettings.name                       | Settings.name                       | "project.gradle.settings"
-        DefaultProject.name                        | Project.name                        | "project"
-        DefaultTaskContainer.name                  | TaskContainer.name                  | "project.tasks"
-        DefaultTaskDependency.name                 | TaskDependency.name                 | "project.tasks.getByName('build').taskDependencies"
-        DefaultTask.name                           | Task.name                           | "project.tasks.other"
-        DefaultSourceSetContainer.name             | SourceSetContainer.name             | "project.sourceSets"
-        DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"
-        // Dependency Resolution Services
-        DefaultConfigurationContainer.name         | ConfigurationContainer.name         | "project.configurations"
-        // DefaultConfiguration.name                  | Configuration.name                  | "project.configurations.maybeCreate('some')"
-        DefaultResolutionStrategy.name             | ResolutionStrategy.name             | "project.configurations.maybeCreate('some').resolutionStrategy"
-        ErrorHandlingResolvedConfiguration.name    | ResolvedConfiguration.name          | "project.configurations.maybeCreate('some').resolvedConfiguration"
-        ErrorHandlingLenientConfiguration.name     | LenientConfiguration.name           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
-        DefaultDependencyConstraintSet.name        | DependencyConstraintSet.name        | "project.configurations.maybeCreate('some').dependencyConstraints"
-        DefaultRepositoryHandler.name              | RepositoryHandler.name              | "project.repositories"
-        DefaultMavenArtifactRepository.name        | ArtifactRepository.name             | "project.repositories.mavenCentral()"
-        DefaultDependencyHandler.name              | DependencyHandler.name              | "project.dependencies"
-        DefaultDependencyConstraintHandler.name    | DependencyConstraintHandler.name    | "project.dependencies.constraints"
-        DefaultComponentMetadataHandler.name       | ComponentMetadataHandler.name       | "project.dependencies.components"
-        DefaultComponentModuleMetadataHandler.name | ComponentModuleMetadataHandler.name | "project.dependencies.modules"
-        DefaultAttributesSchema.name               | AttributesSchema.name               | "project.dependencies.attributesSchema"
-        DefaultAttributeMatchingStrategy.name      | AttributeMatchingStrategy.name      | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)"
-        DefaultCompatibilityRuleChain.name         | CompatibilityRuleChain.name         | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules"
-        DefaultDisambiguationRuleChain.name        | DisambiguationRuleChain.name        | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).disambiguationRules"
-        DefaultArtifactResolutionQuery.name        | ArtifactResolutionQuery.name        | "project.dependencies.createArtifactResolutionQuery()"
-        DefaultArtifactTypeContainer.name          | ArtifactTypeContainer.name          | "project.dependencies.artifactTypes"
-        DefaultDependencySet.name                  | DependencySet.name                  | "project.configurations.maybeCreate('some').dependencies"
-        DefaultExternalModuleDependency.name       | Dependency.name                     | "project.dependencies.create('junit:junit:4.12')"
-        DefaultDependencyLockingHandler.name       | DependencyLockingHandler.name       | "project.dependencyLocking"
     }
 
     def "restores task abstract properties"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -23,18 +23,63 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraintSet
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.LenientConfiguration
+import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.DependencyLockingHandler
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.query.ArtifactResolutionQuery
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.type.ArtifactTypeContainer
+import org.gradle.api.attributes.AttributeMatchingStrategy
+import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.attributes.CompatibilityRuleChain
+import org.gradle.api.attributes.DisambiguationRuleChain
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.artifacts.DefaultDependencyConstraintSet
+import org.gradle.api.internal.artifacts.DefaultDependencySet
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler
+import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler
+import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingLenientConfiguration
+import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingResolvedConfiguration
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
+import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
+import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
+import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.DefaultCompatibilityRuleChain
+import org.gradle.api.internal.attributes.DefaultDisambiguationRuleChain
 import org.gradle.api.internal.project.DefaultProject
+import org.gradle.api.internal.tasks.DefaultSourceSet
+import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.api.internal.tasks.DefaultTaskContainer
+import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskDependency
+import org.gradle.groovy.scripts.internal.DefaultScriptCompilationHandler.ScriptClassLoader
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.locking.DefaultDependencyLockingHandler
 import org.gradle.invocation.DefaultGradle
 import org.gradle.jvm.toolchain.JavaInstallationRegistry
 import org.gradle.process.ExecOperations
@@ -44,6 +89,10 @@ import org.slf4j.Logger
 import spock.lang.Unroll
 
 import javax.inject.Inject
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors.FinalizableDelegatedExecutorService
+import java.util.concurrent.Executors.DefaultThreadFactory
+import java.util.concurrent.ThreadFactory
 
 class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
@@ -924,6 +973,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
     @Unroll
     def "warns when task field references an object of type #baseType"() {
         buildFile << """
+            plugins { id "java" }
+
             class SomeBean {
                 private ${baseType} badReference
             }
@@ -962,13 +1013,49 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("bean.reference = null")
 
         where:
-        concreteType                       | baseType                    | reference
-        DefaultProject.name                | Project.name                | "project"
-        DefaultGradle.name                 | Gradle.name                 | "project.gradle"
-        DefaultSettings.name               | Settings.name               | "project.gradle.settings"
-        DefaultTask.name                   | Task.name                   | "project.tasks.other"
-        DefaultTaskContainer.name          | TaskContainer.name          | "project.tasks"
-        DefaultConfigurationContainer.name | ConfigurationContainer.name | "project.configurations"
+        concreteType                               | baseType                            | reference
+        // Live JVM state
+        ScriptClassLoader.name                     | ClassLoader.name                    | "getClass().classLoader"
+        Thread.name                                | Thread.name                         | "Thread.currentThread()"
+        DefaultThreadFactory.name                  | ThreadFactory.name                  | "java.util.concurrent.Executors.defaultThreadFactory()"
+        FinalizableDelegatedExecutorService.name   | Executor.name                       | "java.util.concurrent.Executors.newSingleThreadExecutor().tap { shutdown() }"
+        ByteArrayInputStream.name                  | InputStream.name                    | "new java.io.ByteArrayInputStream([] as byte[])"
+        ByteArrayOutputStream.name                 | OutputStream.name                   | "new java.io.ByteArrayOutputStream()"
+        FileDescriptor.name                        | FileDescriptor.name                 | "FileDescriptor.in"
+        RandomAccessFile.name                      | RandomAccessFile.name               | "new RandomAccessFile(project.file('some').tap { text = '' }, 'r').tap { close() }"
+        Socket.name                                | Socket.name                         | "new java.net.Socket()"
+        ServerSocket.name                          | ServerSocket.name                   | "new java.net.ServerSocket(0).tap { close() }"
+        // Gradle Build Model
+        DefaultGradle.name                         | Gradle.name                         | "project.gradle"
+        DefaultSettings.name                       | Settings.name                       | "project.gradle.settings"
+        DefaultProject.name                        | Project.name                        | "project"
+        DefaultTaskContainer.name                  | TaskContainer.name                  | "project.tasks"
+        DefaultTaskDependency.name                 | TaskDependency.name                 | "project.tasks.getByName('build').taskDependencies"
+        DefaultTask.name                           | Task.name                           | "project.tasks.other"
+        DefaultSourceSetContainer.name             | SourceSetContainer.name             | "project.sourceSets"
+        DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"
+        // Dependency Resolution Services
+        DefaultConfigurationContainer.name         | ConfigurationContainer.name         | "project.configurations"
+        // DefaultConfiguration.name                  | Configuration.name                  | "project.configurations.maybeCreate('some')"
+        DefaultResolutionStrategy.name             | ResolutionStrategy.name             | "project.configurations.maybeCreate('some').resolutionStrategy"
+        ErrorHandlingResolvedConfiguration.name    | ResolvedConfiguration.name          | "project.configurations.maybeCreate('some').resolvedConfiguration"
+        ErrorHandlingLenientConfiguration.name     | LenientConfiguration.name           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
+        DefaultDependencyConstraintSet.name        | DependencyConstraintSet.name        | "project.configurations.maybeCreate('some').dependencyConstraints"
+        DefaultRepositoryHandler.name              | RepositoryHandler.name              | "project.repositories"
+        DefaultMavenArtifactRepository.name        | ArtifactRepository.name             | "project.repositories.mavenCentral()"
+        DefaultDependencyHandler.name              | DependencyHandler.name              | "project.dependencies"
+        DefaultDependencyConstraintHandler.name    | DependencyConstraintHandler.name    | "project.dependencies.constraints"
+        DefaultComponentMetadataHandler.name       | ComponentMetadataHandler.name       | "project.dependencies.components"
+        DefaultComponentModuleMetadataHandler.name | ComponentModuleMetadataHandler.name | "project.dependencies.modules"
+        DefaultAttributesSchema.name               | AttributesSchema.name               | "project.dependencies.attributesSchema"
+        DefaultAttributeMatchingStrategy.name      | AttributeMatchingStrategy.name      | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)"
+        DefaultCompatibilityRuleChain.name         | CompatibilityRuleChain.name         | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules"
+        DefaultDisambiguationRuleChain.name        | DisambiguationRuleChain.name        | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).disambiguationRules"
+        DefaultArtifactResolutionQuery.name        | ArtifactResolutionQuery.name        | "project.dependencies.createArtifactResolutionQuery()"
+        DefaultArtifactTypeContainer.name          | ArtifactTypeContainer.name          | "project.dependencies.artifactTypes"
+        DefaultDependencySet.name                  | DependencySet.name                  | "project.configurations.maybeCreate('some').dependencies"
+        DefaultExternalModuleDependency.name       | Dependency.name                     | "project.dependencies.create('junit:junit:4.12')"
+        DefaultDependencyLockingHandler.name       | DependencyLockingHandler.name       | "project.dependencyLocking"
     }
 
     def "restores task abstract properties"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -216,8 +216,7 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
         then:
         outputContains("""
             1 instant execution problem was found, 1 of which seems unique:
-              - field 'this\$0' from type 'Build_gradle\$1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.
-            See the complete report at
+              - field 'this${'$'}0' from type 'Build_gradle${'$'}1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.
         """.stripIndent())
         noExceptionThrown()
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -214,7 +214,11 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
         instantRun ":some"
 
         then:
-        outputContains("instant-execution > cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.")
+        outputContains("""
+            1 instant execution problem was found, 1 of which seems unique:
+              - field 'this\$0' from type 'Build_gradle\$1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.
+            See the complete report at
+        """.stripIndent())
         noExceptionThrown()
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraintSet
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.LenientConfiguration
+import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.DependencyLockingHandler
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.query.ArtifactResolutionQuery
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.type.ArtifactTypeContainer
+import org.gradle.api.attributes.AttributeMatchingStrategy
+import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.attributes.CompatibilityRuleChain
+import org.gradle.api.attributes.DisambiguationRuleChain
+import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.artifacts.DefaultDependencyConstraintSet
+import org.gradle.api.internal.artifacts.DefaultDependencySet
+import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler
+import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler
+import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingLenientConfiguration
+import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingResolvedConfiguration
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
+import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
+import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
+import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.DefaultCompatibilityRuleChain
+import org.gradle.api.internal.attributes.DefaultDisambiguationRuleChain
+import org.gradle.api.internal.project.DefaultProject
+import org.gradle.api.internal.tasks.DefaultSourceSet
+import org.gradle.api.internal.tasks.DefaultSourceSetContainer
+import org.gradle.api.internal.tasks.DefaultTaskContainer
+import org.gradle.api.internal.tasks.DefaultTaskDependency
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskDependency
+import org.gradle.groovy.scripts.internal.DefaultScriptCompilationHandler.ScriptClassLoader
+import org.gradle.initialization.DefaultSettings
+import org.gradle.internal.locking.DefaultDependencyLockingHandler
+import org.gradle.invocation.DefaultGradle
+import spock.lang.Unroll
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors.DefaultThreadFactory
+import java.util.concurrent.Executors.FinalizableDelegatedExecutorService
+import java.util.concurrent.ThreadFactory
+
+
+class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    @Unroll
+    def "warns when task field references an object of type #baseType"() {
+        buildFile << """
+            plugins { id "java" }
+
+            class SomeBean {
+                private ${baseType} badReference
+            }
+
+            class SomeTask extends DefaultTask {
+                private final ${baseType} badReference
+                private final bean = new SomeBean()
+
+                SomeTask() {
+                    badReference = ${reference}
+                    bean.badReference = ${reference}
+                }
+
+                @TaskAction
+                void run() {
+                    println "this.reference = " + badReference
+                    println "bean.reference = " + bean.badReference
+                }
+            }
+
+            task other
+            task broken(type: SomeTask)
+        """
+
+        when:
+        instantRun "broken"
+
+        then:
+        outputContains("""
+            2 instant execution problems were found, 2 of which seem unique:
+              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
+              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
+            See the complete report at
+        """.stripIndent())
+
+        when:
+        instantRun "broken"
+
+        then:
+        outputContains("this.reference = null")
+        outputContains("bean.reference = null")
+
+        where:
+        concreteType                               | baseType                            | reference
+        // Live JVM state
+        ScriptClassLoader.name                     | ClassLoader.name                    | "getClass().classLoader"
+        Thread.name                                | Thread.name                         | "Thread.currentThread()"
+        DefaultThreadFactory.name                  | ThreadFactory.name                  | "java.util.concurrent.Executors.defaultThreadFactory()"
+        FinalizableDelegatedExecutorService.name   | Executor.name                       | "java.util.concurrent.Executors.newSingleThreadExecutor().tap { shutdown() }"
+        ByteArrayInputStream.name                  | InputStream.name                    | "new java.io.ByteArrayInputStream([] as byte[])"
+        ByteArrayOutputStream.name                 | OutputStream.name                   | "new java.io.ByteArrayOutputStream()"
+        FileDescriptor.name                        | FileDescriptor.name                 | "FileDescriptor.in"
+        RandomAccessFile.name                      | RandomAccessFile.name               | "new RandomAccessFile(project.file('some').tap { text = '' }, 'r').tap { close() }"
+        Socket.name                                | Socket.name                         | "new java.net.Socket()"
+        ServerSocket.name                          | ServerSocket.name                   | "new java.net.ServerSocket(0).tap { close() }"
+        // Gradle Build Model
+        DefaultGradle.name                         | Gradle.name                         | "project.gradle"
+        DefaultSettings.name                       | Settings.name                       | "project.gradle.settings"
+        DefaultProject.name                        | Project.name                        | "project"
+        DefaultTaskContainer.name                  | TaskContainer.name                  | "project.tasks"
+        DefaultTaskDependency.name                 | TaskDependency.name                 | "project.tasks.getByName('build').taskDependencies"
+        DefaultTask.name                           | Task.name                           | "project.tasks.other"
+        DefaultSourceSetContainer.name             | SourceSetContainer.name             | "project.sourceSets"
+        DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"
+        // Dependency Resolution Services
+        DefaultConfigurationContainer.name         | ConfigurationContainer.name         | "project.configurations"
+        // DefaultConfiguration.name                  | Configuration.name                  | "project.configurations.maybeCreate('some')"
+        DefaultResolutionStrategy.name             | ResolutionStrategy.name             | "project.configurations.maybeCreate('some').resolutionStrategy"
+        ErrorHandlingResolvedConfiguration.name    | ResolvedConfiguration.name          | "project.configurations.maybeCreate('some').resolvedConfiguration"
+        ErrorHandlingLenientConfiguration.name     | LenientConfiguration.name           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
+        DefaultDependencyConstraintSet.name        | DependencyConstraintSet.name        | "project.configurations.maybeCreate('some').dependencyConstraints"
+        DefaultRepositoryHandler.name              | RepositoryHandler.name              | "project.repositories"
+        DefaultMavenArtifactRepository.name        | ArtifactRepository.name             | "project.repositories.mavenCentral()"
+        DefaultDependencyHandler.name              | DependencyHandler.name              | "project.dependencies"
+        DefaultDependencyConstraintHandler.name    | DependencyConstraintHandler.name    | "project.dependencies.constraints"
+        DefaultComponentMetadataHandler.name       | ComponentMetadataHandler.name       | "project.dependencies.components"
+        DefaultComponentModuleMetadataHandler.name | ComponentModuleMetadataHandler.name | "project.dependencies.modules"
+        DefaultAttributesSchema.name               | AttributesSchema.name               | "project.dependencies.attributesSchema"
+        DefaultAttributeMatchingStrategy.name      | AttributeMatchingStrategy.name      | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)"
+        DefaultCompatibilityRuleChain.name         | CompatibilityRuleChain.name         | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules"
+        DefaultDisambiguationRuleChain.name        | DisambiguationRuleChain.name        | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).disambiguationRules"
+        DefaultArtifactResolutionQuery.name        | ArtifactResolutionQuery.name        | "project.dependencies.createArtifactResolutionQuery()"
+        DefaultArtifactTypeContainer.name          | ArtifactTypeContainer.name          | "project.dependencies.artifactTypes"
+        DefaultDependencySet.name                  | DependencySet.name                  | "project.configurations.maybeCreate('some').dependencies"
+        DefaultExternalModuleDependency.name       | Dependency.name                     | "project.dependencies.create('junit:junit:4.12')"
+        DefaultDependencyLockingHandler.name       | DependencyLockingHandler.name       | "project.dependencyLocking"
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -63,12 +63,10 @@ import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.internal.tasks.DefaultSourceSet
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.api.internal.tasks.DefaultTaskContainer
-import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.groovy.scripts.internal.DefaultScriptCompilationHandler.ScriptClassLoader
 import org.gradle.initialization.DefaultSettings
 import org.gradle.internal.locking.DefaultDependencyLockingHandler
@@ -148,7 +146,6 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultSettings.name                       | Settings.name                       | "project.gradle.settings"
         DefaultProject.name                        | Project.name                        | "project"
         DefaultTaskContainer.name                  | TaskContainer.name                  | "project.tasks"
-        DefaultTaskDependency.name                 | TaskDependency.name                 | "project.tasks.getByName('build').taskDependencies"
         DefaultTask.name                           | Task.name                           | "project.tasks.other"
         DefaultSourceSetContainer.name             | SourceSetContainer.name             | "project.sourceSets"
         DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -154,7 +154,6 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"
         // Dependency Resolution Services
         DefaultConfigurationContainer.name         | ConfigurationContainer.name         | "project.configurations"
-        // DefaultConfiguration.name                  | Configuration.name                  | "project.configurations.maybeCreate('some')"
         DefaultResolutionStrategy.name             | ResolutionStrategy.name             | "project.configurations.maybeCreate('some').resolutionStrategy"
         ErrorHandlingResolvedConfiguration.name    | ResolvedConfiguration.name          | "project.configurations.maybeCreate('some').resolvedConfiguration"
         ErrorHandlingLenientConfiguration.name     | LenientConfiguration.name           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -87,11 +87,11 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
             plugins { id "java" }
 
             class SomeBean {
-                private ${baseType} badReference
+                private ${baseType.name} badReference
             }
 
             class SomeTask extends DefaultTask {
-                private final ${baseType} badReference
+                private final ${baseType.name} badReference
                 private final bean = new SomeBean()
 
                 SomeTask() {
@@ -116,8 +116,8 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         then:
         outputContains("""
             2 instant execution problems were found, 2 of which seem unique:
-              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
-              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType}', a subtype of '${baseType}', as these are not supported with instant execution.
+              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.
+              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.
             See the complete report at
         """.stripIndent())
 
@@ -129,46 +129,46 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         outputContains("bean.reference = null")
 
         where:
-        concreteType                               | baseType                            | reference
+        concreteType                          | baseType                       | reference
         // Live JVM state
-        ScriptClassLoader.name                     | ClassLoader.name                    | "getClass().classLoader"
-        Thread.name                                | Thread.name                         | "Thread.currentThread()"
-        DefaultThreadFactory.name                  | ThreadFactory.name                  | "java.util.concurrent.Executors.defaultThreadFactory()"
-        FinalizableDelegatedExecutorService.name   | Executor.name                       | "java.util.concurrent.Executors.newSingleThreadExecutor().tap { shutdown() }"
-        ByteArrayInputStream.name                  | InputStream.name                    | "new java.io.ByteArrayInputStream([] as byte[])"
-        ByteArrayOutputStream.name                 | OutputStream.name                   | "new java.io.ByteArrayOutputStream()"
-        FileDescriptor.name                        | FileDescriptor.name                 | "FileDescriptor.in"
-        RandomAccessFile.name                      | RandomAccessFile.name               | "new RandomAccessFile(project.file('some').tap { text = '' }, 'r').tap { close() }"
-        Socket.name                                | Socket.name                         | "new java.net.Socket()"
-        ServerSocket.name                          | ServerSocket.name                   | "new java.net.ServerSocket(0).tap { close() }"
+        ScriptClassLoader                     | ClassLoader                    | "getClass().classLoader"
+        Thread                                | Thread                         | "Thread.currentThread()"
+        DefaultThreadFactory                  | ThreadFactory                  | "java.util.concurrent.Executors.defaultThreadFactory()"
+        FinalizableDelegatedExecutorService   | Executor                       | "java.util.concurrent.Executors.newSingleThreadExecutor().tap { shutdown() }"
+        ByteArrayInputStream                  | InputStream                    | "new java.io.ByteArrayInputStream([] as byte[])"
+        ByteArrayOutputStream                 | OutputStream                   | "new java.io.ByteArrayOutputStream()"
+        FileDescriptor                        | FileDescriptor                 | "FileDescriptor.in"
+        RandomAccessFile                      | RandomAccessFile               | "new RandomAccessFile(project.file('some').tap { text = '' }, 'r').tap { close() }"
+        Socket                                | Socket                         | "new java.net.Socket()"
+        ServerSocket                          | ServerSocket                   | "new java.net.ServerSocket(0).tap { close() }"
         // Gradle Build Model
-        DefaultGradle.name                         | Gradle.name                         | "project.gradle"
-        DefaultSettings.name                       | Settings.name                       | "project.gradle.settings"
-        DefaultProject.name                        | Project.name                        | "project"
-        DefaultTaskContainer.name                  | TaskContainer.name                  | "project.tasks"
-        DefaultTask.name                           | Task.name                           | "project.tasks.other"
-        DefaultSourceSetContainer.name             | SourceSetContainer.name             | "project.sourceSets"
-        DefaultSourceSet.name                      | SourceSet.name                      | "project.sourceSets['main']"
+        DefaultGradle                         | Gradle                         | "project.gradle"
+        DefaultSettings                       | Settings                       | "project.gradle.settings"
+        DefaultProject                        | Project                        | "project"
+        DefaultTaskContainer                  | TaskContainer                  | "project.tasks"
+        DefaultTask                           | Task                           | "project.tasks.other"
+        DefaultSourceSetContainer             | SourceSetContainer             | "project.sourceSets"
+        DefaultSourceSet                      | SourceSet                      | "project.sourceSets['main']"
         // Dependency Resolution Services
-        DefaultConfigurationContainer.name         | ConfigurationContainer.name         | "project.configurations"
-        DefaultResolutionStrategy.name             | ResolutionStrategy.name             | "project.configurations.maybeCreate('some').resolutionStrategy"
-        ErrorHandlingResolvedConfiguration.name    | ResolvedConfiguration.name          | "project.configurations.maybeCreate('some').resolvedConfiguration"
-        ErrorHandlingLenientConfiguration.name     | LenientConfiguration.name           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
-        DefaultDependencyConstraintSet.name        | DependencyConstraintSet.name        | "project.configurations.maybeCreate('some').dependencyConstraints"
-        DefaultRepositoryHandler.name              | RepositoryHandler.name              | "project.repositories"
-        DefaultMavenArtifactRepository.name        | ArtifactRepository.name             | "project.repositories.mavenCentral()"
-        DefaultDependencyHandler.name              | DependencyHandler.name              | "project.dependencies"
-        DefaultDependencyConstraintHandler.name    | DependencyConstraintHandler.name    | "project.dependencies.constraints"
-        DefaultComponentMetadataHandler.name       | ComponentMetadataHandler.name       | "project.dependencies.components"
-        DefaultComponentModuleMetadataHandler.name | ComponentModuleMetadataHandler.name | "project.dependencies.modules"
-        DefaultAttributesSchema.name               | AttributesSchema.name               | "project.dependencies.attributesSchema"
-        DefaultAttributeMatchingStrategy.name      | AttributeMatchingStrategy.name      | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)"
-        DefaultCompatibilityRuleChain.name         | CompatibilityRuleChain.name         | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules"
-        DefaultDisambiguationRuleChain.name        | DisambiguationRuleChain.name        | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).disambiguationRules"
-        DefaultArtifactResolutionQuery.name        | ArtifactResolutionQuery.name        | "project.dependencies.createArtifactResolutionQuery()"
-        DefaultArtifactTypeContainer.name          | ArtifactTypeContainer.name          | "project.dependencies.artifactTypes"
-        DefaultDependencySet.name                  | DependencySet.name                  | "project.configurations.maybeCreate('some').dependencies"
-        DefaultExternalModuleDependency.name       | Dependency.name                     | "project.dependencies.create('junit:junit:4.12')"
-        DefaultDependencyLockingHandler.name       | DependencyLockingHandler.name       | "project.dependencyLocking"
+        DefaultConfigurationContainer         | ConfigurationContainer         | "project.configurations"
+        DefaultResolutionStrategy             | ResolutionStrategy             | "project.configurations.maybeCreate('some').resolutionStrategy"
+        ErrorHandlingResolvedConfiguration    | ResolvedConfiguration          | "project.configurations.maybeCreate('some').resolvedConfiguration"
+        ErrorHandlingLenientConfiguration     | LenientConfiguration           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
+        DefaultDependencyConstraintSet        | DependencyConstraintSet        | "project.configurations.maybeCreate('some').dependencyConstraints"
+        DefaultRepositoryHandler              | RepositoryHandler              | "project.repositories"
+        DefaultMavenArtifactRepository        | ArtifactRepository             | "project.repositories.mavenCentral()"
+        DefaultDependencyHandler              | DependencyHandler              | "project.dependencies"
+        DefaultDependencyConstraintHandler    | DependencyConstraintHandler    | "project.dependencies.constraints"
+        DefaultComponentMetadataHandler       | ComponentMetadataHandler       | "project.dependencies.components"
+        DefaultComponentModuleMetadataHandler | ComponentModuleMetadataHandler | "project.dependencies.modules"
+        DefaultAttributesSchema               | AttributesSchema               | "project.dependencies.attributesSchema"
+        DefaultAttributeMatchingStrategy      | AttributeMatchingStrategy      | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)"
+        DefaultCompatibilityRuleChain         | CompatibilityRuleChain         | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules"
+        DefaultDisambiguationRuleChain        | DisambiguationRuleChain        | "project.dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).disambiguationRules"
+        DefaultArtifactResolutionQuery        | ArtifactResolutionQuery        | "project.dependencies.createArtifactResolutionQuery()"
+        DefaultArtifactTypeContainer          | ArtifactTypeContainer          | "project.dependencies.artifactTypes"
+        DefaultDependencySet                  | DependencySet                  | "project.configurations.maybeCreate('some').dependencies"
+        DefaultExternalModuleDependency       | Dependency                     | "project.dependencies.create('junit:junit:4.12')"
+        DefaultDependencyLockingHandler       | DependencyLockingHandler       | "project.dependencyLocking"
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
@@ -90,7 +90,6 @@ fun IsolateContext.logNotImplemented(feature: String) {
 private
 fun IsolateContext.logPropertyWarning(message: StructuredMessageBuilder) {
     val problem = PropertyProblem.Warning(trace, build(message))
-    logger.warn("instant-execution > {}", problem.message)
     logPropertyProblem("serialize", problem)
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
@@ -128,7 +128,9 @@ class BindingsBuilder {
         bind(type, SerializerCodec(serializer))
 
     fun bind(type: Class<*>, codec: Codec<*>) {
-        require(bindings.all { it.encodingForType(type) == null })
+        require(bindings.all { it.encodingForType(type) == null }) {
+            "There's already a binding that provide encoding for type '$type'"
+        }
         val codecForAny = codec.uncheckedCast<Codec<Any>>()
         val encodingProducer = producerForSubtypesOf(type, codecForAny)
         bind(encodingProducer, codecForAny)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
@@ -129,7 +129,7 @@ class BindingsBuilder {
 
     fun bind(type: Class<*>, codec: Codec<*>) {
         require(bindings.all { it.encodingForType(type) == null }) {
-            "There's already a binding that provide encoding for type '$type'"
+            "There's already an encoding for type '$type'"
         }
         val codecForAny = codec.uncheckedCast<Codec<Any>>()
         val encodingProducer = producerForSubtypesOf(type, codecForAny)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -16,31 +16,8 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
-import org.gradle.api.Project
-import org.gradle.api.Script
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.DependencyConstraintSet
-import org.gradle.api.artifacts.DependencySet
-import org.gradle.api.artifacts.LenientConfiguration
-import org.gradle.api.artifacts.ResolutionStrategy
-import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
-import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
-import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
-import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.artifacts.dsl.DependencyLockingHandler
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.artifacts.query.ArtifactResolutionQuery
-import org.gradle.api.artifacts.repositories.ArtifactRepository
-import org.gradle.api.artifacts.type.ArtifactTypeContainer
-import org.gradle.api.attributes.AttributeMatchingStrategy
-import org.gradle.api.attributes.AttributesSchema
-import org.gradle.api.attributes.CompatibilityRuleChain
-import org.gradle.api.attributes.DisambiguationRuleChain
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
-import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
@@ -56,21 +33,15 @@ import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
-import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.initialization.BuildRequestMetaData
 import org.gradle.instantexecution.serialization.ownerServiceCodec
 import org.gradle.instantexecution.serialization.reentrant
-import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
@@ -94,19 +65,10 @@ import org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.internal.state.ManagedFactoryRegistry
-import org.gradle.kotlin.dsl.*
 import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecActionFactory
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.workers.WorkerExecutor
-import java.io.FileDescriptor
-import java.io.InputStream
-import java.io.OutputStream
-import java.io.RandomAccessFile
-import java.net.ServerSocket
-import java.net.Socket
-import java.util.concurrent.Executor
-import java.util.concurrent.ThreadFactory
 
 
 class Codecs(
@@ -198,58 +160,6 @@ class Codecs(
         // we can still get them for the other codecs, for instance,
         // with deeply nested Lists, deeply nested Maps, etc.
         bind(reentrant(BeanCodec()))
-    }
-
-    private
-    fun BindingsBuilder.unsupportedTypes() {
-
-        // Live JVM state
-        bind(unsupported<ClassLoader>())
-        bind(unsupported<Thread>())
-        bind(unsupported<ThreadFactory>())
-        bind(unsupported<Executor>())
-        bind(unsupported<InputStream>())
-        bind(unsupported<OutputStream>())
-        bind(unsupported<FileDescriptor>())
-        bind(unsupported<RandomAccessFile>())
-        bind(unsupported<Socket>())
-        bind(unsupported<ServerSocket>())
-
-        // Gradle Scripts
-        bind(unsupported<Script>())
-        bind(unsupported<KotlinScript>())
-
-        // Gradle Build Model
-        bind(unsupported<Gradle>())
-        bind(unsupported<Settings>())
-        bind(unsupported<Project>())
-        bind(unsupported<TaskContainer>())
-        bind(unsupported<TaskDependency>())
-        bind(unsupported<SourceSetContainer>())
-        bind(unsupported<SourceSet>())
-
-        // Dependency Resolution Services
-        bind(unsupported<ConfigurationContainer>())
-        // bind(unsupported<Configuration>()) // TODO this breaks lots of core plugins
-        bind(unsupported<ResolutionStrategy>())
-        bind(unsupported<ResolvedConfiguration>())
-        bind(unsupported<LenientConfiguration>())
-        bind(unsupported<DependencyConstraintSet>())
-        bind(unsupported<RepositoryHandler>())
-        bind(unsupported<ArtifactRepository>())
-        bind(unsupported<DependencyHandler>())
-        bind(unsupported<DependencyConstraintHandler>())
-        bind(unsupported<ComponentMetadataHandler>())
-        bind(unsupported<ComponentModuleMetadataHandler>())
-        bind(unsupported<ArtifactTypeContainer>())
-        bind(unsupported<AttributesSchema>())
-        bind(unsupported<AttributeMatchingStrategy<*>>())
-        bind(unsupported<CompatibilityRuleChain<*>>())
-        bind(unsupported<DisambiguationRuleChain<*>>())
-        bind(unsupported<ArtifactResolutionQuery>())
-        bind(unsupported<DependencySet>())
-        bind(unsupported<Dependency>())
-        bind(unsupported<DependencyLockingHandler>())
     }
 
     val internalTypesCodec = BindingsBackedCodec {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -86,7 +86,6 @@ fun BindingsBuilder.unsupportedTypes() {
 
     // Dependency Resolution Services
     bind(unsupported<ConfigurationContainer>())
-    // bind(unsupported<Configuration>()) // TODO this breaks lots of core plugins
     bind(unsupported<ResolutionStrategy>())
     bind(unsupported<ResolvedConfiguration>())
     bind(unsupported<LenientConfiguration>())

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -43,7 +43,6 @@ import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.kotlin.dsl.*
 import java.io.FileDescriptor
@@ -80,7 +79,6 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<Settings>())
     bind(unsupported<Project>())
     bind(unsupported<TaskContainer>())
-    bind(unsupported<TaskDependency>())
     bind(unsupported<SourceSetContainer>())
     bind(unsupported<SourceSet>())
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.Project
+import org.gradle.api.Script
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraintSet
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.LenientConfiguration
+import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.DependencyLockingHandler
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.query.ArtifactResolutionQuery
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.type.ArtifactTypeContainer
+import org.gradle.api.attributes.AttributeMatchingStrategy
+import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.attributes.CompatibilityRuleChain
+import org.gradle.api.attributes.DisambiguationRuleChain
+import org.gradle.api.initialization.Settings
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskDependency
+import org.gradle.instantexecution.serialization.unsupported
+import org.gradle.kotlin.dsl.*
+import java.io.FileDescriptor
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.RandomAccessFile
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.Executor
+import java.util.concurrent.ThreadFactory
+
+
+internal
+fun BindingsBuilder.unsupportedTypes() {
+
+    // Live JVM state
+    bind(unsupported<ClassLoader>())
+    bind(unsupported<Thread>())
+    bind(unsupported<ThreadFactory>())
+    bind(unsupported<Executor>())
+    bind(unsupported<InputStream>())
+    bind(unsupported<OutputStream>())
+    bind(unsupported<FileDescriptor>())
+    bind(unsupported<RandomAccessFile>())
+    bind(unsupported<Socket>())
+    bind(unsupported<ServerSocket>())
+
+    // Gradle Scripts
+    bind(unsupported<Script>())
+    bind(unsupported<KotlinScript>())
+
+    // Gradle Build Model
+    bind(unsupported<Gradle>())
+    bind(unsupported<Settings>())
+    bind(unsupported<Project>())
+    bind(unsupported<TaskContainer>())
+    bind(unsupported<TaskDependency>())
+    bind(unsupported<SourceSetContainer>())
+    bind(unsupported<SourceSet>())
+
+    // Dependency Resolution Services
+    bind(unsupported<ConfigurationContainer>())
+    // bind(unsupported<Configuration>()) // TODO this breaks lots of core plugins
+    bind(unsupported<ResolutionStrategy>())
+    bind(unsupported<ResolvedConfiguration>())
+    bind(unsupported<LenientConfiguration>())
+    bind(unsupported<DependencyConstraintSet>())
+    bind(unsupported<RepositoryHandler>())
+    bind(unsupported<ArtifactRepository>())
+    bind(unsupported<DependencyHandler>())
+    bind(unsupported<DependencyConstraintHandler>())
+    bind(unsupported<ComponentMetadataHandler>())
+    bind(unsupported<ComponentModuleMetadataHandler>())
+    bind(unsupported<ArtifactTypeContainer>())
+    bind(unsupported<AttributesSchema>())
+    bind(unsupported<AttributeMatchingStrategy<*>>())
+    bind(unsupported<CompatibilityRuleChain<*>>())
+    bind(unsupported<DisambiguationRuleChain<*>>())
+    bind(unsupported<ArtifactResolutionQuery>())
+    bind(unsupported<DependencySet>())
+    bind(unsupported<Dependency>())
+    bind(unsupported<DependencyLockingHandler>())
+}


### PR DESCRIPTION
For the sake of better diagnostics and failing faster to consume less memory, alleviating OOMEs, on problematic graphs. We might decide to support some of these in the future but they aren't currently, so better report that clearly.

`Configuration` is not reported as an unsupported type yet as it breaks lots tests for core plugins, this will be done in a subsequent PR. It probably needs to be different though as we want `FileCollection` properties assigned with a `Configuration` to work, but properties _declared_ with the `Configuration` type to be detected as a problem.
