### PR TITLE
Re-enable VFS retention with newer Gradle wrapper

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,7 @@ systemProp.org.gradle.internal.ide.scan=true
 
 # Enable VFS retention using file watching on Windows, Linux and macOS
 # Remove the property when VFS retention is enabled by default
-# VFS retention is disabled until https://github.com/gradle/gradle/issues/12457 has been fixed.
-# systemProp.org.gradle.unsafe.vfs.retention=true
+systemProp.org.gradle.unsafe.vfs.retention=true
 
 # Enable partial VFS invalidation, i.e. only remove the in-memory file system state for declared outputs before running task actions.
 # Remove the property when partial invalidation is enabled by default.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.4-20200305230054+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.4-20200319114351+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.4-20200319114351+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.4-20200319134018+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Now that https://github.com/gradle/gradle/pull/12533 is fixed, let's enable VFS-retention on the `gradle/gradle` build!