### PR TITLE
Fix handling of transitive aspect of constraints

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -128,7 +128,8 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
 
     @Override
     public boolean isTransitive() {
-        return true;
+        // Constraints are _never_ transitive
+        return !isConstraint();
     }
 
     @Override


### PR DESCRIPTION
Dependency constraints are never transitive, they only provide
information on their target module. They cannot count as one more path
towards the module for exclude computation.