### PR TITLE
fix Maven bare ‘SNAPSHOT’ version string

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -285,7 +285,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     protected static boolean isNonUniqueSnapshot(ModuleComponentIdentifier moduleComponentIdentifier) {
-        return moduleComponentIdentifier.getVersion().endsWith("-SNAPSHOT");
+        return "SNAPSHOT".equals(moduleComponentIdentifier.getVersion()) ||
+            moduleComponentIdentifier.getVersion().endsWith("-SNAPSHOT");
     }
 
     private MavenUniqueSnapshotComponentIdentifier composeSnapshotIdentifier(ModuleComponentIdentifier moduleComponentIdentifier, MavenUniqueSnapshotModuleSource uniqueSnapshotVersion) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenPomMetadataSource
@@ -125,6 +126,15 @@ class MavenResolverTest extends Specification {
 
         expect:
         resolver1.id != resolver2.id
+    }
+
+    def "identifies bare SNAPSHOT version as a non-unique snapshot"() {
+        given:
+        ModuleComponentIdentifier id = Mock()
+        id.getVersion() >> "SNAPSHOT"
+
+        expect:
+        MavenResolver.isNonUniqueSnapshot(id)
     }
 
     private MavenResolver resolver(boolean useGradleMetadata = false, boolean alwaysProvidesMetadataForModules = false) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifierTest.groovy
@@ -53,6 +53,19 @@ class MavenUniqueSnapshotComponentIdentifierTest extends Specification {
         "1.0-timestamp" | _
     }
 
+    def "can request bare timestamp or bare symbolic version"() {
+        def id = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, version, "timestamp")
+
+        expect:
+        id.timestampedVersion == "timestamp"
+        id.snapshotVersion == "SNAPSHOT"
+
+        where:
+        version     | _
+        "SNAPSHOT"  | _
+        "timestamp" | _
+    }
+
     def "has useful display name"() {
         def id = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, version, "timestamp")
 


### PR DESCRIPTION
Fixes #5613

### Context
Maven compatibility bug fix, since it allows bare ’SNAPSHOT’ as the version string. Discussed in issue #5613.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes