### PR TITLE
Check version rejector for project dependency

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -500,6 +500,35 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         }
     }
 
+    def "incompatible strict constraint and local project fail to resolve"() {
+        given:
+
+        settingsFile << "\ninclude 'foo'"
+        buildFile << """
+            project(':foo') {
+                configurations.create('default')
+                group = 'org'
+                version = '1.2'
+            }
+            dependencies {
+                constraints {
+                    conf('org:foo') {
+                       version { strictly '1.0' }
+                    }
+                }
+                conf(project(':foo'))
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
+   Dependency path ':test:unspecified' --> 'project :foo'
+   Constraint path ':test:unspecified' --> 'org:foo:{strictly 1.0}'""")
+    }
+
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "original version constraint is not ignored if there is another parent"() {
         given:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -99,7 +99,11 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
             if (componentMetaData == null) {
                 result.failed(new ModuleVersionResolveException(selector, () -> projectId + " not found."));
             } else {
-                result.resolved(componentMetaData);
+                if (rejector != null && rejector.accept(componentMetaData.getModuleVersionId().getVersion())) {
+                    result.rejected(projectId, componentMetaData.getModuleVersionId());
+                } else {
+                    result.resolved(componentMetaData);
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
@@ -29,7 +30,10 @@ class RejectedModuleMessageBuilder {
     String buildFailureMessage(ModuleResolveState module) {
         boolean hasRejectAll = false;
         for (SelectorState candidate : module.getSelectors()) {
-            hasRejectAll |= candidate.getVersionConstraint().isRejectAll();
+            ResolvedVersionConstraint versionConstraint = candidate.getVersionConstraint();
+            if (versionConstraint != null) {
+                hasRejectAll |= versionConstraint.isRejectAll();
+            }
         }
         StringBuilder sb = new StringBuilder();
         if (hasRejectAll) {


### PR DESCRIPTION
When a project selector was considered, we never looked at the
compatibility of its version with the constraints on accepted version.
This change introduces such a check, so that if the project version is a
rejected version it cannot be selected.

This is a draft PR because I wonder about the implications of such a change on build out there that could work before it and break after it.
It also illustrates an issue with constraints added by plugins, as it is impossible to work around the issue since competing `strictly` are invalid.