### PR TITLE
Fix trivial copy paste error in CodeNarc plugin docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/codenarc_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/codenarc_plugin.adoc
@@ -38,15 +38,15 @@ The CodeNarc plugin adds the following tasks to the project:
 
 `codenarcMain` — link:{groovyDslPath}/org.gradle.api.plugins.quality.CodeNarc.html[CodeNarc]::
 +
-Runs CodeNarc against the production Java source files.
+Runs CodeNarc against the production Groovy source files.
 
 `codenarcTest` — link:{groovyDslPath}/org.gradle.api.plugins.quality.CodeNarc.html[CodeNarc]::
 +
-Runs CodeNarc against the test Java source files.
+Runs CodeNarc against the test Groovy source files.
 
 `codenarc__SourceSet__` — link:{groovyDslPath}/org.gradle.api.plugins.quality.CodeNarc.html[CodeNarc]::
 +
-Runs CodeNarc against the given source set's Java source files.
+Runs CodeNarc against the given source set's Groovy source files.
 
 === Dependencies added to other tasks
 


### PR DESCRIPTION
### Context
The documentation was referring to the CodeNarc analyising Java sources but it's analysing Groovy.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
