### PR TITLE
Use release/targetComp setting of compile task for jvm version attribute

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.AttributeCompatibilityRule;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
@@ -47,19 +46,18 @@ public abstract class JavaEcosystemSupport {
         configureTargetPlatform(attributesSchema);
     }
 
-    public static void configureDefaultTargetPlatform(HasAttributes configuration, JavaVersion version) {
-        String majorVersion = version.getMajorVersion();
+    public static void configureDefaultTargetPlatform(HasAttributes configuration, int majorVersion) {
         AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
         // If nobody said anything about this variant's target platform, use whatever the convention says
         if (!attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
-            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(majorVersion));
+            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, majorVersion);
         }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {
         AttributeMatchingStrategy<Integer> targetPlatformSchema = attributesSchema.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE);
         targetPlatformSchema.getCompatibilityRules().ordered(Ordering.natural());
-        targetPlatformSchema.getDisambiguationRules().pickLast(Ordering.<Integer>natural());
+        targetPlatformSchema.getDisambiguationRules().pickLast(Ordering.natural());
     }
 
     private static void configureBundling(AttributesSchema attributesSchema) {

--- a/subprojects/core/src/main/java/org/gradle/internal/jpms/JavaModuleDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jpms/JavaModuleDetector.java
@@ -80,13 +80,23 @@ public class JavaModuleDetector {
         return classpath.filter(modulePathFilter);
     }
 
-    public boolean isModule(FileCollection files) {
+    public boolean isModule(boolean inferModulePath, FileCollection files) {
+        if (!inferModulePath) {
+            return false;
+        }
         for(File file : files.getFiles()) {
-            if (cache.get(file)) {
+            if (isModule(file)) {
                 return true;
             }
         }
         return false;
+    }
+
+    public boolean isModule(boolean inferModulePath, File file) {
+        if (!inferModulePath) {
+            return false;
+        }
+        return isModule(file);
     }
 
     private boolean isModule(File file) {
@@ -103,7 +113,10 @@ public class JavaModuleDetector {
         return !isModule(file);
     }
 
-    public static boolean isModuleSource(Iterable<File> sourcesRoots) {
+    public static boolean isModuleSource(boolean inferModulePath, Iterable<File> sourcesRoots) {
+        if (!inferModulePath) {
+            return false;
+        }
         for (File srcFolder : sourcesRoots) {
             if (isModuleSourceFolder(srcFolder)) {
                 return true;

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -52,6 +52,15 @@ dependencyLocking {
 
 Users of the Groovy DSL should not be impacted as the notation `lockMode = LockMode.STRICT` remains valid.
 
+==== Java versions in published metadata
+
+If a Java library is published with Gradle Module Metadata, the information which Java version it supports is encoded in the `org.gradle.jvm.version` attribute.
+By default, this attribute was set to what you configured in `java.targetCompatibility`.
+If that was not configured, it was set to the current Java version running Gradle.
+Changing the version of a particular compile task, e.g. `javaCompile.targetCompatibility` had no effect on that attribute, leading to wrong information if the attribute was not adjusted manually.
+This is now fixed and the attribute defaults to the setting of the compile task that is associated with the sources from which the published jar is built.
+In addition, there is a new `release` property (`java.release.set(...)` or `javaCompile.release.set(...)`) which can be used for Java versions 9+ and takes precedence over the `targetCompatibility` setting.
+
 ==== Ivy repositories with custom layouts
 
 Gradle versions from 6.0 to 6.3.x included could generate bad Gradle Module Metadata when publishing on an Ivy repository which had a custom repository layout.

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -239,7 +239,7 @@ public class JavaCompile extends AbstractCompile {
     private DefaultJavaCompileSpec createSpec() {
         List<File> sourcesRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) getStableSources().getAsFileTree());
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
-        boolean isModule = modularClasspathHandling.getInferModulePath().get() && JavaModuleDetector.isModuleSource(sourcesRoots);
+        boolean isModule = JavaModuleDetector.isModuleSource(modularClasspathHandling.getInferModulePath().get(), sourcesRoots);
 
         final DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions).create();
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -133,7 +133,7 @@ public class Javadoc extends SourceTask {
 
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
         List<File> sourcesRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) getSource());
-        boolean isModule = modularClasspathHandling.getInferModulePath().get() && JavaModuleDetector.isModuleSource(sourcesRoots);
+        boolean isModule = JavaModuleDetector.isModuleSource(modularClasspathHandling.getInferModulePath().get(), sourcesRoots);
 
         options.classpath(new ArrayList<>(javaModuleDetector.inferClasspath(isModule, getClasspath()).getFiles()));
         options.modulePath(new ArrayList<>(javaModuleDetector.inferModulePath(isModule, getClasspath()).getFiles()));

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -148,7 +148,16 @@ public class FxApp extends Application {
         given:
         goodCode()
         buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_7 // this will be ignored when compiling, but used for the TargetJvmVersion attribute
 compileJava.options.compilerArgs.addAll(['--release', '8'])
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+    }
+}
 """
 
         expect:
@@ -161,7 +170,18 @@ compileJava.options.compilerArgs.addAll(['--release', '8'])
         given:
         goodCode()
         buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
+java.release.set(6) // ignored
+compileJava.targetCompatibility = '10' // ignored
 compileJava.release.set(8)
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+    }
+}
 """
 
         expect:
@@ -174,7 +194,86 @@ compileJava.release.set(8)
         given:
         goodCode()
         buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
+compileJava.targetCompatibility = '10' // ignored
 java.release.set(8)
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+    }
+}
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile with release property and autoTargetJvmDisabled"() {
+        given:
+        goodCode()
+        buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
+compileJava.targetCompatibility = '10' // ignored
+java.release.set(8)
+java.disableAutoTargetJvm()
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert !configurations.compileClasspath.attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
+        assert !configurations.runtimeClasspath.attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
+    }
+}
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    def "compile with target compatibility"() {
+        given:
+        goodCode()
+        buildFile.text = buildFile.text.replace("<< '-Werror'", '') // warning: [options] bootstrap class path not set in conjunction with -source 8
+        buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_9 // ignored
+compileJava.targetCompatibility = '1.8'
+compileJava.sourceCompatibility = '1.8'
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+    }
+}
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    def "compile with target compatibility set in plugin extension"() {
+        given:
+        goodCode()
+        buildFile.text = buildFile.text.replace("<< '-Werror'", '') // warning: [options] bootstrap class path not set in conjunction with -source 8
+        buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+    }
+}
 """
 
         expect:
@@ -200,6 +299,33 @@ public class FailsOnJava8<T> {
 
         buildFile << """
 compileJava.options.compilerArgs.addAll(['--release', '8'])
+"""
+
+        expect:
+        fails 'compileJava'
+        output.contains(logStatement())
+        failure.assertHasErrorOutput("cannot find symbol")
+        failure.assertHasErrorOutput("method takeWhile")
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile fails when using newer API with release property"() {
+        given:
+        file("src/main/java/compile/test/FailsOnJava8.java") << '''
+package compile.test;
+
+import java.util.stream.Stream;
+import java.util.function.Predicate;
+
+public class FailsOnJava8<T> {
+    public Stream<T> takeFromStream(Stream<T> stream) {
+        return stream.takeWhile(Predicate.isEqual("foo"));
+    }
+}
+'''
+
+        buildFile << """
+java.release.set(8)
 """
 
         expect:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -179,6 +179,8 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 TaskProvider<JavaCompile> compileTask = createCompileJavaTask(sourceSet, sourceSet.getJava(), project);
                 createClassesTask(sourceSet, project);
 
+                configureTargetPlatform(compileTask, sourceSet, configurations, pluginConvention);
+
                 // If we are potentially compiling a module, we require JARs of all dependencies as they may potentially include an Automatic-Module-Name
                 if (JavaModuleDetector.isModuleSource(CompilationSourceDirs.inferSourceRoots((FileTreeInternal) sourceSet.getJava().getAsFileTree()))) {
                     Configuration compileClasspathConfiguration = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
@@ -195,6 +197,12 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 }));
             }
         });
+    }
+
+    private void configureTargetPlatform(TaskProvider<JavaCompile> compileTaskProvider, SourceSet sourceSet, ConfigurationContainer configurations, JavaPluginConvention pluginConvention) {
+        Action<ConfigurationInternal> configureDefaultTargetPlatform = JvmPluginsHelper.configureDefaultTargetPlatform(pluginConvention, false, compileTaskProvider);
+        ((ConfigurationInternal) configurations.getByName(sourceSet.getCompileClasspathConfigurationName())).beforeLocking(configureDefaultTargetPlatform);
+        ((ConfigurationInternal) configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName())).beforeLocking(configureDefaultTargetPlatform);
     }
 
     private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
@@ -275,8 +283,6 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         String apiElementsConfigurationName = sourceSet.getApiElementsConfigurationName();
         String runtimeElementsConfigurationName = sourceSet.getRuntimeElementsConfigurationName();
         String sourceSetName = sourceSet.toString();
-        Action<ConfigurationInternal> configureDefaultTargetPlatform = JvmPluginsHelper.configureDefaultTargetPlatform(convention);
-
 
         DeprecatableConfiguration compileConfiguration = (DeprecatableConfiguration) configurations.maybeCreate(compileConfigurationName);
         compileConfiguration.setVisible(false);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -171,7 +171,7 @@ public abstract class JavaPluginConvention {
     public abstract void disableAutoTargetJvm();
 
     /**
-     * Tells if automatic JVM targetting is enabled. When disabled, Gradle
+     * Tells if automatic JVM targeting is enabled. When disabled, Gradle
      * will not automatically try to get dependencies corresponding to the
      * same (or compatible) level as the target compatibility of this module.
      *

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -117,7 +117,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
         ConfigurationInternal plugins = (ConfigurationInternal) project.getConfigurations().create(SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME);
         plugins.setTransitive(false);
         plugins.setCanBeConsumed(false);
-        JvmPluginsHelper.configureAttributesForRuntimeClasspath(plugins, project.getConvention().getPlugin(JavaPluginConvention.class), objectFactory);
+        JvmPluginsHelper.configureAttributesForRuntimeClasspath(plugins, objectFactory);
 
         Configuration zinc = project.getConfigurations().create(ZINC_CONFIGURATION_NAME);
         zinc.setVisible(false);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -604,9 +604,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     protected JvmTestExecutionSpec createTestExecutionSpec() {
         JavaForkOptions javaForkOptions = getForkOptionsFactory().newJavaForkOptions();
         copyTo(javaForkOptions);
-        boolean testIsModule = getJavaModuleDetector().isModule(getTestClassesDirs());
-        boolean inferModulePath = modularClasspathHandling.getInferModulePath().get();
-        return new JvmTestExecutionSpec(getTestFramework(), getClasspath(), testIsModule && inferModulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
+        boolean testIsModule = getJavaModuleDetector().isModule(modularClasspathHandling.getInferModulePath().get(), getTestClassesDirs());
+        return new JvmTestExecutionSpec(getTestFramework(), getClasspath(), testIsModule, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
     }
 
     private Set<String> getPreviousFailedTestClasses() {


### PR DESCRIPTION
Before the 'release' property was ignored completely. The' targetCompatiblity' was always taken from the extension/convention and not from the task. Now we have the following setup which corresponds to how the compile task determines settings for the Java compiler:

- Use the release property of the task
- If that is not set, its conventions is the release property of the extension
- If that is not set, we take the targetCompatiblity of the task
- If that is not set, its convention is the targetCompatiblity of the extension/convention
- If that is not set, its convention is the current Java version

Follow up to: #12648
