### PR TITLE
Always prefer Java version configured in release over target/source

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -115,6 +115,9 @@ public enum JavaVersion {
         if (value instanceof JavaVersion) {
             return (JavaVersion) value;
         }
+        if (value instanceof Integer) {
+            return getVersionForMajor((Integer) value);
+        }
 
         String name = value.toString();
 

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r64/ToolingApiIdeaModelJavaVersionCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r64/ToolingApiIdeaModelJavaVersionCrossVersionSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r64
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.tooling.model.idea.IdeaProject
+
+@TargetGradleVersion(">=6.4")
+class ToolingApiIdeaModelJavaVersionCrossVersionSpec extends ToolingApiSpecification {
+
+    def "gets language level from release property if set"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+            java.targetCompatibility = JavaVersion.VERSION_1_10
+            java.sourceCompatibility = JavaVersion.VERSION_1_10
+            java.release.set(8)
+        """
+
+        when:
+        def ideaProject = loadIdeaProjectModel()
+
+        then:
+        ideaProject.javaLanguageSettings.languageLevel == JavaVersion.VERSION_1_8
+        ideaProject.javaLanguageSettings.targetBytecodeVersion == JavaVersion.VERSION_1_8
+    }
+
+    private IdeaProject loadIdeaProjectModel() {
+        withConnection { connection -> connection.getModel(IdeaProject) }
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -251,9 +251,12 @@ public class JavaCompile extends AbstractCompile {
             compileOptions.setSourcepath(getProjectLayout().files(sourcesRoots));
         }
         spec.setAnnotationProcessorPath(compileOptions.getAnnotationProcessorPath() == null ? ImmutableList.of() : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
-        spec.setRelease(getRelease().getOrNull());
-        spec.setTargetCompatibility(getTargetCompatibility());
-        spec.setSourceCompatibility(getSourceCompatibility());
+        if (getRelease().isPresent()) {
+            spec.setRelease(getRelease().get());
+        } else {
+            spec.setTargetCompatibility(getTargetCompatibility());
+            spec.setSourceCompatibility(getSourceCompatibility());
+        }
         spec.setCompileOptions(compileOptions);
         spec.setSourcesRoots(sourcesRoots);
         if (((JavaToolChainInternal) getToolChain()).getJavaVersion().compareTo(JavaVersion.VERSION_1_8) < 0) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -353,12 +354,18 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 conventionMapping.map("sourceCompatibility", new Callable<Object>() {
                     @Override
                     public Object call() {
+                        if (compile.getRelease().isPresent()) {
+                            return JavaVersion.toVersion(compile.getRelease().get()).toString();
+                        }
                         return javaConvention.getSourceCompatibility().toString();
                     }
                 });
                 conventionMapping.map("targetCompatibility", new Callable<Object>() {
                     @Override
                     public Object call() {
+                        if (compile.getRelease().isPresent()) {
+                            return JavaVersion.toVersion(compile.getRelease().get()).toString();
+                        }
                         return javaConvention.getTargetCompatibility().toString();
                     }
                 });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -21,11 +21,13 @@ import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.java.archives.internal.DefaultManifest;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.reporting.ReportingExtension;
@@ -51,6 +53,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     private JavaVersion srcCompat;
     private JavaVersion targetCompat;
+    private Provider<Integer> internalReleaseFlagProperty = Providers.notDefined();
 
     private boolean autoTargetJvm = true;
 
@@ -60,6 +63,10 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
         docsDirName = "docs";
         testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
         testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;
+    }
+
+    void internalReleaseFlagProperty(Provider<Integer> release) {
+        this.internalReleaseFlagProperty = release;
     }
 
     @Override
@@ -93,7 +100,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     @Override
     public JavaVersion getSourceCompatibility() {
-        return srcCompat != null ? srcCompat : JavaVersion.current();
+        return internalReleaseFlagProperty.isPresent() ? JavaVersion.toVersion(internalReleaseFlagProperty.get()) : srcCompat != null ? srcCompat : JavaVersion.current();
     }
 
     @Override
@@ -108,7 +115,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     @Override
     public JavaVersion getTargetCompatibility() {
-        return targetCompat != null ? targetCompat : getSourceCompatibility();
+        return internalReleaseFlagProperty.isPresent() ? JavaVersion.toVersion(internalReleaseFlagProperty.get()) : targetCompat != null ? targetCompat : getSourceCompatibility();
     }
 
     @Override
@@ -123,7 +130,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     @Override
     public Manifest manifest() {
-        return manifest(Actions.<Manifest>doNothing());
+        return manifest(Actions.doNothing());
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -66,6 +66,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         this.project = project;
         this.modularClasspathHandling = project.getObjects().newInstance(DefaultModularClasspathHandling.class);
         this.release = project.getObjects().property(Integer.class);
+        ((DefaultJavaPluginConvention) convention).internalReleaseFlagProperty(release);
     }
 
     @Override

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.java.archives.Manifest
 import org.gradle.api.java.archives.internal.DefaultManifest
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.internal.DefaultJavaPluginConvention
+import org.gradle.api.plugins.internal.DefaultJavaPluginExtension
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import spock.lang.Specification
 import org.gradle.util.TestUtil
@@ -54,12 +55,23 @@ class DefaultJavaPluginConventionTest extends Specification {
         convention.testReportDirName == 'tests'
     }
 
-   def sourceCompatibilityDefaultsToCurentJvmVersion() {
+   def "source and targe compatibility default to curent jvm version"() {
         given:
-        JavaVersion currentJvmVersion = JavaVersion.toVersion(System.properties["java.version"]);
+        JavaVersion currentJvmVersion = JavaVersion.toVersion(System.properties["java.version"])
         expect:
         convention.sourceCompatibility == currentJvmVersion
         convention.targetCompatibility == currentJvmVersion
+    }
+
+    def "source and target compatibility default to release if set"() {
+        given:
+        JavaPluginExtension extension = new DefaultJavaPluginExtension(convention, project)
+        project.getExtensions().add("java", extension)
+        extension.release.set(8)
+
+        expect:
+        convention.sourceCompatibility == JavaVersion.VERSION_1_8
+        convention.targetCompatibility == JavaVersion.VERSION_1_8
     }
 
     @Test

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -557,5 +558,22 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task.taskDependencies.getDependencies(task)*.path as Set == [':middle:build', ':app:buildDependents'] as Set
+    }
+
+    void "source and target compatibility of compile tasks default to release if set"() {
+        given:
+        project.pluginManager.apply(JavaPlugin)
+        def compileJava = project.tasks.named("compileJava", AbstractCompile).get()
+        def testCompileJava = project.tasks.named("compileTestJava", AbstractCompile).get()
+
+        when:
+        compileJava.release.set(8)
+        testCompileJava.release.set(9)
+
+        then:
+        compileJava.targetCompatibility == "1.8"
+        compileJava.sourceCompatibility == "1.8"
+        testCompileJava.targetCompatibility == "1.9"
+        testCompileJava.sourceCompatibility == "1.9"
     }
 }


### PR DESCRIPTION
This is needed for backwards compatibility with the tooling API and plugins that rely on the old API to get the Java version of a project/task.

Follow up to: #12648 