### PR TITLE
Add support for recursive generic type in TypeInspector

### DIFF
--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/TypeInspectorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/TypeInspectorTest.groovy
@@ -40,4 +40,13 @@ class TypeInspectorTest extends Specification {
         def types2 = inspector.getReachableTypes(Child)
         types2 == types
     }
+
+    def "inspects cyclic generic types"() {
+        expect:
+        def types = inspector.getReachableTypes(GenericChild)
+        types == [GenericItem1, GenericItem2, GenericChild] as Set
+
+        def types2 = inspector.getReachableTypes(GenericChild)
+        types2.is(types)
+    }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/TypeInspectorTestHelper.java
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/TypeInspectorTestHelper.java
@@ -61,4 +61,14 @@ public class TypeInspectorTestHelper {
         Parent getParent();
         Child getNextSibling();
     }
+
+    interface GenericItem1<T> {
+    }
+
+    interface GenericItem2<T> {
+    }
+
+    interface  GenericChild<T extends GenericItem1<? extends T>> extends GenericItem1<T> {
+        <U extends GenericItem2<? super U>> void method(GenericItem2<U> p);
+    }
 }


### PR DESCRIPTION
Detail:
Relative issue: https://github.com/gradle/gradle/issues/12454
I tried call getReachableTypes(Stream.class) and the logic will ends with stackoverflow,
because current logic cannot prevent endless recursive generic definition, like <T extend GenericInterface<? extend/super T>, which can be found in Comparator's static method https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html#thenComparing-java.util.function.Function-.
So I add a set to end the endless recursive.

Signed-off-by: Shawlaw <Shawlaw@126.com>

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/12454

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
