### PR TITLE
Fix build event subscriptions when a `buildSrc` child build is present

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -239,6 +239,10 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         @Override
         public void buildFinished(BuildResult result) {
             // TODO - maybe make the registry a build scoped service
+            if (result.getGradle().getParent() != null) {
+                // Stop only when the root build completes
+                return;
+            }
             try {
                 for (Object listener : listeners) {
                     listenerManager.removeListener(listener);

--- a/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
+++ b/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.build.event
 
 import org.gradle.BuildListener
 import org.gradle.BuildResult
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.provider.Providers
 import org.gradle.initialization.BuildEventConsumer
 import org.gradle.internal.build.event.types.DefaultTaskDescriptor
@@ -44,6 +45,7 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
     def factory = new MockBuildEventListenerFactory()
     def listenerManager = new DefaultListenerManager()
     def buildOperationListenerManager = new DefaultBuildOperationListenerManager()
+    def buildResult = new BuildResult(Mock(GradleInternal), null)
     def registry = new DefaultBuildEventsListenerRegistry([factory], listenerManager, buildOperationListenerManager, executorFactory)
 
     def cleanup() {
@@ -172,7 +174,7 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
     }
 
     private signalBuildFinished() {
-        listenerManager.getBroadcaster(BuildListener).buildFinished(Stub(BuildResult))
+        listenerManager.getBroadcaster(BuildListener).buildFinished(buildResult)
     }
 
     private DefaultTaskFinishedProgressEvent taskFinishEvent() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
