### PR TITLE
Write cache fingerprint directly to the file system asynchronously with string deduplication

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -60,6 +60,7 @@ import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.ArrayList
 
 
@@ -239,7 +240,8 @@ class DefaultInstantExecution internal constructor(
     fun writeInstantExecutionCacheFingerprint() {
         Files.move(
             instantExecutionTemporaryFingerprintFile.toPath(),
-            instantExecutionFingerprintFile.toPath()
+            instantExecutionFingerprintFile.toPath(),
+            REPLACE_EXISTING
         )
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -75,10 +75,12 @@ class DefaultInstantExecution internal constructor(
 
     interface Host {
 
+        // TODO: rename ClassicModeBuild to VintageBuild
         val currentBuild: ClassicModeBuild
 
         fun createBuild(rootProjectName: String): InstantExecutionBuild
 
+        // TODO: rename to service
         fun <T> getService(serviceType: Class<T>): T
 
         fun <T> factory(serviceType: Class<T>): Factory<T>

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -237,8 +237,9 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun writeInstantExecutionCacheFingerprint() {
-        instantExecutionTemporaryFingerprintFile.renameTo(
-            instantExecutionFingerprintFile
+        Files.move(
+            instantExecutionTemporaryFingerprintFile.toPath(),
+            instantExecutionFingerprintFile.toPath()
         )
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
@@ -29,6 +29,8 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.vfs.VirtualFileSystem
+import org.gradle.kotlin.dsl.concurrent.AsyncIOScopeFactory
+import org.gradle.kotlin.dsl.concurrent.IOScope
 import org.gradle.util.GFileUtils
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -44,7 +46,8 @@ class InstantExecutionCacheFingerprintController internal constructor(
     private val taskInputsListeners: TaskInputsListeners,
     private val valueSourceProviderFactory: ValueSourceProviderFactory,
     private val virtualFileSystem: VirtualFileSystem,
-    private val fileCollectionFingerprinter: AbsolutePathFileCollectionFingerprinter
+    private val fileCollectionFingerprinter: AbsolutePathFileCollectionFingerprinter,
+    private val asyncIOScopeFactory: AsyncIOScopeFactory
 ) {
 
     private
@@ -137,6 +140,9 @@ class InstantExecutionCacheFingerprintController internal constructor(
     private
     inner class CacheFingerprintComponentHost
         : InstantExecutionCacheFingerprintWriter.Host, InstantExecutionCacheFingerprintChecker.Host {
+
+        override fun newIOScope(): IOScope =
+            asyncIOScopeFactory.newScope()
 
         override fun hashCodeOf(file: File) =
             virtualFileSystem.hashCodeOf(file)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -62,6 +62,9 @@ class DefaultWriteContext(
     private
     val scopes = WriteIdentities()
 
+    private
+    val strings = WriteStrings()
+
     /**
      * Closes the given [encoder] if it is [AutoCloseable].
      */
@@ -80,6 +83,9 @@ class DefaultWriteContext(
             encode(value)
         }
     }
+
+    override fun writeString(string: CharSequence) =
+        strings.writeString(string, encoder)
 
     override fun writeClass(type: Class<*>) {
         val id = classes.getId(type)
@@ -130,10 +136,6 @@ class DefaultWriteContext(
             writeBinary(hashCode.toByteArray())
         }
     }
-
-    // TODO: consider interning strings
-    override fun writeString(string: CharSequence) =
-        encoder.writeString(string)
 
     override fun newIsolate(owner: IsolateOwner): WriteIsolate =
         DefaultWriteIsolate(owner)
@@ -187,6 +189,9 @@ class DefaultReadContext(
     val scopes = ReadIdentities()
 
     private
+    val strings = ReadStrings()
+
+    private
     lateinit var projectProvider: ProjectProvider
 
     override lateinit var classLoader: ClassLoader
@@ -206,6 +211,9 @@ class DefaultReadContext(
     override suspend fun read(): Any? = getCodec().run {
         decode()
     }
+
+    override fun readString(): String =
+        strings.readString(decoder)
 
     override val isolate: ReadIsolate
         get() = getIsolate()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -175,7 +175,7 @@ class DefaultReadContext(
     val constructors: BeanConstructors,
 
     override val logger: Logger
-) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, Decoder by decoder {
+) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, Decoder by decoder, AutoCloseable {
 
     override val sharedIdentities = ReadIdentities()
 
@@ -195,6 +195,10 @@ class DefaultReadContext(
     lateinit var projectProvider: ProjectProvider
 
     override lateinit var classLoader: ClassLoader
+
+    override fun close() {
+        (decoder as? AutoCloseable)?.close()
+    }
 
     internal
     fun initClassLoader(classLoader: ClassLoader) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization
+
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+
+
+class WriteStrings {
+
+    fun writeString(string: CharSequence, encoder: Encoder) = encoder.run {
+        string.toString().let { string ->
+            val id = strings[string]
+            if (id != null) {
+                writeSmallInt(id)
+            } else {
+                val newId = strings.size
+                writeSmallInt(-1)
+                writeString(string)
+                strings[string] = newId
+            }
+        }
+    }
+
+    private
+    val strings = HashMap<String, Int>()
+}
+
+
+class ReadStrings {
+
+    fun readString(decoder: Decoder): String = decoder.run {
+        when (val index = readSmallInt()) {
+            -1 -> readString().also { strings.add(it) }
+            else -> strings[index]
+        }
+    }
+
+    private
+    val strings = mutableListOf<String>()
+}


### PR DESCRIPTION
This PR recovers the performance lost due to the inclusion of `buildSrc` task inputs in the instant execution cache fingerprint by:
- unblocking `buildSrc` tasks while the fingerprint is being encoded/written to the file;
- deduplicating strings;

The deduplication of strings reduces the fingerprint size and task graph state size quite significantly, for `gradle/gradle:compileJava` they go from `9.9MB` and `3.1MB` respectively to `1.6MB` and `1.4MB`.

The combined result is that `gradle/gradle:compileJava` loads faster than before `buildSrc` was part of the cache fingerprint and stores almost as fast as before:

![buildSrc-cache-fingerprint-benchmarks](https://user-images.githubusercontent.com/51689/78056636-d9b5a600-735b-11ea-9b2f-6a80fe1c3279.png)
