### PR TITLE
Update documentation regarding http proxy.

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -639,7 +639,7 @@ A proxy for S3 can be configured using the following system properties:
 * `https.proxyPort`
 * `https.proxyUser`
 * `https.proxyPassword`
-* `http.nonProxyHosts`
+* `https.nonProxyHosts`
 
 If the `org.gradle.s3.endpoint` property has been specified with a HTTP (not HTTPS) URI the following system proxy settings can be used:
 


### PR DESCRIPTION
Gradle uses separate proxy settings for http vs https.
This is slightly different than the traditional JVM proxy settings which
use the same `http.nonProxyHosts` for both.
[Regular JVM docs here](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html)
Notice the line: The HTTPS protocol handler will use the same nonProxyHosts property as the HTTP protocol.

Gradle behaves differently!

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
