### PR TITLE
Add property to configure the `--release` flag

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -130,9 +130,13 @@ public class JavaCompilerArgumentsBuilder {
         if (!includeMainOptions) {
             return;
         }
-
+        Integer release = spec.getRelease();
         final MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
-        if (!releaseOptionIsSet(compilerArgs)) {
+
+        if (release != null) {
+            args.add("--release");
+            args.add(release.toString());
+        } else if (!releaseOptionIsSet(compilerArgs)) {
             String sourceCompatibility = spec.getSourceCompatibility();
             if (sourceCompatibility != null) {
                 args.add("-source");

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -251,6 +251,7 @@ public class JavaCompile extends AbstractCompile {
             compileOptions.setSourcepath(getProjectLayout().files(sourcesRoots));
         }
         spec.setAnnotationProcessorPath(compileOptions.getAnnotationProcessorPath() == null ? ImmutableList.of() : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
+        spec.setRelease(getRelease().getOrNull());
         spec.setTargetCompatibility(getTargetCompatibility());
         spec.setSourceCompatibility(getSourceCompatibility());
         spec.setCompileOptions(compileOptions);

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -93,6 +93,16 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.build() == defaultOptions + ['--release', '7']
     }
 
+    def "removes -source and -target option if release property is set"() {
+        when:
+        spec.release = 7
+        spec.sourceCompatibility = '1.7'
+        spec.targetCompatibility = '1.7'
+
+        then:
+        builder.build() == ['--release', '7'] + defaultOptions
+    }
+
     def "generates -d option"() {
         def file = new File("/project/build")
         spec.destinationDir = file

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
@@ -28,6 +29,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     private List<File> classpath;
     private File destinationDir;
     private Iterable<File> sourceFiles;
+    private Integer release;
     private String sourceCompatibility;
     private String targetCompatibility;
     private List<File> sourceRoots;
@@ -82,6 +84,17 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     @Override
     public void setCompileClasspath(List<File> classpath) {
         this.classpath = classpath;
+    }
+
+    @Override
+    @Nullable
+    public Integer getRelease() {
+        return release;
+    }
+
+    @Override
+    public void setRelease(@Nullable Integer release) {
+        this.release = release;
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.language.base.internal.compile.CompileSpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -41,6 +42,11 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
     List<File> getCompileClasspath();
 
     void setCompileClasspath(List<File> classpath);
+
+    @Nullable
+    Integer getRelease();
+
+    void setRelease(@Nullable Integer release);
 
     String getSourceCompatibility();
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
@@ -20,9 +20,11 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 
@@ -37,10 +39,12 @@ public abstract class AbstractCompile extends SourceTask {
     private FileCollection classpath;
     private String sourceCompatibility;
     private String targetCompatibility;
+    private Property<Integer> release;
 
     public AbstractCompile() {
         this.destinationDirectory = getProject().getObjects().directoryProperty();
         this.destinationDirectory.convention(getProject().getProviders().provider(new BackwardCompatibilityOutputDirectoryConvention()));
+        this.release = getProject().getObjects().property(Integer.class);
     }
 
     /**
@@ -101,6 +105,21 @@ public abstract class AbstractCompile extends SourceTask {
      */
     public void setDestinationDir(Provider<File> destinationDir) {
         this.destinationDirectory.set(getProject().getLayout().dir(destinationDir));
+    }
+
+    /**
+     * Configure the minimal Java release version for this compile task (--release compiler flag)
+     *
+     * If set, it will take precedences over the {@link #getSourceCompatibility()} and {@link #getTargetCompatibility()} settings,
+     * which will have no effect in that case.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    @Input
+    @Optional
+    public Property<Integer> getRelease() {
+        return release;
     }
 
     /**

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -153,6 +153,33 @@ compileJava.options.compilerArgs.addAll(['--release', '8'])
 
         expect:
         succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile with release property set"() {
+        given:
+        goodCode()
+        buildFile << """
+compileJava.release.set(8)
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile with release property set in plugin extension"() {
+        given:
+        goodCode()
+        buildFile << """
+java.release.set(8)
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
@@ -387,6 +414,15 @@ class Main {
         then:
         fails("compileJava")
         failure.assertHasErrorOutput("package ${gradleBaseServicesClass.package.name} does not exist")
+    }
+
+    def bytecodeVersion() {
+        def classFile = javaClassFile('compile/test/Person.class').newDataInputStream()
+        classFile.readInt()
+        classFile.readUnsignedShort()
+        def majorVersion = classFile.readUnsignedShort()
+        classFile.close()
+        return majorVersion
     }
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -214,6 +214,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 String generatedHeadersDir = "generated/sources/headers/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
                 compileTask.getOptions().getHeaderOutputDirectory().convention(target.getLayout().getBuildDirectory().dir(generatedHeadersDir));
                 JavaPluginExtension javaPluginExtension = target.getExtensions().getByType(JavaPluginExtension.class);
+                compileTask.getRelease().convention(javaPluginExtension.getRelease());
                 compileTask.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
             }
         });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Property;
 import org.gradle.api.jpms.ModularClasspathHandling;
 
 /**
@@ -28,6 +29,18 @@ import org.gradle.api.jpms.ModularClasspathHandling;
  * @since 4.10
  */
 public interface JavaPluginExtension {
+
+    /**
+     * Configure the minimal Java release version for compiling Java sources (--release compiler flag).
+     *
+     * If set, it will take precedences over the {@link #getSourceCompatibility()} and {@link #getTargetCompatibility()} settings,
+     * which will have no effect in that case.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    Property<Integer> getRelease();
+
     /**
      * Returns the source compatibility used for compiling Java sources.
      */

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -30,6 +30,7 @@ import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
@@ -55,6 +56,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final TaskContainer tasks;
     private final Project project;
     private final ModularClasspathHandling modularClasspathHandling;
+    private final Property<Integer> release;
 
     public DefaultJavaPluginExtension(JavaPluginConvention convention,
                                       Project project) {
@@ -66,6 +68,12 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         this.tasks = project.getTasks();
         this.project = project;
         this.modularClasspathHandling = project.getObjects().newInstance(DefaultModularClasspathHandling.class);
+        this.release = project.getObjects().property(Integer.class);
+    }
+
+    @Override
+    public Property<Integer> getRelease() {
+        return release;
     }
 
     @Override


### PR DESCRIPTION
Fixes #2510

A more convenient, and provider-based, method to configure the `--release` flag in place of using a plain compiler args like `compilerArgs.addAll(['--release', '...'])`.

Documentation will be added soon when we update the docs as part of #12603.