### PR TITLE
Add warning when user logs at `--debug` level

### DIFF
--- a/subprojects/bootstrap/src/main/java/org/gradle/launcher/bootstrap/EntryPoint.java
+++ b/subprojects/bootstrap/src/main/java/org/gradle/launcher/bootstrap/EntryPoint.java
@@ -21,6 +21,8 @@ import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
 import org.gradle.internal.logging.text.StreamingStyledTextOutputFactory;
 
+import javax.annotation.CheckForNull;
+
 /**
  * An entry point is the point at which execution will never return from.
  * <p>
@@ -75,6 +77,7 @@ public abstract class EntryPoint {
             this.failure = failure;
         }
 
+        @CheckForNull
         public Throwable getFailure() {
             return failure;
         }

--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -48,9 +48,9 @@ To generate the user manual and see your changes, run:
     
 This will generate:
 
- - A multi-page HTML manual in `build/docs/userguide` for each chapter. There is a 1-1 mapping from `.adoc` file to `.html` file.
- - A single-page HTML manual at `build/docs/userguide/userguide_single.html`
- - A PDF at `build/docs/userguide/userguide.pdf`
+ - A multi-page HTML manual in `build/working/usermanual/render-multi/` for each chapter. There is a 1-1 mapping from `.adoc` file to `.html` file.
+ - A single-page HTML manual at `build/working/usermanual/render-single/userguide_single.html`
+ - A PDF at `build/working/usermanual/render-single/userguide_single.pdf`
 
 Note that PNG files in the source are generated from ".graphml" files in the same directory.  You can edit these files
 with tools like [yEd](http://www.yworks.com/en/products_yed_about.html) and then generate the associated PNG.
@@ -142,7 +142,7 @@ To build it, run:
 ./gradlew :docs:dslHtml
 ```
 
-The output is available under `build/docs/dsl`.
+The output is available under `build/working/dsl`.
 
 ### Useful docbook tags
 
@@ -168,7 +168,7 @@ To build these, run:
 
     ./gradlew :docs:javadoc
 
-The output is available within `build/docs/javadoc`.
+The output is available within `build/javadoc`.
 
 ## Building all the docs
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -36,6 +36,19 @@ details of 2
 ## n
 -->
 
+## Security Improvements
+
+During our investigation of a recent security vulnerability in the [Plugin Portal Publish Plugin](https://blog.gradle.org/plugin-portal-update) we became aware of how much potentially sensitive information is logged when Gradle is executed at `--debug` level.
+This information can be publicly exposed when Gradle builds are executed on public CI like Travis CI, CircleCI, & GitHub Actions where build logs are publicly visible.
+This information may include sensitive credentials and authentication tokens.
+Much of this sensitive information logging occurs deep in components of the JVM and other libraries outside the control of Gradle.
+While debugging, this information may be inherently useful for build maintainers.
+
+To strike a balance between the security risks of logging sensitive information and the needs of build maintainers who may find this information useful,
+this version of Gradle now warns users about the risks of using `--debug` at the beginning and end of the log on every build.
+
+We recommend plugin maintainers avoid logging sensitive information if possible, and if it's not possible, that all sensitive information be logged exclusively at `--debug` level and no higher.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -53,6 +53,13 @@ You can use the command line switches shown in <<#logLevelCommandLineOptions, Lo
 | `-d` or `--debug` | DEBUG and higher (that is, all log messages)
 |===
 
+[CAUTION]
+====
+
+The DEBUG log level can <<#sec:debug_security, expose security sensitive information to the console>>.
+
+====
+
 [[stacktraces]]
 
 === Stacktrace command-line options
@@ -66,6 +73,30 @@ The full stacktraces are printed out. This option renders stacktraces for deprec
 &lt;No stacktrace options&gt;::
 No stacktraces are printed to the console in case of a build error (e.g. a compile error). Only in case of internal exceptions will stacktraces be printed. If the `DEBUG` log level is chosen, truncated stacktraces are always printed.
 
+[[sec:debug_security]]
+
+== Debug Security
+
+Running Gradle with the DEBUG log level can expose security sensitive information to the console.
+This information can include (but is not limited to):
+
+- Environment variables
+- Private repository credentials
+- Build cache & Gradle Enterprise Credentials
+- https://plugins.gradle.org/[Plugin Portal] publishing credentials
+
+The DEBUG log level should *not* be used when running on public CI (eg. Travis CI, Circle CI, GitHub Actions, ect...).
+Public CI logs are usually world-viewable and https://edoverflow.com/2019/ci-knew-there-would-be-bugs-here/[can expose this sensitive information].
+Depending upon your organization's threat model, logging sensitive credentials in private CI may also be a vulnerability.
+Please discuss this with your organization's security team.
+
+Some CI frameworks attempt to scrub sensitive credentials from logs, however, this is historically imperfect and usually only scrubs exact-matches of pre-configured secrets.
+
+[[debug_security_plugins]]
+=== Published Plugins
+
+Plugin authors should be aware that logging sensitive information at a level higher than DEBUG in their plugin is a security vulnerability.
+If you believe that your Gradle Plugin may be exposing sensitive information, please contact mailto:security@gradle.com[security@gradle.com] for disclosure assistance.
 
 [[sec:sending_your_own_log_messages]]
 == Writing your own log messages

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
@@ -20,6 +20,10 @@ A Gradle plugin packages up reusable pieces of build logic, which can be used ac
 You can implement a Gradle plugin in any language you like, provided the implementation ends up compiled as JVM bytecode. In our examples, we are going to use Groovy as the implementation language. Groovy, Java or Kotlin are all good choices as the language to use to implement a plugin, as the Gradle API has been designed to work well with these languages. In general, a plugin implemented using Java or Kotlin, which are statically typed, will perform better than the same plugin implemented using Groovy.
 
 
+CAUTION: When developing Gradle Plugins it is important to be cautions of the information the plugin logs.
+For publicly published plugins, logging sensitive information (eg. credentials, tokens, certain environment variables), at log levels above `--debug` is considered a security vulnerability.
+Build logs for Public CI (eg. Travis CI, Circle CI, GitHub Actions, ect...) are world-viewable and https://edoverflow.com/2019/ci-knew-there-would-be-bugs-here/[can expose this sensitive information].
+
 [[sec:packaging_a_plugin]]
 == Packaging a plugin
 

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
@@ -21,7 +21,7 @@ You can implement a Gradle plugin in any language you like, provided the impleme
 
 
 CAUTION: When developing Gradle Plugins it is important to be cautious of the information the plugin logs.
-For publicly published plugins, logging sensitive information (eg. credentials, tokens, certain environment variables), at log levels above `--debug` is considered a security vulnerability.
+For publicly published plugins, logging sensitive information (eg. credentials, tokens, certain environment variables), at log levels above DEBUG is <<logging.adoc#debug_security_plugins,considered a security vulnerability>>.
 Build logs for Public CI (eg. Travis CI, Circle CI, GitHub Actions, ect...) are world-viewable and https://edoverflow.com/2019/ci-knew-there-would-be-bugs-here/[can expose this sensitive information].
 
 [[sec:packaging_a_plugin]]

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
@@ -20,7 +20,7 @@ A Gradle plugin packages up reusable pieces of build logic, which can be used ac
 You can implement a Gradle plugin in any language you like, provided the implementation ends up compiled as JVM bytecode. In our examples, we are going to use Groovy as the implementation language. Groovy, Java or Kotlin are all good choices as the language to use to implement a plugin, as the Gradle API has been designed to work well with these languages. In general, a plugin implemented using Java or Kotlin, which are statically typed, will perform better than the same plugin implemented using Groovy.
 
 
-CAUTION: When developing Gradle Plugins it is important to be cautions of the information the plugin logs.
+CAUTION: When developing Gradle Plugins it is important to be cautious of the information the plugin logs.
 For publicly published plugins, logging sensitive information (eg. credentials, tokens, certain environment variables), at log levels above `--debug` is considered a security vulnerability.
 Build logs for Public CI (eg. Travis CI, Circle CI, GitHub Actions, ect...) are world-viewable and https://edoverflow.com/2019/ci-knew-there-would-be-bugs-here/[can expose this sensitive information].
 

--- a/subprojects/docs/src/snippets/userguide/tutorial/logging/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/tutorial/logging/groovy/build.gradle
@@ -5,7 +5,7 @@ logger.warn('A warning log message.')
 logger.lifecycle('A lifecycle info log message.')
 logger.info('An info log message.')
 logger.debug('A debug log message.')
-logger.trace('A trace log message.')
+logger.trace('A trace log message.') // Gradle never logs TRACE level logs
 // end::use-logger[]
 
 // tag::use-logger-placeholder[]

--- a/subprojects/docs/src/snippets/userguide/tutorial/logging/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/tutorial/logging/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ logger.warn("A warning log message.")
 logger.lifecycle("A lifecycle info log message.")
 logger.info("An info log message.")
 logger.debug("A debug log message.")
-logger.trace("A trace log message.")
+logger.trace("A trace log message.") // Gradle never logs TRACE level logs
 // end::use-logger[]
 
 // tag::use-logger-placeholder[]

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -100,6 +100,28 @@ ${getReleaseNotesDetailsMessage(distribution.version)}
         markerFile.exists()
     }
 
+    def "when debug logging is enabled, debug warning is logged first"() {
+        given:
+        def expectedWarning = """
+###################################################################################
+#                                SECURITY WARNING!                                #
+#                                                                                 #
+#    Enabling the debug level logger can leak security sensitive information!     #
+#         We DO NOT advise enabling the debug logger in CI/CD environments.       #
+#    Doing so in public CI/CD (eg. Travis, CircleCI, GitHub Actions) can expose   #
+#         security sensitive information & secrets to malicious actors.           #
+#                                                                                 #
+###################################################################################
+"""
+        withDebugLogging()
+
+        when:
+        succeeds()
+
+        then:
+        outputContains(expectedWarning)
+    }
+
     static String readReleaseFeatures() {
         InputStream inputStream = NotificationsIntegrationTest.class.getClassLoader().getResourceAsStream('release-features.txt')
         StringWriter writer = new StringWriter()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli
 
 import org.apache.commons.io.IOUtils
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import org.gradle.util.GradleVersion
@@ -24,6 +25,8 @@ import org.gradle.util.ToBeImplemented
 import spock.lang.Ignore
 
 class NotificationsIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry()
 
     def customGradleUserHomeDir = testDirectoryProvider.getTestDirectory().file('user-home')
     def markerFile
@@ -103,15 +106,13 @@ ${getReleaseNotesDetailsMessage(distribution.version)}
     def "when debug logging is enabled, debug warning is logged first"() {
         given:
         def expectedWarning = """
-###################################################################################
-#                                SECURITY WARNING!                                #
-#                                                                                 #
-#    Enabling the debug level logger can leak security sensitive information!     #
-#         We DO NOT advise enabling the debug logger in CI/CD environments.       #
-#    Doing so in public CI/CD (eg. Travis, CircleCI, GitHub Actions) can expose   #
-#         security sensitive information & secrets to malicious actors.           #
-#                                                                                 #
-###################################################################################
+#############################################################################
+   WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+   Debug level logging will leak security sensitive information!
+
+   ${DOCUMENTATION_REGISTRY.getDocumentationFor("logging", "debug_security")}
+#############################################################################
 """
         withDebugLogging()
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DebugLoggerWarningAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DebugLoggerWarningAction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.Action;
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.logging.configuration.LoggingConfiguration;
+import org.gradle.launcher.bootstrap.ExecutionListener;
+
+import java.util.Objects;
+
+final class DebugLoggerWarningAction implements Action<ExecutionListener> {
+
+    static final String WARNING_MESSAGE_BODY;
+
+    static {
+        @SuppressWarnings("StringBufferReplaceableByString") // Readability is better this way.
+        final StringBuilder sb = new StringBuilder();
+        sb.append("###################################################################################\n");
+        sb.append("#                                SECURITY WARNING!                                #\n");
+        sb.append("#                                                                                 #\n");
+        sb.append("#    Enabling the debug level logger can leak security sensitive information!     #\n");
+        sb.append("#         We DO NOT advise enabling the debug logger in CI/CD environments.       #\n");
+        sb.append("#    Doing so in public CI/CD (eg. Travis, CircleCI, GitHub Actions) can expose   #\n");
+        sb.append("#         security sensitive information & secrets to malicious actors.           #\n");
+        sb.append("#                                                                                 #\n");
+        sb.append("###################################################################################\n");
+        WARNING_MESSAGE_BODY = sb.toString();
+    }
+
+
+    private final Logger logger;
+    private final LoggingConfiguration loggingConfiguration;
+    private final Action<ExecutionListener> action;
+
+    DebugLoggerWarningAction(
+        LoggingConfiguration loggingConfiguration,
+        Action<ExecutionListener> action
+    ) {
+        this(Logging.getLogger(DebugLoggerWarningAction.class), loggingConfiguration, action);
+    }
+
+    @VisibleForTesting
+    DebugLoggerWarningAction(
+        Logger logger,
+        LoggingConfiguration loggingConfiguration,
+        Action<ExecutionListener> action
+    ) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.loggingConfiguration = Objects.requireNonNull(loggingConfiguration, "loggingConfiguration");
+        this.action = Objects.requireNonNull(action, "action");
+    }
+
+    private void logWarningIfEnabled() {
+        if (LogLevel.DEBUG.equals(loggingConfiguration.getLogLevel())) {
+            logger.lifecycle("\n" + WARNING_MESSAGE_BODY);
+        }
+    }
+
+    @Override
+    public void execute(ExecutionListener executionListener) {
+        // Add to the top of the log file.
+        logWarningIfEnabled();
+        try {
+            action.execute(executionListener);
+        } finally {
+            // Add again to the bottom of the log file.
+            logWarningIfEnabled();
+        }
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DebugLoggerWarningAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DebugLoggerWarningAction.java
@@ -18,6 +18,7 @@ package org.gradle.launcher.cli;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.Action;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -28,21 +29,21 @@ import java.util.Objects;
 
 final class DebugLoggerWarningAction implements Action<ExecutionListener> {
 
+    static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
     static final String WARNING_MESSAGE_BODY;
 
     static {
         @SuppressWarnings("StringBufferReplaceableByString") // Readability is better this way.
         final StringBuilder sb = new StringBuilder();
-        sb.append("###################################################################################\n");
-        sb.append("#                                SECURITY WARNING!                                #\n");
-        sb.append("#                                                                                 #\n");
-        sb.append("#    Enabling the debug level logger can leak security sensitive information!     #\n");
-        sb.append("#         We DO NOT advise enabling the debug logger in CI/CD environments.       #\n");
-        sb.append("#    Doing so in public CI/CD (eg. Travis, CircleCI, GitHub Actions) can expose   #\n");
-        sb.append("#         security sensitive information & secrets to malicious actors.           #\n");
-        sb.append("#                                                                                 #\n");
-        sb.append("###################################################################################\n");
-        WARNING_MESSAGE_BODY = sb.toString();
+        sb.append('\n');
+        sb.append("#############################################################################\n");
+        sb.append("   WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING\n");
+        sb.append('\n');
+        sb.append("   Debug level logging will leak security sensitive information!\n");
+        sb.append('\n');
+        sb.append("   %s\n");
+        sb.append("#############################################################################\n");
+        WARNING_MESSAGE_BODY = String.format(sb.toString(), DOCUMENTATION_REGISTRY.getDocumentationFor("logging", "debug_security"));
     }
 
 
@@ -70,7 +71,7 @@ final class DebugLoggerWarningAction implements Action<ExecutionListener> {
 
     private void logWarningIfEnabled() {
         if (LogLevel.DEBUG.equals(loggingConfiguration.getLogLevel())) {
-            logger.lifecycle("\n" + WARNING_MESSAGE_BODY);
+            logger.lifecycle(WARNING_MESSAGE_BODY);
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -251,9 +251,10 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
             loggingManager.start();
 
             Action<ExecutionListener> exceptionReportingAction =
-                    new ExceptionReportingAction(reporter, loggingManager,
-                            new NativeServicesInitializingAction(buildLayout, loggingConfiguration, loggingManager,
-                                    new WelcomeMessageAction(buildLayout, action)));
+                new ExceptionReportingAction(reporter, loggingManager,
+                    new DebugLoggerWarningAction(loggingConfiguration,
+                        new NativeServicesInitializingAction(buildLayout, loggingConfiguration, loggingManager,
+                            new WelcomeMessageAction(buildLayout, action))));
             try {
                 exceptionReportingAction.execute(executionListener);
             } finally {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DebugLoggerWarningActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DebugLoggerWarningActionTest.groovy
@@ -25,8 +25,6 @@ import org.gradle.internal.logging.ToStringLogger
 import org.gradle.launcher.bootstrap.ExecutionListener
 import spock.lang.Specification
 
-import java.util.regex.Pattern
-
 class DebugLoggerWarningActionTest extends Specification {
 
     ToStringLogger log
@@ -47,14 +45,7 @@ class DebugLoggerWarningActionTest extends Specification {
 
     private void assertDoublePrintInOutput(String output) {
         // This should exist twice
-        assert output.contains(DebugLoggerWarningAction.WARNING_MESSAGE_BODY)
-        // Now we've confirmed it exists 1 time, remove the first one
-        def outputFirstRemoved = output.replaceFirst(
-            Pattern.quote(DebugLoggerWarningAction.WARNING_MESSAGE_BODY),
-            ""
-        )
-        // Should still exist again.
-        assert outputFirstRemoved.contains(DebugLoggerWarningAction.WARNING_MESSAGE_BODY)
+        assert output.count(DebugLoggerWarningAction.WARNING_MESSAGE_BODY) == 2
     }
 
     def "prints twice when debugging is enabled"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DebugLoggerWarningActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DebugLoggerWarningActionTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli
+
+import org.gradle.api.Action
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.LoggingConfiguration
+import org.gradle.integtests.tooling.fixture.TextUtil
+import org.gradle.internal.logging.DefaultLoggingConfiguration
+import org.gradle.internal.logging.ToStringLogger
+import org.gradle.launcher.bootstrap.ExecutionListener
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+class DebugLoggerWarningActionTest extends Specification {
+
+    ToStringLogger log
+    LoggingConfiguration loggingConfiguration
+    Action<ExecutionListener> delegateAction
+    ExecutionListener listener
+
+    def setup() {
+        log = new ToStringLogger()
+        loggingConfiguration = new DefaultLoggingConfiguration()
+        delegateAction = Mock()
+        listener = Mock()
+    }
+
+    private DebugLoggerWarningAction createDebugLoggerWarning() {
+        return new DebugLoggerWarningAction(log, loggingConfiguration, delegateAction)
+    }
+
+    private void assertDoublePrintInOutput(String output) {
+        // This should exist twice
+        assert output.contains(DebugLoggerWarningAction.WARNING_MESSAGE_BODY)
+        // Now we've confirmed it exists 1 time, remove the first one
+        def outputFirstRemoved = output.replaceFirst(
+            Pattern.quote(DebugLoggerWarningAction.WARNING_MESSAGE_BODY),
+            ""
+        )
+        // Should still exist again.
+        assert outputFirstRemoved.contains(DebugLoggerWarningAction.WARNING_MESSAGE_BODY)
+    }
+
+    def "prints twice when debugging is enabled"() {
+        given:
+        loggingConfiguration.setLogLevel(LogLevel.DEBUG)
+        def action = createDebugLoggerWarning()
+        when:
+        action.execute(listener)
+        then:
+        def output = TextUtil.normaliseFileSeparators(log.toString())
+        assertDoublePrintInOutput(output)
+        1 * delegateAction.execute(_)
+    }
+
+    def "prints twice when debugging is enabled and an exception is thrown"() {
+        delegateAction.execute(listener) >> { throw new RuntimeException("Boom!") }
+
+        given:
+        loggingConfiguration.setLogLevel(LogLevel.DEBUG)
+        def action = createDebugLoggerWarning()
+
+        when:
+        action.execute(listener)
+
+        then:
+        thrown(RuntimeException)
+        def output = TextUtil.normaliseFileSeparators(log.toString())
+        assertDoublePrintInOutput(output)
+    }
+}

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
@@ -19,9 +19,7 @@ package org.gradle.launcher.cli
 import com.google.common.base.Function
 import org.gradle.api.Action
 import org.gradle.initialization.BuildLayoutParameters
-import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger
-import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext
-import org.gradle.internal.time.MockClock
+import org.gradle.internal.logging.ToStringLogger
 import org.gradle.launcher.bootstrap.ExecutionListener
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
@@ -197,25 +195,5 @@ For more details see https://docs.gradle.org/42.0/release-notes.html''')
 
     private TestFile markerFile(String version) {
         new TestFile(gradleUserHomeDir, "notifications", version, "release-features.rendered")
-    }
-
-    private static class ToStringLogger extends OutputEventListenerBackedLogger {
-
-        private final StringBuilder log = new StringBuilder()
-
-        ToStringLogger() {
-            super("ToStringLogger", new OutputEventListenerBackedLoggerContext(new MockClock()), new MockClock())
-        }
-
-        @Override
-        void lifecycle(String message) {
-            log.append(message)
-            log.append('\n')
-        }
-
-        @Override
-        String toString() {
-            log.toString()
-        }
     }
 }

--- a/subprojects/logging/logging.gradle.kts
+++ b/subprojects/logging/logging.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 
     testFixturesImplementation(project(":baseServices"))
+    testFixturesImplementation(testFixtures(project(":core")))
     testFixturesImplementation(library("slf4j_api"))
 }
 

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/Logger.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/Logger.java
@@ -24,6 +24,11 @@ package org.gradle.api.logging;
  * Logging#getLogger(String)}. A {@code Logger} instance is also available through {@link
  * org.gradle.api.Project#getLogger()}, {@link org.gradle.api.Task#getLogger()} and {@link
  * org.gradle.api.Script#getLogger()}.</p>
+ * <br/>
+ * <p><b>CAUTION!</b>
+ * For publicly published plugins, logging sensitive information (credentials, tokens, certain environment variables), at log levels above {@link Logger#debug} is a security vulnerability.
+ * Build logs for Public CI (eg. Travis CI, Circle CI, GitHub Actions) are world-viewable and can expose this sensitive information.
+ * </p>
  */
 public interface Logger extends org.slf4j.Logger {
     /**

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/Logger.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/Logger.java
@@ -24,10 +24,10 @@ package org.gradle.api.logging;
  * Logging#getLogger(String)}. A {@code Logger} instance is also available through {@link
  * org.gradle.api.Project#getLogger()}, {@link org.gradle.api.Task#getLogger()} and {@link
  * org.gradle.api.Script#getLogger()}.</p>
- * <br/>
+ * <br>
  * <p><b>CAUTION!</b>
- * For publicly published plugins, logging sensitive information (credentials, tokens, certain environment variables), at log levels above {@link Logger#debug} is a security vulnerability.
- * Build logs for Public CI (eg. Travis CI, Circle CI, GitHub Actions) are world-viewable and can expose this sensitive information.
+ * Logging sensitive information (credentials, tokens, certain environment variables) above {@link Logger#debug} level is a security vulnerability.
+ * See <a href="https://docs.gradle.org/current/userguide/logging.html#sec:debug_security">our recommendations</a> for more information.
  * </p>
  */
 public interface Logger extends org.slf4j.Logger {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -69,7 +69,13 @@ public class LoggingConfigurationBuildOptions {
         private static final String[] ALL_SHORT_OPTIONS = new String[]{QUIET_SHORT_OPTION, WARN_SHORT_OPTION, INFO_SHORT_OPTION, DEBUG_SHORT_OPTION};
 
         public LogLevelOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(QUIET_LONG_OPTION, QUIET_SHORT_OPTION, "Log errors only."), CommandLineOptionConfiguration.create(WARN_LONG_OPTION, WARN_SHORT_OPTION, "Set log level to warn."), CommandLineOptionConfiguration.create(INFO_LONG_OPTION, INFO_SHORT_OPTION, "Set log level to info."), CommandLineOptionConfiguration.create(DEBUG_LONG_OPTION, DEBUG_SHORT_OPTION, "Log in debug mode (includes normal stacktrace)."));
+            super(
+                GRADLE_PROPERTY,
+                CommandLineOptionConfiguration.create(QUIET_LONG_OPTION, QUIET_SHORT_OPTION, "Log errors only."),
+                CommandLineOptionConfiguration.create(WARN_LONG_OPTION, WARN_SHORT_OPTION, "Set log level to warn."),
+                CommandLineOptionConfiguration.create(INFO_LONG_OPTION, INFO_SHORT_OPTION, "Set log level to info."),
+                CommandLineOptionConfiguration.create(DEBUG_LONG_OPTION, DEBUG_SHORT_OPTION, "Log in debug mode (includes normal stacktrace).")
+            );
         }
 
         @Override

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/TestOutputEventListener.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/TestOutputEventListener.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.internal.logging
 
+import groovy.transform.CompileStatic
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.OutputEvent
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.events.StyledTextOutputEvent
 
+@CompileStatic
 class TestOutputEventListener implements OutputEventListener {
     final StringWriter writer = new StringWriter()
 

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging
+
+import groovy.transform.CompileStatic;
+import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger;
+import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext
+import org.gradle.internal.time.MockClock;
+
+@CompileStatic
+class ToStringLogger extends OutputEventListenerBackedLogger {
+
+    private final StringBuilder log = new StringBuilder();
+
+    ToStringLogger() {
+        super("ToStringLogger", new OutputEventListenerBackedLoggerContext(new MockClock()), new MockClock())
+    }
+
+    @Override
+    void lifecycle(String message) {
+        log.append(message)
+        log.append('\n')
+    }
+
+    @Override
+    void debug(String message){
+        log.append(message)
+        log.append('\n')
+    }
+
+    @Override
+    String toString() {
+        log.toString()
+    }
+}


### PR DESCRIPTION
### Context

Related: https://blog.gradle.org/plugin-portal-update

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
