### PR TITLE
Remove instant execution workarounds for AGP 3.x

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Workarounds.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Workarounds.kt
@@ -24,10 +24,7 @@ internal
 object Workarounds {
 
     private
-    val ignoredBeanFields = listOf(
-        // Ignore a lambda field for now
-        "mFolderFilter" to "com.android.ide.common.resources.DataSet"
-    )
+    val ignoredBeanFields: List<Pair<String, String>> = emptyList()
 
     fun isIgnoredBeanField(field: Field) =
         ignoredBeanFields.contains(field.name to field.declaringClass.name)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Workarounds.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Workarounds.kt
@@ -18,7 +18,6 @@ package org.gradle.instantexecution.serialization
 
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import java.lang.reflect.Field
-import java.util.concurrent.ForkJoinPool
 
 
 internal
@@ -34,11 +33,7 @@ object Workarounds {
         ignoredBeanFields.contains(field.name to field.declaringClass.name)
 
     private
-    val staticFieldsByTypeName = mapOf(
-        "com.android.build.gradle.internal.tasks.Workers" to mapOf(
-            "aapt2ThreadPool" to { ForkJoinPool(8) }
-        )
-    )
+    val staticFieldsByTypeName: Map<String, Map<String, () -> Any?>> = emptyMap()
 
     fun maybeSetDefaultStaticStateIn(scope: ClassLoaderScope) {
         listOf(scope.localClassLoader, scope.exportClassLoader).forEach { loader ->


### PR DESCRIPTION
As they are not needed anymore given instant execution now targets 4.x.