### PR TITLE
Fix spelling mistakes and logical/structural errors in the userguide

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -136,11 +136,11 @@ Instead, Gradle will dynamically generate a module descriptor (without any depen
 [NOTE]
 ====
 As Gradle prefers to use modules whose descriptor has been created from real meta-data rather than being generated, flat directory repositories cannot be used to override artifacts with real meta-data from other repositories declared in the build.
-====
 
 For example, if Gradle finds only `jmxri-1.2.1.jar` in a flat directory repository, but `jmxri-1.2.1.pom` in another repository that supports meta-data, it will use the second repository to provide the module.
 
 For the use case of overriding remote artifacts with local ones consider using an Ivy or Maven repository instead whose URL points to a local directory.
+====
 
 If you only work with flat directory repositories you don't need to set all attributes of a dependency.
 
@@ -362,7 +362,7 @@ Alternatively, Gradle provides an API which lets you declare that a repository _
 If you do so:
 
 - an artifact declared in a repository _can't_ be found in any other
-- exclusive repository content must be declared in extension (just like for <<#sec:declaring-repository-filter, repository-level content))
+- exclusive repository content must be declared in extension (just like for <<#sec:declaring-repository-filter, repository-level content>>))
 
 .Declaring exclusive repository contents
 ====
@@ -599,7 +599,7 @@ Authentication based on any custom HTTP header, e.g. private tokens, OAuth token
 [[sub:preemptive_authentication]]
 === Using preemptive authentication
 
-Gradle's default behavior is to only submit credentials when a server responds with an authentication challenge in the form of a HTTP 401 response. In some cases, the server will respond with a different code (ex. for repositories hosted on GitHub a 404 is returned) causing dependency resolution to fail. To get around this behavior, credentials may be sent to the server preemptively. To enable preemptive authentication simply configure your repository to explicitly use the link:{javadocPath}/org/gradle/authentication/http/BasicAuthentication.html[BasicAuthentication] scheme:
+Gradle's default behavior is to only submit credentials when a server responds with an authentication challenge in the form of an HTTP 401 response. In some cases, the server will respond with a different code (ex. for repositories hosted on GitHub a 404 is returned) causing dependency resolution to fail. To get around this behavior, credentials may be sent to the server preemptively. To enable preemptive authentication simply configure your repository to explicitly use the link:{javadocPath}/org/gradle/authentication/http/BasicAuthentication.html[BasicAuthentication] scheme:
 
 .Configure repository to use preemptive authentication
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -362,7 +362,7 @@ Alternatively, Gradle provides an API which lets you declare that a repository _
 If you do so:
 
 - an artifact declared in a repository _can't_ be found in any other
-- exclusive repository content must be declared in extension (just like for <<#sec:declaring-repository-filter, repository-level content>>))
+- exclusive repository content must be declared in extension (just like for <<#sec:declaring-repository-filter, repository-level content>>)
 
 .Declaring exclusive repository contents
 ====
@@ -599,7 +599,10 @@ Authentication based on any custom HTTP header, e.g. private tokens, OAuth token
 [[sub:preemptive_authentication]]
 === Using preemptive authentication
 
-Gradle's default behavior is to only submit credentials when a server responds with an authentication challenge in the form of an HTTP 401 response. In some cases, the server will respond with a different code (ex. for repositories hosted on GitHub a 404 is returned) causing dependency resolution to fail. To get around this behavior, credentials may be sent to the server preemptively. To enable preemptive authentication simply configure your repository to explicitly use the link:{javadocPath}/org/gradle/authentication/http/BasicAuthentication.html[BasicAuthentication] scheme:
+Gradle's default behavior is to only submit credentials when a server responds with an authentication challenge in the form of an HTTP 401 response.
+In some cases, the server will respond with a different code (ex. for repositories hosted on GitHub a 404 is returned) causing dependency resolution to fail.
+To get around this behavior, credentials may be sent to the server preemptively.
+To enable preemptive authentication simply configure your repository to explicitly use the link:{javadocPath}/org/gradle/authentication/http/BasicAuthentication.html[BasicAuthentication] scheme:
 
 .Configure repository to use preemptive authentication
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -73,11 +73,11 @@ Out of these versions, it will select the _highest_ one.
 As you have seen, Gradle supports a concept of <<rich_versions.adoc#,rich version declaration>>, so what is the highest version depends on the way versions were declared:
 
 * If no ranges are involved, then the highest version that is not rejected will be selected.
-** If a strictly is lower than that version, selection will fail.
+** If a version declared as `strictly` is lower than that version, selection will fail.
 * If ranges are involved:
 ** If there is a non range version that falls within the specified ranges or is higher than their upper bound, it will be selected.
 ** If there are only ranges, the highest _existing_ version of the range with the highest upper bound will be selected.
-** If a strictly is lower than that version, selection will fail.
+** If a version declared as `strictly` is lower than that version, selection will fail.
 
 Note that in the case where ranges come into play, Gradle requires metadata to determine which versions do exist for the considered range.
 This causes an intermediate lookup for metadata, as described in <<#sec:how-gradle-downloads-deps>>.
@@ -134,7 +134,7 @@ Given a required dependency, with a version, Gradle attempts to resolve the depe
 
 [NOTE]
 ====
-The last point above is what can make the integration with <<declaring_repositories.adoc#sec:case-for-maven-local,Maven Local>> problematic.
+The penultimate point above is what can make the integration with <<declaring_repositories.adoc#sec:case-for-maven-local,Maven Local>> problematic.
 As it is a cache for Maven, it will sometimes miss some artifacts of a given module.
 If Gradle is sourcing such a module from Maven Local, it will consider the missing artifacts to be missing altogether.
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -272,7 +272,7 @@ See <<sec:troubleshooting-verification,troubleshooting dependency verification>>
 
 === What checksums are verified?
 
-If a dependency verification metadata files declares more than one checksum for a dependency, Gradle will verify _all of them_ and fail if _any of them fails_.
+If a dependency verification metadata file declares more than one checksum for a dependency, Gradle will verify _all of them_ and fail if _any of them fails_.
 For example, the following configuration would check both the `md5` and `sha256` checksums:
 
 [source,xml]
@@ -297,11 +297,11 @@ There are multiple reasons why you'd like to do so:
 In addition to <<sec:checksum-verification,checksums>>, Gradle supports verification of signatures.
 Signatures are used to assess the _provenance_ of a dependency (it tells who signed the artifacts, which usually corresponds to who produced it).
 
-While enabling signature verification usually means a higher level of security, you might want to replace checksum verification with signature verification.
+As enabling signature verification usually means a higher level of security, you might want to replace checksum verification with signature verification.
 
 [WARNING]
 ====
-Signatures _can_ also used to assess the integrity of a dependency similarly to checksums.
+Signatures _can_ also be used to assess the integrity of a dependency similarly to checksums.
 Signatures are signatures of the _hash_ of artifacts, not artifacts themselves.
 This means that if the signature is done on an _unsafe hash_ (even SHA1), then you're not correctly assessing the _integrity_ of a file.
 For this reason, if you care about both, you need to add both signatures _and_ checksums to your verification metadata.
@@ -433,7 +433,7 @@ You should be careful when trusting a key globally: try to limit it to the appro
 
 It means you can trust the key `A` for the first artifact, probably only up to the released version before the key was stolen, but not for `B`.
 
-Remember that anybody can put arbitrary name when generating PGP key, so never trust the key solely based on the key name.
+Remember that anybody can put an arbitrary name when generating a PGP key, so never trust the key solely based on the key name.
 Verify if the key is listed at the official site.
 For example, Apache projects typically provide a KEYS.txt file that you can trust.
 ====
@@ -547,7 +547,7 @@ However, because there might be verification failures, missing keys or missing s
 
 this means that Gradle will verify the signatures and fallback to SHA-256 checksums when there's a problem.
 
-When bootstrapping, Gradle performs _optimitic verification_ and therefore assumes a sane build environment.
+When bootstrapping, Gradle performs _optimistic verification_ and therefore assumes a sane build environment.
 It will therefore:
 
 - automatically add the trusted keys as soon as verification passes

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
@@ -259,7 +259,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/dependencyLocking/l
 [[locking_limitations]]
 == Locking limitations
 
-* Locking can not yet be applied to source dependencies.
+* Locking cannot yet be applied to source dependencies.
 
 == Nebula locking plugin
 

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dynamic_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dynamic_versions.adoc
@@ -125,7 +125,7 @@ This is done by comparing published SHA1 values in the repository with the SHA1 
 
 [NOTE]
 ====
-Refreshing dependencies will cause Gradle to invalidate it's listing caches.
+Refreshing dependencies will cause Gradle to invalidate its listing caches.
 However:
 
 - it will perform HTTP HEAD requests on metadata files but _will not re-download them_ if they are identical

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
@@ -92,7 +92,7 @@ That is, does the rule still produce a correct and useful result if applied in a
 
 == Fixing wrong dependency details ==
 
-Lets consider as an example the publication of the Jaxen XPath Engine on link:https://repo1.maven.org/maven2/jaxen/jaxen[Maven central].
+Let's consider as an example the publication of the Jaxen XPath Engine on link:https://repo1.maven.org/maven2/jaxen/jaxen[Maven central].
 The pom of version 1.1.3 declares a number of dependencies in the compile scope which are not actually needed for compilation.
 These have been removed in the 1.1.4 pom.
 Assuming that we need to work with 1.1.3 for some reason, we can fix the metadata with the following rule:
@@ -146,7 +146,7 @@ Thus, there is no information that these jars exist and if there are any other d
 
 In Gradle Module Metadata, this variant information would be present and for the already published Quasar library, we can add it using the following rule:
 
-.Rule to add Jdk 8 variants to Quasar metadata
+.Rule to add JDK 8 variants to Quasar metadata
 ====
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy",files="build.gradle[tags=quasar-rule]"]
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin",files="build.gradle.kts[tags=quasar-rule]"]
@@ -184,14 +184,14 @@ However, since both variants are always published together we can assume that th
 And since they are published with Maven repository conventions, we know the location of each file if we know module name and version.
 We can write the following rule:
 
-.Rule to add Jdk 6 and Jdk 8 variants to Guava metadata
+.Rule to add JDK 6 and JDK 8 variants to Guava metadata
 ====
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy",files="build.gradle[tags=guava-rule]"]
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin",files="build.gradle.kts[tags=guava-rule]"]
 ====
 
 Similar to the previous example, we add runtime and compile variants for both Java versions.
-In the `withFile` block however, we now also specify a relative path for the corresponding jar file which allows Gradle to find the file no matter if it has selected a _-jre_ or _-android_ version.
+In the `withFiles` block however, we now also specify a relative path for the corresponding jar file which allows Gradle to find the file no matter if it has selected a _-jre_ or _-android_ version.
 The path is always relative to the location of the metadata (in this case `pom`) file of the selection module version.
 So with this rules, both Guava 28 "versions" carry both the _jdk6_ and _jdk8_ variants.
 So it does not matter to which one Gradle resolves.
@@ -221,7 +221,7 @@ Only this time we have five different runtime variants we add and nothing we nee
 The runtime variants are all based on the existing _runtime_ variant and we do not change any existing information.
 All Java ecosystem attributes, the dependencies and the main jar file stay part of each of the runtime variants.
 We only set the additional attributes `OPERATING_SYSTEM_ATTRIBUTE` and `ARCHITECTURE_ATTRIBUTE` which are defined as part of Gradle's <<building_cpp_projects.adoc#,native support>>.
-And we add the corresponding native jar file so that each runtime variant now carries two files: tha main jar and the native jar.
+And we add the corresponding native jar file so that each runtime variant now carries two files: the main jar and the native jar.
 
 In the build script, we can now request a specific variant and Gradle will fail with a selection error if more information is needed to make a decision.
 
@@ -257,7 +257,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/customizingResoluti
 ====
 
 The new variants also have the dependency on the standardized aop interfaces library `aopalliance:aopalliance` removed, as this is clearly not needed by these variants.
-Again, this is information that can not be expressed in pom metadata.
+Again, this is information that cannot be expressed in pom metadata.
 We can now select a `guice-no_aop` variant and will get the correct jar file *and* the correct dependencies.
 
 .Applying and utilising rule for Guice metadata

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_downgrade_and_exclude.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_downgrade_and_exclude.adoc
@@ -131,7 +131,7 @@ So if our code would be more dynamic, and we would forget to cover the error cas
 
 This is only an example to illustrate potential pitfalls.
 In practice, larger libraries or frameworks can bring in a huge set of dependencies.
-If those libraries fail to declare features sepratly and can only be consumed in a "all or nothing" fashion, excludes can be a valid method to reduce the library to the feature set actually required.
+If those libraries fail to declare features separately and can only be consumed in a "all or nothing" fashion, excludes can be a valid method to reduce the library to the feature set actually required.
 
 On the upside, Gradle's exclude handling is, in contrast to Maven, taking the whole dependency graph into account.
 So if there are multiple dependencies on a library, excludes are only exercised if all dependencies agree on them.
@@ -163,9 +163,9 @@ You may consider to look into the following features:
   By this, you tell Gradle that a dependency between two modules is never needed — i.e. the metadata was wrong — and therefore should *never* be considered.
   If you are developing a library, you have to be aware that this information is not published, and so sometimes an _exclude_ can be the better alternative.
 - <<dependency_capability_conflict.adoc#,Resolving mutually exclusive dependency conflicts>>:
-  Another situation that you often see solved by excludes is that two dependencies can not be used together because they represent two implementations of the same thing (the same <<dependency_capability_conflict.adoc#sub:capabilities,capability>>).
+  Another situation that you often see solved by excludes is that two dependencies cannot be used together because they represent two implementations of the same thing (the same <<dependency_capability_conflict.adoc#sub:capabilities,capability>>).
   A popular example are clashing logging API implementations (like `log4j` and `log4j-over-slf4j`) or modules that have different coordinates in different versions (like `com.google.collections` and `guava`).
   In this case, if this information is not known to Gradle, it is recommended to add the missing capability information via component metadata rules as described in the <<dependency_capability_conflict.adoc#sub:declaring-component-capabilities,declaring component capabilities>> section.
-  Even if you are developing a library, and your consumers will have to deal with resolving the conflict again, it is often the right solution to leave the decssion to the final consumers of libraries.
+  Even if you are developing a library, and your consumers will have to deal with resolving the conflict again, it is often the right solution to leave the decision to the final consumers of libraries.
   I.e. you as a library author should not have to decide which logging implementation your consumers use in the end.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
@@ -75,8 +75,8 @@ NOTE: This behavior is enforced for published components only if you use Gradle 
 [[sec:align-versions-unpublished]]
 == Aligning versions of modules not published with Gradle
 
-Whenever the publisher doesn't use Gradle, like in our Jackson example, we can explain to Gradle that that all Jackson modules "belong to" the same platform and benefit from the same behavior as with native alignment.
-There are are two options to express that a set of modules belong to a platform:
+Whenever the publisher doesn't use Gradle, like in our Jackson example, we can explain to Gradle that all Jackson modules "belong to" the same platform and benefit from the same behavior as with native alignment.
+There are two options to express that a set of modules belong to a platform:
 
 1. A platform is **published** as a <<platforms.adoc#sub:bom_import,BOM>> and can be used:
    For example, `com.fasterxml.jackson:jackson-bom` can be used as platform.
@@ -110,7 +110,7 @@ In that BOM, the following versions are defined and will be used:
 `jackson-core:2.9.5`,
 `jackson-databind:2.9.5` and
 `jackson-annotation:2.9.0`.
-The lower versions of `jackson-annotation` here might be the desired result as the it is what the BOM recommends.
+The lower versions of `jackson-annotation` here might be the desired result as it is what the BOM recommends.
 
 NOTE: This behavior is working reliable since Gradle 6.1. Effectively, it is similar to a <<component_metadata_rules.adoc#,component metadata rule>> that adds a platform dependency to all members of the platform using `withDependencies`.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
@@ -7,7 +7,7 @@ This section covers mechanisms Gradle offers to directly influence the behavior 
 In contrast to the other concepts covered in this chapter, like <<dependency_constraints.adoc#,dependency constraints>> or <<component_metadata_rules.adoc#,component metadata rules>>, which are all *inputs* to resolution, the following mechanisms allow you to write rules which are directly injected into the resolution engine.
 Because of this, they can be seen as _brute force_ solutions, that may hide future problems (e.g. if new dependencies are added).
 Therefore, the general advice is to only use the following mechanisms if other means are not sufficient.
-If you are are authoring a <<library_vs_application.adoc#,library>>, you should always prefer <<dependency_constraints.adoc#,dependency constraints>> as they are published for your consumers.
+If you are authoring a <<library_vs_application.adoc#,library>>, you should always prefer <<dependency_constraints.adoc#,dependency constraints>> as they are published for your consumers.
 ====
 
 [[sec:dependency_resolve_rules]]
@@ -18,7 +18,7 @@ The feature currently offers the ability to change the group, name and/or versio
 
 Dependency resolve rules provide a very powerful way to control the dependency resolution process, and can be used to implement all sorts of advanced patterns in dependency management.
 Some of these patterns are outlined below.
-or more information and code samples see the link:{groovyDslPath}/org.gradle.api.artifacts.ResolutionStrategy.html[ResolutionStrategy] class in the API documentation.
+For more information and code samples see the link:{groovyDslPath}/org.gradle.api.artifacts.ResolutionStrategy.html[ResolutionStrategy] class in the API documentation.
 
 [[sec:custom_versioning_scheme]]
 === Implementing a custom versioning scheme

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_strategy_tuning.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_strategy_tuning.adoc
@@ -13,9 +13,9 @@ Gradle provides ways to perform this by configuring the resolution strategy.
 == Failing on version conflict
 
 There's a version conflict whenever Gradle finds the same module in two different versions in a dependency graph.
-By default, Gradle performs _optimitic upgrades_, meaning that if version `1.1` and `1.3` are found in the graph, we resolve to the highest version, `1.3`.
+By default, Gradle performs _optimistic upgrades_, meaning that if version `1.1` and `1.3` are found in the graph, we resolve to the highest version, `1.3`.
 However, it is easy to miss that some dependencies are upgraded because of a transitive dependency.
-In the example above, if `1.1` was a version used in your build script and `1.3` a version brough transitively, you could use `1.3` without actually noticing.
+In the example above, if `1.1` was a version used in your build script and `1.3` a version brought transitively, you could use `1.3` without actually noticing.
 
 To make sure that you are aware of such upgrades, Gradle provides a mode that can be activated in the resolution strategy of a configuration.
 Imagine the following dependencies declaration:

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/artifact_transforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/artifact_transforms.adoc
@@ -172,7 +172,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/artifactTransforms/
 <1> Declare the parameter type
 <2> Interface for the transform parameters
 <3> Use the parameters
-<4> Use the unchanged input artifact when not minification is required
+<4> Use the unchanged input artifact when no minification is required
 
 Remember that the input artifact is a dependency, which may have its own dependencies.
 If your artifact transform needs access to those transitive dependencies, it can declare an abstract getter returning a `FileCollection` and annotate it with link:{javadocPath}/org/gradle/api/artifacts/transform/InputArtifactDependencies.html[@InputArtifactDependencies].
@@ -183,7 +183,7 @@ Moreover, artifact transforms can make use of the <<build_cache.adoc#build_cache
 To enable the build cache for an artifact transform, add the `@link:{javadocPath}/org/gradle/api/artifacts/transform/CacheableTransform.html[CacheableTransform]` annotation on the action class.
 For cacheable transforms, you must annotate its link:{javadocPath}/org/gradle/api/artifacts/transform/InputArtifact.html[@InputArtifact] property — and any property marked with link:{javadocPath}/org/gradle/api/artifacts/transform/InputArtifactDependencies.html[@InputArtifactDependencies] — with normalization annotations such as link:{javadocPath}/org/gradle/api/tasks/PathSensitive.html[@PathSensitive].
 
-The following example shows a more complicated transforms.
+The following example shows a more complicated transform.
 It moves some selected classes of a JAR to a different package, rewriting the byte code of the moved classes and all classes using the moved classes (class relocation).
 In order to determine the classes to relocate, it looks at the packages of the input artifact and the dependencies of the input artifact.
 It also does not relocate packages contained in JAR files in an external classpath.
@@ -222,7 +222,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/artifactTransforms/
 include::sample[dir="snippets/userguide/dependencyManagement/artifactTransforms/unzip/kotlin",files="build.gradle.kts[tags=artifact-transform-registration]"]
 ====
 
-Another example is that you want minify JARs by only keeping some `class` files from them.
+Another example is that you want to minify JARs by only keeping some `class` files from them.
 Note the use of the `parameters {}` block to provide the classes to keep in the minified JARs to the `Minify` transform.
 
 .Artifact transform registration with parameters

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
@@ -91,7 +91,6 @@ Capabilities are published to Gradle Module Metadata.
 However, they have _no equivalent_ in POM or Ivy metadata files.
 As a consequence, when publishing such a component, Gradle will warn you that this feature is only for Gradle consumers:
 
-[source]
 ----
 Maven publication 'maven' contains dependencies that cannot be represented in a published pom file.
   - Declares capability com.acme:my-library:1.0

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
@@ -91,8 +91,9 @@ Capabilities are published to Gradle Module Metadata.
 However, they have _no equivalent_ in POM or Ivy metadata files.
 As a consequence, when publishing such a component, Gradle will warn you that this feature is only for Gradle consumers:
 
-```
+[source]
+----
 Maven publication 'maven' contains dependencies that cannot be represented in a published pom file.
   - Declares capability com.acme:my-library:1.0
   - Declares capability com.other:module:1.1
-```
+----

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
@@ -17,12 +17,13 @@ In order to be _safe to share_ between projects and allow maximum performance (p
 ====
 A frequent anti-pattern to declare cross-project dependencies is:
 
-```groovy
+[source,groovy]
+----
 dependencies {
    // this is unsafe!
    implementation project(":other").tasks.someOtherJar
 }
-```
+----
 
 This publication model is _unsafe_ and can lead to non-reproducible and hard to parallelize builds.
 This section explains how to _properly create cross-project boundaries_ by defining "exchanges" between projects by using _variants_.
@@ -63,7 +64,7 @@ Doing so, Gradle can automatically track dependencies of this task and build the
 This is possible because the `Jar` task extends `AbstractArchiveTask`.
 If it's not the case, you will need to explicitly declare how the artifact is generated.
 
-.Expliciting the task dependency of an artifact
+.Explicitly declaring the task dependency of an artifact
 ====
 include::sample[dir="snippets/userguide/dependencyManagement/modelingFeatures/crossProjectPublications/simple/groovy",files="producer/build.gradle[tags=attach-outgoing-artifact-explicit]"]
 include::sample[dir="snippets/userguide/dependencyManagement/modelingFeatures/crossProjectPublications/simple/kotlin",files="producer/build.gradle.kts[tags=attach-outgoing-artifact-explicit]"]
@@ -120,14 +121,15 @@ Therefore, we need to understand what our new variant is used for in order to se
 Let's look at the attributes we find on the `runtimeElements` configuration:
 
 .gradle outgoingVariants --variant runtimeElements
-```
+[source]
+----
 Attributes
     - org.gradle.category            = library
     - org.gradle.dependency.bundling = external
     - org.gradle.jvm.version         = 11
     - org.gradle.libraryelements     = jar
     - org.gradle.usage               = java-runtime
-```
+----
 
 What it tells us is that the Java Library plugin produces variants with 5 attributes:
 
@@ -223,7 +225,7 @@ So, **avoid publishing custom variants** if they are for internal use only.
 [[targeting-different-platforms]]
 == Targeting different platforms
 
-It common for a library to target different platforms.
+It is common for a library to target different platforms.
 In the Java ecosystem, we often see different artifacts for the same library, distinguished by a different _classifier_.
 A typical example is Guava, which is published as this:
 

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
@@ -121,7 +121,6 @@ Therefore, we need to understand what our new variant is used for in order to se
 Let's look at the attributes we find on the `runtimeElements` configuration:
 
 .gradle outgoingVariants --variant runtimeElements
-[source]
 ----
 Attributes
     - org.gradle.category            = library

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
@@ -55,7 +55,7 @@ If we do so, a consumer would then have to declare two dependencies:
 
 [NOTE]
 ====
-While the engine supports feature variants independently of the the ecosystem, this feature is currently only available using the Java plugins and is incubating.
+While the engine supports feature variants independently of the ecosystem, this feature is currently only available using the Java plugins and is incubating.
 ====
 
 [[sec::declare_feature_variants]]
@@ -221,9 +221,10 @@ include::sample[dir="snippets/java-feature-variant/incompatible-variants/kotlin/
 
 Dependency resolution would fail with the following error:
 
-```
+[source]
+----
 Cannot choose between
    org.gradle.demo:producer:1.0 variant mysqlSupportRuntimeElements and
    org.gradle.demo:producer:1.0 variant postgresSupportRuntimeElements
    because they provide the same capability: org.gradle.demo:producer-db-support:1.0
-```
+----

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
@@ -221,7 +221,6 @@ include::sample[dir="snippets/java-feature-variant/incompatible-variants/kotlin/
 
 Dependency resolution would fail with the following error:
 
-[source]
 ----
 Cannot choose between
    org.gradle.demo:producer:1.0 variant mysqlSupportRuntimeElements and

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -38,7 +38,7 @@ In both cases, Gradle performs _variant aware selection_.
 == Configuration and variant attributes
 
 Local components expose variants as _outgoing configurations_, which are <<declaring_dependencies.adoc#sec:resolvable-consumable-configs,consumable configurations>>.
-When dependency resolution happens, the engine will select one variant of an outgoing component by selecting one of its _consumable configurations).
+When dependency resolution happens, the engine will select one variant of an outgoing component by selecting one of its _consumable configurations_.
 
 [NOTE]
 ====
@@ -62,7 +62,7 @@ This is where attributes come into play: their role is to perform the selection 
 ====
 For external components, the terminology is to use the word _variants_, not _configurations_. Configurations are a super-set of variants.
 
-This means that an external component provide _variants_, which also have attributes.
+This means that an external component provides _variants_, which also have attributes.
 However, sometimes the term _configuration_ may leak into the DSL for historical reasons, or because you use Ivy which also has this concept of _configuration_.
 ====
 
@@ -169,7 +169,7 @@ The variant _name_ is there mostly for debugging purposes and to get a nicer dis
 The name, in particular, doesn't participate in the _id_ of a variant: only its attributes do.
 That is to say that to search for a particular variant, one _must_ rely on its attributes, _not_ its name.
 
-There are no restriction on the number of variants a component can expose.
+There are no restrictions on the number of variants a component can expose.
 Traditionally, a component would expose an API and an implementation, but we may, for example, want to expose the test fixtures of a component too.
 It is also possible to expose _different APIs_ for different consumers (think about different environments, like Linux vs Windows).
 ====
@@ -335,7 +335,7 @@ See the {metadata-file-spec}[Gradle Module Metadata specification] for more info
 
 Modules published on a Maven repository are converted into variant-aware modules.
 A particularity of Maven modules is that there is no way to know what kind of component is published.
-In particular, there's no way to make the difference between a BOM representing a _platform_, and a BOM used as a super-POM..
+In particular, there's no way to make the difference between a BOM representing a _platform_, and a BOM used as a super-POM.
 Sometimes, it is even possible for a POM file to act both as a platform _and_ a library.
 
 As a consequence, Maven modules are derived into 6 distinct variants, which allows Gradle users to explain precisely what they depend on:
@@ -383,6 +383,6 @@ Dependencies and artifacts of the variants are taken from the underlying configu
 If not all consumed ivy modules follow this pattern, the rule can be adjusted or only applied to a selected set of modules.
 
 For all ivy modules without variants, Gradle falls back to legacy configuration selection (i.e. Gradle does _not_ perform variant aware resolution for these modules).
-This means the either the `default` configuration or the configuration explicitly defined in the dependency to the corresponding module is selected.
+This means either the `default` configuration or the configuration explicitly defined in the dependency to the corresponding module is selected.
 (Note that explicit configuration selection is only possible from build scripts or ivy metadata, and should be avoided in favor of variant selection.)
 

--- a/subprojects/docs/src/docs/userguide/dep-man/05-multirepo-environment/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/05-multirepo-environment/composite_builds.adoc
@@ -78,7 +78,7 @@ include::sample[dir="snippets/compositeBuilds/basic/groovy",files="composite/bui
 include::sample[dir="snippets/compositeBuilds/basic/kotlin",files="composite/build.gradle.kts[tags=run]"]
 ====
 
-More details tasks that depend on included build tasks below.
+More details about tasks that depend on included build tasks are below.
 
 [[included_builds]]
 === Restrictions on included builds

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
@@ -24,7 +24,7 @@ include::sample[dir="snippets/userguide/dependencyManagement/modelingFeatures/cr
 include::sample[dir="snippets/userguide/dependencyManagement/modelingFeatures/crossProjectPublications/advanced-published/kotlin/buildSrc/src/main/kotlin/com/acme",files="InstrumentedJarsPlugin.kt[tags=add_variant_to_existing_component]"]
 ====
 
-In other cases, you might want to modify a variant that was added by the one of the Java plugin already.
+In other cases, you might want to modify a variant that was added by one of the Java plugins already.
 For example, if you activate publishing of Javadoc and sources, these become additional variants of the `java` component.
 If you only want to publish one of them, e.g. only Javadoc but no sources, you can modify the `sources` variant to not being published:
 
@@ -37,7 +37,7 @@ include::sample[dir="snippets/maven-publish/javaProject/kotlin",files="build.gra
 [[sec:publishing-custom-components]]
 == Creating and publishing custom components
 
-In the <<sec:adding-variants-to-existing-components, previous example>>, we have demonstrated how to extend or modify an existing component, like the components provided by a Java plugins.
+In the <<sec:adding-variants-to-existing-components, previous example>>, we have demonstrated how to extend or modify an existing component, like the components provided by the Java plugins.
 But Gradle also allows you to build a custom component (not a Java Library, not a Java Platform, not something supported natively by Gradle).
 
 To create a custom component, you first need to create an empty _adhoc_ component.
@@ -90,7 +90,7 @@ Please refer to the <<cross_project_publications.adoc#sec:variant-aware-sharing,
 
 If you attach extra artifacts to a publication directly, they are published "out of context".
 That means, they are not referenced in the metadata at all and can then only be addressed directly through a classifier on a dependency.
-In contrast to Gradle Module Metadata, Maven pom metadata will not contain information on additional artifacts regardless of whether they are added though a variant or directly, as variants can not be represented in the pom format.
+In contrast to Gradle Module Metadata, Maven pom metadata will not contain information on additional artifacts regardless of whether they are added through a variant or directly, as variants cannot be represented in the pom format.
 ====
 
 The following section describes how you publish artifacts directly if you are sure that metadata, for example Gradle or POM metadata, is irrelevant for your use case.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
@@ -104,7 +104,7 @@ include::sample[dir="snippets/ivy-publish/descriptor-customization/kotlin",files
 
 In this example we are simply adding a 'description' element to the generated Ivy dependency descriptor, but this hook allows you to modify any aspect of the generated descriptor. For example, you could replace the version range for a dependency with the actual version used to produce the build.
 
-You can also add arbitrary XML to the descriptor file via link:{groovyDslPath}/org.gradle.api.publish.ivy.IvyModuleDescriptorSpec.html#org.gradle.api.publish.ivy.IvyModuleDescriptorSpec:withXml(org.gradle.api.Action)[IvyModuleDescriptorSpec.withXml(org.gradle.api.Action)], but you can not use it to modify any part of the module identifier (organisation, module, revision).
+You can also add arbitrary XML to the descriptor file via link:{groovyDslPath}/org.gradle.api.publish.ivy.IvyModuleDescriptorSpec.html#org.gradle.api.publish.ivy.IvyModuleDescriptorSpec:withXml(org.gradle.api.Action)[IvyModuleDescriptorSpec.withXml(org.gradle.api.Action)], but you cannot use it to modify any part of the module identifier (organisation, module, revision).
 
 CAUTION: It is possible to modify the descriptor in such a way that it is no longer a valid Ivy module descriptor, so care must be taken when using this feature.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
@@ -30,7 +30,7 @@ Directories are common in the case of inter-project dependencies to avoid the co
 == Capability
 
 A capability identifies a feature offered by one or multiple components.
-A capability is identified by coordinates similar to the coordinates used for a <<sub:terminology_module_version,module versions>>.
+A capability is identified by coordinates similar to the coordinates used for <<sub:terminology_module_version,module versions>>.
 By default, each module version offers a capability that matches its coordinates, for example `com.google:guava:18.0`.
 Capabilities can be used to express that a component provides multiple <<sub:terminology_feature_variant,feature variants>> or that two different components implement the same feature (and thus cannot be used together).
 For more details, see the section on <<component_capabilities.adoc#,capabilities>>.

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/artifactTransforms/incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/artifactTransforms/incremental/groovy/build.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.transform.TransformParameters
 // tag::artifact-transform-countloc[]
 abstract class CountLoc implements TransformAction<TransformParameters.None> {
 
-    @Inject
+    @Inject                                                             // <1>
     abstract InputChanges getInputChanges()
 
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -29,7 +29,7 @@ abstract class CountLoc implements TransformAction<TransformParameters.None> {
     abstract Provider<FileSystemLocation> getInput()
 
     @Override
-    void transform(TransformOutputs outputs) {                          // <1>
+    void transform(TransformOutputs outputs) {
         def outputDir = outputs.dir("${input.get().asFile.name}.loc")
         println("Running transform on ${input.get().asFile.name}, incremental: ${inputChanges.incremental}")
         inputChanges.getFileChanges(input).forEach { change ->          // <2>

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/artifactTransforms/incremental/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/artifactTransforms/incremental/kotlin/build.gradle.kts
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.transform.TransformParameters
 // tag::artifact-transform-countloc[]
 abstract class CountLoc : TransformAction<TransformParameters.None> {
 
-    @get:Inject
+    @get:Inject                                                         // <1>
     abstract val inputChanges: InputChanges
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -29,7 +29,7 @@ abstract class CountLoc : TransformAction<TransformParameters.None> {
     abstract val input: Provider<FileSystemLocation>
 
     override
-    fun transform(outputs: TransformOutputs) {                          // <1>
+    fun transform(outputs: TransformOutputs) {
         val outputDir = outputs.dir("${input.get().asFile.name}.loc")
         println("Running transform on ${input.get().asFile.name}, incremental: ${inputChanges.isIncremental}")
         inputChanges.getFileChanges(input).forEach { change ->          // <2>


### PR DESCRIPTION
Signed-off-by: Lars Kaulen <lars.kaulen@outlook.de>

### Context
<!--- Why do you believe many users will benefit from this change? -->
While working through the **Dependency Management** section of the usermanual some spelling/grammatical and logical/structural errors caught my eye, so I directly fixed them. As the documentation is pretty _huge_, it added up to quite a few (minor) changes.

Mostly spelling and grammatical errors, a few fixes in asciidoc syntax and some structural errors, for example when sentences were wrongly outside of a `NOTE` block.
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
