### PR TITLE
exclusiveContent can be used in build script block

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.artifacts.repositories;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.NamedDomainObjectCollection;
@@ -27,7 +29,6 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.MetadataSupplierAware;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalRepositoryResourceAccessor;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.model.ObjectFactory;
@@ -36,6 +37,7 @@ import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ImplicitInputsCapturingInstantiator;
@@ -53,11 +55,11 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
     private Action<? super ActionConfiguration> componentMetadataSupplierRuleConfiguration;
     private Action<? super ActionConfiguration> componentMetadataListerRuleConfiguration;
     private final ObjectFactory objectFactory;
-    private final RepositoryContentDescriptorInternal repositoryContentDescriptor;
+    private Supplier<RepositoryContentDescriptorInternal> repositoryContentDescriptor = Suppliers.memoize(this::createRepositoryDescriptor);
 
     protected AbstractArtifactRepository(ObjectFactory objectFactory) {
         this.objectFactory = objectFactory;
-        this.repositoryContentDescriptor = createRepositoryDescriptor();
+
     }
 
     @Override
@@ -108,17 +110,17 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
     }
 
     protected RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultRepositoryContentDescriptor();
+        return new DefaultRepositoryContentDescriptor(getDisplayName());
     }
 
     @Nullable
     public Action<? super ArtifactResolutionDetails> getContentFilter() {
-        return repositoryContentDescriptor.toContentFilter();
+        return repositoryContentDescriptor.get().toContentFilter();
     }
 
     @Override
     public void content(Action<? super RepositoryContentDescriptor> configureAction) {
-        configureAction.execute(repositoryContentDescriptor);
+        configureAction.execute(repositoryContentDescriptor.get());
     }
 
     InstantiatingAction<ComponentMetadataSupplierDetails> createComponentMetadataSupplierFactory(Instantiator instantiator, IsolatableFactory isolatableFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -32,7 +32,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolver
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.repositories.descriptor.MavenRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
@@ -61,6 +60,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
@@ -349,7 +349,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     @Override
     protected RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultMavenRepositoryContentDescriptor();
+        return new DefaultMavenRepositoryContentDescriptor(getDisplayName());
     }
 
     private static class DefaultDescriber implements Transformer<String, MavenArtifactRepository> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
@@ -23,6 +23,10 @@ class DefaultMavenRepositoryContentDescriptor extends DefaultRepositoryContentDe
     private boolean snapshots = true;
     private boolean releases = true;
 
+    public DefaultMavenRepositoryContentDescriptor(String repositoryName) {
+        super(repositoryName);
+    }
+
     @Override
     public void releasesOnly() {
         snapshots = false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -41,10 +41,15 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private boolean locked;
 
     private Action<? super ArtifactResolutionDetails> cachedAction;
+    private String repositoryName;
+
+    public DefaultRepositoryContentDescriptor(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
 
     private void assertMutable() {
         if (locked) {
-            throw new IllegalStateException("Cannot mutate content repository descriptor after repository has been used");
+            throw new IllegalStateException(String.format("Cannot mutate content repository descriptor '%s' after repository has been used", repositoryName));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -49,7 +49,9 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
 
     private void assertMutable() {
         if (locked) {
-            throw new IllegalStateException(String.format("Cannot mutate content repository descriptor '%s' after repository has been used", repositoryName));
+            throw new IllegalStateException("Cannot mutate content repository descriptor '" +
+                repositoryName +
+                "' after repository has been used");
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Unroll
 class DefaultRepositoryContentDescriptorTest extends Specification {
 
     @Subject
-    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor()
+    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor("repoName")
 
     @Unroll
     def "reasonable error message when input is incorrect (include string)"() {
@@ -362,7 +362,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.message == "Cannot mutate content repository descriptor after repository has been used"
+        ex.message == "Cannot mutate content repository descriptor 'repoName' after repository has been used"
     }
 
     def "can include and exclude at the same time"() {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -154,4 +154,41 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
         then:
         failure.assertThatDescription(startsWith("Plugin [id: '$HELLO_WORLD_PLUGIN_ID', version: '$HELLO_WORLD_PLUGIN_VERSION'] was not found"))
     }
+
+    def "can resolve plugin from portal with repository filters present"() {
+        given:
+        def helloWorldGroup = 'org.gradle'
+        def helloWorldName = 'gradle-hello-world-plugin'
+
+        when:
+        buildScript """
+            buildscript {
+                repositories {
+                    exclusiveContent {
+                      forRepository {
+                        maven {
+                          url = "https://storage.googleapis.com/r8-releases/raw"
+                          metadataSources {
+                            artifact()
+                          }
+                        }
+                      }
+                      filter {
+                        includeModule("com.android.tools", "r8")
+                      }
+                    }
+                }
+            }
+
+            plugins {
+                id "$HELLO_WORLD_PLUGIN_ID" version "$HELLO_WORLD_PLUGIN_VERSION"
+            }
+        """
+
+        then:
+        succeeds("helloWorld")
+
+        and:
+        output.contains("Hello World!")
+    }
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -157,8 +157,7 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
 
     def "can resolve plugin from portal with repository filters present"() {
         given:
-        def helloWorldGroup = 'org.gradle'
-        def helloWorldName = 'gradle-hello-world-plugin'
+        mavenRepo.module('com.android.tools', 'r8', '1.5.70').publish()
 
         when:
         buildScript """
@@ -167,7 +166,7 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
                     exclusiveContent {
                       forRepository {
                         maven {
-                          url = "https://storage.googleapis.com/r8-releases/raw"
+                          url = "${mavenRepo.uri}"
                           metadataSources {
                             artifact()
                           }
@@ -194,19 +193,21 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
 
     def "resolution fails from portal with repository filters present"() {
         given:
+        mavenRepo.module('com.android.tools', 'r8', '1.5.70').publish()
+
         buildScript """
             buildscript {
                 repositories {
                     exclusiveContent {
                         forRepository {
-                            mavenCentral()
+                            ${mavenCentralRepository()}
                         }
                         filter {
                             includeModule("com.android.tools", "r8") // force resolving r8 from wrong repo
                         }
                     }
                     maven {
-                        url = "https://storage.googleapis.com/r8-releases/raw"
+                        url = "${mavenRepo.uri}"
                         metadataSources {
                             artifact()
                         }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -16,10 +16,7 @@
 
 package org.gradle.plugin.use.internal;
 
-import com.google.common.collect.Iterables;
-import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
@@ -85,17 +82,10 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
         }
 
         final PluginResolver effectivePluginResolver = wrapInAlreadyInClasspathResolver(classLoaderScope);
-
         if (!requests.isEmpty()) {
             addPluginArtifactRepositories(scriptHandler.getRepositories());
         }
-        List<Result> results = collect(requests, new Transformer<Result, PluginRequestInternal>() {
-            @Override
-            public Result transform(PluginRequestInternal request) {
-                PluginRequestInternal configuredRequest = pluginResolutionStrategy.applyTo(request);
-                return resolveToFoundResult(effectivePluginResolver, configuredRequest);
-            }
-        });
+        List<Result> results = resolvePluginRequests(requests, effectivePluginResolver);
 
         // Could be different to ids in the requests as they may be unqualified
         final Map<Result, PluginId> legacyActualPluginIds = newLinkedHashMap();
@@ -130,6 +120,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
 
                             @Override
                             public void addFromDifferentLoader(PluginImplementation<?> plugin) {
+                                pluginImpls.put(result, plugin);
                                 pluginImplsFromOtherLoaders.put(result, plugin);
                             }
                         });
@@ -141,34 +132,34 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
         }
 
         defineScriptHandlerClassScope(scriptHandler, classLoaderScope, pluginImplsFromOtherLoaders.values());
+        applyLegacyPlugins(target, legacyActualPluginIds);
+        applyPlugins(target, pluginImpls);
+    }
 
-        // We're making an assumption here that the target's plugin registry is backed classLoaderScope.
-        // Because we are only build.gradle files right now, this holds.
-        // It won't for arbitrary scripts though.
-        for (final Map.Entry<Result, PluginId> entry : legacyActualPluginIds.entrySet()) {
-            final PluginRequestInternal request = entry.getKey().request;
-            final PluginId id = entry.getValue();
-            applyPlugin(request, id, new Runnable() {
-                @Override
-                public void run() {
-                    if (request.isApply()) {
-                        target.apply(id.toString());
-                    }
-                }
-            });
-        }
+    private void applyPlugins(PluginManagerInternal target, Map<Result, PluginImplementation<?>> regularPlugins) {
+        regularPlugins.forEach((result, impl) -> applyPlugin(result.request, result.found.getPluginId(), () -> {
+            if (result.request.isApply()) {
+                target.apply(impl);
+            }
+        }));
+    }
 
-        for (final Map.Entry<Result, PluginImplementation<?>> entry : Iterables.concat(pluginImpls.entrySet(), pluginImplsFromOtherLoaders.entrySet())) {
-            final Result result = entry.getKey();
-            applyPlugin(result.request, result.found.getPluginId(), new Runnable() {
-                @Override
-                public void run() {
-                    if (result.request.isApply()) {
-                        target.apply(entry.getValue());
-                    }
-                }
-            });
-        }
+    // We're making an assumption here that the target's plugin registry is backed classLoaderScope.
+    // Because we are only build.gradle files right now, this holds.
+    // It won't for arbitrary scripts though.
+    private void applyLegacyPlugins(@Nullable PluginManagerInternal target, Map<Result, PluginId> legacyActualPluginIds) {
+        legacyActualPluginIds.forEach((result, id) -> applyPlugin(result.request, id, () -> {
+            if (result.request.isApply()) {
+                target.apply(id.toString());
+            }
+        }));
+    }
+
+    private List<Result> resolvePluginRequests(PluginRequests requests, PluginResolver effectivePluginResolver) {
+        return collect(requests, request -> {
+            PluginRequestInternal configuredRequest = pluginResolutionStrategy.applyTo(request);
+            return resolveToFoundResult(effectivePluginResolver, configuredRequest);
+        });
     }
 
     private void addPluginArtifactRepositories(RepositoryHandler repositories) {
@@ -182,18 +173,9 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
         final Set<String> existingMavenUrls = existingMavenUrls(repositories);
         for (final String repoUrl : repoUrls) {
             if (!existingMavenUrls.contains(repoUrl)) {
-                maven(repositories, repoUrl);
+                repositories.maven(repository -> repository.setUrl(repoUrl));
             }
         }
-    }
-
-    private void maven(RepositoryHandler repositories, final String m2RepoUrl) {
-        repositories.maven(new Action<MavenArtifactRepository>() {
-            @Override
-            public void execute(MavenArtifactRepository mavenArtifactRepository) {
-                mavenArtifactRepository.setUrl(m2RepoUrl);
-            }
-        });
     }
 
     private Set<String> existingMavenUrls(RepositoryHandler repositories) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -86,6 +86,9 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
 
         final PluginResolver effectivePluginResolver = wrapInAlreadyInClasspathResolver(classLoaderScope);
 
+        if (!requests.isEmpty()) {
+            addPluginArtifactRepositories(scriptHandler.getRepositories());
+        }
         List<Result> results = collect(requests, new Transformer<Result, PluginRequestInternal>() {
             @Override
             public Result transform(PluginRequestInternal request) {
@@ -101,9 +104,6 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
 
         if (!results.isEmpty()) {
             final RepositoryHandler repositories = scriptHandler.getRepositories();
-
-            addPluginArtifactRepositories(repositories);
-
             final Set<String> repoUrls = newLinkedHashSet();
 
             for (final Result result : results) {


### PR DESCRIPTION
Fixes #12452

### Context
This adds the plugin repository before we resolve the plugin requests. This allows filters on other repos (e.g. `includeModule`) to be applied to the plugin repository (e.g. as exclude) before the repositories are used.