### PR TITLE
Disable GMM publication if custom pattern is used

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/IvyRepositoryDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/IvyRepositoryDescriptor.java
@@ -22,6 +22,7 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -70,6 +71,14 @@ public final class IvyRepositoryDescriptor extends UrlRepositoryDescriptor {
         builder.put(Property.ARTIFACT_PATTERNS.name(), artifactPatterns);
         builder.put(Property.LAYOUT_TYPE.name(), layoutType);
         builder.put(Property.M2_COMPATIBLE.name(), m2Compatible);
+    }
+
+    public List<String> getIvyPatterns() {
+        return ivyPatterns;
+    }
+
+    public List<String> getArtifactPatterns() {
+        return artifactPatterns;
     }
 
     public static class Builder extends UrlRepositoryDescriptor.Builder<Builder> {

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -38,7 +38,8 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Potential breaking changes
 
-There were no breaking changes between Gradle 6.3 and 6.4.
+Gradle versions from 6.0 to 6.3.x included could generate bad Gradle Module Metadata when publishing on an Ivy repository which had a custom repository layout.
+Starting from 6.4, Gradle will no longer publish Gradle Module Metadata if it detects that you are using a custom repository layout.
 
 === Deprecations
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -38,6 +38,8 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Potential breaking changes
 
+==== Ivy repositories with custom layouts
+
 Gradle versions from 6.0 to 6.3.x included could generate bad Gradle Module Metadata when publishing on an Ivy repository which had a custom repository layout.
 Starting from 6.4, Gradle will no longer publish Gradle Module Metadata if it detects that you are using a custom repository layout.
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy.internal.artifact;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -79,7 +80,8 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     }
 
     public boolean isEnabled() {
-        return generator.get().getEnabled();
+        TaskInternal task = (TaskInternal) generator.get();
+        return task.getOnlyIf().isSatisfiedBy(task);
     }
 
     private class GeneratorTaskDependency extends AbstractTaskDependency {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -21,12 +21,19 @@ import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.descriptor.IvyRepositoryDescriptor;
+import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPlatformPlugin;
@@ -45,16 +52,21 @@ import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
 import org.gradle.api.publish.ivy.tasks.PublishToIvyRepository;
 import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
+import org.gradle.api.specs.AndSpec;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.model.Path;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.commons.lang.StringUtils.capitalize;
 
@@ -64,6 +76,7 @@ import static org.apache.commons.lang.StringUtils.capitalize;
  * @since 1.3
  */
 public class IvyPublishPlugin implements Plugin<Project> {
+    private final static Logger LOGGER = Logging.getLogger(IvyPublishPlugin.class);
 
     private final Instantiator instantiator;
     private final ObjectFactory objectFactory;
@@ -105,7 +118,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
         publications.all(publication -> {
             final String publicationName = publication.getName();
             createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir);
-            createGenerateMetadataTask(tasks, publication, publications, buildDir);
+            createGenerateMetadataTask(tasks, publication, publications, buildDir, repositories);
             createPublishTaskForEachRepository(tasks, publication, publicationName, repositories);
         });
     }
@@ -147,7 +160,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
         publication.setIvyDescriptorGenerator(generatorTask);
     }
 
-    private void createGenerateMetadataTask(final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir) {
+    private void createGenerateMetadataTask(final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir, NamedDomainObjectList<IvyArtifactRepository> repositories) {
         final String publicationName = publication.getName();
         String descriptorTaskName = "generateMetadataFileFor" + capitalize(publicationName) + "Publication";
         TaskProvider<GenerateModuleMetadata> generatorTask = tasks.register(descriptorTaskName, GenerateModuleMetadata.class, generateTask -> {
@@ -156,8 +169,47 @@ public class IvyPublishPlugin implements Plugin<Project> {
             generateTask.getPublication().set(publication);
             generateTask.getPublications().set(publications);
             generateTask.getOutputFile().convention(buildDir.file("publications/" + publicationName + "/module.json"));
+            disableGradleMetadataGenerationIfCustomLayout(repositories, generateTask);
         });
         publication.setModuleDescriptorGenerator(generatorTask);
+    }
+
+    private void disableGradleMetadataGenerationIfCustomLayout(NamedDomainObjectList<IvyArtifactRepository> repositories, GenerateModuleMetadata generateTask) {
+        AtomicBoolean didWarn = new AtomicBoolean();
+        Spec<? super Task> checkStandardLayout = task -> {
+            boolean standard = repositories.stream().allMatch(this::hasStandardPattern);
+            if (!standard && !didWarn.getAndSet(true)) {
+                LOGGER.warn("Publication of Gradle Module Metadata is disabled because you have configured an Ivy repository with a non-standard layout");
+            }
+            return standard;
+        };
+        Spec<TaskInternal> spec = new AndSpec<TaskInternal>(generateTask.getOnlyIf(), checkStandardLayout);
+        generateTask.setOnlyIf(Cast.<Spec<? super Task>>uncheckedCast(spec));
+    }
+
+    private boolean hasStandardPattern(IvyArtifactRepository ivyArtifactRepository) {
+        DefaultIvyArtifactRepository repo = (DefaultIvyArtifactRepository) ivyArtifactRepository;
+        RepositoryDescriptor descriptor = repo.getDescriptor();
+        if (descriptor instanceof IvyRepositoryDescriptor) {
+            IvyRepositoryDescriptor desc = (IvyRepositoryDescriptor) descriptor;
+            List<String> artifactPatterns = desc.getArtifactPatterns();
+            if (artifactPatterns.size() == 1) {
+                if (!artifactPatterns.get(0).equals(IvyArtifactRepository.GRADLE_ARTIFACT_PATTERN)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            List<String> ivyPatterns = desc.getIvyPatterns();
+            if (ivyPatterns.size() == 1) {
+                if (!ivyPatterns.get(0).equals(IvyArtifactRepository.GRADLE_IVY_PATTERN)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static class IvyPublicationFactory implements NamedDomainObjectFactory<IvyPublication> {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -59,7 +59,6 @@ import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Generates a Gradle metadata file to represent a published {@link org.gradle.api.component.SoftwareComponent} instance.
@@ -71,7 +70,6 @@ public class GenerateModuleMetadata extends DefaultTask {
     private final ListProperty<Publication> publications;
     private final RegularFileProperty outputFile;
     private final ChecksumService checksumService;
-    private Supplier<Boolean> enabledIf;
 
     public GenerateModuleMetadata() {
         ObjectFactory objectFactory = getProject().getObjects();

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -37,7 +37,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.internal.GradleModuleMetadataWriter;
 import org.gradle.api.publish.internal.PublicationInternal;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -60,6 +59,7 @@ import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Generates a Gradle metadata file to represent a published {@link org.gradle.api.component.SoftwareComponent} instance.
@@ -71,6 +71,7 @@ public class GenerateModuleMetadata extends DefaultTask {
     private final ListProperty<Publication> publications;
     private final RegularFileProperty outputFile;
     private final ChecksumService checksumService;
+    private Supplier<Boolean> enabledIf;
 
     public GenerateModuleMetadata() {
         ObjectFactory objectFactory = getProject().getObjects();
@@ -85,16 +86,13 @@ public class GenerateModuleMetadata extends DefaultTask {
     }
 
     private void mustHaveAttachedComponent() {
-        setOnlyIf(new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task element) {
-                PublicationInternal publication = (PublicationInternal) GenerateModuleMetadata.this.publication.get();
-                if (publication.getComponent() == null) {
-                    getLogger().warn(publication.getDisplayName() + " isn't attached to a component. Gradle metadata only supports publications with software components (e.g. from component.java)");
-                    return false;
-                }
-                return true;
+        setOnlyIf(element -> {
+            PublicationInternal publication = (PublicationInternal) GenerateModuleMetadata.this.publication.get();
+            if (publication.getComponent() == null) {
+                getLogger().warn(publication.getDisplayName() + " isn't attached to a component. Gradle metadata only supports publications with software components (e.g. from component.java)");
+                return false;
             }
+            return true;
         });
     }
 

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
@@ -194,19 +194,11 @@ class IvyPublishSftpIntegrationTest extends AbstractIvyPublishIntegTest {
         module.ivy.sha256.expectFileUpload()
         module.ivy.sha512.expectParentCheckdir()
         module.ivy.sha512.expectFileUpload()
-        module.moduleMetadata.expectParentCheckdir()
-        module.moduleMetadata.expectFileUpload()
-        module.moduleMetadata.sha1.expectParentCheckdir()
-        module.moduleMetadata.sha1.expectFileUpload()
-        module.moduleMetadata.sha256.expectParentCheckdir()
-        module.moduleMetadata.sha256.expectFileUpload()
-        module.moduleMetadata.sha512.expectParentCheckdir()
-        module.moduleMetadata.sha512.expectFileUpload()
 
         then:
         succeeds 'publish'
 
-        module.assertMetadataAndJarFilePublished()
+        module.assertIvyAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
 
         where:

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -365,8 +365,11 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         ivyRepoFile("ivy-${version}.xml.asc").assertExists()
         ivyRepoFile("$artifactId-${version}-source.jar").assertExists()
         ivyRepoFile("$artifactId-${version}-source.jar.asc").assertExists()
-        ivyRepoFile("$artifactId-${version}.module").assertExists()
-        ivyRepoFile("$artifactId-${version}.module.asc").assertExists()
+        ivyRepoFile("$artifactId-${version}.module").assertDoesNotExist()
+        ivyRepoFile("$artifactId-${version}.module.asc").assertDoesNotExist()
+
+        and:
+        outputContains "Publication of Gradle Module Metadata is disabled because you have configured an Ivy repository with a non-standard layout"
     }
 
     @ToBeFixedForInstantExecution


### PR DESCRIPTION
This commit works around issue #12339 by disabling publication
of Gradle Module Metadata if using a non standard Ivy repository
layout.

Fixes #12339

