### PR TITLE
Serialize the result of `FileCollection.minus()` and `filter()` to the instant execution cache

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
@@ -103,7 +103,8 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
      * <p>Restricts the contents of this collection to those files which match the given criteria. The filtered
      * collection is live, so that it reflects any changes to this collection.</p>
      *
-     * <p>The given closure is passed the File as a parameter, and should return a boolean value.</p>
+     * <p>The given closure is passed the @{link File} as a parameter, and should return a boolean value. The closure should return {@code true}
+     * to include the file in the result and {@code false} to exclude the file from the result.</p>
      *
      * @param filterClosure The closure to use to select the contents of the filtered collection.
      * @return The filtered collection.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -485,8 +485,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor) {
-        intrinsicFiles.visitStructure(visitor);
+    protected void visitContents(FileCollectionStructureVisitor visitor) {
+        intrinsicFiles.visitContents(visitor);
     }
 
     @Override
@@ -1230,9 +1230,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
 
         @Override
-        public void visitStructure(FileCollectionStructureVisitor visitor) {
-            ResolvedFilesCollectingVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
-            visitContents(collectingVisitor);
+        protected void visitContents(FileCollectionStructureVisitor visitor) {
+            visitContents(new ResolvedFileCollectionVisitor(visitor));
         }
 
         private void visitContents(ResolvedFilesCollectingVisitor visitor) {

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
@@ -76,7 +76,7 @@ class ConfigurableFileTreeIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.assertTaskNotSkipped(":generate")
-        output.count("checking") == 22 // checked twice, once to snapshot and once when the task action runs
+        output.count("checking") == 22 // checked twice, once to snapshot and once when the task action runs. Should be memoized when snapshotting
         outputContains("checking a/a.txt")
         outputContains("checking d/d.txt")
         file("out.txt").text == "a.txt,c.txt,d.txt"
@@ -138,7 +138,7 @@ class ConfigurableFileTreeIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.assertTaskNotSkipped(":generate")
-        output.count("checking") == 20 // checked twice, once for snapshots and once when the task action runs
+        output.count("checking") == 20 // checked twice, once for snapshots and once when the task action runs. Should be memoized when snapshotting
         outputContains("checking a.txt")
         outputContains("checking d/e/f.txt")
         file("out.txt").text == "a.txt,c.txt,f.txt"

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/ConfigurableFileTreeIntegrationTest.groovy
@@ -143,4 +143,56 @@ class ConfigurableFileTreeIntegrationTest extends AbstractIntegrationSpec {
         outputContains("checking d/e/f.txt")
         file("out.txt").text == "a.txt,c.txt,f.txt"
     }
+
+    def "can filter the elements of a tree using a closure that receives pattern set"() {
+        given:
+        file('files/one.txt').createFile()
+        file('files/a/one.txt').createFile()
+        file('files/b/ignore.txt').createFile()
+        file('files/b/one.ignore').createFile()
+        buildFile << """
+            def files = fileTree(dir: 'files')
+            files.include('**/*one*')
+            def filtered = files.matching {
+                include('**/*.txt')
+                exclude('**/*ignore*')
+            }
+            task copy(type: Copy) {
+                from filtered
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'a/one.txt'
+        )
+
+        when:
+        file('files/a/more-ignore.txt').createFile() // not an input
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'a/one.txt'
+        )
+
+        when:
+        file('files/c/more-one.txt').createFile()
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'a/one.txt',
+            'c/more-one.txt'
+        )
+    }
 }

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -184,4 +184,46 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             'three.txt'
         )
     }
+
+    def "can filter the elements of a file collection using a closure"() {
+        given:
+        file('files/a/one.txt').createFile()
+        file('files/b/two.txt').createFile()
+        buildFile << """
+            def files = files('files/a', 'files/b').filter { it.name != 'b' }
+            task copy(type: Copy) {
+                from files
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.txt'
+        )
+
+        when:
+        file('files/b/ignore.txt').createFile()
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt'
+        )
+
+        when:
+        file('files/a/three.txt').createFile()
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'three.txt'
+        )
+    }
 }

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class FileTreeIntegrationTest extends AbstractIntegrationSpec {
+    def "can subtract the elements of another tree"() {
+        given:
+        file('files/one.txt').createFile()
+        file('files/a/two.txt').createFile()
+        file('files/b/ignore.txt').createFile()
+        buildFile << """
+            def files = fileTree(dir: 'files').minus(fileTree(dir: 'files/b'))
+            task copy(type: Copy) {
+                from files
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt' // does not preserve structure, but probably should
+        )
+
+        when:
+        file('file/b/other.txt').createFile() // not an input
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt'
+        )
+
+        when:
+        file('files/a/three.txt').createFile()
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt',
+            'three.txt'
+        )
+    }
+
+    def "can add files to the result of subtracting the elements of another tree"() {
+        given:
+        file('files/one.txt').createFile()
+        file('files/a/two.txt').createFile()
+        file('files/b/ignore.txt').createFile()
+        file('other/add-one.txt').createFile()
+        file('other/a/add-two.txt').createFile()
+        buildFile << """
+            def files = fileTree(dir: 'files').minus(fileTree(dir: 'files/b')).plus(fileTree(dir: 'other'))
+            task copy(type: Copy) {
+                from files
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt',
+            'add-one.txt',
+            'a/add-two.txt'
+        )
+
+        when:
+        file('file/b/other.txt').createFile() // not an input
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt',
+            'add-one.txt',
+            'a/add-two.txt'
+        )
+
+        when:
+        file('files/a/three.txt').createFile()
+        file('files/other/add-three.txt').createFile()
+        run 'copy'
+
+        then:
+        result.assertTaskNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'one.txt',
+            'two.txt',
+            'three.txt',
+            'add-one.txt',
+            'a/add-two.txt',
+            'add-three.txt'
+        )
+    }
+}

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
@@ -194,7 +194,7 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
         file('other/c/other-one.txt').createFile()
         file('other/c/other-ignore.txt').createFile()
         buildFile << """
-            def files = fileTree(dir: 'files').plus(fileTree(dir: 'other')).matching {
+            def files = files('files', 'other').asFileTree.matching {
                 include("**/*.txt")
                 exclude("**/*ignore*")
             }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -15,9 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import groovy.lang.Closure;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.FileCollection;
@@ -40,14 +38,12 @@ import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
-import org.gradle.util.CollectionUtils;
 import org.gradle.util.GUtil;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -255,33 +251,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public FileCollection filter(final Spec<? super File> filterSpec) {
-        final Predicate<File> predicate = filterSpec::isSatisfiedBy;
-        return new AbstractFileCollection(patternSetFactory) {
-            @Override
-            public String getDisplayName() {
-                return AbstractFileCollection.this.getDisplayName();
-            }
-
-            @Override
-            public void visitDependencies(TaskDependencyResolveContext context) {
-                AbstractFileCollection.this.visitDependencies(context);
-            }
-
-            @Override
-            public Set<File> getFiles() {
-                return CollectionUtils.filter(AbstractFileCollection.this, new LinkedHashSet<>(), filterSpec);
-            }
-
-            @Override
-            public boolean contains(File file) {
-                return AbstractFileCollection.this.contains(file) && predicate.apply(file);
-            }
-
-            @Override
-            public Iterator<File> iterator() {
-                return Iterators.filter(AbstractFileCollection.this.iterator(), predicate);
-            }
-        };
+        return new FilteredFileCollection(this, filterSpec);
     }
 
     /**
@@ -333,4 +303,5 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             return builder.build();
         }
     }
+
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -147,7 +147,7 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor) {
+    protected void visitContents(FileCollectionStructureVisitor visitor) {
         for (FileCollectionInternal element : getSourceCollections()) {
             element.visitStructure(visitor);
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -196,7 +196,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         }
 
         @Override
-        public void visitStructure(FileCollectionStructureVisitor visitor) {
+        protected void visitContents(FileCollectionStructureVisitor visitor) {
         }
 
         @Override
@@ -242,7 +242,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         }
 
         @Override
-        public void visitStructure(FileCollectionStructureVisitor visitor) {
+        protected void visitContents(FileCollectionStructureVisitor visitor) {
         }
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.tasks.util.PatternSet;
 
@@ -40,7 +41,20 @@ public interface FileCollectionStructureVisitor {
     }
 
     /**
-     * Called prior to visiting a file collection with the given spec, and allows this visitor to skip the collection.
+     * Called when starting to visit a file collection. Can return true to continue with visiting or false to skip this collection and its contents.
+     *
+     * <p>When a file collection represents a container of file collections, the children of the file collection are visited in order. Visiting a child works in the
+     * same way as visiting this collection, starting with a call to {@link #startVisit(FileCollectionInternal.Source, FileCollectionInternal)}.
+     *
+     * <p>When the file collection contains some other source of files then {@link #prepareForVisit(FileCollectionInternal.Source)} is called for each source in order.
+     */
+    default boolean startVisit(FileCollectionInternal.Source source, FileCollectionInternal fileCollection) {
+        return true;
+    }
+
+    /**
+     * Called prior to visiting a file source with the given spec, and allows this visitor to skip these files.
+     * A "file source" is some opaque source of files that is not a full {@link FileCollection}.
      *
      * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
      * resolved in parallel. However, all visiting is performed sequentially and in order.
@@ -53,7 +67,7 @@ public interface FileCollectionStructureVisitor {
     }
 
     /**
-     * Visits an opaque file collection element that cannot be visited in further detail.
+     * Visits an opaque file source that cannot be visited in further detail.
      */
     void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents);
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import com.google.common.collect.Iterators;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.specs.Spec;
+import org.gradle.util.CollectionUtils;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class FilteredFileCollection extends AbstractFileCollection {
+    private final AbstractFileCollection collection;
+    private final Spec<? super File> filterSpec;
+
+    public FilteredFileCollection(AbstractFileCollection collection, Spec<? super File> filterSpec) {
+        super(collection.patternSetFactory);
+        this.collection = collection;
+        this.filterSpec = filterSpec;
+    }
+
+    public AbstractFileCollection getCollection() {
+        return collection;
+    }
+
+    public Spec<? super File> getFilterSpec() {
+        return filterSpec;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "file collection";
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        collection.visitDependencies(context);
+    }
+
+    @Override
+    public Set<File> getFiles() {
+        return CollectionUtils.filter(collection, new LinkedHashSet<>(), filterSpec);
+    }
+
+    @Override
+    public boolean contains(File file) {
+        return collection.contains(file) && filterSpec.isSatisfiedBy(file);
+    }
+
+    @Override
+    public Iterator<File> iterator() {
+        return Iterators.filter(collection.iterator(), filterSpec::isSatisfiedBy);
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/SubtractingFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/SubtractingFileCollection.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class SubtractingFileCollection extends AbstractFileCollection {
+    private final AbstractFileCollection left;
+    private final FileCollection right;
+
+    public SubtractingFileCollection(AbstractFileCollection left, FileCollection right) {
+        super(left.patternSetFactory);
+        this.left = left;
+        this.right = right;
+    }
+
+    public AbstractFileCollection getLeft() {
+        return left;
+    }
+
+    public FileCollection getRight() {
+        return right;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "file collection";
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        left.visitDependencies(context);
+    }
+
+    @Override
+    public Set<File> getFiles() {
+        Set<File> files = new LinkedHashSet<File>(left.getFiles());
+        files.removeAll(right.getFiles());
+        return files;
+    }
+
+    @Override
+    public boolean contains(File file) {
+        return left.contains(file) && !right.contains(file);
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -96,7 +96,7 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor) {
+    protected void visitContents(FileCollectionStructureVisitor visitor) {
         tree.visitStructure(visitor, this);
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
@@ -63,6 +63,11 @@ public class FilteredMinimalFileTree implements MinimalFileTree, FileSystemMirro
     public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
         tree.visitStructure(new FileCollectionStructureVisitor() {
             @Override
+            public boolean startVisit(FileCollectionInternal.Source source, FileCollectionInternal fileCollection) {
+                throw new IllegalStateException();
+            }
+
+            @Override
             public VisitType prepareForVisit(FileCollectionInternal.Source source) {
                 return visitor.prepareForVisit(source);
             }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -155,35 +155,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         sum.getFiles() == toLinkedSet(file1, file2, file3)
     }
 
-    void canSubtractCollections() {
-        File file1 = new File("f1")
-        File file2 = new File("f2")
-        File file3 = new File("f3")
-        TestFileCollection collection1 = new TestFileCollection(file1, file2)
-        TestFileCollection collection2 = new TestFileCollection(file2, file3)
-
-        when:
-        FileCollection difference = collection1.minus(collection2)
-
-        then:
-        assertThat(difference.getFiles(), equalTo(toLinkedSet(file1)))
-    }
-
-    def "can subtract a collection using - operator"() {
-        File file1 = new File("f1")
-        File file2 = new File("f2")
-        File file3 = new File("f3")
-        TestFileCollection collection1 = new TestFileCollection(file1, file2)
-        TestFileCollection collection2 = new TestFileCollection(file2, file3)
-
-        when:
-        FileCollection difference = collection1 - collection2
-
-        then:
-        difference.files == toLinkedSet(file1)
-    }
-
-    def "can subtract a list of collection"() {
+    def "can subtract a collection"() {
         File file1 = new File("f1")
         File file2 = new File("f2")
         File file3 = new File("f3")
@@ -197,7 +169,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         difference.files == toLinkedSet(file1)
     }
 
-    def "can subtract a list of collections using - operator"() {
+    def "can subtract a collections using - operator"() {
         File file1 = new File("f1")
         File file2 = new File("f2")
         File file3 = new File("f3")
@@ -209,6 +181,24 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
 
         then:
         difference.files == toLinkedSet(file1)
+    }
+
+    def "can visit the result of subtracting a collection"() {
+        def visitor = Mock(FileCollectionStructureVisitor)
+        File file1 = new File("f1")
+        File file2 = new File("f2")
+        File file3 = new File("f3")
+        def collection1 = new TestFileCollection(file1, file2)
+        def collection2 = new TestFileCollection(file2, file3)
+        def difference = collection1.minus(collection2)
+
+        when:
+        difference.visitStructure(visitor)
+
+        then:
+        1 * visitor.startVisit(FileCollectionInternal.OTHER, difference) >> true
+        1 * visitor.visitCollection(FileCollectionInternal.OTHER, difference)
+        0 * visitor._
     }
 
     void canConvertToCollectionTypes() {
@@ -336,7 +326,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         elements.valueProducedByTask
     }
 
-    void visitsSelfAsLeafCollection() {
+    void "visits self when listener requests contents"() {
         def collection = new TestFileCollection()
         def visitor = Mock(FileCollectionStructureVisitor)
 
@@ -344,12 +334,12 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.Visit
+        1 * visitor.startVisit(FileCollectionInternal.OTHER, collection) >> true
         1 * visitor.visitCollection(FileCollectionInternal.OTHER, collection)
         0 * visitor._
     }
 
-    void doesNotVisitSelfWhenVisitorIsNotInterested() {
+    void "does not visit self when listener does not want contents"() {
         def collection = new TestFileCollection()
         def visitor = Mock(FileCollectionStructureVisitor)
 
@@ -357,7 +347,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.NoContents
+        1 * visitor.startVisit(FileCollectionInternal.OTHER, collection) >> false
         0 * visitor._
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -238,33 +238,49 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
     }
 
     void canFilterContentsOfCollectionUsingClosure() {
-        File file1 = new File("f1")
-        File file2 = new File("f2")
+        def file1 = new File("f1")
+        def file2 = new File("f2")
 
-        TestFileCollection collection = new TestFileCollection(file1, file2)
-        FileCollection filtered = collection.filter(TestUtil.toClosure("{f -> f.name == 'f1'}"))
+        def collection = new TestFileCollection(file1, file2)
+        def filtered = collection.filter { f -> f.name == 'f1' }
 
         expect:
-        assertThat(filtered.getFiles(), equalTo(toSet(file1)))
+        filtered.files == toSet(file1)
     }
 
     void filteredCollectionIsLive() {
-        File file1 = new File("f1")
-        File file2 = new File("f2")
-        File file3 = new File("dir/f1")
-        TestFileCollection collection = new TestFileCollection(file1, file2)
+        def file1 = new File("f1")
+        def file2 = new File("f2")
+        def file3 = new File("dir/f1")
+        def collection = new TestFileCollection(file1, file2)
 
         when:
-        FileCollection filtered = collection.filter(TestUtil.toClosure("{f -> f.name == 'f1'}"))
+        def filtered = collection.filter { f -> f.name == 'f1' }
 
         then:
-        assertThat(filtered.getFiles(), equalTo(toSet(file1)))
+        filtered.files == toSet(file1)
 
         when:
         collection.files.add(file3)
 
         then:
-        assertThat(filtered.getFiles(), equalTo(toSet(file1, file3)))
+        filtered.files == toSet(file1, file3)
+    }
+
+    void "can visit filtered collection"() {
+        def file1 = new File("f1")
+        def file2 = new File("f2")
+        def collection = new TestFileCollection(file1, file2)
+        def filtered = collection.filter { f -> f.name == 'f1' }
+        def visitor = Mock(FileCollectionStructureVisitor)
+
+        when:
+        filtered.visitStructure(visitor)
+
+        then:
+        1 * visitor.startVisit(FileCollectionInternal.OTHER, filtered) >> true
+        1 * visitor.visitCollection(FileCollectionInternal.OTHER, filtered)
+        0 * _
     }
 
     void hasNoDependencies() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
@@ -123,10 +123,10 @@ class CompositeFileCollectionTest extends Specification {
         trees[0].dir == dir1
         trees[1].dir == dir2
 
-        1 * source1.visitStructure(_) >> { FileCollectionStructureVisitor visitor ->
+        1 * source1.visitContents(_) >> { FileCollectionStructureVisitor visitor ->
             visitor.visitFileTree(dir1, Stub(PatternSet), source1)
         }
-        1 * source2.visitStructure(_) >> { FileCollectionStructureVisitor visitor ->
+        1 * source2.visitContents(_) >> { FileCollectionStructureVisitor visitor ->
             visitor.visitFileTree(dir2, Stub(PatternSet), source2)
         }
         0 * _

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFiles
 import org.gradle.api.internal.artifacts.transform.TransformationNode
@@ -23,6 +24,7 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.file.SubtractingFileCollection
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.file.collections.MinimalFileSet
 import org.gradle.api.tasks.util.PatternSet
@@ -65,6 +67,7 @@ class FileCollectionCodec(
                     when (element) {
                         is File -> element
                         is TransformationNode -> Callable { element.transformedSubject.get().files }
+                        is SubtractingFileCollectionSpec -> element.left.minus(element.right)
                         is FileTree -> element
                         else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
                     }
@@ -80,8 +83,22 @@ class FileCollectionCodec(
 
 
 private
+class
+SubtractingFileCollectionSpec(val left: FileCollection, val right: FileCollection)
+
+
+private
 class CollectingVisitor : FileCollectionStructureVisitor {
     val elements: MutableSet<Any> = mutableSetOf()
+    override fun startVisit(source: FileCollectionInternal.Source, fileCollection: FileCollectionInternal): Boolean {
+        if (fileCollection is SubtractingFileCollection) {
+            // TODO - when left and right are both static then we could calculate the difference here and serialize the result
+            elements.add(SubtractingFileCollectionSpec(fileCollection.left, fileCollection.right))
+            return false
+        } else {
+            return true
+        }
+    }
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
         return if (source is ConsumerProvidedVariantFiles && source.scheduledNodes.isNotEmpty()) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -24,9 +24,11 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.file.FilteredFileCollection
 import org.gradle.api.internal.file.SubtractingFileCollection
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.file.collections.MinimalFileSet
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
@@ -68,6 +70,7 @@ class FileCollectionCodec(
                         is File -> element
                         is TransformationNode -> Callable { element.transformedSubject.get().files }
                         is SubtractingFileCollectionSpec -> element.left.minus(element.right)
+                        is FilteredFileCollectionSpec -> element.collection.filter(element.filter)
                         is FileTree -> element
                         else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
                     }
@@ -88,12 +91,21 @@ SubtractingFileCollectionSpec(val left: FileCollection, val right: FileCollectio
 
 
 private
+class
+FilteredFileCollectionSpec(val collection: FileCollection, val filter: Spec<in File>)
+
+
+private
 class CollectingVisitor : FileCollectionStructureVisitor {
     val elements: MutableSet<Any> = mutableSetOf()
     override fun startVisit(source: FileCollectionInternal.Source, fileCollection: FileCollectionInternal): Boolean {
         if (fileCollection is SubtractingFileCollection) {
-            // TODO - when left and right are both static then we could calculate the difference here and serialize the result
+            // TODO - when left and right are both static then we should serialize the current contents of the collection
             elements.add(SubtractingFileCollectionSpec(fileCollection.left, fileCollection.right))
+            return false
+        } else if (fileCollection is FilteredFileCollection) {
+            // TODO - when the collection is static then we should serialize the current contents of the collection
+            elements.add(FilteredFileCollectionSpec(fileCollection.collection, fileCollection.filterSpec))
             return false
         } else {
             return true


### PR DESCRIPTION

### Context

Improve the serialization of `FileCollection` instances so that collections created using `minus()` and `filter()` are correctly deserialized.

Also add some test coverage for using `FileTree.matching()` with instant execution, which was fixed a while ago.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
