### PR TITLE
Add shutdown functionality to Tooling API

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
@@ -21,6 +21,8 @@ import org.gradle.internal.UncheckedException;
 import java.io.IOException;
 
 public class GradleLauncherMetaData implements BuildClientMetaData {
+
+    // TODO maybe create a TAPILauncherMetadata
     private final String appName;
 
     public GradleLauncherMetaData() {

--- a/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 public class GradleLauncherMetaData implements BuildClientMetaData {
 
-    // TODO maybe create a TAPILauncherMetadata
     private final String appName;
 
     public GradleLauncherMetaData() {

--- a/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/GradleLauncherMetaData.java
@@ -21,7 +21,6 @@ import org.gradle.internal.UncheckedException;
 import java.io.IOException;
 
 public class GradleLauncherMetaData implements BuildClientMetaData {
-
     private final String appName;
 
     public GradleLauncherMetaData() {

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -138,7 +138,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 378 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 383 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Plugins
         assertIsGradleJar(contentsDir.file("lib/plugins/gradle-dependency-management-${baseVersion}.jar"))

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -69,6 +69,11 @@ pmd {
 ```
 This was contributed by [Matthew Duggan](https://github.com/mduggan).
 
+## Improvements for tooling providers
+
+The GradleConnector class has a new `disconnect` method. Clients can use it to asynchronously cancel release all Tooling API connections without waiting for the current build to finish.
+For more details, refer to the [javadoc](javadoc/org/gradle/tooling/GradleConnector.html). 
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/DaemonStateControl.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/DaemonStateControl.java
@@ -35,6 +35,8 @@ public interface DaemonStateControl {
      */
     void requestForcefulStop(String reason);
 
+    // TODO requestXXXStop() // based on who created the daemon in step 2.
+
     /**
      * Returns the current state of the daemon
      *

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/DaemonStateControl.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/DaemonStateControl.java
@@ -35,8 +35,6 @@ public interface DaemonStateControl {
      */
     void requestForcefulStop(String reason);
 
-    // TODO requestXXXStop() // based on who created the daemon in step 2.
-
     /**
      * Returns the current state of the daemon
      *

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/HandleStop.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/HandleStop.java
@@ -41,6 +41,8 @@ public class HandleStop implements DaemonCommandAction {
         } else if (execution.getCommand() instanceof StopWhenIdle) {
             listenerBroadcast.onExpirationEvent(new DaemonExpirationResult(DaemonExpirationStatus.GRACEFUL_EXPIRE, EXPIRATION_REASON));
             execution.getConnection().completed(new Success(null));
+
+            // TODO add new expiration result to distingu
         } else {
             execution.proceed();
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/HandleStop.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/api/HandleStop.java
@@ -41,8 +41,6 @@ public class HandleStop implements DaemonCommandAction {
         } else if (execution.getCommand() instanceof StopWhenIdle) {
             listenerBroadcast.onExpirationEvent(new DaemonExpirationResult(DaemonExpirationStatus.GRACEFUL_EXPIRE, EXPIRATION_REASON));
             execution.getConnection().completed(new Success(null));
-
-            // TODO add new expiration result to distingu
         } else {
             execution.proceed();
         }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -52,6 +52,7 @@ import org.gradle.tooling.internal.protocol.ModelIdentifier;
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener;
 import org.gradle.tooling.internal.protocol.ProjectVersion3;
 import org.gradle.tooling.internal.protocol.ShutdownParameters;
+import org.gradle.tooling.internal.protocol.InternalStopWhenIdleConnection;
 import org.gradle.tooling.internal.protocol.StoppableConnection;
 import org.gradle.tooling.internal.protocol.exceptions.InternalUnsupportedBuildArgumentException;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionConnection;
@@ -73,7 +74,7 @@ import java.util.List;
 
 public class DefaultConnection implements ConnectionVersion4, InternalConnection, BuildActionRunner,
     ConfigurableConnection, ModelBuilder, InternalBuildActionExecutor, InternalCancellableConnection, InternalParameterAcceptingConnection,
-    StoppableConnection, InternalTestExecutionConnection, InternalPhasedActionConnection, InternalInvalidatableVirtualFileSystemConnection {
+    StoppableConnection, InternalTestExecutionConnection, InternalPhasedActionConnection, InternalInvalidatableVirtualFileSystemConnection, InternalStopWhenIdleConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultConnection.class);
     private static final String UNSUPPORTED_MESSAGE = "Support for clients using a tooling API version older than 3.0 was removed in Gradle 5.0. %sYou should upgrade your tooling API client to version 3.0 or later.";
 
@@ -298,5 +299,11 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
     public void notifyDaemonsAboutChangedPaths(List<String> changedPaths, BuildParameters operationParameters) {
         ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
         connection.notifyDaemonsAboutChangedPaths(changedPaths, providerParameters);
+    }
+
+    @Override
+    public void stopWhenIdle(BuildParameters operationParameters) {
+        ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
+        connection.stopWhenIdle(providerParameters);
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -206,7 +206,6 @@ public class ProviderConnection {
         try {
             BuildActionExecuter<ProviderOperationParameters> executer = createExecuter(providerParameters, parameters);
             boolean interactive = providerParameters.getStandardInput() != null;
-            // TODO inject a different metadata here
             BuildRequestContext buildRequestContext = new DefaultBuildRequestContext(new DefaultBuildRequestMetaData(providerParameters.getStartTime(), interactive), cancellationToken, buildEventConsumer);
             BuildActionResult result = executer.execute(action, buildRequestContext, providerParameters, sharedServices);
             throwFailure(result);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -191,6 +191,13 @@ public class ProviderConnection {
         client.notifyDaemonsAboutChangedPaths(changedPaths);
     }
 
+    public void stopWhenIdle(ProviderOperationParameters providerParameters) {
+        LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newNestedLogging();
+        Parameters params = initParams(providerParameters);
+        ServiceRegistry clientServices = daemonClientFactory.createMessageDaemonServices(loggingServices.get(OutputEventListener.class), params.daemonParams);
+        ((ShutdownCoordinator)clientServices.find(ShutdownCoordinator.class)).stop();
+    }
+
     private Object run(BuildAction action, BuildCancellationToken cancellationToken,
                        ProgressListenerConfiguration progressListenerConfiguration,
                        BuildEventConsumer buildEventConsumer,
@@ -199,6 +206,7 @@ public class ProviderConnection {
         try {
             BuildActionExecuter<ProviderOperationParameters> executer = createExecuter(providerParameters, parameters);
             boolean interactive = providerParameters.getStandardInput() != null;
+            // TODO inject a different metadata here
             BuildRequestContext buildRequestContext = new DefaultBuildRequestContext(new DefaultBuildRequestMetaData(providerParameters.getStartTime(), interactive), cancellationToken, buildEventConsumer);
             BuildActionResult result = executer.execute(action, buildRequestContext, providerParameters, sharedServices);
             throwFailure(result);

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r64
+
+import org.gradle.integtests.tooling.CancellationSpec
+import org.gradle.integtests.tooling.fixture.TestResultHandler
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.GradleConnectionException
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.GradleProject
+import org.gradle.tooling.model.eclipse.EclipseProject
+import spock.util.concurrent.PollingConditions
+
+@ToolingApiVersion(">=6.4")
+class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
+
+    def waitFor
+    def existingDaemonPids
+
+    def setup() {
+        waitFor = new PollingConditions(timeout: 60, initialDelay: 0, factor: 1.25)
+        existingDaemonPids = toolingApi.daemons.daemons.collect { it.context.pid }
+    }
+
+    def "can forcibly stop daemon when running a build"() {
+        toolingApi.requireDaemons()
+        buildFile << """
+            task hang {
+                doLast {
+                    ${server.callFromBuild("waiting")}
+                }
+            }
+        """.stripIndent()
+
+        def sync = server.expectAndBlock("waiting")
+        def resultHandler = new TestResultHandler()
+
+        when:
+        GradleConnector connector = toolingApi.connector()
+        ProjectConnection connection = connector.connect() // using withConnection would call close after the closure
+
+        def build = connection.newBuild()
+        build.forTasks('hang')
+        build.run(resultHandler)
+        sync.waitForAllPendingCalls(resultHandler)
+        connector.disconnect()
+        resultHandler.finished()
+
+        then:
+        waitFor.eventually {
+            toolingApi.daemons.daemons.findAll { !existingDaemonPids.contains(it.context.pid) }.empty
+        }
+    }
+
+    def "can forcibly stop a daemon when querying a tooling model"() {
+        toolingApi.requireDaemons()
+        buildFile << """
+            apply plugin: 'eclipse'
+            eclipse {
+                project {
+                    file {
+                        whenMerged {
+                            ${server.callFromBuild("waiting")}
+                        }
+                    }
+                }
+            }
+        """.stripIndent()
+
+        def sync = server.expectAndBlock("waiting")
+        def resultHandler = new TestResultHandler()
+
+        when:
+        GradleConnector connector = toolingApi.connector()
+        ProjectConnection connection = connector.connect()
+
+        def query = connection.model(EclipseProject)
+        query.get(resultHandler)
+        sync.waitForAllPendingCalls(resultHandler)
+        connector.disconnect()
+        resultHandler.finished()
+
+        then:
+        waitFor.eventually {
+            toolingApi.daemons.daemons.findAll { !existingDaemonPids.contains(it.context.pid) }.empty
+        }
+    }
+
+    def "Cannot run build operations on project connection after disconnect"() {
+        setup:
+        GradleConnector connector = toolingApi.connector()
+        ProjectConnection connection = connector.connect()
+        connection.getModel(GradleProject)
+        connector.disconnect()
+
+        when:
+        connection.getModel(GradleProject)
+
+        then:
+        thrown(GradleConnectionException)
+    }
+
+    def "Cannot create new project connection after disconnect"() {
+        setup:
+        GradleConnector connector = toolingApi.connector()
+        withConnection(connector) { connection ->
+            connection.getModel(EclipseProject)
+        }
+        connector.disconnect()
+
+        when:
+        connector.connect()
+
+        then:
+        thrown(IllegalStateException)
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
@@ -112,7 +112,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         connection.getModel(GradleProject)
 
         then:
-        thrown(GradleConnectionException)
+        thrown(RuntimeException)
     }
 
     def "Cannot create new project connection after disconnect"() {
@@ -127,6 +127,6 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         connector.connect()
 
         then:
-        thrown(IllegalStateException)
+        thrown(RuntimeException)
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/ToolingApiShutdownCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r64
 import org.gradle.integtests.tooling.CancellationSpec
 import org.gradle.integtests.tooling.fixture.TestResultHandler
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.tooling.GradleConnectionException
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.tooling;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.internal.consumer.ConnectorServices;
 
 import java.io.File;
@@ -163,4 +164,17 @@ public abstract class GradleConnector {
      */
     public abstract ProjectConnection connect() throws GradleConnectionException;
 
+    /**
+     * Disconnects all ProjectConnection instances created by this connector.
+     * <p>
+     * Calling this method tries does best effort to clean up daemons. It tries to cancel the existing builds and
+     * shut down the daemons without any guarantees.
+     * <p>
+     * After calling {@code disconnect}, creating new project connections will be rejected and the existing ones
+     * created by this instance will also deny future build operations.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    public abstract void disconnect();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionFactory.java
@@ -32,21 +32,21 @@ public class ConnectionFactory {
     private final LoggingProvider loggingProvider;
 
     public ConnectionFactory(ToolingImplementationLoader toolingImplementationLoader, ExecutorFactory executorFactory, LoggingProvider loggingProvider) {
-        this.toolingImplementationLoader = toolingImplementationLoader;
-        this.executorFactory = executorFactory;
-        this.loggingProvider = loggingProvider;
+    this.toolingImplementationLoader = toolingImplementationLoader;
+    this.executorFactory = executorFactory;
+    this.loggingProvider = loggingProvider;
     }
 
-    public ProjectConnection create(Distribution distribution, ConnectionParameters parameters) {
-        ConsumerActionExecutor lazyConnection = new LazyConsumerActionExecutor(distribution, toolingImplementationLoader, loggingProvider, parameters);
-        ConsumerActionExecutor cancellableConnection = new CancellableConsumerActionExecutor(lazyConnection);
-        ConsumerActionExecutor progressLoggingConnection = new ProgressLoggingConsumerActionExecutor(cancellableConnection, loggingProvider);
-        ConsumerActionExecutor rethrowingErrorsConnection = new RethrowingErrorsConsumerActionExecutor(progressLoggingConnection);
-        AsyncConsumerActionExecutor asyncConnection = new DefaultAsyncConsumerActionExecutor(rethrowingErrorsConnection, executorFactory);
-        return new DefaultProjectConnection(asyncConnection, parameters);
+public ProjectConnection create(Distribution distribution, ConnectionParameters parameters, ProjectConnectionCloseListener listener) {
+    ConsumerActionExecutor lazyConnection = new LazyConsumerActionExecutor(distribution, toolingImplementationLoader, loggingProvider, parameters);
+    ConsumerActionExecutor cancellableConnection = new CancellableConsumerActionExecutor(lazyConnection);
+    ConsumerActionExecutor progressLoggingConnection = new ProgressLoggingConsumerActionExecutor(cancellableConnection, loggingProvider);
+    ConsumerActionExecutor rethrowingErrorsConnection = new RethrowingErrorsConsumerActionExecutor(progressLoggingConnection);
+    AsyncConsumerActionExecutor asyncConnection = new DefaultAsyncConsumerActionExecutor(rethrowingErrorsConnection, executorFactory);
+    return new DefaultProjectConnection(asyncConnection, parameters, listener);
     }
 
     ToolingImplementationLoader getToolingImplementationLoader() {
-        return toolingImplementationLoader;
+    return toolingImplementationLoader;
     }
-}
+    }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
@@ -69,17 +69,7 @@ public class DefaultGradleConnector extends GradleConnector implements ProjectCo
         }
     }
 
-    /**
-     * Disconnects all ProjectConnection instances created by this connector.
-     * <p>
-     * Calling this method cancels all running build operations and sends a 'stop when idle message' to all Gradle daemons.
-     * This method does not block.
-     * <p>
-     * After calling {@code disconnect}, creating new project connections will be rejected and the existing ones
-     * created by this instance will also deny future build operations.\
-     *
-     * TODO (donat) add this method up to the interface.
-     */
+    @Override
     public void disconnect() {
         synchronized (connections) {
             stopped = true;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
@@ -49,7 +49,6 @@ class DefaultProjectConnection implements ProjectConnection {
     }
 
     void disconnect() {
-        // TODO no-op when close() was called
         connection.disconnect();
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
@@ -34,15 +34,23 @@ import java.util.List;
 class DefaultProjectConnection implements ProjectConnection {
     private final AsyncConsumerActionExecutor connection;
     private final ConnectionParameters parameters;
+    private final ProjectConnectionCloseListener listener;
 
-    public DefaultProjectConnection(AsyncConsumerActionExecutor connection, ConnectionParameters parameters) {
+    public DefaultProjectConnection(AsyncConsumerActionExecutor connection, ConnectionParameters parameters, ProjectConnectionCloseListener listener) {
         this.connection = connection;
         this.parameters = parameters;
+        this.listener = listener;
     }
 
     @Override
     public void close() {
         connection.stop();
+        listener.connectionClosed(this);
+    }
+
+    void disconnect() {
+        // TODO no-op when close() was called
+        connection.disconnect();
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ProjectConnectionCloseListener.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ProjectConnectionCloseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.consumer.connection;
+package org.gradle.tooling.internal.consumer;
 
-import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.tooling.ProjectConnection;
 
-/**
- * Implementations must be thread-safe.
- */
-public interface ConsumerActionExecutor extends Stoppable {
-    /**
-     * Blocks until all actions have completed.
-     */
-    @Override
-    void stop();
+public interface ProjectConnectionCloseListener {
 
-    String getDisplayName();
-
-    <T> T run(ConsumerAction<T> action) throws UnsupportedOperationException, IllegalStateException;
-
-    void disconnect();
+    void connectionClosed(ProjectConnection connection);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/AsyncConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/AsyncConsumerActionExecutor.java
@@ -36,4 +36,9 @@ public interface AsyncConsumerActionExecutor {
     void stop();
 
     String getDisplayName();
+
+    /**
+     * Requests cancellation on the current operation and send a 'stop when idle' message to the daemon.
+     */
+    void disconnect();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
@@ -44,7 +44,13 @@ public class DefaultAsyncConsumerActionExecutor implements AsyncConsumerActionEx
 
     @Override
     public void stop() {
+        // TODO instead of stopping the current build, request cancellation and send a stopWhenIdle
         CompositeStoppable.stoppable(lifecycle, executor, actionExecutor).stop();
+    }
+
+    @Override
+    public void disconnect() {
+        actionExecutor.disconnect();
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
@@ -44,7 +44,6 @@ public class DefaultAsyncConsumerActionExecutor implements AsyncConsumerActionEx
 
     @Override
     public void stop() {
-        // TODO instead of stopping the current build, request cancellation and send a stopWhenIdle
         CompositeStoppable.stoppable(lifecycle, executor, actionExecutor).stop();
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
@@ -50,6 +50,7 @@ public class DefaultAsyncConsumerActionExecutor implements AsyncConsumerActionEx
 
     @Override
     public void disconnect() {
+        executor.requestStop();
         actionExecutor.disconnect();
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/AbstractConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/AbstractConsumerConnection.java
@@ -83,4 +83,9 @@ public abstract class AbstractConsumerConnection extends HasCompatibilityMapping
     public void notifyDaemonsAboutChangedPaths(List<String> changedPaths, ConsumerOperationParameters operationParameters) {
         // Default is no-op
     }
+
+    @Override
+    public void stopWhenIdle(ConsumerOperationParameters operationParameters) {
+        // Default is no-op
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableConsumerActionExecutor.java
@@ -44,4 +44,9 @@ public class CancellableConsumerActionExecutor implements ConsumerActionExecutor
         }
         return delegate.run(action);
     }
+
+    @Override
+    public void disconnect() {
+        delegate.disconnect();
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ConsumerConnection.java
@@ -48,4 +48,6 @@ public interface ConsumerConnection extends Stoppable {
     void runTests(TestExecutionRequest testExecutionRequest, ConsumerOperationParameters operationParameters);
 
     void notifyDaemonsAboutChangedPaths(List<String> changedPaths, ConsumerOperationParameters operationParameters);
+
+    void stopWhenIdle(ConsumerOperationParameters operationParameters);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
@@ -90,13 +90,8 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     }
 
     private void requestCancellation() {
-        lock.lock();
-        try {
-            if (cancellationToken != null) {
-                cancellationToken.cancel();
-            }
-        } finally {
-            lock.unlock();
+        if (cancellationToken != null) {
+            cancellationToken.cancel();
         }
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
@@ -19,6 +19,7 @@ import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.tooling.internal.consumer.ConnectionParameters;
+import org.gradle.tooling.internal.consumer.DefaultCancellationTokenSource;
 import org.gradle.tooling.internal.consumer.Distribution;
 import org.gradle.tooling.internal.consumer.LoggingProvider;
 import org.gradle.tooling.internal.consumer.loader.ToolingImplementationLoader;
@@ -46,6 +47,7 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     private ConsumerConnection connection;
 
     private final ConnectionParameters connectionParameters;
+    private BuildCancellationToken cancellationToken;
 
     public LazyConsumerActionExecutor(Distribution distribution, ToolingImplementationLoader implementationLoader, LoggingProvider loggingProvider, ConnectionParameters connectionParameters) {
         this.distribution = distribution;
@@ -73,6 +75,52 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     }
 
     @Override
+    public void disconnect() {
+        lock.lock();
+        try {
+            if (stopped) {
+                return;
+            }
+            requestCancellation();
+            sendStopWhenIdleMessageToDaemons();
+        } finally {
+            stopped = true;
+            lock.unlock();
+        }
+    }
+
+    private void requestCancellation() {
+        lock.lock();
+        try {
+            if (cancellationToken != null) {
+                cancellationToken.cancel();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void sendStopWhenIdleMessageToDaemons() {
+        ConsumerOperationParameters.Builder builder = ConsumerOperationParameters.builder();
+        builder.setCancellationToken(new DefaultCancellationTokenSource().token());
+        builder.setParameters(connectionParameters);
+        builder.setEntryPoint("Request daemon shutdown when idle");
+
+        run(new ConsumerAction<Void>() {
+            @Override
+            public ConsumerOperationParameters getParameters() {
+                return builder.build();
+            }
+
+            @Override
+            public Void run(ConsumerConnection c) {
+                c.stopWhenIdle(getParameters());
+                return null;
+            }
+        });
+    }
+
+    @Override
     public String getDisplayName() {
         return distribution.getDisplayName();
     }
@@ -81,7 +129,7 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     public <T> T run(ConsumerAction<T> action) throws UnsupportedOperationException, IllegalStateException {
         try {
             ConsumerOperationParameters parameters = action.getParameters();
-            BuildCancellationToken cancellationToken = parameters.getCancellationToken();
+            this.cancellationToken = parameters.getCancellationToken();
             InternalBuildProgressListener buildProgressListener = parameters.getBuildProgressListener();
             ConsumerConnection connection = onStartAction(cancellationToken, buildProgressListener);
             return action.run(connection);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/NoToolingApiConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/NoToolingApiConnection.java
@@ -71,4 +71,8 @@ public class NoToolingApiConnection implements ConsumerConnection {
         throw Exceptions.unsupportedFeature(operationParameters.getEntryPointName(), distribution, "6.1");
     }
 
+    @Override
+    public void stopWhenIdle(ConsumerOperationParameters operationParameters) {
+        throw Exceptions.unsupportedFeature(operationParameters.getEntryPointName(), distribution, "6.4");
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
@@ -73,6 +73,11 @@ public class ParameterValidatingConsumerConnection implements ConsumerConnection
         delegate.notifyDaemonsAboutChangedPaths(changedPaths, operationParameters);
     }
 
+    @Override
+    public void stopWhenIdle(ConsumerOperationParameters operationParameters) {
+        delegate.stopWhenIdle(operationParameters);
+    }
+
     private void validateParameters(ConsumerOperationParameters operationParameters) {
         if (!targetVersionDetails.supportsEnvironmentVariablesCustomization()) {
             if (operationParameters.getEnvironmentVariables() != null) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ProgressLoggingConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ProgressLoggingConsumerActionExecutor.java
@@ -67,6 +67,11 @@ public class ProgressLoggingConsumerActionExecutor implements ConsumerActionExec
         }
     }
 
+    @Override
+    public void disconnect() {
+        actionExecutor.disconnect();
+    }
+
     private static class ProgressListenerAdapter implements ProgressListener {
         private final ProgressListenerVersion1 progressListener;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/RethrowingErrorsConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/RethrowingErrorsConsumerActionExecutor.java
@@ -39,4 +39,9 @@ public class RethrowingErrorsConsumerActionExecutor implements ConsumerActionExe
         action.getParameters().getBuildProgressListener().rethrowErrors();
         return result;
     }
+
+    @Override
+    public void disconnect() {
+        delegate.disconnect();
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/StopWhenIdleConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/StopWhenIdleConsumerConnection.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.connection;
+
+import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
+import org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters;
+import org.gradle.tooling.internal.consumer.versioning.ModelMapping;
+import org.gradle.tooling.internal.protocol.ConnectionVersion4;
+import org.gradle.tooling.internal.protocol.InternalInvalidatableVirtualFileSystemConnection;
+import org.gradle.tooling.internal.protocol.InternalStopWhenIdleConnection;
+
+/**
+ * An adapter for {@link InternalInvalidatableVirtualFileSystemConnection}.
+ *
+ * <p>Used for providers >= 6.4.</p>
+ */
+public class StopWhenIdleConsumerConnection extends NotifyDaemonsAboutChangedPathsConsumerConnection {
+    public StopWhenIdleConsumerConnection(ConnectionVersion4 delegate, ModelMapping modelMapping, ProtocolToModelAdapter adapter) {
+        super(delegate, modelMapping, adapter);
+    }
+
+    @Override
+    public void stopWhenIdle(ConsumerOperationParameters operationParameters) {
+        ((InternalStopWhenIdleConnection) getDelegate()).stopWhenIdle(operationParameters);
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/UnsupportedOlderVersionConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/UnsupportedOlderVersionConnection.java
@@ -86,6 +86,11 @@ public class UnsupportedOlderVersionConnection implements ConsumerConnection {
         throw unsupported();
     }
 
+    @Override
+    public void stopWhenIdle(ConsumerOperationParameters operationParameters) {
+        throw unsupported();
+    }
+
     private UnsupportedVersionException unsupported() {
         return new UnsupportedVersionException(String.format("Support for builds using Gradle versions older than 2.6 was removed in tooling API version 5.0. You are currently using Gradle version %s. You should upgrade your Gradle build to use Gradle 2.6 or later.", version));
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
@@ -35,6 +35,7 @@ import org.gradle.tooling.internal.consumer.connection.NotifyDaemonsAboutChanged
 import org.gradle.tooling.internal.consumer.connection.ParameterAcceptingConsumerConnection;
 import org.gradle.tooling.internal.consumer.connection.ParameterValidatingConsumerConnection;
 import org.gradle.tooling.internal.consumer.connection.PhasedActionAwareConsumerConnection;
+import org.gradle.tooling.internal.consumer.connection.StopWhenIdleConsumerConnection;
 import org.gradle.tooling.internal.consumer.connection.TestExecutionConsumerConnection;
 import org.gradle.tooling.internal.consumer.connection.UnsupportedOlderVersionConnection;
 import org.gradle.tooling.internal.consumer.converters.ConsumerTargetTypeProvider;
@@ -45,6 +46,7 @@ import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 import org.gradle.tooling.internal.protocol.InternalInvalidatableVirtualFileSystemConnection;
 import org.gradle.tooling.internal.protocol.InternalParameterAcceptingConnection;
 import org.gradle.tooling.internal.protocol.InternalPhasedActionConnection;
+import org.gradle.tooling.internal.protocol.InternalStopWhenIdleConnection;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,8 +83,9 @@ public class DefaultToolingImplementationLoader implements ToolingImplementation
 
             ProtocolToModelAdapter adapter = new ProtocolToModelAdapter(new ConsumerTargetTypeProvider());
             ModelMapping modelMapping = new ModelMapping();
-
-            if (connection instanceof InternalInvalidatableVirtualFileSystemConnection) {
+            if (connection instanceof InternalStopWhenIdleConnection) {
+                return createConnection(new StopWhenIdleConsumerConnection(connection, modelMapping, adapter), connectionParameters);
+            } else if (connection instanceof InternalInvalidatableVirtualFileSystemConnection) {
                 return createConnection(new NotifyDaemonsAboutChangedPathsConsumerConnection(connection, modelMapping, adapter), connectionParameters);
             } else if (connection instanceof InternalPhasedActionConnection) {
                 return createConnection(new PhasedActionAwareConsumerConnection(connection, modelMapping, adapter), connectionParameters);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalStopWhenIdleConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalStopWhenIdleConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.consumer.connection;
-
-import org.gradle.internal.concurrent.Stoppable;
+package org.gradle.tooling.internal.protocol;
 
 /**
- * Implementations must be thread-safe.
+ * @since 6.4
+ * @see ConnectionVersion4
  */
-public interface ConsumerActionExecutor extends Stoppable {
-    /**
-     * Blocks until all actions have completed.
-     */
-    @Override
-    void stop();
-
-    String getDisplayName();
-
-    <T> T run(ConsumerAction<T> action) throws UnsupportedOperationException, IllegalStateException;
-
-    void disconnect();
+public interface InternalStopWhenIdleConnection extends InternalProtocolInterface {
+    void stopWhenIdle(BuildParameters parameters);
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultGradleConnectorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultGradleConnectorTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.tooling.internal.consumer
 
 import org.gradle.tooling.GradleConnector
-import org.gradle.tooling.ProjectConnection
 import spock.lang.Specification
 
 class DefaultGradleConnectorTest extends Specification {
@@ -27,7 +26,7 @@ class DefaultGradleConnectorTest extends Specification {
     final GradleConnector connector = new DefaultGradleConnector(connectionFactory, distributionFactory)
 
     def canCreateAConnectionGivenAProjectDirectory() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
 
         when:
         def result = connector.forProjectDirectory(projectDir).connect()
@@ -37,11 +36,11 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDefaultDistribution(projectDir, true) >> distribution
-        1 * connectionFactory.create(distribution, { it.projectDir == projectDir }) >> connection
+        1 * connectionFactory.create(distribution, { it.projectDir == projectDir }, connector) >> connection
     }
 
     def canSpecifyUserHomeDir() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
         File userDir = new File('user-dir')
 
         when:
@@ -52,11 +51,11 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDefaultDistribution(projectDir, true) >> distribution
-        1 * connectionFactory.create(distribution, { it.gradleUserHomeDir == userDir }) >> connection
+        1 * connectionFactory.create(distribution, { it.gradleUserHomeDir == userDir }, connector) >> connection
     }
 
     def canSpecifyDistributionAndUserHomeDir() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
         URI gradleDist = new URI('http://server/dist.zip')
         File userDir = new File('user-dir')
 
@@ -70,11 +69,11 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDistribution(gradleDist) >> distribution
-        1 * connectionFactory.create(distribution, { it.gradleUserHomeDir == userDir }) >> connection
+        1 * connectionFactory.create(distribution, { it.gradleUserHomeDir == userDir }, connector) >> connection
     }
 
     def canSpecifyAGradleInstallationToUse() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
         File gradleHome = new File('install-dir')
 
         when:
@@ -85,11 +84,11 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDistribution(gradleHome) >> distribution
-        1 * connectionFactory.create(distribution, !null) >> connection
+        1 * connectionFactory.create(distribution, !null, connector) >> connection
     }
 
     def canSpecifyAGradleDistributionToUse() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
         URI gradleDist = new URI('http://server/dist.zip')
 
         when:
@@ -100,11 +99,11 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDistribution(gradleDist) >> distribution
-        1 * connectionFactory.create(distribution, !null) >> connection
+        1 * connectionFactory.create(distribution, !null, connector) >> connection
     }
 
     def canSpecifyAGradleVersionToUse() {
-        ProjectConnection connection = Mock()
+        DefaultProjectConnection connection = Mock()
 
         when:
         def result = connector.useGradleVersion('1.0').forProjectDirectory(projectDir).connect()
@@ -114,7 +113,7 @@ class DefaultGradleConnectorTest extends Specification {
 
         and:
         1 * distributionFactory.getDistribution('1.0') >> distribution
-        1 * connectionFactory.create(distribution, !null) >> connection
+        1 * connectionFactory.create(distribution, !null, connector) >> connection
     }
 
     def mustSpecifyAProjectDirectory() {

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultProjectConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultProjectConnectionTest.groovy
@@ -24,7 +24,9 @@ class DefaultProjectConnectionTest extends Specification {
     final ConnectionParameters parameters = Stub() {
         getProjectDir() >> new File("foo")
     }
-    final DefaultProjectConnection connection = new DefaultProjectConnection(protocolConnection, parameters)
+    final ProjectConnectionCloseListener listener = Mock()
+
+    final DefaultProjectConnection connection = new DefaultProjectConnection(protocolConnection, parameters, listener)
 
     def canCreateAModelBuilder() {
         expect:
@@ -51,6 +53,7 @@ class DefaultProjectConnectionTest extends Specification {
 
         then:
         1 * protocolConnection.stop()
+        1 * listener.connectionClosed(connection)
     }
 
     def "can create phased build action builder"() {


### PR DESCRIPTION
This pull request adds `disconnect()` method to `GradleConnector` to let IDEs asynchronously release the existing project connections which try to clean exiting daemons in a best-effort fashion.

Implementation-wise this best-effort means:
- Canceling running builds
- Calling `requestStop` on the executor service
- Sending `stop when idle` message to recent daemons

One side-effect of this change is that clients need to save the reference to the `GradleConnector` to be able to call disconnect. The following code needs to be adjusted from
```
ProjectConnection connection = GradleConnector.newConnector()
    .forProjectDirectory(new File("someFolder"))
    .connect();
connection.newBuild()
    .forTasks("tasks")
    .setStandardOutput(System.out)
    .run();
```
to
```
GradleConnector connector = GradleConnector.newConnector();
ProjectConnection connection = connector
    .forProjectDirectory(new File("someFolder"))
    .connect();
connection.newBuild()
    .forTasks("tasks")
    .setStandardOutput(System.out)
    .run();
connector.disconnect()
```

Remaining items:
- [x] Complete test coverage
- [x] Add section to the release notes describing this feature