### PR TITLE
Use Gradle Enterprise Gradle plugin RC repository

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -88,6 +88,10 @@ allprojects {
             }
         }
         maven {
+            name = "Gradle Enterprise Gradle plugin RC"
+            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local")
+        }
+        maven {
             name = "kotlinx"
             url = uri("https://dl.bintray.com/kotlin/kotlinx")
         }

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -27,6 +27,7 @@ val originalUrls: Map<String, String> = mapOf(
     "gradle-libs" to "https://repo.gradle.org/gradle/libs",
     "gradle-releases" to "https://repo.gradle.org/gradle/libs-releases",
     "gradle-snapshots" to "https://repo.gradle.org/gradle/libs-snapshots",
+    "gradle-enterprise-plugin-rc" to "https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local",
     "kotlinx" to "https://kotlin.bintray.com/kotlinx/",
     "kotlineap" to "https://dl.bintray.com/kotlin/kotlin-eap/"
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,11 +20,12 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
+        maven { url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local") }
     }
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.1")
+    id("com.gradle.enterprise").version("3.1.1")
 }
 
 apply(from = "gradle/build-cache-configuration.settings.gradle.kts")


### PR DESCRIPTION
The Spring Maven repository configured the https://gradle.jfrog.io/gradle/libs repository in which we had the RC versions of the Gradle Enterprise Gradle plugin and the Gradle Enterprise Maven extension. This then showed up on mvnrepository.com as it indexes repo.spring.io.

I now already removed these RC versions from the https://gradle.jfrog.io/gradle/libs repository and we now need to add them explicitly to the Gradle build such that we can dogfood the RC versions.

This PR also updates the plugin version to `3.1.1` which is the current latest one.