### PR TITLE
Fix equals() and hashCode() of GradleDependencyMetadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/compatibility/ArtifactAndClassifierCompatibilityIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/compatibility/ArtifactAndClassifierCompatibilityIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.integtests.resolve.compatibility
 
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
 
 class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -171,7 +170,6 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
     }
 
     @Issue("gradle/gradle#11825")
-    @ToBeImplemented
     def "dependency on both classifier and regular jar of a given module"() {
         given:
         repository {
@@ -194,10 +192,6 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             }
         """
 
-        // This flag and its use has to be removed to have the right behavior with GMM
-        and:
-        def metadataPublished = isGradleMetadataPublished()
-
         when:
         repositoryInteractions {
             'org:foo:1.0' {
@@ -205,9 +199,7 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             }
             'org:bar:1.0' {
                 expectGetMetadata()
-                if (!metadataPublished) {
-                    expectGetArtifact()
-                }
+                expectGetArtifact()
                 expectGetArtifact(classifier: 'classy')
             }
         }
@@ -218,9 +210,7 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             root(':', ':test:') {
                 module("org:foo:1.0") {
                     module("org:bar:1.0") {
-                        if (!metadataPublished) {
-                            artifact([:])
-                        }
+                        artifact([:])
                         artifact(classifier: 'classy')
                     }
                 }
@@ -229,7 +219,6 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
     }
 
     @Issue("gradle/gradle#11825")
-    @ToBeImplemented
     def "dependency on different classifiers of a given module"() {
         given:
         repository {
@@ -253,10 +242,6 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             }
         """
 
-        // This flag and its use has to be removed to have the right behavior with GMM
-        and:
-        def metadataPublished = isGradleMetadataPublished()
-
         when:
         repositoryInteractions {
             'org:foo:1.0' {
@@ -264,9 +249,7 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             }
             'org:bar:1.0' {
                 expectGetMetadata()
-                if (!metadataPublished) {
-                    expectGetArtifact(classifier: 'other')
-                }
+                expectGetArtifact(classifier: 'other')
                 expectGetArtifact(classifier: 'classy')
             }
         }
@@ -277,9 +260,7 @@ class ArtifactAndClassifierCompatibilityIntegrationTest extends AbstractModuleDe
             root(':', ':test:') {
                 module("org:foo:1.0") {
                     module("org:bar:1.0") {
-                        if (!metadataPublished) {
-                            artifact(classifier: 'other')
-                        }
+                        artifact(classifier: 'other')
                         artifact(classifier: 'classy')
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -175,11 +175,12 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
             force == that.force &&
             Objects.equal(selector, that.selector) &&
             Objects.equal(excludes, that.excludes) &&
-            Objects.equal(reason, that.reason);
+            Objects.equal(reason, that.reason) &&
+            Objects.equal(artifacts, that.artifacts);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(selector, excludes, constraint, reason, force);
+        return Objects.hashCode(selector, excludes, constraint, reason, force, artifacts);
     }
 }


### PR DESCRIPTION
This was missed in  #10372.

Fixes #11825.



