### PR TITLE
De-incubate org.gradle.jvm.tasks

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/package-info.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Tasks that add support for JVM runtime.
  */
-@org.gradle.api.Incubating
 package org.gradle.jvm.tasks;


### PR DESCRIPTION
The package contains one public class "Jar" which is effectively stable.

Fixes #12447 
