### PR TITLE
Pull module path calculation into Test task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
@@ -62,14 +62,14 @@ class DefaultMultiRequestWorkerProcessBuilder<IN, OUT> implements MultiRequestWo
     }
 
     @Override
-    public WorkerProcessSettings setInferApplicationModulePath(boolean inferApplicationModulePath) {
-        workerProcessBuilder.setInferApplicationModulePath(inferApplicationModulePath);
+    public WorkerProcessSettings applicationModulePath(Iterable<File> files) {
+        workerProcessBuilder.applicationModulePath(files);
         return this;
     }
 
     @Override
-    public boolean isInferApplicationModulePath() {
-        return workerProcessBuilder.isInferApplicationModulePath();
+    public Set<File> getApplicationModulePath() {
+        return workerProcessBuilder.getApplicationModulePath();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultSingleRequestWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultSingleRequestWorkerProcessBuilder.java
@@ -70,14 +70,14 @@ class DefaultSingleRequestWorkerProcessBuilder<IN, OUT> implements SingleRequest
     }
 
     @Override
-    public WorkerProcessSettings setInferApplicationModulePath(boolean inferApplicationModulePath) {
-        builder.setInferApplicationModulePath(inferApplicationModulePath);
+    public WorkerProcessSettings applicationModulePath(Iterable<File> files) {
+        builder.applicationModulePath(files);
         return this;
     }
 
     @Override
-    public boolean isInferApplicationModulePath() {
-        return builder.isInferApplicationModulePath();
+    public Set<File> getApplicationModulePath() {
+        return builder.getApplicationModulePath();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -56,7 +56,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
     private final JavaExecHandleBuilder javaCommand;
     private final Set<String> packages = new HashSet<>();
     private final Set<File> applicationClasspath = new LinkedHashSet<>();
-    private boolean inferApplicationModulePath = false;
+    private final Set<File> applicationModulePath = new LinkedHashSet<>();
 
     private final MemoryManager memoryManager;
     private Action<? super WorkerProcessContext> action;
@@ -103,18 +103,20 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
         return this;
     }
 
-    public boolean isInferApplicationModulePath() {
-        return inferApplicationModulePath;
+    @Override
+    public Set<File> getApplicationClasspath() {
+        return applicationClasspath;
     }
 
-    public WorkerProcessBuilder setInferApplicationModulePath(boolean inferApplicationModulePath) {
-        this.inferApplicationModulePath = inferApplicationModulePath;
+    @Override
+    public WorkerProcessBuilder applicationModulePath(Iterable<File> files) {
+        GUtil.addToCollection(applicationModulePath, files);
         return this;
     }
 
     @Override
-    public Set<File> getApplicationClasspath() {
-        return applicationClasspath;
+    public Set<File> getApplicationModulePath() {
+        return applicationModulePath;
     }
 
     @Override
@@ -213,6 +215,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
 
         LOGGER.debug("Creating {}", displayName);
         LOGGER.debug("Using application classpath {}", applicationClasspath);
+        LOGGER.debug("Using application module path {}", applicationModulePath);
         LOGGER.debug("Using implementation classpath {}", implementationClassPath);
         LOGGER.debug("Using implementation module path {}", implementationModulePath);
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessBuilder.java
@@ -37,7 +37,7 @@ public interface WorkerProcessBuilder extends WorkerProcessSettings {
     WorkerProcessBuilder applicationClasspath(Iterable<File> files);
 
     @Override
-    WorkerProcessBuilder setInferApplicationModulePath(boolean inferApplicationModulePath);
+    WorkerProcessBuilder applicationModulePath(Iterable<File> files);
 
     @Override
     WorkerProcessBuilder setBaseName(String baseName);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessSettings.java
@@ -39,9 +39,9 @@ public interface WorkerProcessSettings {
 
     Set<File> getApplicationClasspath();
 
-    WorkerProcessSettings setInferApplicationModulePath(boolean inferApplicationModulePath);
+    WorkerProcessSettings applicationModulePath(Iterable<File> files);
 
-    boolean isInferApplicationModulePath();
+    Set<File> getApplicationModulePath();
 
     WorkerProcessSettings sharedPackages(String... packages);
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -92,13 +92,12 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
     @Override
     public void prepareJavaCommand(long workerId, String displayName, WorkerProcessBuilder processBuilder, List<URL> implementationClassPath, List<URL> implementationModulePath, Address serverAddress, JavaExecHandleBuilder execSpec, boolean publishProcessInfo) {
         Collection<File> applicationClasspath = processBuilder.getApplicationClasspath();
-        boolean inferApplicationModulePath = processBuilder.isInferApplicationModulePath();
+        Set<File> applicationModulePath = processBuilder.getApplicationModulePath();
         LogLevel logLevel = processBuilder.getLogLevel();
         Set<String> sharedPackages = processBuilder.getSharedPackages();
         Object requestedSecurityManager = execSpec.getSystemProperties().get("java.security.manager");
         List<File> workerMainClassPath = classPathRegistry.getClassPath("WORKER_MAIN").getAsFiles();
 
-        execSpec.getModularClasspathHandling().getInferModulePath().set(inferApplicationModulePath);
         execSpec.getMainModule().set("gradle.worker");
         execSpec.getMainClass().set("worker." + GradleWorkerMain.class.getName());
 
@@ -106,7 +105,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
         if (useOptionsFile) {
             // Use an options file to pass across application classpath
             File optionsFile = temporaryFileProvider.createTemporaryFile("gradle-worker-classpath", "txt");
-            List<String> jvmArgs = writeOptionsFile(workerMainClassPath, implementationModulePath, applicationClasspath, inferApplicationModulePath, optionsFile);
+            List<String> jvmArgs = writeOptionsFile(execSpec.getModularClasspathHandling().getInferModulePath().get(), workerMainClassPath, implementationModulePath, applicationClasspath, applicationModulePath, optionsFile);
             execSpec.jvmArgs(jvmArgs);
         } else {
             // Use a dummy security manager, which hacks the application classpath into the system ClassLoader
@@ -178,17 +177,17 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
         return executableVersion != null && executableVersion.isJava9Compatible();
     }
 
-    private List<String> writeOptionsFile(Collection<File> workerMainClassPath, Collection<URL> implementationModulePath, Collection<File> applicationClasspath, boolean inferApplicationModulePath, File optionsFile) {
+    private List<String> writeOptionsFile(boolean runAsModule, Collection<File> workerMainClassPath, Collection<URL> implementationModulePath, Collection<File> applicationClasspath, Set<File> applicationModulePath, File optionsFile) {
         List<File> classpath = new ArrayList<>();
         List<File> modulePath = new ArrayList<>();
 
-        if (inferApplicationModulePath) {
+        if (runAsModule) {
             modulePath.addAll(workerMainClassPath);
         } else {
             classpath.addAll(workerMainClassPath);
         }
-        modulePath.addAll(javaModuleDetector.inferModulePath(inferApplicationModulePath, applicationClasspath).getFiles());
-        classpath.addAll(javaModuleDetector.inferClasspath(inferApplicationModulePath, applicationClasspath).getFiles());
+        modulePath.addAll(applicationModulePath);
+        classpath.addAll(applicationClasspath);
 
         if (!modulePath.isEmpty() && implementationModulePath != null && !implementationModulePath.isEmpty()) {
             // We add the implementation module path as well, as we do not load modules dynamically through a separate class loader in the worker.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -45,7 +45,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private final WorkerTestClassProcessorFactory processorFactory;
     private final JavaForkOptions options;
     private final Iterable<File> classPath;
-    private final boolean inferModulePath;
+    private final Iterable<File> modulePath;
     private final List<String> testWorkerImplementationModules;
     private final Action<WorkerProcessBuilder> buildConfigAction;
     private final ModuleRegistry moduleRegistry;
@@ -58,14 +58,14 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private boolean stoppedNow;
 
     public ForkingTestClassProcessor(WorkerLeaseRegistry.WorkerLease parentWorkerLease, WorkerProcessFactory workerFactory, WorkerTestClassProcessorFactory processorFactory, JavaForkOptions options,
-                                     Iterable<File> classPath, boolean inferModulePath, List<String> testWorkerImplementationModules,
+                                     Iterable<File> classPath, Iterable<File> modulePath, List<String> testWorkerImplementationModules,
                                      Action<WorkerProcessBuilder> buildConfigAction, ModuleRegistry moduleRegistry, DocumentationRegistry documentationRegistry) {
         this.currentWorkerLease = parentWorkerLease;
         this.workerFactory = workerFactory;
         this.processorFactory = processorFactory;
         this.options = options;
         this.classPath = classPath;
-        this.inferModulePath = inferModulePath;
+        this.modulePath = modulePath;
         this.testWorkerImplementationModules = testWorkerImplementationModules;
         this.buildConfigAction = buildConfigAction;
         this.moduleRegistry = moduleRegistry;
@@ -108,8 +108,9 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         builder.setImplementationClasspath(getTestWorkerImplementationClasspath());
         builder.setImplementationModulePath(getTestWorkerImplementationModulePath());
         builder.applicationClasspath(classPath);
-        builder.setInferApplicationModulePath(inferModulePath);
+        builder.applicationModulePath(modulePath);
         options.copyTo(builder.getJavaCommand());
+        builder.getJavaCommand().getModularClasspathHandling().getInferModulePath().set(modulePath.iterator().hasNext());
         builder.getJavaCommand().jvmArgs("-Dorg.gradle.native=false");
         buildConfigAction.execute(builder);
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -46,7 +46,7 @@ class ForkingTestClassProcessorTest extends Specification {
     List<String> testWorkerImplementationModules = []
 
     @Subject
-    processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], false, testWorkerImplementationModules, Mock(Action), moduleRegistry, documentationRegistry])
+    processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], testWorkerImplementationModules, Mock(Action), moduleRegistry, documentationRegistry])
 
     def setup() {
         workerProcessBuilder.build() >> workerProcess
@@ -111,7 +111,7 @@ class ForkingTestClassProcessorTest extends Specification {
     }
 
     def "stopNow propagates to worker process"() {
-        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(Stub(WorkerLeaseRegistry.WorkerLease), workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")],false, [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
+        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(Stub(WorkerLeaseRegistry.WorkerLease), workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
 
         setup:
         1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }
@@ -125,7 +125,7 @@ class ForkingTestClassProcessorTest extends Specification {
     }
 
     def "no exception when stop after stopNow"() {
-        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(Stub(WorkerLeaseRegistry.WorkerLease), workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], false, [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
+        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(Stub(WorkerLeaseRegistry.WorkerLease), workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
 
         setup:
         1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -22,12 +22,13 @@ import org.gradle.process.JavaForkOptions;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Set;
 
 public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final TestFramework testFramework;
     private final Iterable<? extends File> classpath;
-    private final boolean inferModulePath;
+    private final Iterable<? extends File> modulePath;
     private final FileTree candidateClassFiles;
     private final boolean scanForTestClasses;
     private final FileCollection testClassesDirs;
@@ -42,13 +43,13 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
      * Required by test-retry-gradle-plugin <= 1.1.3
      */
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
-        this(testFramework, classpath, false, candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
+        this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
     }
 
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, boolean inferModulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
+    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
         this.testFramework = testFramework;
         this.classpath = classpath;
-        this.inferModulePath = inferModulePath;
+        this.modulePath = modulePath;
         this.candidateClassFiles = candidateClassFiles;
         this.scanForTestClasses = scanForTestClasses;
         this.testClassesDirs = testClassesDirs;
@@ -68,8 +69,8 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         return classpath;
     }
 
-    public boolean isInferModulePath() {
-        return inferModulePath;
+    public Iterable<? extends File> getModulePath() {
+        return modulePath;
     }
 
     public FileTree getCandidateClassFiles() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -84,12 +84,13 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         final WorkerTestClassProcessorFactory testInstanceFactory = testFramework.getProcessorFactory();
         final WorkerLeaseRegistry.WorkerLease currentWorkerLease = workerLeaseRegistry.getCurrentWorkerLease();
         final Set<File> classpath = ImmutableSet.copyOf(testExecutionSpec.getClasspath());
+        final Set<File> modulePath = ImmutableSet.copyOf(testExecutionSpec.getModulePath());
         final List<String> testWorkerImplementationModules = testFramework.getTestWorkerImplementationModules();
         final Factory<TestClassProcessor> forkingProcessorFactory = new Factory<TestClassProcessor>() {
             @Override
             public TestClassProcessor create() {
                 return new ForkingTestClassProcessor(currentWorkerLease, workerFactory, testInstanceFactory, testExecutionSpec.getJavaForkOptions(),
-                    classpath, testExecutionSpec.isInferModulePath(), testWorkerImplementationModules, testFramework.getWorkerConfigurationAction(), moduleRegistry, documentationRegistry);
+                    classpath, modulePath, testWorkerImplementationModules, testFramework.getWorkerConfigurationAction(), moduleRegistry, documentationRegistry);
             }
         };
         final Factory<TestClassProcessor> reforkingProcessorFactory = new Factory<TestClassProcessor>() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -604,8 +604,11 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     protected JvmTestExecutionSpec createTestExecutionSpec() {
         JavaForkOptions javaForkOptions = getForkOptionsFactory().newJavaForkOptions();
         copyTo(javaForkOptions);
-        boolean testIsModule = getJavaModuleDetector().isModule(modularClasspathHandling.getInferModulePath().get(), getTestClassesDirs());
-        return new JvmTestExecutionSpec(getTestFramework(), getClasspath(), testIsModule, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
+        JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
+        boolean testIsModule = javaModuleDetector.isModule(modularClasspathHandling.getInferModulePath().get(), getTestClassesDirs());
+        FileCollection classpath = javaModuleDetector.inferClasspath(testIsModule, getClasspath());
+        FileCollection modulePath = javaModuleDetector.inferModulePath(testIsModule, getClasspath());
+        return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
     }
 
     private Set<String> getPreviousFailedTestClasses() {


### PR DESCRIPTION
This way, the `JvmTestExecutionSpec` already carries the final classpath and module path. This makes is easier to create alternative test worker implementations based on the spec.
