### PR TITLE
Proper extra attribute keys disambiguation

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -215,7 +215,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
             BitSet any = new BitSet(candidateCount);
             for (int c = 0; c < candidateCount; c++) {
                 ImmutableAttributes candidateAttributeSet = candidateAttributeSets[c];
-                if (candidateAttributeSet.getAttributes().contains(extraAttribute)) {
+                if (candidateAttributeSet.findEntry(extraAttribute.getName()).isPresent()) {
                     any.set(c);
                 }
             }


### PR DESCRIPTION
When attempting to disambiguate variants that have extra attributes
present, the code did not account for rich vs. desugared attributes.