### PR TITLE
Module path support in generated start scripts 

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -312,7 +312,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         then:
         with(operations()[0].result.taskPlan) {
             task.taskPath == [":producer:compileJava", ":producer:processResources", ":producer:classes", ":producer:jar", ":compileJava", ":processResources", ":classes", ":jar", ":startScripts", ":distZip"]
-            dependencies.taskPath.collect { it.sort() } == [[], [], [":producer:compileJava", ":producer:processResources"], [":producer:classes"], [":producer:compileJava"], [], [":compileJava", ":processResources"], [":classes"], [], [":jar", ":producer:jar", ":startScripts"]]
+            dependencies.taskPath.collect { it.sort() } == [[], [], [":producer:compileJava", ":producer:processResources"], [":producer:classes"], [":producer:compileJava"], [], [":compileJava", ":processResources"], [":classes"], [":jar", ":producer:jar"], [":jar", ":producer:jar", ":startScripts"]]
         }
     }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -15,6 +15,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.jvm.application.scripts.JavaAppStartScriptGenerationDetails",
+            "member": "Method org.gradle.jvm.application.scripts.JavaAppStartScriptGenerationDetails.getAppNameSystemProperty()",
+            "acceptation": "This was nullable before, but the package is now annotated with @NonNullApi",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
         }
     ]
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -314,11 +314,11 @@ installDist.destinationDir = buildDir
         then:
         File generatedWindowsStartScript = file("build/scripts/application.bat")
         generatedWindowsStartScript.exists()
-        assertLineSeparators(generatedWindowsStartScript, TextUtil.windowsLineSeparator, 103)
+        assertLineSeparators(generatedWindowsStartScript, TextUtil.windowsLineSeparator, 104)
 
         File generatedLinuxStartScript = file("build/scripts/application")
         generatedLinuxStartScript.exists()
-        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 183)
+        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 185)
         assertLineSeparators(generatedLinuxStartScript, TextUtil.windowsLineSeparator, 1)
 
         file("build/scripts/application").exists()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
@@ -19,7 +19,10 @@ package org.gradle.api.plugins
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.ScriptExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
+import spock.lang.Unroll
 
 class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationSpec {
     @ToBeFixedForInstantExecution
@@ -38,8 +41,8 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
         """
 
         buildFile << """
-            plugins { 
-                id("application") 
+            plugins {
+                id("application")
             }
             application {
                 mainClassName = "test.Main"
@@ -58,5 +61,65 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
         then:
         executer.run().assertNormalExitValue()
         out.toString() == TextUtil.toPlatformLineSeparators("all good\n")
+    }
+
+    @ToBeFixedForInstantExecution
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    @Unroll
+    def "can configure using project extension for main class and main module"() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+
+        file("src/main/java/test/Main.java") << """
+            package test;
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("Module: " + Main.class.getModule().getName());
+                }
+            }
+        """
+        file("src/main/java/module-info.java") << "module test.main {}"
+
+        buildFile << """
+            plugins {
+                id("application")
+            }
+            application {
+                $configClass
+                $configModule
+            }
+            compileJava {
+                modularClasspathHandling.inferModulePath.set(true)
+            }
+            startScripts {
+                modularClasspathHandling.inferModulePath.set(true)
+            }
+        """
+
+        if (configClass == '') {
+            // set the main class directly in the compile task
+            buildFile << "compileJava { options.javaModuleMainClass.set('test.Main') }"
+        }
+
+        when:
+        run("installDist")
+
+        def out = new ByteArrayOutputStream()
+        def executer = new ScriptExecuter()
+        executer.workingDir = testDirectory
+        executer.standardOutput = out
+        executer.commandLine = "build/install/test/bin/test"
+
+        then:
+        executer.run().assertNormalExitValue()
+        out.toString() == TextUtil.toPlatformLineSeparators("Module: $expectedModule\n")
+
+        where:
+        configClass                   | configModule                  | expectedModule
+        "mainClassName = 'test.Main'" | ''                            | 'null'
+        "mainClass.set('test.Main')"  | ''                            | 'null'
+        "mainClass.set('test.Main')"  | "mainModule.set('test.main')" | 'test.main'
+        ''                            | "mainModule.set('test.main')" | 'test.main'
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -46,13 +46,41 @@ class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
         unixStartScriptContent.contains('DEFAULT_JVM_OPTS=""')
         unixStartScriptContent.contains('APP_NAME="sample"')
         unixStartScriptContent.contains('CLASSPATH=\$APP_HOME/lib/sample.jar')
+        !unixStartScriptContent.contains('MODULE_PATH=')
         unixStartScriptContent.contains('exec "\$JAVACMD" "\$@"')
         File windowsStartScript = assertGeneratedWindowsStartScript()
         String windowsStartScriptContentText = windowsStartScript.text
         windowsStartScriptContentText.contains('@rem  sample startup script for Windows')
         windowsStartScriptContentText.contains('set DEFAULT_JVM_OPTS=')
         windowsStartScriptContentText.contains('set CLASSPATH=%APP_HOME%\\lib\\sample.jar')
+        !windowsStartScriptContentText.contains('set MODULE_PATH=')
         windowsStartScriptContentText.contains('"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SAMPLE_OPTS%  -classpath "%CLASSPATH%" org.gradle.test.Main %CMD_LINE_ARGS%')
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "can generate start scripts with module path"() {
+        given:
+        configureMainModule()
+
+        when:
+        succeeds('startScripts')
+
+        then:
+        File unixStartScript = assertGeneratedUnixStartScript()
+        String unixStartScriptContent = unixStartScript.text
+        unixStartScriptContent.contains('##  sample start up script for UN*X')
+        unixStartScriptContent.contains('DEFAULT_JVM_OPTS=""')
+        unixStartScriptContent.contains('APP_NAME="sample"')
+        unixStartScriptContent.contains('CLASSPATH="\\\\\\"\\\\\\""')
+        unixStartScriptContent.contains('MODULE_PATH=\$APP_HOME/lib/sample.jar')
+        unixStartScriptContent.contains('exec "\$JAVACMD" "\$@"')
+        File windowsStartScript = assertGeneratedWindowsStartScript()
+        String windowsStartScriptContentText = windowsStartScript.text
+        windowsStartScriptContentText.contains('@rem  sample startup script for Windows')
+        windowsStartScriptContentText.contains('set DEFAULT_JVM_OPTS=')
+        windowsStartScriptContentText.contains('set CLASSPATH=')
+        windowsStartScriptContentText.contains('set MODULE_PATH=%APP_HOME%\\lib\\sample.jar')
+        windowsStartScriptContentText.contains('"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SAMPLE_OPTS%  -classpath "%CLASSPATH%" --module-path "%MODULE_PATH%" --module org.gradle.test.main/org.gradle.test.Main %CMD_LINE_ARGS%')
     }
 
     def "can generate starts script generation with custom user configuration"() {
@@ -525,6 +553,21 @@ public class Main {
 apply plugin: 'application'
 
 mainClassName = 'org.gradle.test.Main'
+"""
+    }
+
+    private void configureMainModule() {
+        file("src/main/java/module-info.java") << "module org.gradle.test.main { requires java.management; }"
+        buildFile << """
+application {
+    mainModule.set('org.gradle.test.main')
+}
+compileJava {
+    modularClasspathHandling.inferModulePath.set(true)
+}
+startScripts {
+    modularClasspathHandling.inferModulePath.set(true)
+}
 """
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -578,16 +578,12 @@ rootProject.name = 'sample'
         skipped(":startScripts")
     }
 
-    def "up-to-date if only the content change"() {
-        given:
-        succeeds("startScripts")
-
+    def "start script generation depends on jar creation"() {
         when:
-        generateMainClass """System.out.println("Goodbye World!");"""
-        succeeds("startScripts")
+        succeeds('startScripts')
 
         then:
-        skipped(":startScripts")
+        executed ":processResources", ":classes", ":jar"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4627")

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultJavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultJavaAppStartScriptGenerationDetails.java
@@ -18,7 +18,9 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.jvm.application.scripts.JavaAppStartScriptGenerationDetails;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 public final class DefaultJavaAppStartScriptGenerationDetails implements JavaAppStartScriptGenerationDetails {
 
@@ -28,17 +30,19 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
     private final String mainClassName;
     private final List<String> defaultJvmOpts;
     private final List<String> classpath;
+    private final List<String> modulePath;
     private final String scriptRelPath;
     private final String appNameSystemProperty;
 
-    public DefaultJavaAppStartScriptGenerationDetails(String applicationName, String optsEnvironmentVar, String exitEnvironmentVar, String mainClassName, List<String> defaultJvmOpts,
-                                                      List<String> classpath, String scriptRelPath, String appNameSystemProperty) {
+    public DefaultJavaAppStartScriptGenerationDetails(String applicationName, String optsEnvironmentVar, String exitEnvironmentVar, String mainClassName,
+                                                      List<String> defaultJvmOpts, List<String> classpath, List<String> modulePath, String scriptRelPath, @Nullable String appNameSystemProperty) {
         this.applicationName = applicationName;
         this.optsEnvironmentVar = optsEnvironmentVar;
         this.exitEnvironmentVar = exitEnvironmentVar;
         this.mainClassName = mainClassName;
         this.defaultJvmOpts = defaultJvmOpts;
         this.classpath = classpath;
+        this.modulePath = modulePath;
         this.scriptRelPath = scriptRelPath;
         this.appNameSystemProperty = appNameSystemProperty;
     }
@@ -74,11 +78,17 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
     }
 
     @Override
+    public List<String> getModulePath() {
+        return modulePath;
+    }
+
+    @Override
     public String getScriptRelPath() {
         return scriptRelPath;
     }
 
     @Override
+    @Nullable
     public String getAppNameSystemProperty() {
         return appNameSystemProperty;
     }
@@ -95,28 +105,31 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
 
         DefaultJavaAppStartScriptGenerationDetails that = (DefaultJavaAppStartScriptGenerationDetails) o;
 
-        if (appNameSystemProperty != null ? !appNameSystemProperty.equals(that.appNameSystemProperty) : that.appNameSystemProperty != null) {
+        if (!Objects.equals(appNameSystemProperty, that.appNameSystemProperty)) {
             return false;
         }
-        if (applicationName != null ? !applicationName.equals(that.applicationName) : that.applicationName != null) {
+        if (!Objects.equals(applicationName, that.applicationName)) {
             return false;
         }
-        if (classpath != null ? !classpath.equals(that.classpath) : that.classpath != null) {
+        if (!Objects.equals(classpath, that.classpath)) {
             return false;
         }
-        if (defaultJvmOpts != null ? !defaultJvmOpts.equals(that.defaultJvmOpts) : that.defaultJvmOpts != null) {
+        if (!Objects.equals(modulePath, that.modulePath)) {
             return false;
         }
-        if (exitEnvironmentVar != null ? !exitEnvironmentVar.equals(that.exitEnvironmentVar) : that.exitEnvironmentVar != null) {
+        if (!Objects.equals(defaultJvmOpts, that.defaultJvmOpts)) {
             return false;
         }
-        if (mainClassName != null ? !mainClassName.equals(that.mainClassName) : that.mainClassName != null) {
+        if (!Objects.equals(exitEnvironmentVar, that.exitEnvironmentVar)) {
             return false;
         }
-        if (optsEnvironmentVar != null ? !optsEnvironmentVar.equals(that.optsEnvironmentVar) : that.optsEnvironmentVar != null) {
+        if (!Objects.equals(mainClassName, that.mainClassName)) {
             return false;
         }
-        if (scriptRelPath != null ? !scriptRelPath.equals(that.scriptRelPath) : that.scriptRelPath != null) {
+        if (!Objects.equals(optsEnvironmentVar, that.optsEnvironmentVar)) {
+            return false;
+        }
+        if (!Objects.equals(scriptRelPath, that.scriptRelPath)) {
             return false;
         }
 
@@ -131,6 +144,7 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
         result = 31 * result + (mainClassName != null ? mainClassName.hashCode() : 0);
         result = 31 * result + (defaultJvmOpts != null ? defaultJvmOpts.hashCode() : 0);
         result = 31 * result + (classpath != null ? classpath.hashCode() : 0);
+        result = 31 * result + (modulePath != null ? modulePath.hashCode() : 0);
         result = 31 * result + (scriptRelPath != null ? scriptRelPath.hashCode() : 0);
         result = 31 * result + (appNameSystemProperty != null ? appNameSystemProperty.hashCode() : 0);
         return result;

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
@@ -35,6 +35,7 @@ public class StartScriptGenerator {
     private String mainClassName;
     private Iterable<String> defaultJvmOpts = Collections.emptyList();
     private Iterable<String> classpath;
+    private Iterable<String> modulePath = Collections.emptyList();
     private String scriptRelPath;
     private String appNameSystemProperty;
 
@@ -64,6 +65,10 @@ public class StartScriptGenerator {
 
     public void setClasspath(Iterable<String> classpath) {
         this.classpath = classpath;
+    }
+
+    public void setModulePath(Iterable<String> modulePath) {
+        this.modulePath = modulePath;
     }
 
     public void setScriptRelPath(String scriptRelPath) {
@@ -96,6 +101,7 @@ public class StartScriptGenerator {
                 mainClassName,
                 CollectionUtils.toStringList(defaultJvmOpts),
                 CollectionUtils.toStringList(classpath),
+                CollectionUtils.toStringList(modulePath),
                 scriptRelPath,
                 appNameSystemProperty
         );
@@ -110,7 +116,7 @@ public class StartScriptGenerator {
         IoActions.writeTextFile(windowsScript, new Generate(createStartScriptGenerationDetails(), windowsStartScriptGenerator));
     }
 
-    static interface UnixFileOperation {
+    interface UnixFileOperation {
         void createExecutablePermission(File file);
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -66,7 +66,7 @@ public class ApplicationPlugin implements Plugin<Project> {
         ApplicationPluginConvention pluginConvention = addConvention(project);
         JavaApplication pluginExtension = addExtensions(project, pluginConvention);
         addRunTask(project, pluginExtension, pluginConvention);
-        addCreateScriptsTask(project, pluginConvention);
+        addCreateScriptsTask(project, pluginExtension, pluginConvention);
         configureJavaCompileTask(tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class), pluginExtension);
         configureJarTask(tasks.named(JavaPlugin.JAR_TASK_NAME, Jar.class), pluginExtension);
         configureInstallTask(tasks.named(TASK_INSTALL_NAME, Sync.class), pluginConvention);
@@ -144,12 +144,13 @@ public class ApplicationPlugin implements Plugin<Project> {
     }
 
     // @Todo: refactor this task configuration to extend a copy task and use replace tokens
-    private void addCreateScriptsTask(Project project, ApplicationPluginConvention pluginConvention) {
+    private void addCreateScriptsTask(Project project, JavaApplication pluginExtension, ApplicationPluginConvention pluginConvention) {
         project.getTasks().register(TASK_START_SCRIPTS_NAME, CreateStartScripts.class, startScripts -> {
             startScripts.setDescription("Creates OS specific scripts to run the project as a JVM application.");
             startScripts.setClasspath(project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles().plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
 
-            startScripts.getConventionMapping().map("mainClassName", pluginConvention::getMainClassName);
+            startScripts.getMainModule().set(pluginExtension.getMainModule());
+            startScripts.getMainClass().set(pluginExtension.getMainClass());
 
             startScripts.getConventionMapping().map("applicationName", pluginConvention::getApplicationName);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
@@ -63,7 +63,8 @@ package org.gradle.api.tasks.application;
  * <li>{@code applicationName}</li>
  * <li>{@code optsEnvironmentVar}</li>
  * <li>{@code exitEnvironmentVar}</li>
- * <li>{@code mainClassName}</li>
+ * <li>{@code mainModule}</li>
+ * <li>{@code mainClass}</li>
  * <li>{@code defaultJvmOpts}</li>
  * <li>{@code appNameSystemProperty}</li>
  * <li>{@code appHomeRelativePath}</li>

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.application.scripts;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -55,6 +56,7 @@ public interface JavaAppStartScriptGenerationDetails {
     /**
      * This system property to use to pass the script name to the application. May be null.
      */
+    @Nullable
     String getAppNameSystemProperty();
 }
 

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
@@ -16,6 +16,8 @@
 
 package org.gradle.jvm.application.scripts;
 
+import org.gradle.api.Incubating;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -47,6 +49,14 @@ public interface JavaAppStartScriptGenerationDetails {
      * The classpath, relative to the application home directory.
      */
     List<String> getClasspath();
+
+    /**
+     * The module path, relative to the application home directory.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    List<String> getModulePath();
 
     /**
      * The path of the script, relative to the application home directory.

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/package-info.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Classes that enable JVM application script generation.
  */
+@NonNullApi
 package org.gradle.jvm.application.scripts;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.plugins.StartScriptGenerator;
 import org.gradle.api.internal.plugins.UnixStartScriptGenerator;
 import org.gradle.api.internal.plugins.WindowsStartScriptGenerator;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -247,8 +248,9 @@ public class CreateStartScripts extends ConventionTask {
     /**
      * The class path for the application.
      */
-    @Internal
     @Nullable
+    @Classpath
+    @Optional
     public FileCollection getClasspath() {
         return classpath;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -16,27 +16,34 @@
 
 package org.gradle.jvm.application.tasks;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.plugins.StartScriptGenerator;
 import org.gradle.api.internal.plugins.UnixStartScriptGenerator;
 import org.gradle.api.internal.plugins.WindowsStartScriptGenerator;
+import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.jpms.DefaultModularClasspathHandling;
+import org.gradle.internal.jpms.JavaModuleDetector;
 import org.gradle.jvm.application.scripts.ScriptGenerator;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 /**
  * Creates start scripts for launching JVM applications.
@@ -86,7 +93,8 @@ import java.util.Collections;
  * <li>{@code applicationName}</li>
  * <li>{@code optsEnvironmentVar}</li>
  * <li>{@code exitEnvironmentVar}</li>
- * <li>{@code mainClassName}</li>
+ * <li>{@code mainModule}</li>
+ * <li>{@code mainClass}</li>
  * <li>{@code executableDir}</li>
  * <li>{@code defaultJvmOpts}</li>
  * <li>{@code appNameSystemProperty}</li>
@@ -106,14 +114,32 @@ public class CreateStartScripts extends ConventionTask {
 
     private File outputDir;
     private String executableDir = "bin";
-    private String mainClassName;
+    private final Property<String> mainModule;
+    private final Property<String> mainClass;
     private Iterable<String> defaultJvmOpts = Lists.newLinkedList();
     private String applicationName;
     private String optsEnvironmentVar;
     private String exitEnvironmentVar;
     private FileCollection classpath;
+    private final ModularClasspathHandling modularClasspathHandling;
     private ScriptGenerator unixStartScriptGenerator = new UnixStartScriptGenerator();
     private ScriptGenerator windowsStartScriptGenerator = new WindowsStartScriptGenerator();
+
+    public CreateStartScripts() {
+        this.mainModule = getObjectFactory().property(String.class);
+        this.mainClass = getObjectFactory().property(String.class);
+        this.modularClasspathHandling = getObjectFactory().newInstance(DefaultModularClasspathHandling.class);
+    }
+
+    @Inject
+    protected ObjectFactory getObjectFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected JavaModuleDetector getJavaModuleDetector() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * The environment variable to use to provide additional options to the JVM.
@@ -198,16 +224,42 @@ public class CreateStartScripts extends ConventionTask {
     }
 
     /**
-     * The main classname used to start the Java application.
+     * The main module name used to start the modular Java application.
+     *
+     * @since 6.4
      */
+    @Incubating
+    @Optional
     @Input
+    public Property<String> getMainModule() {
+        return mainModule;
+    }
+
+    /**
+     * The main class name used to start the Java application.
+     *
+     * Use this property instead of {@link #getMainClassName()} and {@link #setMainClassName(String)}.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    @Optional
+    @Input
+    public Property<String> getMainClass() {
+        return mainClass;
+    }
+
+    /**
+     * The main class name used to start the Java application.
+     */
+    @Internal
     @Nullable
     public String getMainClassName() {
-        return mainClassName;
+        return mainClass.getOrNull();
     }
 
     public void setMainClassName(@Nullable String mainClassName) {
-        this.mainClassName = mainClassName;
+        this.mainClass.set(mainClassName);
     }
 
     /**
@@ -255,6 +307,17 @@ public class CreateStartScripts extends ConventionTask {
         return classpath;
     }
 
+    /**
+     * Returns the module path handling for executing the main class.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    @Nested
+    public ModularClasspathHandling getModularClasspathHandling() {
+        return modularClasspathHandling;
+    }
+
     public void setClasspath(@Nullable FileCollection classpath) {
         this.classpath = classpath;
     }
@@ -290,12 +353,14 @@ public class CreateStartScripts extends ConventionTask {
     @TaskAction
     public void generate() {
         StartScriptGenerator generator = new StartScriptGenerator(unixStartScriptGenerator, windowsStartScriptGenerator);
+        JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
         generator.setApplicationName(getApplicationName());
-        generator.setMainClassName(getMainClassName());
+        generator.setMainClassName(fullMainArgument());
         generator.setDefaultJvmOpts(getDefaultJvmOpts());
         generator.setOptsEnvironmentVar(getOptsEnvironmentVar());
         generator.setExitEnvironmentVar(getExitEnvironmentVar());
-        generator.setClasspath(getRelativeClasspath());
+        generator.setClasspath(getRelativePath(javaModuleDetector.inferClasspath(mainModule.isPresent(), getClasspath())));
+        generator.setModulePath(getRelativePath(javaModuleDetector.inferModulePath(mainModule.isPresent(), getClasspath())));
         if (StringUtils.isEmpty(getExecutableDir())) {
             generator.setScriptRelPath(getUnixScript().getName());
         } else {
@@ -303,6 +368,21 @@ public class CreateStartScripts extends ConventionTask {
         }
         generator.generateUnixScript(getUnixScript());
         generator.generateWindowsScript(getWindowsScript());
+    }
+
+    private String fullMainArgument() {
+        String main = "";
+        if (mainModule.isPresent()) {
+            main += "--module ";
+            main += mainModule.get();
+            if (mainClass.isPresent()) {
+                main += "/";
+            }
+        }
+        if (mainClass.isPresent()) {
+            main += mainClass.get();
+        }
+        return main;
     }
 
     @Input
@@ -313,12 +393,11 @@ public class CreateStartScripts extends ConventionTask {
         if (classpathNullable == null) {
             return Collections.emptyList();
         }
-        return Lists.newArrayList(Iterables.transform(classpathNullable.getFiles(), new Function<File, String>() {
-            @Override
-            public String apply(File input) {
-                return "lib/" + input.getName();
-            }
-        }));
+        return getRelativePath(classpathNullable);
+    }
+
+    private Iterable<String> getRelativePath(FileCollection path) {
+        return path.getFiles().stream().map(input -> "lib/" + input.getName()).collect(Collectors.toCollection(Lists::newArrayList));
     }
 
 }

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -81,6 +81,7 @@ case "`uname`" in
 esac
 
 CLASSPATH=$classpath
+<% if ( mainClassName.startsWith('--module ') ) { %>MODULE_PATH=$modulePath<% } %>
 
 # Determine the Java command to use to start the JVM.
 if [ -n "\$JAVA_HOME" ] ; then
@@ -129,6 +130,7 @@ fi
 if [ "\$cygwin" = "true" -o "\$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
+    <% if ( mainClassName.startsWith('--module ') ) { %>MODULE_PATH=`cygpath --path --mixed "\$MODULE_PATH"`<% } %>
     JAVACMD=`cygpath --unix "\$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
@@ -178,6 +180,6 @@ save () {
 APP_ARGS=`save "\$@"`
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
 
 exec "\$JAVACMD" "\$@"

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -84,9 +84,10 @@ set CMD_LINE_ARGS=%*
 @rem Setup the command line
 
 set CLASSPATH=$classpath
+<% if ( mainClassName.startsWith('--module ') ) { %>set MODULE_PATH=$modulePath<% } %>
 
 @rem Execute ${applicationName}
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath "%CLASSPATH%" ${mainClassName} %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath "%CLASSPATH%" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>${mainClassName} %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/StartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/StartScriptGeneratorTest.groovy
@@ -31,6 +31,7 @@ class StartScriptGeneratorTest extends Specification {
     private static final String MAIN_CLASSNAME = 'org.gradle.launcher.GradleMain'
     private static final Iterable<String> DEFAULT_JVM_OPTS = ['-Xmx1024m']
     private static final Iterable<String> CLASSPATH = ['libs/gradle.jar']
+    private static final Iterable<String> MODULE_PATH = []
     private static final String SCRIPT_REL_PATH = 'bin/gradle'
     private static final String APP_NAME_SYS_PROP = 'org.gradle.appname'
 
@@ -77,11 +78,12 @@ class StartScriptGeneratorTest extends Specification {
         startScriptGenerator.mainClassName = MAIN_CLASSNAME
         startScriptGenerator.defaultJvmOpts = DEFAULT_JVM_OPTS
         startScriptGenerator.classpath = CLASSPATH
+        startScriptGenerator.modulePath = MODULE_PATH
         startScriptGenerator.scriptRelPath = SCRIPT_REL_PATH
         startScriptGenerator.appNameSystemProperty = APP_NAME_SYS_PROP
     }
 
     private JavaAppStartScriptGenerationDetails createJavaAppStartScriptGenerationDetails() {
-        return new DefaultJavaAppStartScriptGenerationDetails(APP_NAME, OPTS_ENV_VAR, EXIT_ENV_VAR, MAIN_CLASSNAME, DEFAULT_JVM_OPTS, CLASSPATH, SCRIPT_REL_PATH, APP_NAME_SYS_PROP)
+        return new DefaultJavaAppStartScriptGenerationDetails(APP_NAME, OPTS_ENV_VAR, EXIT_ENV_VAR, MAIN_CLASSNAME, DEFAULT_JVM_OPTS, CLASSPATH, MODULE_PATH, SCRIPT_REL_PATH, APP_NAME_SYS_PROP)
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.unixLineSeparator).length == 183
+        destination.toString().split(TextUtil.unixLineSeparator).length == 185
     }
 
     def "defaultJvmOpts is expanded properly in unix script"() {
@@ -136,6 +136,6 @@ class UnixStartScriptGeneratorTest extends Specification {
     private JavaAppStartScriptGenerationDetails createScriptGenerationDetails(List<String> defaultJvmOpts, String scriptRelPath) {
         final String applicationName = 'TestApp'
         final List<String> classpath = WrapUtil.toList('path\\to\\Jar.jar')
-        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, null, null, null, defaultJvmOpts, classpath, scriptRelPath, null)
+        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, null, null, "", defaultJvmOpts, classpath, [], scriptRelPath, null)
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 103
+        destination.toString().split(TextUtil.windowsLineSeparator).length == 104
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {
@@ -112,6 +112,6 @@ class WindowsStartScriptGeneratorTest extends Specification {
     private JavaAppStartScriptGenerationDetails createScriptGenerationDetails(List<String> defaultJvmOpts, String scriptRelPath) {
         final String applicationName = 'TestApp'
         final List<String> classpath = WrapUtil.toList('path/to/Jar.jar')
-        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, null, null, null, defaultJvmOpts, classpath, scriptRelPath, null)
+        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, null, null, "", defaultJvmOpts, classpath, [], scriptRelPath, null)
     }
 }


### PR DESCRIPTION
Fixes #12613

Notes:

- The script generation now again depends on the actual actual classpath - i.e. content of jars. This was removed in #1936 (for 4.0). This revert is necessary, because the JAR content needs to be inspected to decide if a JAR should go on the module path.
- The template parameters (like `mainClassName`) and the shell variables generated into the script (like `$CLASSPATH`) are effectively public API. 
Hence, the name of the parameter `mainClassName` was not changed although it may carry more information now than only the class name. We could use more additional variables, but I also wanted to keep the logic inside the template minimal (`<% if ...` statements) as it is very hard to read.
The `$CLASSPATH` variable is always there even if the `-classpath` is empty. The `$MODULE_PATH` variable is only added if we run a module, so that a script **not** running a module can be executed with Java versions < 9.