### PR TITLE
Add some smoke test coverage for testing Gradle when instant execution is enabled

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -24,16 +24,24 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JvmInstallation
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import java.text.SimpleDateFormat
 
-
 @Requires(value = TestPrecondition.JDK9_OR_LATER, adhoc = {
     GradleContextualExecuter.isNotInstant() && GradleBuildJvmSpec.isAvailable()
 })
 class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
+    private BuildResult result
+
+    BuildResult getResult() {
+        if (result == null) {
+            throw new IllegalStateException("Need to run a build before result is availble.")
+        }
+        return result
+    }
 
     def "can build gradle with instant execution enabled"() {
 
@@ -51,31 +59,41 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
         ]
 
         when:
-        def result = instantRun(*supportedTasks)
+        instantRun(*supportedTasks)
 
         then:
         result.output.count("Calculating task graph as no instant execution cache is available") == 1
 
         when:
+        instantRun(*supportedTasks)
+
+        then:
+        result.output.count("Reusing instant execution cache") == 1
+        result.task(":distributions:binZip").outcome == TaskOutcome.UP_TO_DATE
+        result.task(":core:integTest").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
         run("clean")
 
         and:
-        result = instantRun(*supportedTasks)
+        instantRun(*supportedTasks)
 
         then:
         result.output.count("Reusing instant execution cache") == 1
 
         and:
         file("build/distributions").allDescendants().count { it ==~ /gradle-.*-bin.zip/ } == 1
+        result.task(":core:integTest").outcome == TaskOutcome.SUCCESS
         new DefaultTestExecutionResult(file("subprojects/core"), "build", "", "", "integTest")
             .assertTestClassesExecuted("org.gradle.NameValidationIntegrationTest")
     }
 
-    private BuildResult instantRun(String... tasks) {
-        return run("-Dorg.gradle.unsafe.instant-execution=true", *tasks)
+    private void instantRun(String... tasks) {
+        result = run("-Dorg.gradle.unsafe.instant-execution=true", *tasks)
     }
 
     BuildResult run(String... tasks) {
+        result = null
         return runner(*(tasks + GRADLE_BUILD_TEST_ARGS)).build()
     }
 


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
