### PR TITLE
 Dedupe strings stored to the instant execution cache

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -63,6 +63,9 @@ class DefaultWriteContext(
     private
     val scopes = WriteIdentities()
 
+    private
+    val strings = WriteStrings()
+
     /**
      * Closes the given [encoder] if it is [AutoCloseable].
      */
@@ -81,6 +84,9 @@ class DefaultWriteContext(
             encode(value)
         }
     }
+
+    override fun writeString(string: CharSequence) =
+        strings.writeString(string, encoder)
 
     override fun writeClass(type: Class<*>) {
         val id = classes.getId(type)
@@ -131,10 +137,6 @@ class DefaultWriteContext(
             writeBinary(hashCode.toByteArray())
         }
     }
-
-    // TODO: consider interning strings
-    override fun writeString(string: CharSequence) =
-        encoder.writeString(string)
 
     override fun newIsolate(owner: IsolateOwner): WriteIsolate =
         DefaultWriteIsolate(owner)
@@ -192,6 +194,9 @@ class DefaultReadContext(
     val scopes = ReadIdentities()
 
     private
+    val strings = ReadStrings()
+
+    private
     lateinit var projectProvider: ProjectProvider
 
     override lateinit var classLoader: ClassLoader
@@ -211,6 +216,9 @@ class DefaultReadContext(
     override suspend fun read(): Any? = getCodec().run {
         decode()
     }
+
+    override fun readString(): String =
+        strings.readString(decoder)
 
     override val isolate: ReadIsolate
         get() = getIsolate()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization
+
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+
+
+class WriteStrings {
+
+    fun writeString(string: CharSequence, encoder: Encoder) = encoder.run {
+        string.toString().let { string ->
+            val id = strings[string]
+            if (id != null) {
+                writeSmallInt(id)
+            } else {
+                val newId = strings.size
+                writeSmallInt(-1)
+                writeString(string)
+                strings[string] = newId
+            }
+        }
+    }
+
+    private
+    val strings = HashMap<String, Int>()
+}
+
+
+class ReadStrings {
+
+    fun readString(decoder: Decoder): String = decoder.run {
+        when (val index = readSmallInt()) {
+            -1 -> readString().also { strings.add(it) }
+            else -> strings[index]
+        }
+    }
+
+    private
+    val strings = mutableListOf<String>()
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -28,8 +28,8 @@ class WriteStrings {
             if (id != null) {
                 writeSmallInt(id)
             } else {
-                val newId = strings.size
-                writeSmallInt(-1)
+                val newId = strings.size + 1
+                writeSmallInt(0)
                 writeString(string)
                 strings[string] = newId
             }
@@ -45,8 +45,8 @@ class ReadStrings {
 
     fun readString(decoder: Decoder): String = decoder.run {
         when (val index = readSmallInt()) {
-            -1 -> readString().also { strings.add(it) }
-            else -> strings[index]
+            0 -> readString().also { strings.add(it) }
+            else -> strings[index - 1]
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -46,10 +46,12 @@ class ReadStrings {
     fun readString(decoder: Decoder): String = decoder.run {
         when (val index = readSmallInt()) {
             0 -> readString().also { strings.add(it) }
-            else -> strings[index - 1]
+            else -> strings[index]
         }
     }
 
+    // the collection is initialized with an empty string to avoid
+    // one subtraction per decoded string
     private
-    val strings = mutableListOf<String>()
+    val strings = mutableListOf<String>("")
 }


### PR DESCRIPTION
This PR attempts to recover some of the performance lost due to the inclusion of `buildSrc` task inputs in the instant execution cache fingerprint by deduplicating strings upon store.

The deduplication reduces the fingerprint size and task graph state size quite significantly, for `gradle/gradle:compileJava` they go from `377K` and `3.1M` respectively to `76K` (80% smaller) and `1.4M` (55% smaller).

`gradle/gradle:compileJava` also stores faster than before `buildSrc` was part of the cache fingerprint and loads almost as fast as before, around 2% faster than current master:

![benchmark-before-master-dedupe-crop](https://user-images.githubusercontent.com/51689/78263405-4b1a6380-74d8-11ea-9866-8e5859ed5b1c.png)

```
.instant-execution-state/6.4-20200326182042+0000:
   3.0M  6m14v12jvgzl3uhoo2yzn6o69.bin
    35K  6m14v12jvgzl3uhoo2yzn6o69.bin.fingerprint

.instant-execution-state/6.4-20200402122718+0000:
   3.1M  6m14v12jvgzl3uhoo2yzn6o69.bin
   377K  6m14v12jvgzl3uhoo2yzn6o69.bin.fingerprint

.instant-execution-state/6.4-20200402123654+0000:
   1.4M  6m14v12jvgzl3uhoo2yzn6o69.bin
    76K  6m14v12jvgzl3uhoo2yzn6o69.bin.fingerprint
```

Although the results for this particular scenario are encouraging, further benchmarks are required before we can be confident with this change.

Supercedes #12689