### PR TITLE
Let instant execution be strict by default

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -43,6 +43,14 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
         return new InstantExecutionBuildOperationsFixture(new BuildOperationsFixture(executer, temporaryFolder))
     }
 
+    protected void withDoNotFailOnProblems() {
+        executer.withArgument("-D${SystemProperties.failOnProblems}=false")
+    }
+
+    protected void withFailOnProblems() {
+        executer.withArgument("-D${SystemProperties.failOnProblems}=true")
+    }
+
     protected void assertTestsExecuted(String testClass, String... testNames) {
         new DefaultTestExecutionResult(testDirectory)
             .testClass(testClass)

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -32,7 +32,7 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
 
         then:
         instantExecution.assertStateStored()
-        output.contains("Gradle runtime: support for included builds is not yet implemented with instant execution.")
+        expectInstantExecutionProblems("- Gradle runtime: support for included builds is not yet implemented with instant execution.")
 
         when:
         withFailOnProblems()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.instantexecution
 
 class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    def "warns for not implemented included builds support"() {
+    def "problem when included builds are present"() {
 
         given:
         def instantExecution = newInstantExecutionFixture()
@@ -27,6 +27,7 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         file("included/settings.gradle") << ""
 
         when:
+        withDoNotFailOnProblems()
         instantRun("help")
 
         then:
@@ -34,6 +35,7 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         output.contains("Gradle runtime: support for included builds is not yet implemented with instant execution.")
 
         when:
+        withFailOnProblems()
         instantRun("help")
 
         then:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -30,18 +30,28 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         buildFile << '\njacocoTestReport.dependsOn test'
         def htmlReportDir = file("build/reports/jacoco/test/html")
 
-        expect:
+        when:
         withDoNotFailOnProblems()
         instantRun 'test', 'jacocoTestReport'
+        expectInstantExecutionProblems(
+            4,
+            "- field 'val\$testTaskProvider' from type 'org.gradle.testing.jacoco.plugins.JacocoPlugin\$11': cannot serialize object of type 'org.gradle.api.tasks.testing.Test', a subtype of 'org.gradle.api.Task', as these are not supported with instant execution.",
+            "- field 'project' from type 'org.gradle.testing.jacoco.plugins.JacocoPluginExtension': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.",
+            "- field 'project' from type 'org.gradle.testing.jacoco.plugins.JacocoPlugin': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution."
+        )
+
+        then:
         htmlReportDir.assertIsDir()
 
         when:
         succeeds 'clean'
         htmlReportDir.assertDoesNotExist()
 
-        then:
+        and:
         withFailOnProblems()
         instantRun 'test', 'jacocoTestReport'
+
+        then:
         htmlReportDir.assertIsDir()
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -31,6 +31,7 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         def htmlReportDir = file("build/reports/jacoco/test/html")
 
         expect:
+        withDoNotFailOnProblems()
         instantRun 'test', 'jacocoTestReport'
         htmlReportDir.assertIsDir()
 
@@ -39,6 +40,7 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         htmlReportDir.assertDoesNotExist()
 
         then:
+        withFailOnProblems()
         instantRun 'test', 'jacocoTestReport'
         htmlReportDir.assertIsDir()
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -135,7 +135,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         """
 
         when:
-        instantRun "c"
+        instantFails "c"
 
         then:
         def reportDir = stateDirForTasks("c")

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -178,7 +178,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         expectedNumberOfProblems = Math.max(1, maxProblems)
     }
 
-    def "can request to fail on problems"() {
+    def "can request to not fail on problems"() {
         given:
         buildFile << """
             class Bean { Project p1 }
@@ -193,10 +193,9 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         """
 
         when:
-        instantFails "foo", "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=true"
+        instantRun "foo", "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false"
 
         then:
-        failureDescriptionStartsWith "Problems found while caching instant execution state"
         expectInstantExecutionProblems(
             "- field 'p1' from type 'Bean': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution."
         )

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.instantexecution
 
 import org.gradle.internal.hash.HashUtil
-import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
 
@@ -243,9 +242,5 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
     private TestFile stateDirForTasks(String... requestedTaskNames) {
         def baseName = HashUtil.createCompactMD5(requestedTaskNames.join("/"))
         file("build/reports/instant-execution/$baseName")
-    }
-
-    private static String clickableUrlFor(File file) {
-        new ConsoleRenderer().asClickableFileUrl(file)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -214,11 +214,9 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
         instantFails ":some"
 
         then:
-        outputContains("""
-            1 instant execution problem was found, 1 of which seems unique:
-              - field 'this${'$'}0' from type 'Build_gradle${'$'}1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.
-        """.stripIndent())
-        noExceptionThrown()
+        expectInstantExecutionProblems(
+            "- field 'this${'\$'}0' from type 'Build_gradle${'\$'}1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution."
+        )
     }
 
     def "task with type declared in Groovy script is up-to-date when no inputs have changed"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -199,7 +199,7 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
         result.groupedOutput.task(":b:some").assertOutputContains("FIRST").assertOutputContains("LAST")
     }
 
-    def "warns when closure defined in Kotlin script captures state from the script"() {
+    def "problem when closure defined in Kotlin script captures state from the script"() {
         given:
         buildKotlinFile << """
             val message = "message"
@@ -211,7 +211,7 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
         """
 
         when:
-        instantRun ":some"
+        instantFails ":some"
 
         then:
         outputContains("""

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -111,6 +111,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         """
 
         when:
+        withDoNotFailOnProblems()
         instantRun "broken"
 
         then:
@@ -122,6 +123,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         """.stripIndent())
 
         when:
+        withFailOnProblems()
         instantRun "broken"
 
         then:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -115,12 +115,10 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         instantRun "broken"
 
         then:
-        outputContains("""
-            2 instant execution problems were found, 2 of which seem unique:
-              - field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.
-              - field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.
-            See the complete report at
-        """.stripIndent())
+        expectInstantExecutionProblems(
+            "- field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.",
+            "- field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution."
+        )
 
         when:
         withFailOnProblems()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -44,7 +44,7 @@ class InstantExecutionStartParameter(
     }
 
     val failOnProblems: Boolean by unsafeLazy {
-        systemPropertyFlag(SystemProperties.failOnProblems)
+        systemPropertyFlag(SystemProperties.failOnProblems, true)
     }
 
     val recreateCache: Boolean
@@ -97,8 +97,8 @@ class InstantExecutionStartParameter(
             .takeIf { !it.startsWith('.') }
 
     private
-    fun systemPropertyFlag(propertyName: String): Boolean =
-        systemProperty(propertyName)?.toBoolean() ?: false
+    fun systemPropertyFlag(propertyName: String, defaultValue: Boolean = false): Boolean =
+        systemProperty(propertyName)?.toBoolean() ?: defaultValue
 
     private
     fun systemProperty(propertyName: String) =

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -26,8 +26,7 @@ class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
     static final List<String> INSTANT_EXECUTION_ARGS = [
         "-D${SystemProperties.isEnabled}=true",
         "-D${SystemProperties.isQuiet}=true",
-        "-D${SystemProperties.maxProblems}=0",
-        "-D${SystemProperties.failOnProblems}=true"
+        "-D${SystemProperties.maxProblems}=0"
     ].collect { it.toString() }
 
     InstantExecutionGradleExecuter(


### PR DESCRIPTION
By defaulting failOnProblems to true making the strict mode the default moving the lenient mode behind a flag.

This PR also add some test helpers to assert on reported problems.