### PR TITLE
Let instant execution capture more details of CopySpecs

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
@@ -58,6 +58,12 @@ class StringDeduplicatingDecoder implements Decoder, Closeable {
         return delegate.readSmallInt();
     }
 
+    @Nullable
+    @Override
+    public Integer readNullableInt() throws IOException {
+        return delegate.readNullableInt();
+    }
+
     @Override
     public boolean readBoolean() throws EOFException, IOException {
         return delegate.readBoolean();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
@@ -60,8 +60,8 @@ class StringDeduplicatingDecoder implements Decoder, Closeable {
 
     @Nullable
     @Override
-    public Integer readNullableInt() throws IOException {
-        return delegate.readNullableInt();
+    public Integer readNullableSmallInt() throws IOException {
+        return delegate.readNullableSmallInt();
     }
 
     @Override

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
@@ -45,6 +46,12 @@ class DefaultCopySpecCodec(
             write(value.destPath)
             write(value.sourceFiles)
             write(value.patterns)
+            writeBoolean(value.isCaseSensitive)
+            writeBoolean(value.includeEmptyDirs)
+            writeString(value.filteringCharset)
+            writeNullableInt(value.dirMode)
+            writeNullableInt(value.fileMode)
+            write(value.duplicatesStrategy)
             writeCollection(value.children)
         }
     }
@@ -54,8 +61,24 @@ class DefaultCopySpecCodec(
             val destPath = read() as String?
             val sourceFiles = read() as FileCollection
             val patterns = read() as PatternSet
+            val isCaseSensitive = readBoolean()
+            val includeEmptyDirs = readBoolean()
+            val filteringCharset = readString()
+            val dirMode = readNullableInt()
+            val fileMode = readNullableInt()
+            val duplicatesStrategy = read() as DuplicatesStrategy
             val children = readList().uncheckedCast<List<CopySpecInternal>>()
             val copySpec = DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
+            copySpec.isCaseSensitive = isCaseSensitive
+            copySpec.includeEmptyDirs = includeEmptyDirs
+            copySpec.filteringCharset = filteringCharset
+            if (dirMode != null) {
+                copySpec.dirMode = dirMode
+            }
+            if (fileMode != null) {
+                copySpec.fileMode = fileMode
+            }
+            copySpec.duplicatesStrategy = duplicatesStrategy
             isolate.identities.putInstance(id, copySpec)
             copySpec
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -29,8 +29,10 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.decodePreservingIdentity
 import org.gradle.instantexecution.serialization.encodePreservingIdentityOf
+import org.gradle.instantexecution.serialization.readEnum
 import org.gradle.instantexecution.serialization.readList
 import org.gradle.instantexecution.serialization.writeCollection
+import org.gradle.instantexecution.serialization.writeEnum
 import org.gradle.internal.reflect.Instantiator
 
 
@@ -46,12 +48,12 @@ class DefaultCopySpecCodec(
             write(value.destPath)
             write(value.sourceFiles)
             write(value.patterns)
-            writeBoolean(value.isCaseSensitive)
+            writeEnum(value.duplicatesStrategy)
             writeBoolean(value.includeEmptyDirs)
+            writeBoolean(value.isCaseSensitive)
             writeString(value.filteringCharset)
             writeNullableInt(value.dirMode)
             writeNullableInt(value.fileMode)
-            write(value.duplicatesStrategy)
             writeCollection(value.children)
         }
     }
@@ -61,16 +63,17 @@ class DefaultCopySpecCodec(
             val destPath = read() as String?
             val sourceFiles = read() as FileCollection
             val patterns = read() as PatternSet
-            val isCaseSensitive = readBoolean()
+            val duplicatesStrategy = readEnum<DuplicatesStrategy>()
             val includeEmptyDirs = readBoolean()
+            val isCaseSensitive = readBoolean()
             val filteringCharset = readString()
             val dirMode = readNullableInt()
             val fileMode = readNullableInt()
-            val duplicatesStrategy = read() as DuplicatesStrategy
             val children = readList().uncheckedCast<List<CopySpecInternal>>()
             val copySpec = DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
-            copySpec.isCaseSensitive = isCaseSensitive
+            copySpec.duplicatesStrategy = duplicatesStrategy
             copySpec.includeEmptyDirs = includeEmptyDirs
+            copySpec.isCaseSensitive = isCaseSensitive
             copySpec.filteringCharset = filteringCharset
             if (dirMode != null) {
                 copySpec.dirMode = dirMode
@@ -78,7 +81,6 @@ class DefaultCopySpecCodec(
             if (fileMode != null) {
                 copySpec.fileMode = fileMode
             }
-            copySpec.duplicatesStrategy = duplicatesStrategy
             isolate.identities.putInstance(id, copySpec)
             copySpec
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -52,8 +52,8 @@ class DefaultCopySpecCodec(
             writeBoolean(value.includeEmptyDirs)
             writeBoolean(value.isCaseSensitive)
             writeString(value.filteringCharset)
-            writeNullableInt(value.dirMode)
-            writeNullableInt(value.fileMode)
+            writeNullableSmallInt(value.dirMode)
+            writeNullableSmallInt(value.fileMode)
             writeCollection(value.children)
         }
     }
@@ -67,8 +67,8 @@ class DefaultCopySpecCodec(
             val includeEmptyDirs = readBoolean()
             val isCaseSensitive = readBoolean()
             val filteringCharset = readString()
-            val dirMode = readNullableInt()
-            val fileMode = readNullableInt()
+            val dirMode = readNullableSmallInt()
+            val fileMode = readNullableSmallInt()
             val children = readList().uncheckedCast<List<CopySpecInternal>>()
             val copySpec = DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
             copySpec.duplicatesStrategy = duplicatesStrategy

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
@@ -154,6 +154,9 @@ class InstantExecutionFingerprintCheckerTest {
         override fun writeNullableString(value: CharSequence?): Unit =
             undefined()
 
+        override fun writeNullableInt(value: Int?): Unit =
+            undefined()
+
         override fun writeLong(value: Long): Unit =
             undefined()
 
@@ -246,6 +249,9 @@ class InstantExecutionFingerprintCheckerTest {
             undefined()
 
         override fun readInt(): Int =
+            undefined()
+
+        override fun readNullableInt(): Int? =
             undefined()
 
         override fun readNullableString(): String? =

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
@@ -154,7 +154,7 @@ class InstantExecutionFingerprintCheckerTest {
         override fun writeNullableString(value: CharSequence?): Unit =
             undefined()
 
-        override fun writeNullableInt(value: Int?): Unit =
+        override fun writeNullableSmallInt(value: Int?): Unit =
             undefined()
 
         override fun writeLong(value: Long): Unit =
@@ -251,7 +251,7 @@ class InstantExecutionFingerprintCheckerTest {
         override fun readInt(): Int =
             undefined()
 
-        override fun readNullableInt(): Int? =
+        override fun readNullableSmallInt(): Int? =
             undefined()
 
         override fun readNullableString(): String? =

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -170,7 +170,6 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             ":a:compileJava", ":a:processResources", ":a:classes", ":a:javadoc")
     }
 
-    @ToBeFixedForInstantExecution
     def "duplicates in an upstream jar are not ignored"() {
         given:
         file("a/build.gradle") << '''

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.launcher.continuous
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -71,7 +70,6 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* source\\.t.*readonly true.*")
     def "using compressed files as inputs - #source - readonly #readonly"() {
         given:
         def packDir = file("pack").createDir()

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.serialize;
 
+import javax.annotation.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +53,16 @@ public abstract class AbstractDecoder implements Decoder {
     @Override
     public long readSmallLong() throws EOFException, IOException {
         return readLong();
+    }
+
+    @Nullable
+    @Override
+    public Integer readNullableInt() throws IOException {
+        if (readBoolean()) {
+            return readInt();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
@@ -57,9 +57,9 @@ public abstract class AbstractDecoder implements Decoder {
 
     @Nullable
     @Override
-    public Integer readNullableInt() throws IOException {
+    public Integer readNullableSmallInt() throws IOException {
         if (readBoolean()) {
-            return readInt();
+            return readSmallInt();
         } else {
             return null;
         }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
@@ -58,6 +58,16 @@ public abstract class AbstractEncoder implements Encoder {
     }
 
     @Override
+    public void writeNullableInt(@Nullable Integer value) throws IOException {
+        if (value == null) {
+            writeBoolean(false);
+        } else {
+            writeBoolean(true);
+            writeInt(value);
+        }
+    }
+
+    @Override
     public void writeNullableString(@Nullable CharSequence value) throws IOException {
         if (value == null) {
             writeBoolean(false);
@@ -80,7 +90,7 @@ public abstract class AbstractEncoder implements Encoder {
 
         @Override
         public void write(int b) throws IOException {
-            writeByte((byte)b);
+            writeByte((byte) b);
         }
     }
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
@@ -58,12 +58,12 @@ public abstract class AbstractEncoder implements Encoder {
     }
 
     @Override
-    public void writeNullableInt(@Nullable Integer value) throws IOException {
+    public void writeNullableSmallInt(@Nullable Integer value) throws IOException {
         if (value == null) {
             writeBoolean(false);
         } else {
             writeBoolean(true);
-            writeInt(value);
+            writeSmallInt(value);
         }
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
@@ -60,6 +60,14 @@ public interface Decoder {
     int readSmallInt() throws EOFException, IOException;
 
     /**
+     * Reads a nullable signed 32 bit int value.
+     *
+     * @see #readInt()
+     */
+    @Nullable
+    Integer readNullableInt() throws EOFException, IOException;
+
+    /**
      * Reads a boolean value. Can read any value that was written using {@link Encoder#writeBoolean(boolean)}.
      *
      * @throws EOFException when the end of the byte stream is reached before the boolean value can be fully read.

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
@@ -62,10 +62,10 @@ public interface Decoder {
     /**
      * Reads a nullable signed 32 bit int value.
      *
-     * @see #readInt()
+     * @see #readSmallInt()
      */
     @Nullable
-    Integer readNullableInt() throws EOFException, IOException;
+    Integer readNullableSmallInt() throws EOFException, IOException;
 
     /**
      * Reads a boolean value. Can read any value that was written using {@link Encoder#writeBoolean(boolean)}.

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
@@ -72,6 +72,13 @@ public interface Encoder {
     void writeInt(int value) throws IOException;
 
     /**
+     * Writes a nullable signed 32 bit int value.
+     *
+     * @see #writeInt(int)
+     */
+    void writeNullableInt(@Nullable Integer value) throws IOException;
+
+    /**
      * Writes a signed 32 bit int value whose value is likely to be small and positive but may not be. The implementation may encode the value in a way that
      * is more efficient for small positive values.
      */

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
@@ -72,17 +72,17 @@ public interface Encoder {
     void writeInt(int value) throws IOException;
 
     /**
-     * Writes a nullable signed 32 bit int value.
-     *
-     * @see #writeInt(int)
-     */
-    void writeNullableInt(@Nullable Integer value) throws IOException;
-
-    /**
      * Writes a signed 32 bit int value whose value is likely to be small and positive but may not be. The implementation may encode the value in a way that
      * is more efficient for small positive values.
      */
     void writeSmallInt(int value) throws IOException;
+
+    /**
+     * Writes a nullable signed 32 bit int value whose value is likely to be small and positive but may not be.
+     *
+     * @see #writeSmallInt(int)
+     */
+    void writeNullableSmallInt(@Nullable Integer value) throws IOException;
 
     /**
      * Writes a boolean value.


### PR DESCRIPTION
Covers all simple properties (primitives, strings, enums).