### PR TITLE
Remove superfluous `test` phase

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -263,14 +263,14 @@ abstract class FileContentGenerator {
                 cleanBuild {
                   tasks = ["clean", "build"]
                   maven {
-                    targets = ["clean", "test", "package", "-T", "4"]
+                    targets = ["clean", "package", "-T", "4"]
                   }
                 }
 
                 cleanBuildCached {
                   tasks = ["clean", "build"]
                   maven {
-                    targets = ["clean", "test", "package", "-T", "4"]
+                    targets = ["clean", "package", "-T", "4"]
                   }
                   gradle-args = ["--build-cache"]
                 }


### PR DESCRIPTION
Using this scenario currently leads to compiling/executing twice
as `package` will execute the `test` phase as well.
