### PR TITLE
Update writing of daemon greeting message

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -96,4 +96,18 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         where:
         javaToolOptions << ["-Xms513m", "-Xmx255m", "-Xms128m -Xmx256m"]
     }
+
+    def 'can start the daemon with ClassLoading tracing enabled'() {
+        given:
+        file('build.gradle') << """
+println 'Started'
+"""
+        executer.useOnlyRequestedJvmOpts()
+
+        when:
+        file('gradle.properties') << 'org.gradle.jvmargs=-XX:+TraceClassLoading'
+
+        then:
+        succeeds()
+    }
 }


### PR DESCRIPTION
This makes sure the message line cannot be interleaved with other output
from the JVM.
It was discovered during attempting to dump JIT compilation information
for JITWatch which required also dumping the class loading info which
happens to write a lot on stdout.