### PR TITLE
Make sure all test files can be removed

### DIFF
--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -136,6 +136,16 @@ tasks.classpathManifest {
     additionalProjects.add(":runtimeApiInfo")
 }
 
+tasks.clean {
+    doFirst {
+        // On daemon crash, read-only cache tests can leave read-only files around.
+        // clean now takes care of those files as well
+        fileTree("$buildDir/tmp/test files").matching {
+            include("**/read-only-cache/**")
+        }.visit { this.file.setWritable(true) }
+    }
+}
+
 afterEvaluate {
     // This is a workaround for the validate plugins task trying to inspect classes which
     // have changed but are NOT tasks


### PR DESCRIPTION
With the read-only dependency cache feature, in some rare cases (daemon
crash, ...) some files may remain read-only on disk.
The dependency management clean task now makes sure they can be deleted.

I have decided to target `release` as this could be a reason for broken builds during the RC1 release and so makes sense to have it available as widely as possible.
But it could be moved to `master` easily.