### PR TITLE
Fix using mapped FileCollection elements with instant execution

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -396,7 +396,6 @@ task showBroken { doLast { println configurations.broken.files } }
         succeeds("showBroken")
     }
 
-    @ToBeFixedForInstantExecution
     public void "reports and caches missing artifact"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -730,7 +730,6 @@ Required by:
         file('libs').assertHasDescendants('projectA-1.0-SNAPSHOT.jar')
     }
 
-    @ToBeFixedForInstantExecution
     def "reports missing unique snapshot artifact"() {
         given:
         def projectA = publishModule('group', 'projectA', "1.0-SNAPSHOT")

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -618,6 +618,41 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         "Provider<String>" | "objects.property(String)"                | "null"
     }
 
+    def "replaces provider with fixed value"() {
+        buildFile << """
+            class SomeTask extends DefaultTask {
+                @Internal
+                Provider<String> value
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value.getOrNull()
+                }
+            }
+
+            task ok(type: SomeTask) {
+                value = providers.provider {
+                    println("calculating value")
+                    'value'
+                }
+            }
+        """
+
+        when:
+        instantRun "ok"
+
+        then:
+        outputContains("calculating value")
+        outputContains("this.value = value")
+
+        when:
+        instantRun "ok"
+
+        then:
+        outputDoesNotContain("calculating value")
+        outputContains("this.value = value")
+    }
+
     @Unroll
     def "restores task fields whose value is broken #type"() {
         def instantExecution = newInstantExecutionFixture()


### PR DESCRIPTION

### Context

Do not eagerly evaluate a mapped `FileCollection.elements` provider when the file collection contains task outputs.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
