### PR TITLE
Add more test coverage for using CopySpec with instant execution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -23,111 +23,132 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Issue
-import spock.lang.Unroll
-
-import java.nio.charset.Charset
 
 class CopySpecIntegrationSpec extends AbstractIntegrationSpec {
 
     @Rule
     public final TestResources resources = new TestResources(testDirectoryProvider, "copyTestResources")
 
-    @Unroll
-    def "can #taskName files with #taskType task using #charsetDescription charset when filteringCharset is #isSetDescription"() {
+    def "copy task uses platform charset to filter text files by default"() {
         given:
+        file('files').createDir()
+        file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
         buildScript """
-            task ($taskName, type:$taskType) {
-                from 'src'
+            task (copy, type: Copy) {
+                from 'files'
                 into 'dest'
                 expand(one: 1)
-                ${filteringCharset ? "filteringCharset = '$filteringCharset'" : ''}
             }
         """.stripIndent()
+        executer.beforeExecute { it.withDefaultCharacterEncoding('ISO-8859-1') }
 
         when:
-        if(platformDefaultCharset) {
-            executer.withDefaultCharacterEncoding(platformDefaultCharset)
-        }
-        run taskName
+        run 'copy'
 
         then:
-        file('dest/accents.c').readLines(readCharset)[0] == expected
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
 
-        where:
-        // UTF8 is the actual encoding of the file accents.c.
-        // Any byte sequence of the file accents.c is a valid ISO-8859-1 character sequence,
-        // so we can read and write it with that encoding as well.
-        taskType | platformDefaultCharset | filteringCharset | expected
-        // platform default charset is honored
-        'Copy'   | 'UTF-8'                | null             | 'éàüî 1'
-        'Copy'   | 'UTF-8'                | null             | 'éàüî 1'
-        'Sync'   | 'UTF-8'                | null             | 'éàüî 1'
-        'Sync'   | 'UTF-8'                | null             | 'éàüî 1'
-        // filtering charset is honored
-        'Copy'   | null                   | 'UTF-8'          | 'éàüî 1'
-        'Copy'   | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'Copy'   | null                   | 'UTF-8'          | 'éàüî 1'
-        'Copy'   | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'Sync'   | null                   | 'UTF-8'          | 'éàüî 1'
-        'Sync'   | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'Sync'   | null                   | 'UTF-8'          | 'éàüî 1'
-        'Sync'   | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        // derived data
-        taskName = taskType.toLowerCase(Locale.US)
-        charsetDescription = filteringCharset ?: "platform default ${platformDefaultCharset ?: Charset.defaultCharset().name()}"
-        isSetDescription = filteringCharset ? 'set' : 'unset'
-        readCharset = filteringCharset ?: platformDefaultCharset
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
+
+        when:
+        file('files/accents.c').write('áëü $one', 'ISO-8859-1')
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest/accents.c').getText('ISO-8859-1') == 'áëü 1'
     }
 
-    @Unroll
-    def "can #operation files with #operation file operation using #charsetDescription charset when filteringCharset is #isSetDescription"() {
+    def "copy task uses declared charset to filter text files"() {
         given:
+        file('files').createDir()
+        file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
         buildScript """
-            task ($operation) {
+            task (copy, type: Copy) {
+                from 'files'
+                into 'dest'
+                expand(one: 1)
+                filteringCharset = 'ISO-8859-1'
+            }
+        """.stripIndent()
+        executer.beforeExecute { it.withDefaultCharacterEncoding('UTF-8') }
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
+
+        when:
+        file('files/accents.c').write('áëü $one', 'ISO-8859-1')
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest/accents.c').getText('ISO-8859-1') == 'áëü 1'
+    }
+
+    def "copy action uses platform charset to filter text files by default"() {
+        given:
+        file('files').createDir()
+        file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
+        buildScript """
+            task copy {
                 def fs = services.get(FileSystemOperations)
                 doLast {
-                    fs.$operation {
-                        from 'src'
+                    fs.copy {
+                        from 'files'
                         into 'dest'
                         expand(one: 1)
-                        ${filteringCharset ? "filteringCharset = '$filteringCharset'" : ''}
                     }
                 }
             }
         """.stripIndent()
+        executer.beforeExecute { it.withDefaultCharacterEncoding('ISO-8859-1') }
 
         when:
-        if(platformDefaultCharset) {
-            executer.withDefaultCharacterEncoding(platformDefaultCharset)
-        }
-        run operation
+        run 'copy'
 
         then:
-        file('dest/accents.c').readLines(readCharset)[0] == expected
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
+    }
 
-        where:
-        // UTF8 is the actual encoding of the file accents.c.
-        // Any byte sequence of the file accents.c is a valid ISO-8859-1 character sequence,
-        // so we can read and write it with that encoding as well.
-        operation | platformDefaultCharset | filteringCharset | expected
-        // platform default charset is honored
-        'copy'    | 'UTF-8'                | null             | 'éàüî 1'
-        'copy'    | 'UTF-8'                | null             | 'éàüî 1'
-        'sync'    | 'UTF-8'                | null             | 'éàüî 1'
-        'sync'    | 'UTF-8'                | null             | 'éàüî 1'
-        // filtering charset is honored
-        'copy'    | null                   | 'UTF-8'          | 'éàüî 1'
-        'copy'    | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'copy'    | null                   | 'UTF-8'          | 'éàüî 1'
-        'copy'    | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'sync'    | null                   | 'UTF-8'          | 'éàüî 1'
-        'sync'    | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        'sync'    | null                   | 'UTF-8'          | 'éàüî 1'
-        'sync'    | null                   | 'ISO-8859-1'     | new String('éàüî 1'.getBytes('UTF-8'), 'ISO-8859-1')
-        // derived data
-        charsetDescription = filteringCharset ?: "platform default ${platformDefaultCharset ?: Charset.defaultCharset().name()}"
-        isSetDescription = filteringCharset ? 'set' : 'unset'
-        readCharset = filteringCharset ?: platformDefaultCharset
+    def "copy action uses declared charset to filter text files"() {
+        given:
+        file('files').createDir()
+        file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
+        buildScript """
+            task copy {
+                def fs = services.get(FileSystemOperations)
+                doLast {
+                    fs.copy {
+                        from 'files'
+                        into 'dest'
+                        expand(one: 1)
+                        filteringCharset = 'ISO-8859-1'
+                    }
+                }
+            }
+        """.stripIndent()
+        executer.beforeExecute { it.withDefaultCharacterEncoding('UTF-8') }
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest/accents.c').getText('ISO-8859-1') == 'éàüî 1'
     }
 
     def "can use filesMatching with List"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Matchers
 import org.gradle.util.ToBeImplemented
 import org.junit.Rule
@@ -30,6 +29,57 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     @Rule
     public final TestResources resources = new TestResources(testDirectoryProvider, "copyTestResources")
+
+    def "copies everything by default"() {
+        given:
+        file("files/sub/a.txt").createFile()
+        file("files/sub/dir/b.txt").createFile()
+        file("files/c.txt").createFile()
+        file("files/sub/empty").createDir()
+        buildScript '''
+            task (copy, type:Copy) {
+               from 'files'
+               into 'dest'
+            }
+        '''.stripIndent()
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants(
+            'sub/a.txt',
+            'sub/dir/b.txt',
+            'c.txt',
+            'sub/empty'
+        )
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(":copy")
+        file('dest').assertHasDescendants(
+            'sub/a.txt',
+            'sub/dir/b.txt',
+            'c.txt',
+            'sub/empty'
+        )
+
+        when:
+        file("files/sub/d.txt").createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(":copy")
+        file('dest').assertHasDescendants(
+            'sub/a.txt',
+            'sub/dir/b.txt',
+            'sub/d.txt',
+            'c.txt',
+            'sub/empty'
+        )
+    }
 
     def "single source with include and exclude pattern"() {
         given:
@@ -57,7 +107,8 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'sub/a.txt',
             'sub/dir/b.txt',
-            'dir/sub/dir/c.txt'
+            'dir/sub/dir/c.txt',
+            'other'
         )
 
         when:
@@ -65,11 +116,12 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(":copy")
+        skipped(":copy")
         file('dest').assertHasDescendants(
             'sub/a.txt',
             'sub/dir/b.txt',
-            'dir/sub/dir/c.txt'
+            'dir/sub/dir/c.txt',
+            'other'
         )
 
         when:
@@ -77,16 +129,17 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(":copy")
+        executedAndNotSkipped(":copy")
         file('dest').assertHasDescendants(
             'sub/a.txt',
             'sub/d.txt',
             'sub/dir/b.txt',
-            'dir/sub/dir/c.txt'
+            'dir/sub/dir/c.txt',
+            'other'
         )
     }
 
-    def "single source with include and exclude closures"() {
+    def "single source with include and exclude Groovy closures"() {
         given:
         file('files/a.a').createFile()
         file('files/a.b').createFile()
@@ -118,7 +171,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         file('dest').assertHasDescendants(
             'a.a',
             'dir/a.a'
@@ -130,7 +183,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'a.a',
             'dir/a.a',
@@ -158,7 +211,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         file('dest/a.txt').text == "1,2"
 
         when:
@@ -166,7 +219,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest/a.txt').text == "1 + 2"
     }
 
@@ -198,7 +251,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         file('dest/a.txt').text == "1"
 
         when:
@@ -206,11 +259,11 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest/a.txt').text == "1 + 2"
     }
 
-    def "can filter content using a closure when copying"() {
+    def "can filter content using a Groovy closure when copying"() {
         file('files/a.txt').text = "one"
         file('files/b.txt').text = "two"
         buildScript """
@@ -232,7 +285,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         file('dest/a.txt').text == "1"
 
         when:
@@ -240,7 +293,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest/a.txt').text == "1 + 2"
     }
 
@@ -282,14 +335,22 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "multiple source with inherited include and exclude patterns"() {
         given:
+        file('files/one/one.a').createFile()
+        file('files/one/one.ignore').createFile()
+        file('files/one/sub/one.a').createFile()
+        file('files/one/sub/ignore/ignore.a').createFile()
+        file('files/two/two.b').createFile()
+        file('files/two/two.ignore').createFile()
+        file('files/two/sub/two.b').createFile()
+        file('files/two/sub/ignore/ignore.b').createFile()
         buildScript '''
             task (copy, type:Copy) {
                into 'dest'
-               from('src/one') {
+               from('files/one') {
                   into '1'
                   include '**/*.a'
                }
-               from('src/two') {
+               from('files/two') {
                   into '2'
                   include '**/*.b'
                }
@@ -303,23 +364,60 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         then:
         file('dest').assertHasDescendants(
             '1/one.a',
-            '1/sub/onesub.a',
+            '1/sub/one.a',
             '2/two.b',
+            '2/sub/two.b'
+        )
+
+        when:
+        file('files/two/ignore-more.ignore').createFile() // not an input
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest').assertHasDescendants(
+            '1/one.a',
+            '1/sub/one.a',
+            '2/two.b',
+            '2/sub/two.b'
+        )
+
+        when:
+        file('files/one/more.a').createFile()
+        file('files/two/more.b').createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            '1/one.a',
+            '1/more.a',
+            '1/sub/one.a',
+            '2/two.b',
+            '2/more.b',
+            '2/sub/two.b'
         )
     }
 
     def "multiple sources with inherited destination"() {
         given:
+        file('files/one/one.a').createFile()
+        file('files/one/one.ignore').createFile()
+        file('files/one/sub/ignore.a').createFile()
+        file('files/two/two.b').createFile()
+        file('files/two/two.ignore').createFile()
+        file('files/two/sub/two.b').createFile()
+        file('files/two/sub/ignore.a').createFile()
         buildScript '''
             task (copy, type:Copy) {
                into 'dest'
                into('common') {
-                  from('src/one') {
+                  from('files/one') {
                      into 'a/one'
                      include '*.a'
                   }
                   into('b') {
-                     from('src/two') {
+                     from('files/two') {
                         into 'two'
                         include '**/*.b'
                      }
@@ -335,6 +433,35 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'common/a/one/one.a',
             'common/b/two/two.b',
+            'common/b/two/sub/two.b'
+        )
+
+        when:
+        file('files/one/dir/ignore.a').createFile()
+        file('files/two/sub/ignore.a').createFile()
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest').assertHasDescendants(
+            'common/a/one/one.a',
+            'common/b/two/two.b',
+            'common/b/two/sub/two.b'
+        )
+
+        when:
+        file('files/one/more.a').createFile()
+        file('files/two/sub/more.b').createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants(
+            'common/a/one/one.a',
+            'common/a/one/more.a',
+            'common/b/two/two.b',
+            'common/b/two/sub/two.b',
+            'common/b/two/sub/more.b'
         )
     }
 
@@ -367,7 +494,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         file('dest').assertHasDescendants(
             'one.renamed',
             'one.b',
@@ -382,7 +509,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'one.renamed',
             'one.b',
@@ -393,7 +520,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         )
     }
 
-    def "can rename files using a closure"() {
+    def "can rename files using a Groovy closure"() {
         given:
         file('files/one.a').createFile()
         file('files/one.b').createFile()
@@ -429,7 +556,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         output.count("rename") == 0
         file('dest').assertHasDescendants(
             'one.renamed',
@@ -445,7 +572,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         output.count("rename") == 6
         outputContains("rename one.a")
         outputContains("rename another.a")
@@ -572,7 +699,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         it.next().startsWith('16')
     }
 
-    def "can rename files in eachFile() action defined using closure"() {
+    def "can rename files in eachFile() action defined using Groovy closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -596,18 +723,20 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         outputContains('visiting dir/b.txt')
         file('dest').assertHasDescendants(
             'sub/a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir' // directories are not passed to eachFile
         )
 
         when:
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         output.count('visiting ') == 0
         file('dest').assertHasDescendants(
             'sub/a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir'
         )
 
         when:
@@ -615,20 +744,21 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         output.count('visiting ') == 3
         outputContains('visiting a.txt')
         outputContains('visiting dir/b.txt')
         outputContains('visiting c.txt')
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'sub/a.txt',
             'sub/c.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir'
         )
     }
 
-    def "can rename files that match a pattern in filesMatching() action defined using closure"() {
+    def "can rename files that match a pattern in filesMatching() action defined using Groovy closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -651,18 +781,20 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         outputContains('visiting dir/b.txt')
         file('dest').assertHasDescendants(
             'a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir' // directories are not passed to filesMatching
         )
 
         when:
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         output.count('visiting ') == 0
         file('dest').assertHasDescendants(
             'a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir'
         )
 
         when:
@@ -671,20 +803,21 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         output.count('visiting ') == 2
         outputContains('visiting dir/b.txt')
         outputContains('visiting dir/d/e.txt')
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'a.txt',
             'c.txt',
             'sub/dir/b.txt',
-            'sub/dir/d/e.txt'
+            'sub/dir/d/e.txt',
+            'dir/d'
         )
     }
 
-    def "can rename files that do not match a pattern in filesNotMatching() action defined using closure"() {
+    def "can rename files that do not match a pattern in filesNotMatching() action defined using Groovy closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -707,18 +840,20 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         outputContains('visiting dir/b.txt')
         file('dest').assertHasDescendants(
             'a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir' // directories are not passed to filesNotMatching
         )
 
         when:
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
         output.count('visiting ') == 0
         file('dest').assertHasDescendants(
             'a.txt',
-            'sub/dir/b.txt'
+            'sub/dir/b.txt',
+            'dir'
         )
 
         when:
@@ -727,16 +862,17 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         output.count('visiting ') == 2
         outputContains('visiting dir/b.txt')
         outputContains('visiting dir/d/e.txt')
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'a.txt',
             'c.txt',
             'sub/dir/b.txt',
-            'sub/dir/d/e.txt'
+            'sub/dir/d/e.txt',
+            'dir/d'
         )
     }
 
@@ -770,14 +906,17 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
             'prefix/one/one.renamed_twice',
             'prefix/one/one.b',
             'prefix/one_sub/onesub.renamed_twice',
-            'prefix/one_sub/onesub.b'
+            'prefix/one_sub/onesub.b',
+            'one/ignore',
+            'one/sub/ignore',
+            'two/ignore'
         )
         def it = file('dest/root.renamed_twice').readLines().iterator()
         it.next().equals('[prefix: line 1]')
         it.next().equals('[prefix: line 2]')
     }
 
-    def "copy from location specified lazily using closure"() {
+    def "copy from location specified lazily using Groovy closure"() {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
@@ -794,7 +933,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''
 
         when:
-        run'copy'
+        run 'copy'
 
         then:
         file('dest').assertHasDescendants(
@@ -806,14 +945,14 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        result.assertTaskSkipped(':copy')
+        skipped(':copy')
 
         when:
         file('files/c.txt').createFile()
         run 'copy'
 
         then:
-        result.assertTaskNotSkipped(':copy')
+        executedAndNotSkipped(':copy')
         file('dest').assertHasDescendants(
             'a.txt',
             'dir/b.txt',
@@ -846,6 +985,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
             'one/one.b',
             'two/two.a',
             'two/two.b',
+            'one/sub'
         )
     }
 
@@ -876,6 +1016,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
             'one/one.b',
             'two/two.a',
             'two/two.b',
+            'one/sub'
         )
     }
 
@@ -906,7 +1047,8 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
             'one/one.a',
             'two/two.a',
             'three/three.a',
-            'a.jar'
+            'a.jar',
+            'one/sub'
         )
     }
 
@@ -1068,7 +1210,9 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         then:
         file('dest').assertHasDescendants(
             'transformedAgain/transformed/subdir/one/one.a',
-            'transformedAgain/transformed/subdir/two/two.a'
+            'transformedAgain/transformed/subdir/two/two.a',
+            'subdir/one',
+            'subdir/two'
         )
     }
 
@@ -1158,16 +1302,93 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         )
     }
 
-    // can't use TestResources here because Git doesn't support committing empty directories
-    def "empty directories are copied by default"() {
+    def 'include and exclude patterns are case sensitive by default'() {
         given:
-        file('src999', 'emptyDir').createDir()
-        file('src999', 'yet', 'another', 'veryEmptyDir').createDir()
-        // need to include a file in the copy, otherwise copy task says "no source files"
-        file('src999', 'dummy').createFile()
+        file('files/sub/a.TXT').createFile()
+        file('files/sub/b.txt').createFile()
+        file('files/sub/c.Txt').createFile()
+        file('files/EXCLUDE/a.TXT').createFile()
+        file('files/sub/Exclude/a.TXT').createFile()
         buildScript '''
             task copy(type: Copy) {
-                from 'src999'
+                from 'files'
+                into 'dest'
+                include '**/*.TXT'
+                exclude '**/EXCLUDE/**'
+            }
+        '''.stripIndent()
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants('sub/a.TXT', 'sub/Exclude/a.TXT')
+
+        when:
+        run 'copy'
+
+        then:
+        file('files/d.txt').createFile()
+        skipped(':copy')
+
+        when:
+        file('files/a.TXT').createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('sub/a.TXT', 'sub/Exclude/a.TXT', 'a.TXT')
+    }
+
+    def 'include and exclude patterns are case insensitive when enabled'() {
+        given:
+        file('files/sub/a.TXT').createFile()
+        file('files/sub/b.txt').createFile()
+        file('files/sub/c.Txt').createFile()
+        file('files/EXCLUDE/a.TXT').createFile()
+        file('files/sub/Exclude/a.TXT').createFile()
+        buildScript '''
+            task copy(type: Copy) {
+                from 'files'
+                into 'dest'
+                include '**/*.TXT'
+                exclude '**/EXCLUDE/**'
+                caseSensitive = false
+            }
+        '''.stripIndent()
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants('sub/a.TXT', 'sub/b.txt', 'sub/c.Txt')
+
+        when:
+        run 'copy'
+
+        then:
+        file('files/exclude/d.txt').createFile()
+        skipped(':copy')
+        file('dest').assertHasDescendants('sub/a.TXT', 'sub/b.txt', 'sub/c.Txt')
+
+        when:
+        file('files/d.TXT').createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('sub/a.TXT', 'sub/b.txt', 'sub/c.Txt', 'd.TXT')
+    }
+
+    def "empty directories are copied by default"() {
+        given:
+        file('files/emptyDir').createDir()
+        file('files/yet/another/veryEmptyDir').createDir()
+        // need to include a file in the copy, otherwise copy task says "no source files"
+        file('files/dummy').createFile()
+        buildScript '''
+            task copy(type: Copy) {
+                from 'files'
                 into 'dest'
             }
         '''.stripIndent()
@@ -1176,21 +1397,34 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        file('dest', 'emptyDir').isDirectory()
-        file('dest', 'emptyDir').list().size() == 0
-        file('dest', 'yet', 'another', 'veryEmptyDir').isDirectory()
-        file('dest', 'yet', 'another', 'veryEmptyDir').list().size() == 0
+        file('dest').assertHasDescendants('emptyDir', 'dummy', 'yet/another/veryEmptyDir')
+        file('dest/emptyDir').assertIsEmptyDir()
+        file('dest/yet/another/veryEmptyDir').assertIsEmptyDir()
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+
+        when:
+        file('files/more').createDir()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('emptyDir', 'dummy', 'more', 'yet/another/veryEmptyDir')
+        file('dest/more').assertIsEmptyDir()
     }
 
     def "empty dirs are not copied if corresponding option is set to false"() {
         given:
-        file('src999', 'emptyDir').createDir()
-        file('src999', 'yet', 'another', 'veryEmptyDir').createDir()
-        // need to include a file in the copy, otherwise copy task says "no source files"
-        file('src999', 'dummy').createFile()
+        file('files/emptyDir').createDir()
+        file('files/yet/another/veryEmptyDir').createDir()
+        file('files/one.txt').createFile()
         buildScript '''
             task copy(type: Copy) {
-                from 'src999'
+                from 'files'
                 into 'dest'
                 includeEmptyDirs = false
             }
@@ -1200,20 +1434,74 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         run 'copy'
 
         then:
-        !file('dest', 'emptyDir').exists()
-        !file('dest', 'yet', 'another', 'veryEmptyDir').exists()
+        file('dest').assertHasDescendants('one.txt')
+
+        when:
+        file('files/more').createDir()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy') // TODO - should be skipped
+        file('dest').assertHasDescendants('one.txt')
+
+        when:
+        file('files/more/more.txt').createFile()
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('one.txt', 'more/more.txt')
     }
 
-    def "copy excludes duplicates"() {
+    def "copy includes duplicates by default and emits deprecation warning when duplicates are present"() {
         given:
-        file('dir1', 'path', 'file.txt').createFile() << "f1"
-        file('dir2', 'path', 'file.txt').createFile() << "f2"
+        file('dir1/path/file.txt').createFile() << 'f1'
+        file('dir2/path/file.txt').createFile() << 'f2'
         buildScript '''
             task copy(type: Copy) {
                 from 'dir1'
                 from 'dir2'
                 into 'dest'
-                eachFile { it.duplicatesStrategy = 'exclude' }
+            }
+        '''.stripIndent()
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: \"path/file.txt\". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated")
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'f2'
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'f2'
+
+        when:
+        file('dir2/path/file.txt').text = 'new'
+        executer.expectDocumentedDeprecationWarning("Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: \"path/file.txt\". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated")
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'new'
+    }
+
+    def "copy excludes duplicates when flag is set, stopping at first duplicate"() {
+        given:
+        file('dir1/path/file.txt').createFile() << 'f1'
+        file('dir2/path/file.txt').createFile() << 'f2'
+        buildScript '''
+            task copy(type: Copy) {
+                from 'dir1'
+                from 'dir2'
+                into 'dest'
+                duplicatesStrategy = 'exclude'
             }
         '''.stripIndent()
 
@@ -1222,7 +1510,62 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
         then:
         file('dest').assertHasDescendants('path/file.txt')
-        file('dest/path/file.txt').assertContents(Matchers.containsText("f1"))
+        file('dest/path/file.txt').text == 'f1'
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'f1'
+
+        when:
+        file('dir1/path/file.txt').text = 'new'
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'new'
+    }
+
+    def "copy includes duplicates when flag is set, overwriting each duplicate"() {
+        given:
+        file('dir1/path/file.txt').createFile() << 'f1'
+        file('dir2/path/file.txt').createFile() << 'f2'
+        buildScript '''
+            task copy(type: Copy) {
+                from 'dir1'
+                from 'dir2'
+                into 'dest'
+                duplicatesStrategy = 'include'
+            }
+        '''.stripIndent()
+
+        when:
+        run 'copy'
+
+        then:
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'f2'
+
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'f2'
+
+        when:
+        file('dir2/path/file.txt').text = 'new'
+        run 'copy'
+
+        then:
+        executedAndNotSkipped(':copy')
+        file('dest').assertHasDescendants('path/file.txt')
+        file('dest/path/file.txt').text == 'new'
     }
 
     def "renamed file can be treated as duplicate"() {
@@ -1504,7 +1847,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped(":copyTask")
         def destinationDir = file("out")
-        destinationDir.assertHasDescendants("a.txt", "b.txt")
+        destinationDir.assertHasDescendants("a.txt", "b.txt", "dirA")
         destinationDir.listFiles().findAll { it.directory }*.name.toSet() == ["dirA"].toSet()
     }
 
@@ -1540,7 +1883,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         executedAndNotSkipped(":copyTask")
 
         def destinationDir = file("out")
-        destinationDir.assertHasDescendants("a.txt", "b.txt")
+        destinationDir.assertHasDescendants("a.txt", "b.txt", "dirA", "dirB")
         destinationDir.listFiles().findAll { it.directory }*.name.toSet() == ["dirA", "dirB"].toSet()
     }
 
@@ -1628,12 +1971,11 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         "**/abc*abc" | "abc"
     }
 
-    @ToBeFixedForInstantExecution
     def "changing case-sensitive setting makes task out-of-date"() {
         given:
         buildScript '''
             task (copy, type:Copy) {
-               caseSensitive = false
+               caseSensitive = providers.systemProperty('case-sensitive').present
                from 'src'
                into 'dest'
                include '**/sub/**'
@@ -1642,19 +1984,23 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
-        buildScript '''
-            task (copy, type:Copy) {
-               caseSensitive = true
-               from 'src'
-               into 'dest'
-               include '**/sub/**'
-               exclude '**/ignore/**'
-            }
-        '''.stripIndent()
         when:
         run "copy"
+
         then:
-        noneSkipped()
+        skipped(':copy')
+
+        when:
+        run "copy", "-Dcase-sensitive"
+
+        then:
+        executedAndNotSkipped(':copy')
+
+        when:
+        run "copy", "-Dcase-sensitive"
+
+        then:
+        skipped(':copy')
     }
 
     @ToBeImplemented
@@ -1758,13 +2104,13 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "changing spec-level property #property makes task out-of-date"() {
         given:
         buildScript """
             task (copy, type:Copy) {
                from ('src') {
-                  $property = $oldValue
+                  def newValue = providers.systemProperty('new-value').present
+                  $property = newValue ? $newValue : $oldValue
                }
                into 'dest'
             }
@@ -1772,20 +2118,24 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
         run 'copy'
 
-        buildScript """
-            task (copy, type:Copy) {
-               from ('src') {
-                  $property = $newValue
-               }
-               into 'dest'
-            }
-        """
+        when:
+        run 'copy'
+
+        then:
+        skipped(':copy')
 
         when:
-        run "copy", "--info"
+        run "copy", "--info", "-Dnew-value"
+
         then:
-        noneSkipped()
+        executedAndNotSkipped(':copy')
         output.contains "Value of input property 'rootSpec\$1\$1.$property' has changed for task ':copy'"
+
+        when:
+        run "copy", "--info", "-Dnew-value"
+
+        then:
+        skipped(':copy')
 
         where:
         property             | oldValue                     | newValue

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -467,14 +467,14 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         run("copy")
         then:
         executedAndNotSkipped(":copy")
-        outputDir.assertHasDescendants("modified.txt", "added.txt")
+        outputDir.assertHasDescendants("modified.txt", "added.txt", "subdir")
 
         when:
         inputDir.forceDeleteDir()
         run("copy")
         then:
         executedAndNotSkipped(":copy")
-        outputDir.assertIsEmptyDir()
+        outputDir.assertHasDescendants("subdir")
 
         when:
         inputDir.file("modified.txt").text = "some input"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -415,7 +415,9 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             'prefix/dir1/renamed_file1.txt',
             'prefix/renamed_file1.txt',
             'prefix/dir2/renamed_file2.txt',
+            'scripts/dir1',
             'scripts/dir2/script.sh',
+            'conf/dir1',
             'conf/dir2/config.properties')
 
         expandDir.file('prefix/dir1/renamed_file1.txt').assertContents(equalTo('[abc]'))
@@ -479,6 +481,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             'prefix/dir1/file1.txt',
             'prefix/file1.txt',
             'prefix/dir2/file2.txt',
+            'scripts/dir1',
             'scripts/dir2/script.sh')
 
         expandDir.file('prefix/dir1/file1.txt').assertContents(equalTo(randomAscii))
@@ -489,6 +492,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             'prefix/dir1/file1.txt',
             'prefix/file1.txt',
             'prefix/dir2/file2.txt',
+            'scripts/dir1',
             'scripts/dir2/script.sh')
 
         expandCompressedDir.file('prefix/dir1/file1.txt').assertContents(equalTo(randomAscii))
@@ -526,7 +530,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
         then:
         def expandDir = file('expanded')
         file('build/test.tar').untarTo(expandDir)
-        expandDir.assertHasDescendants('dir1/file1.txt', 'file1.txt', 'dir2/file2.txt', 'scripts/dir2/script.sh')
+        expandDir.assertHasDescendants('dir1/file1.txt', 'file1.txt', 'dir2/file2.txt', 'scripts/dir1', 'scripts/dir2/script.sh')
 
         expandDir.file('dir1/file1.txt').assertContents(equalTo('[abc]'))
     }
@@ -903,7 +907,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         includeEmptyDirs | expectedDescendants
-        true             | ["file2.txt", "file3.txt"] // dir3 is not included as the action does not apply to directories
+        true             | ["file2.txt", "file3.txt", "dir2/dir3"] // dir3 is not renamed as eachFile() does not apply to directories
         false            | ["file2.txt", "file3.txt"]
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -274,6 +274,10 @@ public class DefaultCopySpec implements CopySpecInternal {
         this.includeEmptyDirs = includeEmptyDirs;
     }
 
+    public DuplicatesStrategy getDuplicatesStrategyForThisSpec() {
+        return duplicatesStrategy;
+    }
+
     @Override
     public DuplicatesStrategy getDuplicatesStrategy() {
         return buildRootResolver().getDuplicatesStrategy();
@@ -504,7 +508,7 @@ public class DefaultCopySpec implements CopySpecInternal {
         return this.new DefaultCopySpecResolver(null);
     }
 
-    public FileCollection getSourceFiles() {
+    public FileCollection getSourceRootsForThisSpec() {
         return sourcePaths;
     }
 
@@ -608,7 +612,7 @@ public class DefaultCopySpec implements CopySpecInternal {
 
         @Override
         public FileTree getSource() {
-            return getSourceFiles().getAsFileTree().matching(this.getPatternSet());
+            return getSourceRootsForThisSpec().getAsFileTree().matching(this.getPatternSet());
         }
 
         @Override

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
@@ -63,7 +63,7 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
         0 * _
 
         !outputs.file.exists()
-        outputs.dir.assertHasDescendants("some/notOutput1.txt")
+        outputs.dir.assertHasDescendants("some/notOutput1.txt", "some/notOutput2")
         !outputs.dir.file("some/dir").exists()
         !outputs.dir.file("some/lonelyDir").exists()
         !outputs.dir.file("some/another").exists()

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileTreeIntegrationTest.groovy
@@ -189,8 +189,10 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
         given:
         file('files/one.txt').createFile()
         file('files/a/two.txt').createFile()
+        file('files/a/IGNORE.txt').createFile()
         file('files/b/ignore.txt').createFile()
         file('files/b/one.bin').createFile()
+        file('files/b/wrong case.TXT').createFile()
         file('other/c/other-one.txt').createFile()
         file('other/c/other-ignore.txt').createFile()
         buildFile << """
@@ -201,6 +203,7 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
             task copy(type: Copy) {
                 from files
                 into 'dest'
+                includeEmptyDirs = false
             }
         """
 
@@ -211,11 +214,13 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'one.txt',
             'a/two.txt',
+            'a/IGNORE.txt', // exclude patterns are case sensitive by default
             'c/other-one.txt'
         )
 
         when:
         file('files/a/more-ignore.txt').createFile() // not an input
+        file('files/a/more.TXT').createFile() // not an input
         run 'copy'
 
         then:
@@ -223,6 +228,7 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'one.txt',
             'a/two.txt',
+            'a/IGNORE.txt',
             'c/other-one.txt'
         )
 
@@ -236,6 +242,7 @@ class FileTreeIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'one.txt',
             'a/two.txt',
+            'a/IGNORE.txt',
             'a/three.txt',
             'c/other-one.txt',
             'add-three.txt'

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
@@ -34,7 +34,7 @@ fun IsolateContext.logPropertyProblem(action: String, exception: Throwable? = nu
 
 
 fun IsolateContext.logPropertyInfo(action: String, value: Any?) {
-    logger.info("instant-execution > {}d {} with value {}", action, trace, value)
+    logger.debug("instant-execution > {}d {} with value {}", action, trace, value)
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -116,7 +116,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
 
         bind(ApiTextResourceAdapterCodec)
 
@@ -170,7 +170,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
 
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(buildOperationExecutor, transformListener))
@@ -211,7 +211,7 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileSystem: FileSystem, fileFactory: FileFactory) {
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileSystem: FileSystem, fileFactory: FileFactory, patternSetFactory: Factory<PatternSet>) {
         bind(DirectoryCodec(fileFactory))
         bind(RegularFileCodec(fileFactory))
         bind(ConfigurableFileTreeCodec(fileCollectionFactory))
@@ -220,7 +220,7 @@ class Codecs(
         bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
         bind(fileCollectionCodec)
         bind(IntersectPatternSetCodec)
-        bind(PatternSetCodec)
+        bind(PatternSetCodec(patternSetFactory))
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -48,9 +48,9 @@ class DefaultCopySpecCodec(
     override suspend fun WriteContext.encode(value: DefaultCopySpec) {
         encodePreservingIdentityOf(value) {
             write(value.destPath)
-            write(value.sourceFiles)
+            write(value.sourceRootsForThisSpec)
             write(value.patterns)
-            writeEnum(value.duplicatesStrategy)
+            writeEnum(value.duplicatesStrategyForThisSpec)
             writeBoolean(value.includeEmptyDirs)
             writeBoolean(value.isCaseSensitive)
             writeString(value.filteringCharset)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
@@ -27,11 +27,13 @@ import org.gradle.instantexecution.serialization.readCollection
 import org.gradle.instantexecution.serialization.readStrings
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeStrings
+import org.gradle.internal.Factory
 
 
-object PatternSetCodec : Codec<PatternSet> {
+class PatternSetCodec(private val patternSetFactory: Factory<PatternSet>) : Codec<PatternSet> {
 
     override suspend fun WriteContext.encode(value: PatternSet) {
+        writeBoolean(value.isCaseSensitive)
         writeStrings(value.includes)
         writeStrings(value.excludes)
         writeCollection(value.includeSpecs)
@@ -39,7 +41,8 @@ object PatternSetCodec : Codec<PatternSet> {
     }
 
     override suspend fun ReadContext.decode() =
-        PatternSet().apply {
+        patternSetFactory.create()!!.apply {
+            isCaseSensitive = readBoolean()
             setIncludes(readStrings())
             setExcludes(readStrings())
             readCollection {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -52,10 +52,9 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'dir1/file1.txt',
             'dir2/subdir/file2.txt',
-            'dir2/file3.txt'
+            'dir2/file3.txt',
+            'emptyDir'
         )
-        !file('dest/someOtherEmptyDir').exists()
-        file('dest/emptyDir').exists()
     }
 
     def 'preserve keeps specified files in destDir'() {
@@ -92,6 +91,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             'dir2/file3.txt',
             'extraDir/extra.txt',
             'dir1/extraDir/extra.txt',
+            'emptyDir'
         )
     }
 
@@ -124,13 +124,14 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         run 'sync'
 
         then:
-        file('dest').allDescendants() == [
+        file('dest').assertHasDescendants(
             'dir1/file1.txt',
             'dir2/subdir/file2.txt',
             'dir2/file3.txt',
             'someOtherDir/preserved.txt',
-            'somePreservedDir/preserved.txt'
-        ] as Set
+            'somePreservedDir/preserved.txt',
+            'emptyDir'
+        )
     }
 
     def 'sync is up to date when only changing preserved files'() {
@@ -330,7 +331,8 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants(
             'dir1/file1.txt',
             'dir2/subdir/file2.txt',
-            'dir2/file3.txt'
+            'dir2/file3.txt',
+            'emptyDir'
         )
         file('dest/emptyDir').exists()
         !file('dest/extra1.txt').exists()

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -556,39 +556,42 @@ public class TestFile extends File {
     }
 
     /**
-     * Asserts that this file contains exactly the given set of descendants.
+     * Asserts that this is a directory and contains exactly the given set of descendant files and child directories. Ignores directories that are not empty.
      */
     public TestFile assertHasDescendants(String... descendants) {
         return assertHasDescendants(Arrays.asList(descendants));
     }
 
     /**
-     * Convenience method for {@link #assertHasDescendants(String...)}.
+     * Asserts that this is a directory and contains exactly the given set of descendant files and child directories. Ignores directories that are not empty.
      */
     public TestFile assertHasDescendants(Iterable<String> descendants) {
+        return assertHasDescendants(descendants, false);
+    }
+
+    public TestFile assertHasDescendants(Iterable<String> descendants, boolean ignoreDirs) {
         Set<String> actual = new TreeSet<String>();
         assertIsDir();
-        visit(actual, "", this);
-        Set<String> expected = new TreeSet<String>(Lists.<String>newArrayList(descendants));
+        visit(actual, "", this, ignoreDirs);
+        Set<String> expected = new TreeSet<>(Lists.newArrayList(descendants));
 
-        Set<String> extras = new TreeSet<String>(actual);
+        Set<String> extras = new TreeSet<>(actual);
         extras.removeAll(expected);
-        Set<String> missing = new TreeSet<String>(expected);
+        Set<String> missing = new TreeSet<>(expected);
         missing.removeAll(actual);
 
         assertEquals(String.format("For dir: %s\n extra files: %s, missing files: %s, expected: %s", this, extras, missing, expected), expected, actual);
 
         return this;
-
     }
 
     /**
-     * Convenience method for {@link #assertContainsDescendants(String...)}.
+     * Asserts that this is a directory and contains the given set of descendant files and child directories (and possibly other files). Ignores directories that are not empty.
      */
     public TestFile assertContainsDescendants(Iterable<String> descendants) {
         assertIsDir();
         Set<String> actual = new TreeSet<String>();
-        visit(actual, "", this);
+        visit(actual, "", this, false);
 
         Set<String> expected = new TreeSet<String>(Lists.newArrayList(descendants));
 
@@ -601,14 +604,13 @@ public class TestFile extends File {
     }
 
     /**
-     * Asserts that this file contains the given set of descendants (and possibly other files).
+     * Asserts that this is a directory and contains the given set of descendant files (and possibly other files). Ignores directories that are not empty.
      */
     public TestFile assertContainsDescendants(String... descendants) {
         return assertContainsDescendants(Arrays.asList(descendants));
     }
 
     public TestFile assertIsEmptyDir() {
-        assertIsDir();
         assertHasDescendants();
         return this;
     }
@@ -616,17 +618,17 @@ public class TestFile extends File {
     public Set<String> allDescendants() {
         Set<String> names = new TreeSet<String>();
         if (isDirectory()) {
-            visit(names, "", this);
+            visit(names, "", this, false);
         }
         return names;
     }
 
-    private void visit(Set<String> names, String prefix, File file) {
+    private void visit(Set<String> names, String prefix, File file, boolean ignoreDirs) {
         for (File child : file.listFiles()) {
-            if (child.isFile()) {
+            if (child.isFile() || !ignoreDirs && child.isDirectory() && child.list().length == 0) {
                 names.add(prefix + child.getName());
             } else if (child.isDirectory()) {
-                visit(names, prefix + child.getName() + "/", child);
+                visit(names, prefix + child.getName() + "/", child, ignoreDirs);
             }
         }
     }

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIncrementalBuildIntegrationTest.groovy
@@ -212,11 +212,11 @@ abstract class AbstractJvmLanguageIncrementalBuildIntegrationTest extends Abstra
     }
 
     def assertOutputs(List<JvmSourceFile> expectedClasses, List<JvmSourceFile> expectedResources) {
-        String[] classes = expectedClasses.collect { it.fullPath }
-        String[] resources = expectedResources.collect { it.fullPath }
+        def classes = expectedClasses.collect { it.fullPath }
+        def resources = expectedResources.collect { it.fullPath }
         file("build/classes/main/jar").assertHasDescendants(classes)
-        file("build/resources/main/jar").assertHasDescendants(resources)
-        jarFile("build/jars/main/jar/main.jar").hasDescendants(classes + resources as String[])
+        file("build/resources/main/jar").assertHasDescendants(resources, true)
+        jarFile("build/jars/main/jar/main.jar").hasDescendants((classes + resources) as String[])
         return true
     }
 

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIntegrationTest.groovy
@@ -178,8 +178,8 @@ abstract class AbstractJvmLanguageIntegrationTest extends AbstractIntegrationSpe
         succeeds "assemble"
 
         then:
-        file("build/classes/myLib/jar").assertHasDescendants(app.expectedClasses*.fullPath as String[])
-        file("build/resources/myLib/jar").assertHasDescendants(app.resources*.fullPath as String[])
+        file("build/classes/myLib/jar").assertHasDescendants(app.expectedClasses*.fullPath)
+        file("build/resources/myLib/jar").assertHasDescendants(app.resources*.fullPath, true)
         jarFile("build/jars/myLib/jar/myLib.jar").hasDescendants(app.expectedOutputs*.fullPath as String[])
     }
 


### PR DESCRIPTION

### Context

Also:

- fixes a couple of minor serialization issues
- reduces the verbosity of some instant execution logging
- changes `TestFile.assertHasDescendant()` to also check empty directories (that is, it checks all leafs of the tree).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
