### PR TITLE
Do not cache patchKotlinCompiler for slow internet

### DIFF
--- a/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
@@ -56,6 +56,8 @@ tasks {
         additionalRootFiles.from(classpathManifest)
 
         outputFile.set(jar.get().archiveFile)
+
+        outputs.doNotCacheIfSlowInternetConnection()
     }
 
     jar {


### PR DESCRIPTION
The downloaded artifact is too big.
