### PR TITLE
Make Soak/Smoke tests cacheable

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SmokeTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SmokeTest.kt
@@ -16,8 +16,11 @@
 
 package org.gradle.gradlebuild.test.integrationtests
 
+import org.gradle.api.tasks.CacheableTask
+
 
 /**
  * A test that verifies Gradle can be used with popular third party plugins.
  */
+@CacheableTask
 abstract class SmokeTest : DistributionTest()

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SoakTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SoakTest.kt
@@ -16,8 +16,11 @@
 
 package org.gradle.gradlebuild.test.integrationtests
 
+import org.gradle.api.tasks.CacheableTask
+
 
 /**
  * A test aimed at verifying behavior under heavy load.
  */
+@CacheableTask
 abstract class SoakTest : DistributionTest()


### PR DESCRIPTION
they are no different from the other integration tests,
so let's use the cache for them as well.