### PR TITLE
Disable VFS retention and VFS retention tests on `release`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,9 @@ systemProp.gradle.publish.skip.namespace.check=true
 systemProp.org.gradle.internal.ide.scan=true
 
 # Enable VFS retention using file watching on Windows, Linux and macOS
-# Note that CI builds have this property explicitly disabled via command-line
 # Remove the property when VFS retention is enabled by default
-systemProp.org.gradle.unsafe.vfs.retention=true
+# VFS retention is disabled until https://github.com/gradle/gradle/issues/12457 has been fixed.
+# systemProp.org.gradle.unsafe.vfs.retention=true
 
 # Enable partial VFS invalidation, i.e. only remove the in-memory file system state for declared outputs before running task actions.
 # Remove the property when partial invalidation is enabled by default.

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -21,10 +21,12 @@ import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.VfsRetentionFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecution.Skip.FLAKY
 
+@Ignore("Ignore until https://github.com/gradle/gradle/issues/12457 is fixed")
 // The whole test makes no sense if there isn't a daemon to retain the state.
 @IgnoreIf({ GradleContextualExecuter.noDaemon || GradleContextualExecuter.vfsRetention })
 class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, VfsRetentionFixture {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -24,7 +24,9 @@ import org.gradle.internal.vfs.watch.FileWatcherRegistry
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.experimental.categories.Category
+import spock.lang.Ignore
 
+@Ignore("Ignore until https://github.com/gradle/gradle/issues/12457 is fixed")
 @Category(SoakTest)
 class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implements VfsRetentionFixture {
 


### PR DESCRIPTION
Until #12457 is fixed.