### PR TITLE
ivy-component-metadata-rule sample should check for IvyModuleDescriptor existence to avoid breaking Maven modules

### DIFF
--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/groovy/build.gradle
@@ -15,6 +15,7 @@ class IvyVariantDerivationRule implements ComponentMetadataRule {
     @Inject ObjectFactory getObjects() { }
 
     void execute(ComponentMetadataContext context) {
+        // This filters out any non Ivy module
         if(context.getDescriptor(IvyModuleDescriptor) == null) {
             return
         }

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/groovy/build.gradle
@@ -15,6 +15,10 @@ class IvyVariantDerivationRule implements ComponentMetadataRule {
     @Inject ObjectFactory getObjects() { }
 
     void execute(ComponentMetadataContext context) {
+        if(context.getDescriptor(IvyModuleDescriptor) == null) {
+            return
+        }
+
         context.details.addVariant("runtimeElements", "default") {
             attributes {
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named(LibraryElements, LibraryElements.JAR))

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
@@ -15,6 +15,7 @@ open class IvyVariantDerivationRule : ComponentMetadataRule {
     @Inject open fun getObjects(): ObjectFactory = throw UnsupportedOperationException()
 
     override fun execute(context: ComponentMetadataContext) {
+        // This filters out any non Ivy module
         if(context.getDescriptor(IvyModuleDescriptor) == null) {
             return
         }

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
@@ -15,6 +15,10 @@ open class IvyVariantDerivationRule : ComponentMetadataRule {
     @Inject open fun getObjects(): ObjectFactory = throw UnsupportedOperationException()
 
     override fun execute(context: ComponentMetadataContext) {
+        if(context.getDescriptor(IvyModuleDescriptor) == null) {
+            return
+        }
+
         context.details.addVariant("runtimeElements", "default") {
             attributes {
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named(LibraryElements.JAR))

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/ivyMetadataRule/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@ open class IvyVariantDerivationRule : ComponentMetadataRule {
 
     override fun execute(context: ComponentMetadataContext) {
         // This filters out any non Ivy module
-        if(context.getDescriptor(IvyModuleDescriptor) == null) {
+        if(context.getDescriptor(IvyModuleDescriptor::class) == null) {
             return
         }
 


### PR DESCRIPTION
This enhance docs around `ivy-component-metadata-rule` to prevent breaking Maven based modules

If check for `IvyModuleDescriptor` is not in place, the rule will fail with maven based modules causing issues such as:

```
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.google.guava:guava:19.0.
     Required by:
         project : > foo:my-core:1.0.0
      > Cannot choose between the following variants of com.google.guava:guava:19.0:
          - apiElements
          - compile
          - runtime
        All of them match the consumer attributes:
          - Variant 'apiElements' capability com.google.guava:guava:19.0:
              - Unmatched attributes:
                  - Required org.gradle.dependency.bundling 'external' but no value provided.
``` 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
