### PR TITLE
Wrapper HTTPS proxy authentication

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -661,7 +661,7 @@ A proxy for S3 can be configured using the following system properties:
 * `https.proxyPort`
 * `https.proxyUser`
 * `https.proxyPassword`
-* `https.nonProxyHosts`
+* `http.nonProxyHosts`
 
 If the `org.gradle.s3.endpoint` property has been specified with a HTTP (not HTTPS) URI the following system proxy settings can be used:
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -259,7 +259,7 @@ systemProp.https.proxyHost=www.somehost.org
 systemProp.https.proxyPort=8080
 systemProp.https.proxyUser=userid
 systemProp.https.proxyPassword=password
-systemProp.https.nonProxyHosts=*.nonproxyrepos.com|localhost
+systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost
 ----
 
 You may need to set other properties to access other networks. Here are 2 references that may be helpful:

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "70239e6ca1f0d5e3b2808ef6d82390cf9ad58d3a3a0d271677a51d1b89475857"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests
 
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.fixtures.server.http.TestProxyServer
@@ -133,7 +132,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         file("gradle.properties") << """
     systemProp.http.proxyHost=localhost
     systemProp.http.proxyPort=${proxyServer.port}
-    systemProp.http.nonProxyHosts=${JavaVersion.current() >= JavaVersion.VERSION_1_7 ? '' : '~localhost'}
+    systemProp.http.nonProxyHosts=
 """
         server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
 
@@ -157,7 +156,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         file("gradle.properties") << """
     systemProp.http.proxyHost=localhost
     systemProp.http.proxyPort=${proxyServer.port}
-    systemProp.http.nonProxyHosts=${JavaVersion.current() >= JavaVersion.VERSION_1_7 ? '' : '~localhost'}
+    systemProp.http.nonProxyHosts=
     systemProp.http.proxyUser=my_user
     systemProp.http.proxyPassword=my_password
 """
@@ -257,7 +256,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         file("gradle.properties").writeProperties(
             'systemProp.http.proxyHost': 'localhost',
             'systemProp.http.proxyPort': proxyServer.port as String,
-            'systemProp.http.nonProxyHosts': JavaVersion.current() >= JavaVersion.VERSION_1_7 ? '' : '~localhost',
+            'systemProp.http.nonProxyHosts': '',
             'systemProp.http.proxyUser': proxyUsername,
             'systemProp.http.proxyPassword': proxyPassword
         )

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -19,14 +19,19 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.BlockingHttpsServer
+import org.gradle.test.fixtures.server.http.TestProxyServer
 import org.gradle.wrapper.Download
 import org.junit.Rule
+import spock.lang.Issue
 
 import static org.gradle.test.matchers.UserAgentMatcher.matchesNameAndVersion
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.MatcherAssert.assertThat
 
 class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
-    @Rule TestResources resources = new TestResources(temporaryFolder)
     @Rule BlockingHttpsServer server = new BlockingHttpsServer()
+    @Rule TestProxyServer proxyServer = new TestProxyServer()
+    @Rule TestResources resources = new TestResources(temporaryFolder)
 
     def setup() {
         TestKeyStore keyStore = TestKeyStore.init(resources.dir)
@@ -70,5 +75,57 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         then:
         outputDoesNotContain('WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.')
+    }
+
+    def "downloads wrapper via proxy"() {
+        given:
+        proxyServer.start()
+        prepareWrapper("https://jdoe:changeit@localhost:${server.port}")
+
+        // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
+        file("gradle.properties") << """
+    systemProp.https.proxyHost=localhost
+    systemProp.https.proxyPort=${proxyServer.port}
+    systemProp.http.nonProxyHosts=
+"""
+        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+
+        when:
+        def result = wrapperExecuter.withTasks('hello').run()
+
+        then:
+        assertThat(result.output, containsString('hello'))
+
+        and:
+        proxyServer.requestCount == 1
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/5052')
+    def "downloads wrapper via authenticated proxy"() {
+        given:
+        proxyServer.start('my_user', 'my_password')
+
+        and:
+        prepareWrapper("https://jdoe:changeit@localhost:${server.port}")
+        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+
+        // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
+        file("gradle.properties") << """
+    systemProp.https.proxyHost=localhost
+    systemProp.https.proxyPort=${proxyServer.port}
+    systemProp.http.nonProxyHosts=
+    systemProp.https.proxyUser=my_user
+    systemProp.https.proxyPassword=my_password
+    systemProp.jdk.http.auth.tunneling.disabledSchemes=
+"""
+
+        when:
+        def result = wrapperExecuter.withTasks('hello').run()
+
+        then:
+        assertThat(result.output, containsString('hello'))
+
+        and:
+        proxyServer.requestCount == 1
     }
 }


### PR DESCRIPTION
Fixes #5052 and #11065.

### Context
I'm myself affect from the proxy issue with the wrapper, as well as several people who upvoted the issue report / participated in the discussion.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
