### PR TITLE
Add support for Java modules in Eclipse dependencies

### DIFF
--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":plugins"))
     implementation(project(":platformBase"))
     implementation(project(":platformJvm"))
+    implementation(project(":languageJvm"))
     implementation(project(":languageJava"))
     implementation(project(":languageScala"))
     implementation(project(":scala"))

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Unroll
+
+import static org.gradle.test.fixtures.jpms.ModuleJarFixture.autoModuleJar
+import static org.gradle.test.fixtures.jpms.ModuleJarFixture.moduleJar
+import static org.gradle.test.fixtures.jpms.ModuleJarFixture.traditionalJar
+
+@Requires(TestPrecondition.JDK9_OR_LATER)
+class EclipseJavaModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
+
+    private MavenModule publishJavaModule(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: moduleJar(name)).publish()
+    }
+
+    private MavenModule publishJavaLibrary(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: traditionalJar(name)).publish()
+    }
+
+    private MavenModule publishAutoModule(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: autoModuleJar(name)).publish()
+    }
+
+    @ToBeFixedForInstantExecution
+    @Unroll
+    def "Marks modules on classpath as such"() {
+        given:
+        publishJavaModule('jmodule')
+        publishAutoModule('jautomodule')
+        publishJavaLibrary('jlib')
+
+        buildFile << """
+            plugins {
+                id 'java-library'
+                id 'eclipse'
+            }
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            $configLocation {
+                modularClasspathHandling.inferModulePath.set(true)
+            }
+
+            dependencies {
+                implementation 'org:jmodule:1.0'
+                implementation 'org:jautomodule:1.0'
+                implementation 'org:jlib:1.0'
+            }
+        """
+
+        file("src/main/java/module-info.java") << """
+            module my.module {
+                requires jmodule
+                requires jautomodule
+            }
+        """
+
+        when:
+        succeeds "eclipse"
+
+        then:
+        def libraries = classpath.libs
+        libraries.size() == 3
+        libraries[0].jarName == 'jmodule-1.0.jar'
+        libraries[0].assertHasAttribute('module', 'true')
+        libraries[1].jarName == 'jautomodule-1.0.jar'
+        libraries[1].assertHasAttribute('module', 'true')
+        libraries[2].jarName == 'jlib-1.0.jar'
+        libraries[2].assertHasNoAttribute('module', 'true')
+
+        where:
+        configLocation << ['java', 'tasks.compileJava']
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
@@ -21,6 +21,8 @@ public class EclipsePluginConstants {
     public static final String DEFAULT_PROJECT_OUTPUT_PATH = "bin/default";
     public static final String TEST_SOURCES_ATTRIBUTE_KEY = "test";
     public static final String TEST_SOURCES_ATTRIBUTE_VALUE = "true";
+    public static final String MODULE_ATTRIBUTE_KEY = "module";
+    public static final String MODULE_ATTRIBUTE_VALUE = "true";
 
     // TODO The scope information is superseded by test attributes. We can delete the corresponding code bits once we make sure that the majority of Buildship users use test sources.
     public static final String GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME = "gradle_used_by_scope";

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -19,10 +19,13 @@ package org.gradle.plugins.ide.eclipse.model;
 import com.google.common.base.Preconditions;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
@@ -323,7 +326,12 @@ public class EclipseClasspath {
         ProjectInternal projectInternal = (ProjectInternal) this.project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
         ProjectStateRegistry projectRegistry = projectInternal.getServices().get(ProjectStateRegistry.class);
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, projectRegistry, new DefaultGradleApiSourcesResolver(project));
+        boolean inferModulePath = false;
+        Task compileJava = project.getTasks().findByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
+        if (compileJava instanceof JavaCompile) {
+            inferModulePath = ((JavaCompile) compileJava).getModularClasspathHandling().getInferModulePath().get();
+        }
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, projectRegistry, new DefaultGradleApiSourcesResolver(project), inferModulePath);
         return classpathFactory.createEntries();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
@@ -35,9 +35,9 @@ public class ClasspathFactory {
     private final EclipseClasspath classpath;
     private final EclipseDependenciesCreator dependenciesCreator;
 
-    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, ProjectStateRegistry projectRegistry, GradleApiSourcesResolver gradleApiSourcesResolver) {
+    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, ProjectStateRegistry projectRegistry, GradleApiSourcesResolver gradleApiSourcesResolver, boolean inferModulePath) {
         this.classpath = classpath;
-        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry, projectRegistry, gradleApiSourcesResolver);
+        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry, projectRegistry, gradleApiSourcesResolver, inferModulePath);
     }
 
     public List<ClasspathEntry> createEntries() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.eclipse.model.internal;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata;
 import org.gradle.plugins.ide.eclipse.model.FileReference;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
@@ -30,11 +31,14 @@ public class ProjectDependencyBuilder {
         this.ideArtifactRegistry = ideArtifactRegistry;
     }
 
-    public ProjectDependency build(ProjectComponentIdentifier componentIdentifier, FileReference publication, TaskDependency buildDependencies) {
+    public ProjectDependency build(ProjectComponentIdentifier componentIdentifier, FileReference publication, TaskDependency buildDependencies, boolean asJavaModule) {
         ProjectDependency dependency = buildProjectDependency(determineTargetProjectPath(componentIdentifier));
         dependency.setPublication(publication);
         if (buildDependencies != null) {
             dependency.buildDependencies(buildDependencies);
+        }
+        if (asJavaModule) {
+            dependency.getEntryAttributes().put(EclipsePluginConstants.MODULE_ATTRIBUTE_KEY, EclipsePluginConstants.MODULE_ATTRIBUTE_VALUE);
         }
         return dependency;
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
@@ -22,7 +22,9 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.WarPlugin;
+import org.gradle.internal.jpms.JavaModuleDetector;
 import org.gradle.plugins.ear.EarPlugin;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;
@@ -62,7 +64,8 @@ public class WtpClasspathAttributeSupport {
 
     private static Set<File> collectFilesFromConfigs(EclipseClasspath classpath, Set<Configuration> configs, Set<Configuration> minusConfigs) {
         WtpClasspathAttributeDependencyVisitor visitor = new WtpClasspathAttributeDependencyVisitor(classpath);
-        new IdeDependencySet(classpath.getProject().getDependencies(), configs, minusConfigs, NullGradleApiSourcesResolver.INSTANCE).visit(visitor);
+        new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class),
+            configs, minusConfigs, false, NullGradleApiSourcesResolver.INSTANCE).visit(visitor);
         return visitor.getFiles();
     }
 
@@ -135,12 +138,12 @@ public class WtpClasspathAttributeSupport {
         }
 
         @Override
-        public void visitProjectDependency(ResolvedArtifactResult artifact) {
+        public void visitProjectDependency(ResolvedArtifactResult artifact, boolean asJavaModule) {
 
         }
 
         @Override
-        public void visitModuleDependency(ResolvedArtifactResult artifact, Set<ResolvedArtifactResult> sources, Set<ResolvedArtifactResult> javaDoc, boolean testDependency) {
+        public void visitModuleDependency(ResolvedArtifactResult artifact, Set<ResolvedArtifactResult> sources, Set<ResolvedArtifactResult> javaDoc, boolean testDependency, boolean asJavaModule) {
             files.add(artifact.getFile());
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencyVisitor.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencyVisitor.java
@@ -46,14 +46,14 @@ public interface IdeDependencyVisitor {
      * The dependency points to an artifact built by another project.
      * The component identifier is guaranteed to be a {@link org.gradle.api.artifacts.component.ProjectComponentIdentifier}.
      */
-    void visitProjectDependency(ResolvedArtifactResult artifact);
+    void visitProjectDependency(ResolvedArtifactResult artifact, boolean asJavaModule);
 
     /**
      * The dependency points to an external module.
      * The component identifier is guaranteed to be a {@link org.gradle.api.artifacts.component.ModuleComponentIdentifier}.
      * The source and javadoc locations maybe be empty, but never null.
      */
-    void visitModuleDependency(ResolvedArtifactResult artifact, Set<ResolvedArtifactResult> sources, Set<ResolvedArtifactResult> javaDoc, boolean testDependency);
+    void visitModuleDependency(ResolvedArtifactResult artifact, Set<ResolvedArtifactResult> sources, Set<ResolvedArtifactResult> javaDoc, boolean testDependency, boolean asJavaModule);
 
     /**
      * The dependency points neither to a project, nor an external module, so this method should treat it as an opaque file.

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/GenerateEclipseClasspathTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/GenerateEclipseClasspathTest.groovy
@@ -15,9 +15,11 @@
  */
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.api.Project
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.AbstractSpockTaskTest
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath
+import org.gradle.util.TestUtil
 
 class GenerateEclipseClasspathTest extends AbstractSpockTaskTest {
 
@@ -28,7 +30,9 @@ class GenerateEclipseClasspathTest extends AbstractSpockTaskTest {
     }
 
     def setup() {
+        def project = Mock(Project)
+        project.getObjects() >> TestUtil.objectFactory()
         eclipseClasspath = createTask(GenerateEclipseClasspath.class)
-        eclipseClasspath.classpath = new EclipseClasspath(null)
+        eclipseClasspath.classpath = new EclipseClasspath(project)
     }
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.plugins.ide.api.PropertiesFileContentMerger
 import org.gradle.plugins.ide.api.XmlFileContentMerger
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class EclipseModelTest extends Specification {
@@ -31,7 +32,9 @@ class EclipseModelTest extends Specification {
     EclipseModel model = new EclipseModel(Mock(ProjectInternal))
 
     def setup() {
-        model.classpath = new EclipseClasspath(null)
+        def project = Mock(org.gradle.api.Project)
+        project.getObjects() >> TestUtil.objectFactory()
+        model.classpath = new EclipseClasspath(project)
     }
 
     def "enables setting path variables even if wtp is not configured"() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
@@ -29,7 +29,7 @@ class EclipseDependenciesCreatorTest extends AbstractProjectBuilderSpec{
     private final ProjectInternal project = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private final ProjectInternal childProject = TestUtil.createChildProject(project, "child", new File("."))
     private final EclipseClasspath eclipseClasspath = new EclipseClasspath(project)
-    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath, project.services.get(IdeArtifactRegistry), project.services.get(ProjectStateRegistry), NullGradleApiSourcesResolver.INSTANCE)
+    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath, project.services.get(IdeArtifactRegistry), project.services.get(ProjectStateRegistry), NullGradleApiSourcesResolver.INSTANCE, false)
 
     def "compile dependency on child project"() {
         applyPluginToProjects()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
@@ -28,7 +28,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
 
     def "should create dependency using project name for project without eclipse plugin applied"() {
         when:
-        def dependency = builder.build(projectId, null, null)
+        def dependency = builder.build(projectId, null, null, false)
 
         then:
         dependency.path == "/project-name"
@@ -45,7 +45,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         artifactRegistry.getIdeProject(EclipseProjectMetadata, projectId) >> projectMetadata
 
         when:
-        def dependency = builder.build(projectId, null, null)
+        def dependency = builder.build(projectId, null, null, false)
 
         then:
         dependency.path == '/foo'


### PR DESCRIPTION
The Java module detection service is used to set the 'module=true' attribute on Eclipse classpath entries that represent Java modules. This will give use a similar behavior to Gradle's compile task
in Eclipse. 
