### PR TITLE
Only run help for vfsRetentionTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ buildTypes {
 
     // Run the integration tests with vfs retention enabled
     create("vfsRetentionTest") {
-        tasks("vfsRetentionIntegTest")
+        tasks("help")
     }
 
     create("performanceTests") {


### PR DESCRIPTION
So we don't run the tests on `release` when
we enable them on `master`.
