### PR TITLE
Serialize the actions passed to CopySpec.eachFile() and related method to the instant execution cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -232,6 +232,127 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         )
     }
 
+    def "can rename files using a regexp string and replacement pattern"() {
+        given:
+        file('files/one.a').createFile()
+        file('files/one.b').createFile()
+        file('files/dir/two.a').createFile()
+        file('files/dir/two.b').createFile()
+        buildScript '''
+            task copy(type: Copy) {
+                from 'files'
+                into 'dest'
+                rename '(.*).a', '\$1.renamed'
+            }
+        '''
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'dir/two.renamed',
+            'dir/two.b'
+        )
+
+        when:
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'dir/two.renamed',
+            'dir/two.b'
+        )
+
+        when:
+        file('files/one.c').createNewFile()
+        file('files/dir/another.a').createNewFile()
+
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'one.c',
+            'dir/two.renamed',
+            'dir/two.b',
+            'dir/another.renamed'
+        )
+    }
+
+    def "can rename files using a closure"() {
+        given:
+        file('files/one.a').createFile()
+        file('files/one.b').createFile()
+        file('files/dir/two.a').createFile()
+        file('files/dir/two.b').createFile()
+        buildScript '''
+            task copy(type: Copy) {
+                from 'files'
+                into 'dest'
+                rename {
+                    println("rename $it")
+                    if (it.endsWith('.b')) {
+                        return null
+                    } else {
+                        return it.replace('.a', '.renamed')
+                    }
+                }
+            }
+        '''
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'dir/two.renamed',
+            'dir/two.b'
+        )
+
+        when:
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        output.count("rename") == 0
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'dir/two.renamed',
+            'dir/two.b'
+        )
+
+        when:
+        file('files/one.c').createNewFile()
+        file('files/dir/another.a').createNewFile()
+
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        output.count("rename") == 6
+        outputContains("rename one.a")
+        outputContains("rename another.a")
+        file('dest').assertHasDescendants(
+            'one.renamed',
+            'one.b',
+            'one.c',
+            'dir/two.renamed',
+            'dir/two.b',
+            'dir/another.renamed'
+        )
+    }
+
     def "rename"() {
         given:
         buildScript '''
@@ -345,7 +466,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         it.next().startsWith('16')
     }
 
-    def "can rename files using closure"() {
+    def "can rename files in eachFile() action defined using closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -401,7 +522,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         )
     }
 
-    def "can rename files that match a pattern using closure"() {
+    def "can rename files that match a pattern in filesMatching() action defined using closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -457,7 +578,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         )
     }
 
-    def "can rename files that do not match a pattern using closure"() {
+    def "can rename files that do not match a pattern in filesNotMatching() action defined using closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SourceTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SourceTaskIntegrationTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class SourceTaskIntegrationTest extends AbstractIntegrationSpec {
+    def "can specify source files using a Groovy closure"() {
+        given:
+        file("src/one.txt").createFile()
+        file("src/a/two.txt").createFile()
+
+        buildFile << """
+            class TestTask extends SourceTask {
+                @TaskAction
+                def list() {
+                    source.visit { fte -> println("visit " + fte.relativePath) }
+                }
+            }
+
+            def location = null
+
+            task source(type: TestTask) {
+                source { file(location) }
+            }
+
+            location = 'src'
+        """
+
+        when:
+        run "source"
+
+        then:
+        output.count("visit ") == 3
+        outputContains("visit one.txt")
+        outputContains("visit a")
+        outputContains("visit a/two.txt")
+
+        when:
+        file("src/a/three.txt").createFile()
+        run "source"
+
+        then:
+        output.count("visit ") == 4
+        outputContains("visit one.txt")
+        outputContains("visit a")
+        outputContains("visit a/two.txt")
+        outputContains("visit a/three.txt")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -96,10 +96,11 @@ public class DefaultCopySpec implements CopySpecInternal {
         this.patternSet = patternSet;
     }
 
-    public DefaultCopySpec(FileCollectionFactory fileCollectionFactory, Instantiator instantiator, Factory<PatternSet> patternSetFactory, @Nullable String destPath, FileCollection source, PatternSet patternSet, Collection<CopySpecInternal> children) {
+    public DefaultCopySpec(FileCollectionFactory fileCollectionFactory, Instantiator instantiator, Factory<PatternSet> patternSetFactory, @Nullable String destPath, FileCollection source, PatternSet patternSet, Collection<? extends Action<? super FileCopyDetails>> copyActions, Collection<CopySpecInternal> children) {
         this(fileCollectionFactory, instantiator, patternSetFactory, patternSet);
         sourcePaths.from(source);
         destDir = destPath;
+        this.copyActions.addAll(copyActions);
         for (CopySpecInternal child : children) {
             addChildSpec(child);
         }
@@ -118,8 +119,7 @@ public class DefaultCopySpec implements CopySpecInternal {
         return false;
     }
 
-    @VisibleForTesting
-    List<Action<? super FileCopyDetails>> getCopyActions() {
+    public List<Action<? super FileCopyDetails>> getCopyActions() {
         return copyActions;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/RegExpNameMapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/RegExpNameMapper.java
@@ -21,22 +21,27 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RegExpNameMapper implements Transformer<String, String> {
-    private Matcher matcher;
-    private String replacement;
+    private final Pattern pattern;
+    private transient Matcher matcher;
+    private final String replacement;
 
     public RegExpNameMapper(String sourceRegEx, String replaceWith) {
         this(Pattern.compile(sourceRegEx), replaceWith);
     }
 
     public RegExpNameMapper(Pattern sourceRegEx, String replaceWith) {
-        matcher = sourceRegEx.matcher("");
+        pattern = sourceRegEx;
         replacement = replaceWith;
     }
 
     @Override
     public String transform(String source) {
+        if (matcher == null) {
+            matcher = pattern.matcher(source);
+        } else {
+            matcher.reset(source);
+        }
         String result = source;
-        matcher.reset(source);
         if (matcher.find()) {
             result = matcher.replaceFirst(replacement);
         }

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.file
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-class FileTreeIntegrationTest extends AbstractIntegrationSpec {
+class ConfigurableFileTreeIntegrationTest extends AbstractIntegrationSpec {
     def "can include the elements of a tree using a Groovy closure spec"() {
         buildFile << """
             class SomeTask extends DefaultTask {
@@ -70,12 +70,13 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file("src/d/d.txt").createFile()
+        file("src/ignore-3.txt").createFile()
 
         run("generate")
 
         then:
         result.assertTaskNotSkipped(":generate")
-        output.count("checking") == 20 // checked twice, once to snapshot and once when the task action runs
+        output.count("checking") == 22 // checked twice, once to snapshot and once when the task action runs
         outputContains("checking a/a.txt")
         outputContains("checking d/d.txt")
         file("out.txt").text == "a.txt,c.txt,d.txt"
@@ -131,12 +132,13 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file("src/d/e/f.txt").createFile()
+        file("src/a/ignore-3.txt").createFile()
 
         run("generate")
 
         then:
         result.assertTaskNotSkipped(":generate")
-        output.count("checking") == 18 // checked twice, once for snapshots and once when the task action runs
+        output.count("checking") == 20 // checked twice, once for snapshots and once when the task action runs
         outputContains("checking a.txt")
         outputContains("checking d/e/f.txt")
         file("out.txt").text == "a.txt,c.txt,f.txt"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClosureCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClosureCodec.kt
@@ -23,6 +23,8 @@ import org.gradle.instantexecution.serialization.WriteContext
 
 
 object ClosureCodec : Codec<Closure<*>> {
+    private
+    val defaultOwner = Any()
 
     private
     val beanCodec = BeanCodec()
@@ -33,6 +35,9 @@ object ClosureCodec : Codec<Closure<*>> {
     }
 
     override suspend fun ReadContext.decode(): Closure<*>? {
-        return beanCodec.run { decode() as Closure<*> }
+        return beanCodec.run {
+            val closure = decode() as Closure<*>
+            closure.rehydrate(null, defaultOwner, defaultOwner)
+        }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -260,5 +260,6 @@ class Codecs(
 
         bind(arrayCodec)
         bind(EnumCodec)
+        bind(RegexpPatternCodec)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -16,8 +16,10 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.Action
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
@@ -54,6 +56,7 @@ class DefaultCopySpecCodec(
             writeString(value.filteringCharset)
             writeNullableSmallInt(value.dirMode)
             writeNullableSmallInt(value.fileMode)
+            writeCollection(value.copyActions)
             writeCollection(value.children)
         }
     }
@@ -69,8 +72,9 @@ class DefaultCopySpecCodec(
             val filteringCharset = readString()
             val dirMode = readNullableSmallInt()
             val fileMode = readNullableSmallInt()
+            val actions = readList().uncheckedCast<List<Action<FileCopyDetails>>>()
             val children = readList().uncheckedCast<List<CopySpecInternal>>()
-            val copySpec = DefaultCopySpec(fileCollectionFactory, instantiator, patternSetFactory, destPath, sourceFiles, patterns, children)
+            val copySpec = DefaultCopySpec(fileCollectionFactory, instantiator, patternSetFactory, destPath, sourceFiles, patterns, actions, children)
             copySpec.duplicatesStrategy = duplicatesStrategy
             copySpec.includeEmptyDirs = includeEmptyDirs
             copySpec.isCaseSensitive = isCaseSensitive

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/RegexpPatternCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/RegexpPatternCodec.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import java.util.regex.Pattern
+
+
+object RegexpPatternCodec : Codec<Pattern> {
+    override suspend fun WriteContext.encode(value: Pattern) {
+        writeString(value.pattern())
+        writeInt(value.flags())
+    }
+
+    override suspend fun ReadContext.decode(): Pattern? {
+        return Pattern.compile(readString(), readInt())
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -21,6 +21,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -73,9 +74,12 @@ public class Jar extends Zip {
                 manifestInternal.setContentCharset(manifestContentCharset);
                 manifestInternal.writeTo(outputStream);
             }));
-        getMainSpec().appendCachingSafeCopyAction(details -> {
-            if (details.getPath().equalsIgnoreCase("META-INF/MANIFEST.MF")) {
-                details.exclude();
+        getMainSpec().appendCachingSafeCopyAction(new Action<FileCopyDetails>() {
+            @Override
+            public void execute(FileCopyDetails details) {
+                if (details.getPath().equalsIgnoreCase("META-INF/MANIFEST.MF")) {
+                    details.exclude();
+                }
             }
         });
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -74,14 +74,7 @@ public class Jar extends Zip {
                 manifestInternal.setContentCharset(manifestContentCharset);
                 manifestInternal.writeTo(outputStream);
             }));
-        getMainSpec().appendCachingSafeCopyAction(new Action<FileCopyDetails>() {
-            @Override
-            public void execute(FileCopyDetails details) {
-                if (details.getPath().equalsIgnoreCase("META-INF/MANIFEST.MF")) {
-                    details.exclude();
-                }
-            }
-        });
+        getMainSpec().appendCachingSafeCopyAction(new ExcludeManifestAction());
     }
 
     /**
@@ -223,5 +216,14 @@ public class Jar extends Zip {
         CopySpec metaInf = getMetaInf();
         configureAction.execute(metaInf);
         return metaInf;
+    }
+
+    private static class ExcludeManifestAction implements Action<FileCopyDetails> {
+        @Override
+        public void execute(FileCopyDetails details) {
+            if (details.getPath().equalsIgnoreCase("META-INF/MANIFEST.MF")) {
+                details.exclude();
+            }
+        }
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.workers.internal
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.ProcessFixture
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.ConcurrentTestUtil
@@ -171,7 +170,6 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         assertDifferentDaemonsWereUsed("runInWorker1", "runInWorker2")
     }
 
-    @ToBeFixedForInstantExecution
     def "worker daemons are not reused when they fail unexpectedly"() {
         workerExecutorThatCanFailUnexpectedly.writeToBuildFile()
         buildFile << """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.util.Requires
@@ -108,7 +107,6 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         isolationMode << ISOLATION_MODES
     }
 
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*PROCESS")
     def "can create and use a work action defined in an external jar in #isolationMode"() {
         def workActionJarName = "workAction.jar"
         withWorkActionClassInExternalJar(file(workActionJarName))


### PR DESCRIPTION
### Context

Serialize the actions passed to `CopySpec.eachFile()`, `filesMatching()`, `filesNotMatching()` and `rename()` to the instant execution cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
