### PR TITLE
Serialize `ConfigurableFileTree` instances and `PatternSet` specs for instant execution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -488,7 +488,6 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         outputDir.assertIsEmptyDir()
     }
 
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*ConfigurableFileTree.*")
     def "outputs are cleaned out on rebuild (output type: #type)"() {
         file("buildSrc").deleteDir()
         buildFile.text = """

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.file
+package org.gradle.api.file
 
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionLifecycleIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionLifecycleIntegrationTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.file
+package org.gradle.api.file
 
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class FileTreeIntegrationTest extends AbstractIntegrationSpec {
+    def "can include the elements of a tree using a Groovy closure spec"() {
+        buildFile << """
+            class SomeTask extends DefaultTask {
+                @InputFiles
+                final ConfigurableFileTree sourceFiles = project.objects.fileTree()
+
+                @OutputFile
+                final RegularFileProperty outputFile = project.objects.fileProperty()
+
+                @TaskAction
+                def go() {
+                    def names = sourceFiles.files.name.sort().join(",")
+                    outputFile.asFile.get().text = names
+                }
+            }
+
+            task generate(type: SomeTask) {
+                sourceFiles.from("src")
+                sourceFiles.include { element ->
+                    println("checking " + element.relativePath)
+                    element.directory || element.relativePath.segments.length == 2
+                }
+                outputFile = file("out.txt")
+            }
+        """
+
+        when:
+        file("src/ignore.txt").createFile()
+        file("src/a/a.txt").createFile()
+        file("src/a/b/ignore.txt").createFile()
+        file("src/c/c.txt").createFile()
+
+        run("generate")
+
+        then:
+        file("out.txt").text == "a.txt,c.txt"
+
+        when:
+        file("src/ignore-2.txt").createFile()
+
+        run("generate")
+
+        then:
+        result.assertTaskSkipped(":generate")
+        output.count("checking") == 8
+        outputContains("checking a/a.txt")
+        outputContains("checking ignore-2.txt")
+        file("out.txt").text == "a.txt,c.txt"
+
+        when:
+        file("src/d/d.txt").createFile()
+
+        run("generate")
+
+        then:
+        result.assertTaskNotSkipped(":generate")
+        output.count("checking") == 20 // checked twice, once to snapshot and once when the task action runs
+        outputContains("checking a/a.txt")
+        outputContains("checking d/d.txt")
+        file("out.txt").text == "a.txt,c.txt,d.txt"
+    }
+
+    def "can exclude the elements of a tree using a Groovy closure spec"() {
+        buildFile << """
+            class SomeTask extends DefaultTask {
+                @InputFiles
+                final ConfigurableFileTree sourceFiles = project.objects.fileTree()
+
+                @OutputFile
+                final RegularFileProperty outputFile = project.objects.fileProperty()
+
+                @TaskAction
+                def go() {
+                    def names = sourceFiles.files.name.sort().join(",")
+                    outputFile.asFile.get().text = names
+                }
+            }
+
+            task generate(type: SomeTask) {
+                sourceFiles.from("src")
+                sourceFiles.exclude { element ->
+                    println("checking " + element.relativePath)
+                    !element.directory && element.relativePath.segments.length == 2
+                }
+                outputFile = file("out.txt")
+            }
+        """
+
+        when:
+        file("src/a.txt").createFile()
+        file("src/a/ignore.txt").createFile()
+        file("src/a/b/c.txt").createFile()
+
+        run("generate")
+
+        then:
+        file("out.txt").text == "a.txt,c.txt"
+
+        when:
+        file("src/a/ignore-2.txt").createFile()
+
+        run("generate")
+
+        then:
+        result.assertTaskSkipped(":generate")
+        output.count("checking") == 6
+        outputContains("checking a.txt")
+        outputContains("checking a/ignore-2.txt")
+        file("out.txt").text == "a.txt,c.txt"
+
+        when:
+        file("src/d/e/f.txt").createFile()
+
+        run("generate")
+
+        then:
+        result.assertTaskNotSkipped(":generate")
+        output.count("checking") == 18 // checked twice, once for snapshots and once when the task action runs
+        outputContains("checking a.txt")
+        outputContains("checking d/e/f.txt")
+        file("out.txt").text == "a.txt,c.txt,f.txt"
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -215,9 +215,11 @@ class Codecs(
     fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, patternSetFactory: Factory<PatternSet>, fileSystem: FileSystem, fileFactory: FileFactory) {
         bind(DirectoryCodec(fileFactory))
         bind(RegularFileCodec(fileFactory))
+        bind(ConfigurableFileTreeCodec(fileCollectionFactory))
         bind(FileTreeCodec(directoryFileTreeFactory, patternSetFactory, fileSystem))
-        bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
-        bind(FileCollectionCodec(fileCollectionFactory))
+        val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory)
+        bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
+        bind(fileCollectionCodec)
         bind(IntersectPatternSetCodec)
         bind(PatternSetCodec)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
@@ -16,27 +16,38 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.api.tasks.util.internal.IntersectionPatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readCollection
 import org.gradle.instantexecution.serialization.readStrings
+import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeStrings
 
 
-// TODO includeSpecs & excludeSpecs
 object PatternSetCodec : Codec<PatternSet> {
 
     override suspend fun WriteContext.encode(value: PatternSet) {
         writeStrings(value.includes)
         writeStrings(value.excludes)
+        writeCollection(value.includeSpecs)
+        writeCollection(value.excludeSpecs)
     }
 
     override suspend fun ReadContext.decode() =
         PatternSet().apply {
             setIncludes(readStrings())
             setExcludes(readStrings())
+            readCollection {
+                include(read() as Spec<FileTreeElement>)
+            }
+            readCollection {
+                exclude(read() as Spec<FileTreeElement>)
+            }
         }
 }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -64,12 +64,7 @@ public abstract class DefaultSourceSet implements SourceSet {
 
         String resourcesDisplayName = displayName + " resources";
         resources = objectFactory.sourceDirectorySet("resources", resourcesDisplayName);
-        resources.getFilter().exclude(new Spec<FileTreeElement>() {
-            @Override
-            public boolean isSatisfiedBy(FileTreeElement element) {
-                return javaSource.contains(element.getFile());
-            }
-        });
+        resources.getFilter().exclude(new IsJavaSourceSpec(javaSource));
 
         String allSourceDisplayName = displayName + " source";
         allSource = objectFactory.sourceDirectorySet("allsource", allSourceDisplayName);
@@ -297,5 +292,18 @@ public abstract class DefaultSourceSet implements SourceSet {
     @Override
     public SourceDirectorySet getAllSource() {
         return allSource;
+    }
+
+    private static class IsJavaSourceSpec implements Spec<FileTreeElement> {
+        private final FileCollection javaSource;
+
+        public IsJavaSourceSpec(FileCollection javaSource) {
+            this.javaSource = javaSource;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(FileTreeElement element) {
+            return javaSource.contains(element.getFile());
+        }
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -100,7 +100,6 @@ public class ScalaBasePlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaBasePlugin.class);
 
-
         ScalaRuntime scalaRuntime = project.getExtensions().create(SCALA_RUNTIME_EXTENSION_NAME, ScalaRuntime.class, project);
         ScalaPluginExtension scalaPluginExtension = project.getExtensions().create(ScalaPluginExtension.class, "scala", DefaultScalaPluginExtension.class);
 
@@ -174,12 +173,8 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 scalaDirectorySet.srcDir(project.file("src/" + sourceSet.getName() + "/scala"));
                 sourceSet.getAllJava().source(scalaDirectorySet);
                 sourceSet.getAllSource().source(scalaDirectorySet);
-                sourceSet.getResources().getFilter().exclude(new Spec<FileTreeElement>() {
-                    @Override
-                    public boolean isSatisfiedBy(FileTreeElement element) {
-                        return scalaDirectorySet.contains(element.getFile());
-                    }
-                });
+                FileCollection scalaSource = scalaDirectorySet;
+                sourceSet.getResources().getFilter().exclude(new IsScalaSourceSpec(scalaSource));
 
                 Configuration classpath = project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName());
                 Configuration incrementalAnalysis = project.getConfigurations().create("incrementalScalaAnalysisFor" + sourceSet.getName());
@@ -318,6 +313,19 @@ public class ScalaBasePlugin implements Plugin<Project> {
                     details.closestMatch(javaRuntime);
                 }
             }
+        }
+    }
+
+    private static class IsScalaSourceSpec implements Spec<FileTreeElement> {
+        private final FileCollection scalaSource;
+
+        public IsScalaSourceSpec(FileCollection scalaSource) {
+            this.scalaSource = scalaSource;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(FileTreeElement element) {
+            return scalaSource.contains(element.getFile());
         }
     }
 }


### PR DESCRIPTION

### Context

Also adds some test coverage for earlier changes to serialize the source files of a `CopySpec`. 

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
