### PR TITLE
Correctly serialize a flat mapped provider whose value is produced by a task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -26,6 +26,7 @@ import org.gradle.api.NamedDomainObjectCollection;
 import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Namer;
+import org.gradle.api.NonExtensible;
 import org.gradle.api.Rule;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.internal.collections.CollectionEventRegister;
@@ -808,6 +809,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         return Cast.uncheckedCast(getInstantiator().newInstance(ExistingNamedDomainObjectProvider.class, this, name, new DslObject(object).getDeclaredType()));
     }
 
+    @NonExtensible
     protected abstract class AbstractNamedDomainObjectProvider<I extends T> extends AbstractMinimalProvider<I> implements Named, NamedDomainObjectProvider<I> {
         private final String name;
         private final Class<I> type;
@@ -835,7 +837,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public String toString() {
-            return String.format("provider(%s %s, %s)", getTypeDisplayName(), getName(), getType());
+            return String.format("provider(%s '%s', %s)", getTypeDisplayName(), getName(), getType());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -81,6 +81,11 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     public Provider<RegularFile> file(Provider<File> provider) {
         return new AbstractMappingProvider<RegularFile, File>(RegularFile.class, Providers.internal(provider)) {
             @Override
+            protected String getMapDescription() {
+                return "resolve-file";
+            }
+
+            @Override
             protected RegularFile mapValue(File file) {
                 return fileFactory.file(fileResolver.resolve(file));
             }
@@ -90,6 +95,11 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     @Override
     public Provider<Directory> dir(Provider<File> provider) {
         return new AbstractMappingProvider<Directory, File>(Directory.class, Providers.internal(provider)) {
+            @Override
+            protected String getMapDescription() {
+                return "resolve-dir";
+            }
+
             @Override
             protected Directory mapValue(File file) {
                 return fileFactory.dir(fileResolver.resolve(file));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -33,18 +33,17 @@ import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.DefaultCompositeFileTree;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.pattern.PatternMatcher;
 import org.gradle.api.internal.file.pattern.PatternMatcherFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.ClosureBackedAction;
-import org.gradle.util.CollectionUtils;
 import org.gradle.util.ConfigureUtil;
 
 import javax.annotation.Nullable;
@@ -614,10 +613,9 @@ public class DefaultCopySpec implements CopySpecInternal {
 
         @Override
         public FileTree getAllSource() {
-            final ImmutableList.Builder<FileTree> builder = ImmutableList.builder();
-            walk(copySpecResolver -> builder.add(copySpecResolver.getSource()));
-
-            return new DefaultCompositeFileTree(CollectionUtils.checkedCast(FileTreeInternal.class, builder.build()));
+            final ImmutableList.Builder<FileTreeInternal> builder = ImmutableList.builder();
+            walk(copySpecResolver -> builder.add(Cast.<FileTreeInternal>uncheckedCast(copySpecResolver.getSource())));
+            return fileCollectionFactory.treeOf(builder.build());
         }
 
         @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/file/FileVisitorUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/file/FileVisitorUtil.groovy
@@ -15,15 +15,20 @@
  */
 package org.gradle.api.file
 
-import org.gradle.api.internal.file.collections.MinimalFileTree
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.FileTreeAdapter
+import org.gradle.api.internal.file.collections.MinimalFileTree
 
-import static org.junit.Assert.*
-import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 
 class FileVisitorUtil {
     static void assertCanStopVisiting(MinimalFileTree tree) {
-        assertCanStopVisiting(new FileTreeAdapter(tree))
+        assertCanStopVisiting(new FileTreeAdapter(tree, TestFiles.patternSetFactory))
     }
 
     static void assertCanStopVisiting(FileTree tree) {
@@ -44,7 +49,7 @@ class FileVisitorUtil {
     }
 
     static void assertVisits(MinimalFileTree tree, Iterable<String> expectedFiles, Iterable<String> expectedDirs) {
-        assertVisits(new FileTreeAdapter(tree), expectedFiles, expectedDirs)
+        assertVisits(new FileTreeAdapter(tree, TestFiles.patternSetFactory), expectedFiles, expectedDirs)
     }
 
     static void assertVisits(FileTree tree, Iterable<String> expectedFiles, Iterable<String> expectedDirs) {
@@ -101,7 +106,7 @@ class FileVisitorUtil {
     }
 
     static void assertVisitsPermissions(MinimalFileTree tree, Map<String, Integer> filesWithPermissions) {
-        assertVisitsPermissions(new FileTreeAdapter(tree), filesWithPermissions)
+        assertVisitsPermissions(new FileTreeAdapter(tree, TestFiles.patternSetFactory), filesWithPermissions)
     }
 
     static void assertVisitsPermissions(FileTree tree, Map<String, Integer> filesWithPermissions) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AntBuilderAwareUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AntBuilderAwareUtil.groovy
@@ -22,11 +22,14 @@ import org.apache.tools.ant.types.Resource
 import org.apache.tools.ant.types.ResourceCollection
 import org.gradle.api.AntBuilder
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.project.DefaultAntBuilder
-import static org.hamcrest.CoreMatchers.*
-import static org.junit.Assert.*
-import org.gradle.api.internal.file.collections.MinimalFileTree
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.FileTreeAdapter
+import org.gradle.api.internal.file.collections.MinimalFileTree
+import org.gradle.api.internal.project.DefaultAntBuilder
+
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 
 class AntBuilderAwareUtil {
 
@@ -71,7 +74,7 @@ class AntBuilderAwareUtil {
     }
 
     static def assertSetContainsForAllTypes(MinimalFileTree set, Iterable<String> filenames) {
-        assertSetContainsForAllTypes(new FileTreeAdapter(set), filenames)
+        assertSetContainsForAllTypes(new FileTreeAdapter(set, TestFiles.patternSetFactory), filenames)
     }
 
     static def assertSetContainsForFileSet(FileCollection set, String... filenames) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultCompositeFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultCompositeFileTree.java
@@ -17,13 +17,17 @@
 package org.gradle.api.internal.file;
 
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 
 import java.util.Collection;
+import java.util.List;
 
 public class DefaultCompositeFileTree extends CompositeFileTree {
     private final Collection<? extends FileTreeInternal> fileTrees;
 
-    public DefaultCompositeFileTree(Collection<? extends FileTreeInternal> fileTrees) {
+    public DefaultCompositeFileTree(Factory<PatternSet> patternSetFactory, List<? extends FileTreeInternal> fileTrees) {
+        super(patternSetFactory);
         this.fileTrees = fileTrees;
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -171,6 +171,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         @Override
+        protected String getMapDescription() {
+            return "resolve-path-to-file";
+        }
+
+        @Override
         protected RegularFile mapValue(CharSequence path) {
             return new FixedFile(resolver.resolve(path));
         }
@@ -300,6 +305,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         @Override
+        protected String getMapDescription() {
+            return "resolve-path-to-dir";
+        }
+
+        @Override
         protected Directory mapValue(CharSequence path) {
             File dir = resolver.resolve(path);
             FileResolver dirResolver = this.resolver.newResolver(dir);
@@ -343,6 +353,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         public Provider<Directory> dir(final String path) {
             return new AbstractMappingProvider<Directory, Directory>(Directory.class, this) {
                 @Override
+                protected String getMapDescription() {
+                    return "descendant-dir";
+                }
+
+                @Override
                 protected Directory mapValue(Directory dir) {
                     return dir.dir(path);
                 }
@@ -362,6 +377,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         @Override
         public Provider<RegularFile> file(final String path) {
             return new AbstractMappingProvider<RegularFile, Directory>(RegularFile.class, this) {
+                @Override
+                protected String getMapDescription() {
+                    return "descendant-file";
+                }
+
                 @Override
                 protected RegularFile mapValue(Directory dir) {
                     return dir.file(path);
@@ -388,6 +408,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     static class ToFileProvider extends AbstractMappingProvider<File, FileSystemLocation> {
         ToFileProvider(ProviderInternal<? extends FileSystemLocation> provider) {
             super(File.class, provider);
+        }
+
+        @Override
+        protected String getMapDescription() {
+            return "as-file";
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
@@ -62,44 +63,50 @@ public interface FileCollectionFactory {
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
+     *
+     * <p>The collection is not live. The provided array is queried on construction and discarded.
      */
     FileCollectionInternal fixed(File... files);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
+     *
+     * <p>The collection is not live. The provided {@link Collection} is queried on construction and discarded.
      */
     FileCollectionInternal fixed(Collection<File> files);
 
     /**
-     * Creates a {@link FileCollection} with the given files as content.
+     * Creates a {@link FileCollection} with the given files as content. The result is not live and does not reflect changes to the array.
+     *
+     * <p>The collection is not live. The provided array is queried on construction and discarded.
      */
     FileCollectionInternal fixed(String displayName, File... files);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
-     * The collection is not live. The provided {@link Iterable} is queried on construction and discarded.
+     * <p>The collection is not live. The provided {@link Collection} is queried on construction and discarded.
      */
     FileCollectionInternal fixed(String displayName, Collection<File> files);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
-     * The collection is live and resolves the files on each query. Tracks changes to the source list.
+     * <p>The collection is live and resolves the files on each query. Tracks changes to the source list.
      */
     FileCollectionInternal resolving(String displayName, List<?> sources);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
-     * The collection is live and resolves the files on each query.
+     * <p>The collection is live and resolves the files on each query.
      */
     FileCollectionInternal resolving(String displayName, Object... sources);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
-     * The collection is live and resolves the files on each query.
+     * <p>The collection is live and resolves the files on each query.
      */
     FileCollectionInternal resolving(Object... sources);
 
@@ -122,4 +129,13 @@ public interface FileCollectionFactory {
      * Creates a file tree containing the given generated file.
      */
     FileTreeInternal generated(Factory<File> tmpDir, String fileName, Action<File> fileGenerationListener, Action<OutputStream> contentGenerator);
+
+    /**
+     * Creates a file tree made up of the union of the given trees.
+     *
+     * <p>The tree is not live. The provided list is queried on construction and discarded.
+     */
+    FileTreeInternal treeOf(List<? extends FileTreeInternal> fileTrees);
+
+    FileTreeInternal treeOf(MinimalFileTree tree);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionAdapter.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.file.collections;
 import org.gradle.api.Buildable;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 
 import java.io.File;
 import java.util.Set;
@@ -26,31 +28,36 @@ import java.util.Set;
  * Adapts a {@link MinimalFileSet} into a full {@link org.gradle.api.file.FileCollection}.
  */
 public class FileCollectionAdapter extends AbstractFileCollection implements FileCollectionContainer {
-    private final MinimalFileSet fileCollection;
+    private final MinimalFileSet fileSet;
 
     public FileCollectionAdapter(MinimalFileSet fileSet) {
-        this.fileCollection = fileSet;
+        this.fileSet = fileSet;
+    }
+
+    public FileCollectionAdapter(MinimalFileSet fileSet, Factory<PatternSet> patternSetFactory) {
+        super(patternSetFactory);
+        this.fileSet = fileSet;
     }
 
     @Override
     public String getDisplayName() {
-        return fileCollection.getDisplayName();
+        return fileSet.getDisplayName();
     }
 
     @Override
     public void visitContents(FileCollectionResolveContext context) {
-        context.add(fileCollection);
+        context.add(fileSet);
     }
 
     @Override
     public Set<File> getFiles() {
-        return fileCollection.getFiles();
+        return fileSet.getFiles();
     }
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        if (fileCollection instanceof Buildable) {
-            context.add(fileCollection);
+        if (fileSet instanceof Buildable) {
+            context.add(fileSet);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -33,10 +33,6 @@ import java.io.File;
 public class FileTreeAdapter extends AbstractFileTree implements FileCollectionContainer {
     private final MinimalFileTree tree;
 
-    public FileTreeAdapter(MinimalFileTree tree) {
-        this.tree = tree;
-    }
-
     public FileTreeAdapter(MinimalFileTree tree, Factory<PatternSet> patternSetFactory) {
         super(patternSetFactory);
         this.tree = tree;

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultCompositeFileTreeTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultCompositeFileTreeTest.groovy
@@ -24,7 +24,7 @@ class DefaultCompositeFileTreeTest extends WorkspaceTest {
 
     def "can be empty"() {
         when:
-        def ft = new DefaultCompositeFileTree(Collections.emptyList())
+        def ft = new DefaultCompositeFileTree(TestFiles.patternSetFactory, [])
 
         then:
         ft.files.isEmpty()
@@ -39,7 +39,7 @@ class DefaultCompositeFileTreeTest extends WorkspaceTest {
         when:
         def a = fileResolver.resolving(["a"]).asFileTree
         def b = fileResolver.resolving(["b"]).asFileTree
-        def composite = new DefaultCompositeFileTree(Arrays.asList(a, b))
+        def composite = new DefaultCompositeFileTree(TestFiles.patternSetFactory, [a, b])
 
         then:
         composite.files == [a1, b1].toSet()
@@ -54,7 +54,7 @@ class DefaultCompositeFileTreeTest extends WorkspaceTest {
         when:
         def a = fileResolver.resolving(["a"]).asFileTree
         def b = fileResolver.resolving(["b"]).asFileTree
-        def composite = new DefaultCompositeFileTree(Arrays.asList(a, b))
+        def composite = new DefaultCompositeFileTree(TestFiles.patternSetFactory, [a, b])
 
         and:
         def visited = []
@@ -84,7 +84,7 @@ class DefaultCompositeFileTreeTest extends WorkspaceTest {
         }
 
         expect:
-        def composite = new DefaultCompositeFileTree([tree1, tree2])
+        def composite = new DefaultCompositeFileTree(TestFiles.patternSetFactory, [tree1, tree2])
         composite.buildDependencies.getDependencies(null) as List == [task1, task2, task3]
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet
 import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
@@ -97,21 +98,11 @@ class DefaultFileCollectionFactoryTest extends Specification {
     def "constructs an empty collection"() {
         expect:
         def collection = factory.empty()
-        collection.isEmpty()
-        collection.files.empty
-        collection.buildDependencies.getDependencies(null).empty
-        collection.visitStructure(new BrokenVisitor())
+        emptyCollection(collection)
         collection.toString() == "file collection"
 
         def tree = collection.asFileTree
-        tree.isEmpty()
-        tree.files.empty
-        tree.visit(new BrokenVisitor())
-        tree.buildDependencies.getDependencies(null).empty
-        tree.visitStructure(new BrokenVisitor())
-        tree.matching {} is tree
-        tree.matching(Stub(Action)) is tree
-        tree.matching(Stub(PatternFilterable)) is tree
+        emptyTree(tree)
         tree.toString() == "file tree"
     }
 
@@ -147,7 +138,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection2.toString() == "some collection"
     }
 
-    def "returns empty collection when constructed with empty fixed array"() {
+    def "returns empty collection when fixed collection constructed with empty fixed array"() {
         expect:
         def collection = factory.fixed()
         collection.files.empty
@@ -156,7 +147,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "file collection"
     }
 
-    def "returns empty collection when constructed with display name and a fixed empty array"() {
+    def "returns empty collection when fixed collection constructed with display name and a fixed empty array"() {
         expect:
         def collection = factory.fixed("some collection")
         collection.files.empty
@@ -165,7 +156,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "some collection"
     }
 
-    def "returns empty collection when constructed with a fixed list containing nothing"() {
+    def "returns empty collection when fixed collection constructed with a fixed list containing nothing"() {
         expect:
         def collection = factory.fixed([])
         collection.files.empty
@@ -174,7 +165,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "file collection"
     }
 
-    def "returns empty collection when constructed with display name and a fixed list containing nothing"() {
+    def "returns empty collection when fixed collection constructed with display name and a fixed list containing nothing"() {
         expect:
         def collection = factory.fixed("some collection", [])
         collection.files.empty
@@ -183,7 +174,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "some collection"
     }
 
-    def "returns empty collection when constructed with empty resolving array"() {
+    def "returns empty collection when resolving collection constructed with empty resolving array"() {
         expect:
         def collection = factory.resolving()
         collection.files.empty
@@ -192,7 +183,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "file collection"
     }
 
-    def "returns empty collection when constructed with display name and empty resolving array"() {
+    def "returns empty collection when resolving collection constructed with display name and empty resolving array"() {
         expect:
         def collection = factory.resolving("some collection")
         collection.files.empty
@@ -201,7 +192,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "some collection"
     }
 
-    def "returns live collection when constructed with display name and a resolving list containing nothing"() {
+    def "returns live resolving collection when constructed with display name and a resolving list containing nothing"() {
         def contents = []
 
         expect:
@@ -215,7 +206,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         !collection.files.empty
     }
 
-    def "returns original file collection when constructed with a single collection"() {
+    def "returns original file collection when resolving collection constructed with a single collection"() {
         def original = Stub(FileCollectionInternal)
 
         expect:
@@ -223,7 +214,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.is(original)
     }
 
-    def 'resolves specified files using FileResolver'() {
+    def 'resolves specified files for resolving collection using FileResolver'() {
         def collection = factory.resolving('test files', 'abc', 'def')
 
         when:
@@ -234,7 +225,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         files == [tmpDir.file('abc'), tmpDir.file('def')] as Set
     }
 
-    def 'can use a Closure to specify a single file'() {
+    def 'can use a Closure for resolving collection to specify a single file'() {
         def collection = factory.resolving('test files', [{ 'abc' }] as Object[])
 
         when:
@@ -246,7 +237,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
     }
 
     @Unroll
-    def '#description can return null'() {
+    def 'resolving collection source #description can return null'() {
         def collection = factory.resolving('test files', input)
 
         when:
@@ -275,7 +266,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         exception == thrown
     }
 
-    def 'lazily queries contents of a FileCollection'() {
+    def 'lazily queries contents of a resolving collection'() {
         FileCollectionInternal fileCollection = Mock()
 
         when:
@@ -294,7 +285,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
     }
 
     @Unroll
-    def 'can use a #description to specify the contents of the collection'() {
+    def 'can use a #description to specify the contents of a resolving collection'() {
         def collection = factory.resolving('test files', input)
 
         when:
@@ -312,6 +303,39 @@ class DefaultFileCollectionFactoryTest extends Specification {
         'Callable'         | (({ ['abc', 'def'] } as Callable<Object>) as Object[])
         'Provider'         | providerReturning(['abc', 'def'])
         'nested objects'   | ({ [{ ['abc', { ['def'] as String[] }] }] } as Object[])
+    }
+
+    def 'constructs empty tree when composite tree created with empty list'() {
+        def tree = factory.treeOf([])
+
+        expect:
+        emptyTree(tree)
+    }
+
+    def 'returns source file tree when composite tree created with single entry'() {
+        def source = Stub(FileTreeInternal)
+        def tree = factory.treeOf([source])
+
+        expect:
+        tree.is source
+    }
+
+    @Unroll
+    def 'can use a #description to specify the single content of the collection'() {
+        def collection = factory.resolving('test files', input)
+
+        when:
+        Set<File> files = collection.getFiles()
+
+        then:
+        files == [tmpDir.file('abc')] as Set
+
+        where:
+        description | input
+        'String'    | 'abc'
+        'Path'      | tmpDir.file('abc').toPath()
+        'URI'       | tmpDir.file('abc').toURI()
+        'URL'       | tmpDir.file('abc').toURI().toURL()
     }
 
     private FileCollection fileCollectionOf(final File... files) {
@@ -332,22 +356,20 @@ class DefaultFileCollectionFactoryTest extends Specification {
         return Providers.of(result)
     }
 
-    @Unroll
-    def 'can use a #description to specify the single content of the collection'() {
-        def collection = factory.resolving('test files', input)
+    private void emptyTree(FileTree tree) {
+        emptyCollection(tree)
+        tree.matching {} is tree
+        tree.matching(Stub(Action)) is tree
+        tree.matching(Stub(PatternFilterable)) is tree
+    }
 
-        when:
-        Set<File> files = collection.getFiles()
-
-        then:
-        files == [tmpDir.file('abc')] as Set
-
-        where:
-        description | input
-        'String'    | 'abc'
-        'Path'      | tmpDir.file('abc').toPath()
-        'URI'       | tmpDir.file('abc').toURI()
-        'URL'       | tmpDir.file('abc').toURI().toURL()
+    private void emptyCollection(FileCollectionInternal collection) {
+        collection.isEmpty()
+        collection.files.empty
+        collection.buildDependencies.getDependencies(null).empty
+        collection.visitStructure(new BrokenVisitor())
+        collection.filter {} is collection
+        collection.minus(Stub(FileCollection)) is collection
     }
 
     static class BrokenVisitor implements FileCollectionStructureVisitor, FileVisitor {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
@@ -47,7 +47,7 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         then:
         result.size() == 1
         result[0] instanceof FileCollectionAdapter
-        result[0].fileCollection == fileSet
+        result[0].fileSet == fileSet
     }
 
     def "resolve as FileTree converts the elements of MinimalFileSet"() {
@@ -189,11 +189,11 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         then:
         result.size() == 2
         result[0] instanceof FileCollectionAdapter
-        result[0].fileCollection instanceof ListBackedFileSet
-        result[0].fileCollection.files as List == [file1]
+        result[0].fileSet instanceof ListBackedFileSet
+        result[0].fileSet.files as List == [file1]
         result[1] instanceof FileCollectionAdapter
-        result[1].fileCollection instanceof ListBackedFileSet
-        result[1].fileCollection.files as List == [file2]
+        result[1].fileSet instanceof ListBackedFileSet
+        result[1].fileSet.files as List == [file2]
         1 * resolver.resolve('a') >> file1
         1 * resolver.resolve('b') >> file2
     }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file.collections
 
 import org.gradle.api.Buildable
 import org.gradle.api.file.FileVisitor
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
@@ -29,7 +30,7 @@ class FileTreeAdapterTest extends Specification {
         MinimalFileTree tree = Mock()
         _ * tree.displayName >> 'display name'
 
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         expect:
         adapter.toString() == 'display name'
@@ -37,7 +38,7 @@ class FileTreeAdapterTest extends Specification {
 
     def visitDelegatesToTargetTree() {
         MinimalFileTree tree = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
         FileVisitor visitor = Mock()
 
         when:
@@ -50,7 +51,7 @@ class FileTreeAdapterTest extends Specification {
 
     def resolveAddsTargetTreeToContext() {
         MinimalFileTree tree = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
         FileCollectionResolveContext context = Mock()
 
         when:
@@ -64,7 +65,7 @@ class FileTreeAdapterTest extends Specification {
     def visitDependenciesDelegatesToTargetTreeWhenItImplementsBuildable() {
         TestFileTree tree = Mock()
         TaskDependencyResolveContext context = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         when:
         adapter.visitDependencies(context)
@@ -76,7 +77,7 @@ class FileTreeAdapterTest extends Specification {
     def visitDependenciesDoesNotDelegateToTargetTreeWhenItDoesNotImplementBuildable() {
         MinimalFileTree tree = Mock()
         TaskDependencyResolveContext context = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         when:
         adapter.visitDependencies(context)
@@ -89,7 +90,7 @@ class FileTreeAdapterTest extends Specification {
         PatternFilterableFileTree tree = Mock()
         MinimalFileTree filtered = Mock()
         PatternFilterable filter = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         when:
         def filteredAdapter = adapter.matching(filter)
@@ -103,7 +104,7 @@ class FileTreeAdapterTest extends Specification {
     def matchingWrapsTargetTreeWhenItDoesNotImplementPatternFilterableFileTree() {
         FileSystemMirroringFileTree tree = Mock()
         PatternSet filter = Mock()
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         when:
         def filteredAdapter = adapter.matching(filter)
@@ -118,7 +119,7 @@ class FileTreeAdapterTest extends Specification {
     def containsDelegatesToTargetTreeWhenItImplementsRandomAccessFileCollection() {
         TestFileTree tree = Mock()
         File f = new File('a')
-        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+        FileTreeAdapter adapter = new FileTreeAdapter(tree, TestFiles.patternSetFactory)
 
         when:
         def result = adapter.contains(f)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
@@ -68,7 +68,7 @@ public class GeneratedSingletonFileTreeTest {
         };
         GeneratedSingletonFileTree tree = tree("file.txt", fileAction);
 
-        FileTreeAdapter fileTreeAdapter = new FileTreeAdapter(tree);
+        FileTreeAdapter fileTreeAdapter = new FileTreeAdapter(tree, TestFiles.getPatternSetFactory());
         File file = rootDir.file("file.txt");
 
         assertTrue(fileTreeAdapter.contains(file));

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
@@ -72,6 +72,112 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
         result.assertTasksSkipped(":producer", ":transformer")
     }
 
+    def "task input property can consume the flat mapped output of another task"() {
+        taskTypeWithInputFileProperty()
+        taskTypeWithIntInputProperty()
+
+        buildFile << """
+            def producer = tasks.register('producer', InputFileTask) {
+                inFile = file("in.txt")
+                outFile = layout.buildDirectory.file("out.txt")
+            }
+            task transformer(type: InputTask) {
+                inValue = producer.flatMap { t -> t.outFile.map { f -> f.asFile.text as Integer } }.map { i -> i + 2 }
+                outFile = file("out.txt")
+            }
+        """
+        def input = file("in.txt")
+        def output = file("out.txt")
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        input.text = "12"
+        instantRun(":transformer")
+
+        then:
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "24"
+
+        when:
+        input.text = "4"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "16"
+
+        when:
+        input.text = "10"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "22"
+
+        when:
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksSkipped(":producer", ":transformer")
+    }
+
+    def "task input property can consume the mapped output of another task connected via project property"() {
+        taskTypeWithInputFileProperty()
+        taskTypeWithIntInputProperty()
+
+        buildFile << """
+            def output = objects.property(Integer)
+            task producer(type: InputFileTask) {
+                inFile = file("in.txt")
+                outFile = layout.buildDirectory.file("out.txt")
+            }
+            output.set(producer.outFile.map { f -> f.asFile.text as Integer }.map { i -> i + 2 })
+            task transformer(type: InputTask) {
+                inValue = output
+                outFile = file("out.txt")
+            }
+        """
+        def input = file("in.txt")
+        def output = file("out.txt")
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        input.text = "12"
+        instantRun(":transformer")
+
+        then:
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "24"
+
+        when:
+        input.text = "4"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "16"
+
+        when:
+        input.text = "10"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "22"
+
+        when:
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksSkipped(":producer", ":transformer")
+    }
+
     def "task input collection property can consume the mapped output of another task"() {
         taskTypeWithInputFileProperty()
         taskTypeWithInputListProperty()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -331,6 +331,7 @@ class DefaultInstantExecution internal constructor(
             transformListener = service(),
             valueSourceProviderFactory = service(),
             patternSetFactory = factory(),
+            fileOperations = service(),
             fileSystem = service(),
             fileFactory = service()
         )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -97,6 +97,7 @@ class Codecs(
     transformListener: ArtifactTransformListener,
     valueSourceProviderFactory: ValueSourceProviderFactory,
     patternSetFactory: Factory<PatternSet>,
+    fileOperations: FileOperations,
     fileSystem: FileSystem,
     fileFactory: FileFactory
 ) {
@@ -115,7 +116,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem, fileFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory)
 
         bind(ApiTextResourceAdapterCodec)
 
@@ -169,7 +170,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem, fileFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory)
 
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(buildOperationExecutor, transformListener))
@@ -212,11 +213,11 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, patternSetFactory: Factory<PatternSet>, fileSystem: FileSystem, fileFactory: FileFactory) {
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileSystem: FileSystem, fileFactory: FileFactory) {
         bind(DirectoryCodec(fileFactory))
         bind(RegularFileCodec(fileFactory))
         bind(ConfigurableFileTreeCodec(fileCollectionFactory))
-        bind(FileTreeCodec(directoryFileTreeFactory, patternSetFactory, fileSystem))
+        bind(FileTreeCodec(fileCollectionFactory, directoryFileTreeFactory, fileOperations, fileSystem))
         val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory)
         bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
         bind(fileCollectionCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -207,8 +207,6 @@ class Codecs(
         bind(DirectoryPropertyCodec(filePropertyFactory, nestedCodec))
         bind(RegularFilePropertyCodec(filePropertyFactory, nestedCodec))
         bind(PropertyCodec(propertyFactory, nestedCodec))
-        bind(BuildServiceProviderCodec(buildServiceRegistry))
-        bind(ValueSourceProviderCodec(valueSourceProviderFactory))
         bind(ProviderCodec(nestedCodec))
     }
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -413,6 +413,7 @@ class UserTypesCodecTest {
         transformListener = mock(),
         valueSourceProviderFactory = mock(),
         patternSetFactory = mock(),
+        fileOperations = mock(),
         fileSystem = mock(),
         fileFactory = mock()
     )

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
@@ -68,8 +68,11 @@ public abstract class AbstractMappingProvider<OUT, IN> extends AbstractMinimalPr
 
     protected abstract OUT mapValue(IN v);
 
+    // Included in toString() output
+    protected abstract String getMapDescription();
+
     @Override
     public String toString() {
-        return "map(" + provider + ")";
+        return getMapDescription() + "(" + provider + ")";
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -28,6 +28,8 @@ import org.gradle.internal.state.Managed;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A partial {@link Provider} implementation. Subclasses need to implement {@link ProviderInternal#getType()} and {@link AbstractMinimalProvider#calculateOwnValue()}.
@@ -132,6 +134,12 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public void visitProducerTasks(Action<? super Task> visitor) {
+    }
+
+    protected List<Task> getProducerTasks() {
+        List<Task> producers = new ArrayList<>();
+        visitProducerTasks(producers::add);
+        return producers;
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -129,6 +129,6 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     @Override
     protected String describeContents() {
         // NOTE: Do not realize the value of the Provider in toString().  The debugger will try to call this method and make debugging really frustrating.
-        return String.format("property(%s, %s)", type, getSupplier());
+        return String.format("property(%s, %s)", type.getName(), getSupplier());
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -23,8 +23,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
 
 public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OUT> {
     private final Transformer<? extends OUT, ? super IN> transformer;
@@ -86,12 +84,6 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
                 break; // Only report one producer
             }
         }
-    }
-
-    private List<Task> getProducerTasks() {
-        List<Task> producers = new ArrayList<>();
-        provider.visitProducerTasks(producers::add);
-        return producers;
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TypeSanitizingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TypeSanitizingProvider.java
@@ -32,6 +32,11 @@ class TypeSanitizingProvider<T> extends AbstractMappingProvider<T, T> {
     }
 
     @Override
+    protected String getMapDescription() {
+        return "check-type";
+    }
+
+    @Override
     protected T mapValue(T v) {
         v = Cast.uncheckedCast(sanitizer.sanitize(v));
         if (targetType.isInstance(v)) {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMappingProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMappingProviderTest.groovy
@@ -66,6 +66,11 @@ class AbstractMappingProviderTest extends ProviderSpec<String> {
         }
 
         @Override
+        protected String getMapDescription() {
+            return "thing"
+        }
+
+        @Override
         protected String mapValue(String v) {
             return "{$v}"
         }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -92,8 +92,8 @@ class DefaultPropertyTest extends PropertySpec<String> {
         }))
 
         expect:
-        propertyWithBadValue.toString() == "property(class java.lang.String, map(provider(?)))"
-        providerWithNoValue().toString() == "property(class java.lang.String, undefined)"
+        propertyWithBadValue.toString() == "property(java.lang.String, check-type(provider(?)))"
+        providerWithNoValue().toString() == "property(java.lang.String, undefined)"
     }
 
     def "can set to null value to discard value"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -116,7 +116,7 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         beanWithOverloads.getSomeValue().toString() == "<display name> property 'someValue'"
 
         // Does not assign display name to mutable property
-        mutableBean.someValue.toString() == "property(class java.lang.String, undefined)"
+        mutableBean.someValue.toString() == "property(java.lang.String, undefined)"
     }
 
     def "assigns display name to read only non-final nested property that is not managed"() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -180,7 +180,7 @@ public class InstallExecutable extends DefaultTask {
      */
     @Internal("covered by getInstallDirectory")
     public Provider<RegularFile> getRunScriptFile() {
-        return installDirectory.file(executable.map(executableFile -> OperatingSystem.forName(targetPlatform.get().getOperatingSystem().getName()).getScriptName(executableFile.getAsFile().getName())));
+        return installDirectory.file(executable.getLocationOnly().map(executableFile -> OperatingSystem.forName(targetPlatform.get().getOperatingSystem().getName()).getScriptName(executableFile.getAsFile().getName())));
     }
 
     @Inject


### PR DESCRIPTION

### Context

When a flat map provider's value is produced by a task, write the provider itself rather than the current value to the instant execution cache. This is the same as for map providers.

Also, when writing a provider to the instant execution cache, for whatever reason, replace `Property` instances in the chain of providers with whatever provider the `Property` instance is using as its source. This avoids some writing and recreating state that doesn't do anything (a `Property` instance in a chain of providers is simply going to delegate to its source anyway).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
