### PR TITLE
Let instant execution capture enough of build scans configuration to publish to declared GE instances

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildScanIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildScanIntegrationTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Unroll
+
+
+class InstantExecutionBuildScanIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    def "--scan -Dscan.dump works"() {
+        given:
+        settingsKotlinFile << '''
+            plugins {
+                `gradle-enterprise`
+            }
+
+            gradleEnterprise.buildScan {
+                termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                termsOfServiceAgree = "yes"
+            }
+        '''
+
+        when:
+        instantRun "help", "--scan", "-Dscan.dump"
+
+        then:
+        postBuildOutputContains("Build scan written to")
+
+        when:
+        instantRun "help", "--scan", "-Dscan.dump"
+
+        then:
+        postBuildOutputContains("Build scan written to")
+    }
+
+    @Requires(TestPrecondition.ONLINE)
+    def "can publish build scans using --scan"() {
+
+        given:
+        def instant = newInstantExecutionFixture()
+        settingsKotlinFile << '''
+            plugins {
+                `gradle-enterprise`
+            }
+
+            gradleEnterprise.buildScan {
+                termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                termsOfServiceAgree = "yes"
+            }
+        '''
+
+        when:
+        instantRun "help", "--scan"
+
+        then:
+        instant.assertStateStored()
+        postBuildOutputContains("Publishing build scan...")
+
+        when:
+        instantRun "help", "--scan"
+
+        then:
+        instant.assertStateLoaded()
+        postBuildOutputContains("Publishing build scan...")
+    }
+
+    @Unroll
+    def "can publish build scans to custom server using #customServerProperty"() {
+
+        given:
+        def instant = newInstantExecutionFixture()
+        settingsKotlinFile << """
+            plugins {
+                `gradle-enterprise`
+            }
+
+            gradleEnterprise.buildScan {
+                termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                termsOfServiceAgree = "yes"
+            }
+            $customServerProperty = "https://does.not.exists"
+        """
+
+        when:
+        instantRun "help", "--scan"
+
+        then:
+        instant.assertStateStored()
+        postBuildOutputContains("The hostname 'does.not.exists' could not be resolved.")
+
+        when:
+        instantRun "help", "--scan"
+
+        then:
+        instant.assertStateLoaded()
+        postBuildOutputContains("The hostname 'does.not.exists' could not be resolved.")
+
+        where:
+        customServerProperty << ["gradleEnterprise.server", "gradleEnterprise.buildScan.server"]
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildScanIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildScanIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
 
@@ -47,37 +45,6 @@ class InstantExecutionBuildScanIntegrationTest extends AbstractInstantExecutionI
 
         then:
         postBuildOutputContains("Build scan written to")
-    }
-
-    @Requires(TestPrecondition.ONLINE)
-    def "can publish build scans using --scan"() {
-
-        given:
-        def instant = newInstantExecutionFixture()
-        settingsKotlinFile << '''
-            plugins {
-                `gradle-enterprise`
-            }
-
-            gradleEnterprise.buildScan {
-                termsOfServiceUrl = "https://gradle.com/terms-of-service"
-                termsOfServiceAgree = "yes"
-            }
-        '''
-
-        when:
-        instantRun "help", "--scan"
-
-        then:
-        instant.assertStateStored()
-        postBuildOutputContains("Publishing build scan...")
-
-        when:
-        instantRun "help", "--scan"
-
-        then:
-        instant.assertStateLoaded()
-        postBuildOutputContains("Publishing build scan...")
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -36,32 +36,6 @@ import javax.inject.Inject
 
 class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    def "--scan works"() {
-        given:
-        settingsKotlinFile << '''
-            plugins {
-                `gradle-enterprise`
-            }
-
-            gradleEnterprise.buildScan {
-                termsOfServiceUrl = "https://gradle.com/terms-of-service"
-                termsOfServiceAgree = "yes"
-            }
-        '''
-
-        when:
-        instantRun "help", "--scan", "-Dscan.dump"
-
-        then:
-        postBuildOutputContains("Build scan written to")
-
-        when:
-        instantRun "help", "--scan", "-Dscan.dump"
-
-        then:
-        postBuildOutputContains("Build scan written to")
-    }
-
     def "instant execution for help on empty project"() {
         given:
         instantRun "help"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -145,7 +145,7 @@ class DefaultInstantExecution internal constructor(
 
         stopCollectingCacheFingerprint()
 
-        buildScan.instantExecutionStoreAction()
+        buildScan.onInstantExecutionStoreAction()
 
         buildOperationExecutor.withStoreOperation {
 
@@ -161,7 +161,7 @@ class DefaultInstantExecution internal constructor(
 
                 writeInstantExecutionCacheFingerprint()
 
-                buildScan.instantExecutionStateSize(
+                buildScan.onInstantExecutionStats(
                     instantExecutionStateFile.length(),
                     instantExecutionFingerprintFile.length()
                 )
@@ -218,8 +218,8 @@ class DefaultInstantExecution internal constructor(
 
         readBuildScanState(buildScan)
 
-        buildScan.instantExecutionLoadAction()
-        buildScan.instantExecutionStateSize(
+        buildScan.onInstantExecutionLoadAction()
+        buildScan.onInstantExecutionStats(
             instantExecutionStateFile.length(),
             instantExecutionFingerprintFile.length()
         )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -143,9 +143,9 @@ class DefaultInstantExecution internal constructor(
             return
         }
 
-        buildScan.instantExecutionStoreAction()
-
         stopCollectingCacheFingerprint()
+
+        buildScan.instantExecutionStoreAction()
 
         buildOperationExecutor.withStoreOperation {
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -143,6 +143,9 @@ class DefaultInstantExecution internal constructor(
             return
         }
 
+        buildScan.instantExecutionEnabled()
+        buildScan.instantExecutionStoreAction()
+
         stopCollectingCacheFingerprint()
 
         buildOperationExecutor.withStoreOperation {
@@ -158,6 +161,9 @@ class DefaultInstantExecution internal constructor(
                 }
 
                 writeInstantExecutionCacheFingerprint()
+
+                buildScan.instantExecutionStateSize(instantExecutionStateFile.length())
+                buildScan.instantExecutionFingerprintSize(instantExecutionFingerprintFile.length())
             } catch (error: InstantExecutionError) {
                 // Invalidate unusable state on errors
                 invalidateInstantExecutionState()
@@ -210,6 +216,11 @@ class DefaultInstantExecution internal constructor(
         val build = host.createBuild(rootProjectName)
 
         readBuildScanState(buildScan)
+
+        buildScan.instantExecutionEnabled()
+        buildScan.instantExecutionLoadAction()
+        buildScan.instantExecutionStateSize(instantExecutionStateFile.length())
+        buildScan.instantExecutionFingerprintSize(instantExecutionFingerprintFile.length())
 
         readGradleState(build.gradle)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -143,7 +143,6 @@ class DefaultInstantExecution internal constructor(
             return
         }
 
-        buildScan.instantExecutionEnabled()
         buildScan.instantExecutionStoreAction()
 
         stopCollectingCacheFingerprint()
@@ -162,8 +161,10 @@ class DefaultInstantExecution internal constructor(
 
                 writeInstantExecutionCacheFingerprint()
 
-                buildScan.instantExecutionStateSize(instantExecutionStateFile.length())
-                buildScan.instantExecutionFingerprintSize(instantExecutionFingerprintFile.length())
+                buildScan.instantExecutionStateSize(
+                    instantExecutionStateFile.length(),
+                    instantExecutionFingerprintFile.length()
+                )
             } catch (error: InstantExecutionError) {
                 // Invalidate unusable state on errors
                 invalidateInstantExecutionState()
@@ -217,10 +218,11 @@ class DefaultInstantExecution internal constructor(
 
         readBuildScanState(buildScan)
 
-        buildScan.instantExecutionEnabled()
         buildScan.instantExecutionLoadAction()
-        buildScan.instantExecutionStateSize(instantExecutionStateFile.length())
-        buildScan.instantExecutionFingerprintSize(instantExecutionFingerprintFile.length())
+        buildScan.instantExecutionStateSize(
+            instantExecutionStateFile.length(),
+            instantExecutionFingerprintFile.length()
+        )
 
         readGradleState(build.gradle)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -30,7 +30,7 @@ import org.gradle.instantexecution.extensions.unsafeLazy
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprintController
 import org.gradle.instantexecution.fingerprint.InvalidationReason
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
-import org.gradle.instantexecution.observability.BuildScanFacade
+import org.gradle.instantexecution.observability.InstantExecutionBuildScan
 import org.gradle.instantexecution.problems.InstantExecutionProblems
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
@@ -71,7 +71,7 @@ class DefaultInstantExecution internal constructor(
     private val cacheFingerprintController: InstantExecutionCacheFingerprintController,
     private val beanConstructors: BeanConstructors,
     private val gradlePropertiesController: GradlePropertiesController,
-    private val buildScan: BuildScanFacade
+    private val buildScan: InstantExecutionBuildScan
 ) : InstantExecution {
 
     interface Host {
@@ -387,7 +387,7 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildScanState(buildScan: BuildScanFacade) {
+    suspend fun DefaultWriteContext.writeBuildScanState(buildScan: InstantExecutionBuildScan) {
         writeNullableString(buildScan.enterpriseServer)
         writeNullableString(buildScan.termsOfServiceUrl)
         writeNullableString(buildScan.termsOfServiceAgree)
@@ -397,7 +397,7 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildScanState(buildScan: BuildScanFacade) {
+    suspend fun DefaultReadContext.readBuildScanState(buildScan: InstantExecutionBuildScan) {
         buildScan.enterpriseServer = readNullableString()
         buildScan.termsOfServiceUrl = readNullableString()
         buildScan.termsOfServiceAgree = readNullableString()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -19,7 +19,7 @@ package org.gradle.instantexecution
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprintController
 import org.gradle.instantexecution.initialization.InstantExecutionProjectAccessListener
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
-import org.gradle.instantexecution.observability.DefaultBuildScanFacade
+import org.gradle.instantexecution.observability.DefaultInstantExecutionBuildScan
 import org.gradle.instantexecution.problems.InstantExecutionProblems
 import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.internal.service.ServiceRegistration
@@ -49,7 +49,7 @@ class InstantExecutionServices : AbstractPluginServiceRegistry() {
             add(InstantExecutionCacheFingerprintController::class.java)
             add(InstantExecutionHost::class.java)
             add(DefaultInstantExecution::class.java)
-            add(DefaultBuildScanFacade::class.java)
+            add(DefaultInstantExecutionBuildScan::class.java)
         }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -19,6 +19,7 @@ package org.gradle.instantexecution
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprintController
 import org.gradle.instantexecution.initialization.InstantExecutionProjectAccessListener
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
+import org.gradle.instantexecution.observability.DefaultBuildScanFacade
 import org.gradle.instantexecution.problems.InstantExecutionProblems
 import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.internal.service.ServiceRegistration
@@ -48,6 +49,7 @@ class InstantExecutionServices : AbstractPluginServiceRegistry() {
             add(InstantExecutionCacheFingerprintController::class.java)
             add(InstantExecutionHost::class.java)
             add(DefaultInstantExecution::class.java)
+            add(DefaultBuildScanFacade::class.java)
         }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
@@ -35,6 +35,25 @@ interface BuildScanFacade {
     var isCaptureTaskInputFiles: Boolean
     // TODO not accessible // var isPublishAlways: Boolean
     // TODO not accessible // var isPublishOnFailure: Boolean
+
+    fun tag(tag: String)
+
+    fun value(key: String, value: Any?)
+
+    fun instantExecutionEnabled() =
+        value("instant-execution:enabled", true)
+
+    fun instantExecutionStoreAction() =
+        value("instant-execution:action", "store")
+
+    fun instantExecutionLoadAction() =
+        value("instant-execution:action", "load")
+
+    fun instantExecutionStateSize(size: Long) =
+        value("instant-execution:state:size", size)
+
+    fun instantExecutionFingerprintSize(size: Long) =
+        value("instant-execution:fingerprint:size", size)
 }
 
 
@@ -72,6 +91,14 @@ class DefaultBuildScanFacade(
     override var isCaptureTaskInputFiles: Boolean
         by booleanGroovyProperty("captureTaskInputFiles") { buildScan }
 
+    override fun tag(tag: String): Unit = buildScan {
+        "tag"(tag)
+    }
+
+    override fun value(key: String, value: Any?): Unit = buildScan {
+        "value"(key, value.toString())
+    }
+
     private
     val isBuildScanEnabled: Boolean
         get() = buildScanPluginApplied.isBuildScanPluginApplied
@@ -87,6 +114,11 @@ class DefaultBuildScanFacade(
     private
     fun booleanGroovyProperty(name: String? = null, delegate: () -> Any) =
         GroovyPropertyDelegate(name, delegate) { it as? Boolean ?: false }
+
+    private
+    fun buildScan(dynamicAction: GroovyBuilderScope.() -> Unit) =
+        if (isBuildScanEnabled) buildScan.withGroovyBuilder(dynamicAction)
+        else Unit
 
     private
     inner class GroovyPropertyDelegate<T : Any?>(

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.observability
+
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.instantexecution.InstantExecutionHost
+import org.gradle.instantexecution.extensions.unsafeLazy
+import org.gradle.internal.scan.config.BuildScanPluginApplied
+import org.gradle.kotlin.dsl.*
+import kotlin.reflect.KProperty
+
+
+internal
+interface BuildScanFacade {
+
+    var enterpriseServer: String?
+    var termsOfServiceUrl: String?
+    var termsOfServiceAgree: String?
+    var server: String?
+    var isAllowUntrustedServer: Boolean
+    var isCaptureTaskInputFiles: Boolean
+    // TODO not accessible // var isPublishAlways: Boolean
+    // TODO not accessible // var isPublishOnFailure: Boolean
+}
+
+
+internal
+class DefaultBuildScanFacade(
+    private val host: InstantExecutionHost,
+    private val buildScanPluginApplied: BuildScanPluginApplied
+) : BuildScanFacade {
+
+    private
+    val gradleEnterprise: Any by unsafeLazy {
+        host.currentBuild.gradle.settings.extensionNamed("gradleEnterprise")
+    }
+
+    private
+    val buildScan: Any by unsafeLazy {
+        gradleEnterprise.withGroovyBuilder { getProperty("buildScan") }
+    }
+
+    override var enterpriseServer: String?
+        by stringGroovyProperty("server") { gradleEnterprise }
+
+    override var termsOfServiceUrl: String?
+        by stringGroovyProperty { buildScan }
+
+    override var termsOfServiceAgree: String?
+        by stringGroovyProperty { buildScan }
+
+    override var server: String?
+        by stringGroovyProperty { buildScan }
+
+    override var isAllowUntrustedServer: Boolean
+        by booleanGroovyProperty("allowUntrustedServer") { buildScan }
+
+    override var isCaptureTaskInputFiles: Boolean
+        by booleanGroovyProperty("captureTaskInputFiles") { buildScan }
+
+    private
+    val isBuildScanEnabled: Boolean
+        get() = buildScanPluginApplied.isBuildScanPluginApplied
+
+    private
+    fun Any.extensionNamed(name: String): Any =
+        (this as ExtensionAware).extensions.getByName(name)
+
+    private
+    fun stringGroovyProperty(name: String? = null, delegate: () -> Any) =
+        GroovyPropertyDelegate(name, delegate) { it as? String }
+
+    private
+    fun booleanGroovyProperty(name: String? = null, delegate: () -> Any) =
+        GroovyPropertyDelegate(name, delegate) { it as? Boolean ?: false }
+
+    private
+    inner class GroovyPropertyDelegate<T : Any?>(
+
+        private
+        val name: String? = null,
+
+        private
+        val delegate: () -> Any,
+
+        private
+        val transform: (Any?) -> T
+    ) {
+
+        operator fun getValue(thisRef: Any, property: KProperty<*>): T =
+            if (isBuildScanEnabled) delegate().withGroovyBuilder {
+                transform(getProperty(name ?: property.name))
+            }
+            else transform(null)
+
+        operator fun setValue(thisRef: Any, property: KProperty<*>, value: Any?) =
+            if (isBuildScanEnabled) delegate().withGroovyBuilder {
+                setProperty(name ?: property.name, transform(value))
+            }
+            else Unit
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/BuildScanFacade.kt
@@ -40,20 +40,20 @@ interface BuildScanFacade {
 
     fun value(key: String, value: Any?)
 
-    fun instantExecutionEnabled() =
+    fun instantExecutionStoreAction() {
         value("instant-execution:enabled", true)
-
-    fun instantExecutionStoreAction() =
         value("instant-execution:action", "store")
+    }
 
-    fun instantExecutionLoadAction() =
+    fun instantExecutionLoadAction() {
+        value("instant-execution:enabled", true)
         value("instant-execution:action", "load")
+    }
 
-    fun instantExecutionStateSize(size: Long) =
-        value("instant-execution:state:size", size)
-
-    fun instantExecutionFingerprintSize(size: Long) =
-        value("instant-execution:fingerprint:size", size)
+    fun instantExecutionStateSize(stateSize: Long, fingerprintSize: Long) {
+        value("instant-execution:state:size", stateSize)
+        value("instant-execution:fingerprint:size", fingerprintSize)
+    }
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/InstantExecutionBuildScan.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/observability/InstantExecutionBuildScan.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KProperty
 
 
 internal
-interface BuildScanFacade {
+interface InstantExecutionBuildScan {
 
     var enterpriseServer: String?
     var termsOfServiceUrl: String?
@@ -58,10 +58,10 @@ interface BuildScanFacade {
 
 
 internal
-class DefaultBuildScanFacade(
+class DefaultInstantExecutionBuildScan(
     private val host: InstantExecutionHost,
     private val buildScanPluginApplied: BuildScanPluginApplied
-) : BuildScanFacade {
+) : InstantExecutionBuildScan {
 
     private
     val gradleEnterprise: Any by unsafeLazy {


### PR DESCRIPTION
This PR let's instant execution capture enough of the build scan plugin configuration so that it is possible to publish scans to declared GE instances. Remaining configuration to be captured is `publishAlways`, `publishOnFailure` and `publishIfAuthenticated` as the Build Scan Plugin doesn't allow querying that.

It still requires using `--scan` though. This will be addressed later.

----

This PR also adds some custom values to build scans when both instant execution and build scans are enabled. Those values include the action (`store`/`load`) and the size of the cached state. This is for experimentation purpose for now.
