### PR TITLE
Dependency locking refinement

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
 
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
@@ -53,13 +54,6 @@ public interface DependencyLockingHandler {
      * @since 6.1
      */
     @Incubating
-    LockMode getLockMode();
+    Property<LockMode> getLockMode();
 
-    /**
-     * Sets the lock mode
-     *
-     * @since 6.1
-     */
-    @Incubating
-    void setLockMode(LockMode mode);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -19,6 +19,8 @@ package org.gradle.api.artifacts.dsl;
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
+import java.io.File;
+
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
  *
@@ -55,5 +57,17 @@ public interface DependencyLockingHandler {
      */
     @Incubating
     Property<LockMode> getLockMode();
+
+    /**
+     * Allows to configure the file used for saving lock state
+     * <p>
+     * Make sure the lock file is unique per project and separate between the buildscript and project itself.
+     * <p>
+     * This requires opting in the support for per project single lock file.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    Property<File> getLockFile();
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -220,7 +220,7 @@ task doIt {
         fails 'doIt'
 
         then:
-        failureHasCause("It is illegal to modify the dependency locking mode after any dependency configuration has been resolved")
+        failureHasCause("The value for property 'lockMode' is final and cannot be changed any further.")
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -106,6 +106,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.caching.internal.origin.OriginMetadata;
@@ -557,8 +558,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer, dependencyLockingProvider);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager) {
-            DefaultDependencyLockingProvider dependencyLockingProvider = instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews);
+        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager, PropertyFactory propertyFactory) {
+            DefaultDependencyLockingProvider dependencyLockingProvider = instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews, propertyFactory);
             if (startParameter.isWriteDependencyLocks() && featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)) {
                 listenerManager.addListener(new InternalBuildFinishedListener() {
                     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.provider.Property;
 
 import java.util.Set;
 
@@ -27,9 +28,7 @@ public interface DependencyLockingProvider {
 
     void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult, Set<ModuleComponentIdentifier> changingResolvedModules);
 
-    LockMode getLockMode();
-
-    void setLockMode(LockMode mode);
+    Property<LockMode> getLockMode();
 
     void buildFinished();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.provider.Property;
 
+import java.io.File;
 import java.util.Set;
 
 public interface DependencyLockingProvider {
@@ -31,4 +32,6 @@ public interface DependencyLockingProvider {
     Property<LockMode> getLockMode();
 
     void buildFinished();
+
+    Property<File> getLockFile();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
+import org.gradle.api.provider.Property;
 
 public class DefaultDependencyLockingHandler implements DependencyLockingHandler {
 
@@ -50,12 +51,7 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
     }
 
     @Override
-    public LockMode getLockMode() {
+    public Property<LockMode> getLockMode() {
         return dependencyLockingProvider.getLockMode();
-    }
-
-    @Override
-    public void setLockMode(LockMode mode) {
-        dependencyLockingProvider.setLockMode(mode);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
@@ -24,6 +24,8 @@ import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.provider.Property;
 
+import java.io.File;
+
 public class DefaultDependencyLockingHandler implements DependencyLockingHandler {
 
     private static final Action<Configuration> ACTIVATE_LOCKING = configuration -> configuration.getResolutionStrategy().activateDependencyLocking();
@@ -53,5 +55,10 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
     @Override
     public Property<LockMode> getLockMode() {
         return dependencyLockingProvider.getLockMode();
+    }
+
+    @Override
+    public Property<File> getLockFile() {
+        return dependencyLockingProvider.getLockFile();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -22,7 +22,9 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Property;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +44,7 @@ public class LockFileReaderWriter {
     private static final Logger LOGGER = Logging.getLogger(LockFileReaderWriter.class);
     private static final DocumentationRegistry DOC_REG = new DocumentationRegistry();
 
-    static final String UNIQUE_LOCKFILE_NAME = "project.lockfile";
+    static final String UNIQUE_LOCKFILE_NAME = "gradle.lockfile";
     static final String FILE_SUFFIX = ".lockfile";
     static final String DEPENDENCY_LOCKING_FOLDER = "gradle/dependency-locks";
     static final Charset CHARSET = StandardCharsets.UTF_8;
@@ -52,12 +54,15 @@ public class LockFileReaderWriter {
 
     private final Path lockFilesRoot;
     private final DomainObjectContext context;
+    private final Property<File> lockFile;
 
-    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context) {
+    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context, Property<File> lockFile) {
         this.context = context;
+        this.lockFile = lockFile;
         Path resolve = null;
         if (fileResolver.canResolveRelativePath()) {
             resolve = fileResolver.resolve(DEPENDENCY_LOCKING_FOLDER).toPath();
+            lockFile.convention(fileResolver.resolve(decorate(UNIQUE_LOCKFILE_NAME)));
         }
         this.lockFilesRoot = resolve;
         LOGGER.debug("Lockfiles root: {}", lockFilesRoot);
@@ -177,8 +182,7 @@ public class LockFileReaderWriter {
     }
 
     private Path getUniqueLockfilePath() {
-        String fileName = decorate(UNIQUE_LOCKFILE_NAME);
-        return lockFilesRoot.resolve(fileName);
+        return lockFile.map(File::toPath).get();
     }
 
     private void parseLine(String line, Map<String, List<String>> result) {
@@ -217,6 +221,7 @@ public class LockFileReaderWriter {
 
     private void writeUniqueLockfile(Path lockfilePath, Map<String, List<String>> dependencyToConfigurations, List<String> emptyConfigurations) {
         try {
+            Files.createDirectories(lockfilePath.getParent());
             List<String> content = new ArrayList<>(50);
             content.addAll(LOCKFILE_HEADER_LIST);
             for (Map.Entry<String, List<String>> entry : dependencyToConfigurations.entrySet()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.provider.Property;
 
+import java.io.File;
 import java.util.Set;
 
 public class NoOpDependencyLockingProvider implements DependencyLockingProvider {
@@ -48,6 +49,11 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
 
     @Override
     public Property<LockMode> getLockMode() {
+        throw new IllegalStateException("Should not be invoked on the no-op instance");
+    }
+
+    @Override
+    public Property<File> getLockFile() {
         throw new IllegalStateException("Should not be invoked on the no-op instance");
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
+import org.gradle.api.provider.Property;
 
 import java.util.Set;
 
@@ -46,12 +47,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public LockMode getLockMode() {
-        throw new IllegalStateException("Should not be invoked on the no-op instance");
-    }
-
-    @Override
-    public void setLockMode(LockMode mode) {
+    public Property<LockMode> getLockMode() {
         throw new IllegalStateException("Should not be invoked on the no-op instance");
     }
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -31,22 +31,30 @@ class LockfileFixture {
         internalCreateLockfile(configuration, modules, unique, false)
     }
 
+    static def createCustomLockfile(TestFile lockFile, String configuration, List<String> modules) {
+        internalCreateLockfile(modules, configuration, lockFile)
+    }
+
     private void internalCreateLockfile(String configuration, List<String> modules, boolean unique, boolean buildScript) {
         if (unique) {
             def fileName = buildScript ? LockFileReaderWriter.BUILD_SCRIPT_PREFIX + LockFileReaderWriter.UNIQUE_LOCKFILE_NAME : LockFileReaderWriter.UNIQUE_LOCKFILE_NAME
-            def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, fileName)
-            def lines = new ArrayList(LockFileReaderWriter.LOCKFILE_HEADER_LIST)
-            if (modules.isEmpty()) {
-                lines.add("empty=$configuration")
-            } else {
-                lines.addAll modules.toSorted().collect({ "$it=$configuration".toString()})
-                lines.add("empty=")
-            }
-            lockFile.writelns(lines)
+            def lockFile = testDirectory.file(fileName)
+            internalCreateLockfile(modules, configuration, lockFile)
         } else {
             def fileName = buildScript ? LockFileReaderWriter.BUILD_SCRIPT_PREFIX + configuration : configuration
             createLegacyLockfile(fileName, modules)
         }
+    }
+
+    private static void internalCreateLockfile(List<String> modules, String configuration, TestFile lockFile) {
+        def lines = new ArrayList(LockFileReaderWriter.LOCKFILE_HEADER_LIST)
+        if (modules.isEmpty()) {
+            lines.add("empty=$configuration")
+        } else {
+            lines.addAll modules.toSorted().collect({ "$it=$configuration".toString() })
+            lines.add("empty=")
+        }
+        lockFile.writelns(lines)
     }
 
     private void createLegacyLockfile(String configurationName, List<String> modules) {
@@ -68,49 +76,57 @@ class LockfileFixture {
         internalVerifyLockfile(expected, unique, false)
     }
 
+    static void verifyCustomLockfile(TestFile lockFile, String configuration, List<String> expected) {
+        internalVerifyLockFileWithFile(lockFile, [(configuration): expected])
+    }
+
     private void internalVerifyLockfile(Map<String, List<String>> expected, boolean unique, boolean buildScript) {
         if (unique) {
             def fileName = buildScript ? LockFileReaderWriter.BUILD_SCRIPT_PREFIX + LockFileReaderWriter.UNIQUE_LOCKFILE_NAME : LockFileReaderWriter.UNIQUE_LOCKFILE_NAME
-            def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, fileName)
-            assert lockFile.exists()
-            def lockedModules = []
-            lockFile.eachLine { String line ->
-                if (!line.startsWith('#')) {
-                    lockedModules << line
-                }
-            }
-
-            List<String> emptyConfs = new ArrayList<>()
-            Map<String, List<String>> modulesToConf = new TreeMap<>()
-            expected.keySet().toSorted().each {
-                def modules = expected.get(it)
-                if (modules.isEmpty()) {
-                    emptyConfs.add(it)
-                } else {
-                    for (String module : (modules)) {
-                        modulesToConf.compute(module, {k, v ->
-                            List<String> confs = v
-                            if (confs == null) {
-                                confs = new ArrayList<>()
-                            }
-                            confs.add(it)
-                            return confs
-                        })
-                    }
-                }
-            }
-            List<String> entries = new ArrayList<>()
-            entries.addAll(modulesToConf.entrySet().collect( { "${it.key}=${it.value.join(',')}".toString() } ))
-            entries.sort()
-            entries.add('empty=' + emptyConfs.join(","))
-
-            assert lockedModules == entries
+            def lockFile = testDirectory.file(fileName)
+            internalVerifyLockFileWithFile(lockFile, expected)
         } else {
             expected.entrySet().each {
                 def fileName = buildScript ? LockFileReaderWriter.BUILD_SCRIPT_PREFIX + it.key : it.key
                 verifyLegacyLockfile(fileName, it.value)
             }
         }
+    }
+
+    private static void internalVerifyLockFileWithFile(TestFile lockFile, Map<String, List<String>> expected) {
+        assert lockFile.exists()
+        def lockedModules = []
+        lockFile.eachLine { String line ->
+            if (!line.startsWith('#')) {
+                lockedModules << line
+            }
+        }
+
+        List<String> emptyConfs = new ArrayList<>()
+        Map<String, List<String>> modulesToConf = new TreeMap<>()
+        expected.keySet().toSorted().each {
+            def modules = expected.get(it)
+            if (modules.isEmpty()) {
+                emptyConfs.add(it)
+            } else {
+                for (String module : (modules)) {
+                    modulesToConf.compute(module, { k, v ->
+                        List<String> confs = v
+                        if (confs == null) {
+                            confs = new ArrayList<>()
+                        }
+                        confs.add(it)
+                        return confs
+                    })
+                }
+            }
+        }
+        List<String> entries = new ArrayList<>()
+        entries.addAll(modulesToConf.entrySet().collect({ "${it.key}=${it.value.join(',')}".toString() }))
+        entries.sort()
+        entries.add('empty=' + emptyConfs.join(","))
+
+        assert lockedModules == entries
     }
 
     private void verifyLegacyLockfile(String configurationName, List<String> expectedModules) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -24,6 +24,21 @@ For Java, Groovy, Kotlin and Android compatibility, see the [full compatibility 
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. --> 
 
+## New dependency locking file format
+
+Gradle 6.4 introduces an experimental dependency locking file format.
+This format uses a single lock file per project instead of a file per locked configuration.
+The main benefit is a reduction in the total number of lock files in a given project.
+
+In addition, when using this format, the lock file name can be configured.
+This enables use cases where a given project may resolve different dependency graphs for the same configuration based on some project state.
+A typical example in the JVM world are Scala projects where the Scala version is encoded in dependency names.
+
+The format is experimental because it requires opt-in and a migration for existing dependency locking users.
+It is however stable and expected to become the default format in Gradle 7.0.
+
+Take a look at [the documentation](userguide/dependency_locking.html#single_lock_file_per_project) for more information and how to enable the feature.
+
 <!-- 
 Add release features here!
 ## 1

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
@@ -86,6 +86,7 @@ In order to generate or update lock state, you specify the `--write-locks` comma
 This will cause the creation of lock state for each resolved configuration in that build execution.
 Note that if lock state existed previously, it is overwritten.
 
+[[lock_all_configurations_in_one_build_execution]]
 === Lock all configurations in one build execution
 
 When locking multiple configurations, you may want to lock them all at once, during a single build execution.
@@ -143,6 +144,7 @@ The complete validation is as follows:
 ** A version mismatch or missing resolved module causes a build failure
 * Resolution result must not contain extra dependencies compared to the lock state
 
+[[fine_tuning_dependency_locking_behaviour_with_lock_mode]]
 === Fine tuning dependency locking behaviour with lock mode
 
 While the default lock mode behaves as described above, two other modes are available:
@@ -161,6 +163,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/l
 include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockModeSelection/kotlin",files="build.gradle.kts[tags=lock-mode]"]
 ====
 
+[[selectively_updating_lock_state_entries]]
 == Selectively updating lock state entries
 
 In order to update only specific modules of a configuration, you can use the `--update-locks` command line flag.
@@ -190,6 +193,68 @@ The resolution may cause other module versions to update, as dictated by the Gra
 
 If you only perform the second step above, then locking will effectively no longer be applied.
 However, if that configuration happens to be resolved in the future at a time where lock state is persisted, it will once again be locked.
+
+== Single lock file per project
+
+Gradle now supports an improved lock file format.
+The goal is to have only a single lock file per project, which contains the lock state for all configurations of said project.
+By default the file is named `gradle.lockfile` and is located inside the project directory.
+The lock state for the buildscript itself is found in a file named `buildscript-gradle.lockfile` inside the project directory.
+
+The main benefit is a substantial reduction in the number of lock files compared to the existing format.
+
+This format is experimental and requires opt-in.
+
+[NOTE]
+====
+The objective is to default to this single lock file per project in Gradle 7.0.
+====
+
+The new format can be activated by enabling the matching <<feature_lifecycle#feature_preview, feature preview>>:
+
+.Single lock file per project activation
+====
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy",files="settings.gradle[]"]
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin",files="settings.gradle.kts[]"]
+====
+
+Then with the following dependency declaration and locked configurations:
+
+.Explicit locking
+====
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy",files="build.gradle[tags=locking-explicit]"]
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin",files="build.gradle.kts[tags=locking-explicit]"]
+====
+
+The lockfile will have the following content:
+
+[listing]
+.gradle.lockfile
+----
+include::{samplesPath}/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/gradle.lockfile[]
+----
+
+* Each line still represents a single dependency in the `group:artifact:version` notation
+* Each line then lists all configurations that contain the given dependency
+* The last line of the file lists all empty configurations, that is configurations known to have no dependencies
+
+=== Migrating to the new file format
+
+Once you have activated the feature preview (see above), you can simply follow the documentation for <<#lock_all_configurations_in_one_build_execution, writing>> or <<#selectively_updating_lock_state_entries, updating>> dependency lock state.
+
+Then after confirming the single lock file per project contains the lock state for a given configuration, the matching per configuration lock file can be removed from `gradle/dependency-locks`.
+
+=== Configuring the per project lock file name and location
+
+When using the single lock file per project, you can configure its name and location.
+The main reason for providing this is to enable having a file name that is determined by some project properties, effectively allowing a single project to store different lock state for different execution contexts.
+One trivial example in the JVM ecosystem is the Scala version that is often found in artifact coordinates.
+
+.Changing the lock file name
+====
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy",files="build.gradle[tags=locking-file-name]"]
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin",files="build.gradle.kts[tags=locking-file-name]"]
+====
 
 [[locking_limitations]]
 == Locking limitations

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -38,6 +38,20 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Potential breaking changes
 
+==== Changes in dependency locking
+
+With Gradle 6.4, the incubating API for <<dependency_locking#fine_tuning_dependency_locking_behaviour_with_lock_mode, dependency locking `LockMode`>> has changed.
+The value is now set via a `Property<LockMode>` instead of a direct setter.
+This means that the notation to set the value has to be updated for the Kotlin DSL:
+
+```
+dependencyLocking {
+    lockMode.set(LockMode.STRICT)
+}
+```
+
+Users of the Groovy DSL should not be impacted as the notation `lockMode = LockMode.STRICT` remains valid.
+
 ==== Ivy repositories with custom layouts
 
 Gradle versions from 6.0 to 6.3.x included could generate bad Gradle Module Metadata when publishing on an Ivy repository which had a custom repository layout.

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockModeSelection/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockModeSelection/kotlin/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 // tag::lock-mode[]
 dependencyLocking {
-    lockMode = LockMode.STRICT
+    lockMode.set(LockMode.STRICT)
 }
 // end::lock-mode[]
 

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::locking-file-name[]
+def scalaVersion = "2.12"
+dependencyLocking {
+    lockFile = file("$projectDir/locking/gradle-${scalaVersion}.lockfile")
+}
+// end::locking-file-name[]
+
+// tag::locking-explicit[]
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    runtimeClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    annotationProcessor {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    implementation 'org.springframework:spring-beans:[5.0,6.0)'
+}
+// end::locking-explicit[]

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/gradle.lockfile
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/gradle.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.springframework:spring-beans:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+org.springframework:spring-core:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+org.springframework:spring-jcl:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+empty=annotationProcessor

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/groovy/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'locking-single-file'
+
+enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::locking-file-name[]
+val scalaVersion = "2.12"
+dependencyLocking {
+    lockFile.set(file("$projectDir/locking/gradle-${scalaVersion}.lockfile"))
+}
+// end::locking-file-name[]
+
+
+// tag::locking-explicit[]
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    runtimeClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    annotationProcessor {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    implementation("org.springframework:spring-beans:[5.0,6.0)")
+}
+// end::locking-explicit[]

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/gradle.lockfile
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/gradle.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.springframework:spring-beans:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+org.springframework:spring-core:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+org.springframework:spring-jcl:5.0.5.RELEASE=compileClasspath, runtimeClasspath
+empty=annotationProcessor

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/kotlin/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "locking-single-file"
+
+enableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/locking-single.sample.conf
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyLocking/lockingSingleFilePerProject/locking-single.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]


### PR DESCRIPTION
When using the unique lock file per project, it is possible to configure
the lockfile name and location.
This enables scenarios where the lockfile name depends on some build
properties, allowing to have different lock state for different state of
 the build.