### PR TITLE
Refactors for serialization of Provider types to the instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -25,7 +26,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
-import org.gradle.api.internal.provider.AbstractMappingProvider;
+import org.gradle.api.internal.provider.MappingProvider;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -79,32 +80,22 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
 
     @Override
     public Provider<RegularFile> file(Provider<File> provider) {
-        return new AbstractMappingProvider<RegularFile, File>(RegularFile.class, Providers.internal(provider)) {
+        return new MappingProvider<>(RegularFile.class, Providers.internal(provider), new Transformer<RegularFile, File>() {
             @Override
-            protected String getMapDescription() {
-                return "resolve-file";
-            }
-
-            @Override
-            protected RegularFile mapValue(File file) {
+            public RegularFile transform(File file) {
                 return fileFactory.file(fileResolver.resolve(file));
             }
-        };
+        });
     }
 
     @Override
     public Provider<Directory> dir(Provider<File> provider) {
-        return new AbstractMappingProvider<Directory, File>(Directory.class, Providers.internal(provider)) {
+        return new MappingProvider<>(Directory.class, Providers.internal(provider), new Transformer<Directory, File>() {
             @Override
-            protected String getMapDescription() {
-                return "resolve-dir";
-            }
-
-            @Override
-            protected Directory mapValue(File file) {
+            public Directory transform(File file) {
                 return fileFactory.dir(fileResolver.resolve(file));
             }
-        };
+        });
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -23,8 +23,8 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
-import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.MutationGuard;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.plugins.DslObject;
@@ -203,9 +203,8 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            context.add(get());
-            return true;
+        public ValueProducer getProducer() {
+            return ValueProducer.taskState(get());
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -671,9 +671,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            context.add(get());
-            return true;
+        public ValueProducer getProducer() {
+            return ValueProducer.taskState(get());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -84,12 +84,6 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
         throw new UnsupportedOperationException("Build services cannot be serialized.");
     }
 
-    // TODO - rename this method
-    @Override
-    public boolean isValueProducedByTask() {
-        return true;
-    }
-
     @Override
     protected Value<? extends T> calculateOwnValue() {
         synchronized (this) {
@@ -107,6 +101,11 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
             }
             return Value.of(instance.get());
         }
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        return ExecutionTimeValue.changingValue(this);
     }
 
     public void maybeStop() {

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionPropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionPropertyIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.file
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class FileCollectionPropertyIntegrationTest extends AbstractIntegrationSpec {
@@ -86,7 +85,6 @@ class FileCollectionPropertyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("The value for task ':show' property 'prop' is final and cannot be changed any further.")
     }
 
-    @ToBeFixedForInstantExecution
     def "can wire the output file of multiple tasks as input to another task using property"() {
         buildFile << """
             class FileOutputTask extends DefaultTask {
@@ -223,7 +221,6 @@ class FileCollectionPropertyIntegrationTest extends AbstractIntegrationSpec {
         file("output/merged.txt").text == 'new-file1,new-file1'
     }
 
-    @ToBeFixedForInstantExecution
     def "can wire the output directory of multiple tasks as input to another task using property"() {
         buildFile << """
             class DirOutputTask extends DefaultTask {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -287,7 +287,16 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         }
 
         @Override
-        public boolean isValueProducedByTask() {
+        public ExecutionTimeValue<Set<FileSystemLocation>> calculateExecutionTimeValue() {
+            ExecutionTimeValue<Set<FileSystemLocation>> value = ExecutionTimeValue.fixedValue(get());
+            if (contentsAreBuiltByTask()) {
+                return value.withChangingContent();
+            } else {
+                return value;
+            }
+        }
+
+        private boolean contentsAreBuiltByTask() {
             return !collection.getBuildDependencies().getDependencies(null).isEmpty();
         }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.file;
 
 import com.google.common.collect.ImmutableSet;
 import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemLocation;
@@ -281,9 +283,25 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            context.add(collection);
-            return true;
+        public ValueProducer getProducer() {
+            return new ValueProducer() {
+                @Override
+                public boolean isKnown() {
+                    return true;
+                }
+
+                @Override
+                public boolean isProducesDifferentValueOverTime() {
+                    return false;
+                }
+
+                @Override
+                public void visitProducerTasks(Action<? super Task> visitor) {
+                    for (Task dependency : collection.getBuildDependencies().getDependencies(null)) {
+                        visitor.execute(dependency);
+                    }
+                }
+            };
         }
 
         @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -328,7 +328,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         def task = Mock(TaskInternal)
         _ * dependency.visitDependencies(_) >> { TaskDependencyResolveContext c -> c.add(task) }
 
-        ProviderInternal elements = collection.elements
+        def elements = collection.elements
 
         when:
         def visited = elements.maybeVisitBuildDependencies(context)
@@ -339,7 +339,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         0 * context._
 
         expect:
-        elements.valueProducedByTask
+        elements.calculateExecutionTimeValue().hasChangingContent()
     }
 
     void "visits self when listener requests contents"() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -15,12 +15,12 @@
  */
 package org.gradle.api.internal.file
 
+import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitorUtil
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.tasks.TaskDependencyInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
@@ -306,37 +306,37 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
 
     void elementsProviderHasNoDependenciesWhenThisHasNoDependencies() {
         def collection = new TestFileCollection()
-        def context = Mock(TaskDependencyResolveContext)
-
-        ProviderInternal elements = collection.elements
+        def action = Mock(Action)
+        def elements = collection.elements
 
         when:
-        def visited = elements.maybeVisitBuildDependencies(context)
+        def producer = elements.producer
+        producer.visitProducerTasks(action)
 
         then:
-        visited
-        1 * context.add(collection)
-        0 * context._
+        producer.known
+        0 * action._
 
         expect:
-        !elements.valueProducedByTask
+        !elements.calculateExecutionTimeValue().hasChangingContent()
     }
 
     void elementsProviderHasSameDependenciesAsThis() {
         def collection = new TestFileCollectionWithDependency()
-        def context = Mock(TaskDependencyResolveContext)
+        def action = Mock(Action)
         def task = Mock(TaskInternal)
         _ * dependency.visitDependencies(_) >> { TaskDependencyResolveContext c -> c.add(task) }
 
         def elements = collection.elements
 
         when:
-        def visited = elements.maybeVisitBuildDependencies(context)
+        def producer = elements.producer
+        producer.visitProducerTasks(action)
 
         then:
-        visited
-        1 * context.add(collection)
-        0 * context._
+        producer.known
+        1 * action.execute(task)
+        0 * action._
 
         expect:
         elements.calculateExecutionTimeValue().hasChangingContent()

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal.file
 
+import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.provider.ProviderInternal
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.state.ModelObject
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -273,16 +273,21 @@ class DefaultFilePropertyFactoryTest extends Specification {
         def task = Stub(Task)
         def owner = Stub(ModelObject)
         owner.taskThatOwnsThisObject >> task
-        def context = Mock(TaskDependencyResolveContext)
+        def action = Mock(Action)
 
         when:
         var.attachProducer(owner)
-        def visited = var.maybeVisitBuildDependencies(context)
+        def producer = var.producer
 
         then:
-        visited
-        1 * context.add(task)
-        0 * context._
+        producer.known
+
+        when:
+        producer.visitProducerTasks(action)
+
+        then:
+        1 * action.execute(task)
+        0 * action._
     }
 
     def "can discard the producer task for a directory"() {
@@ -290,15 +295,20 @@ class DefaultFilePropertyFactoryTest extends Specification {
         def task = Stub(Task)
         def owner = Stub(ModelObject)
         owner.taskThatOwnsThisObject >> task
-        def context = Mock(TaskDependencyResolveContext)
+        def action = Mock(Action)
 
         when:
         var.attachProducer(owner)
-        def visited = var.locationOnly.maybeVisitBuildDependencies(context)
+        def producer = var.locationOnly.producer
 
         then:
-        !visited
-        0 * context._
+        !producer.known
+
+        when:
+        producer.visitProducerTasks(action)
+
+        then:
+        0 * action._
     }
 
     def "can specify the producer task for a regular file"() {
@@ -306,16 +316,21 @@ class DefaultFilePropertyFactoryTest extends Specification {
         def task = Stub(Task)
         def owner = Stub(ModelObject)
         owner.taskThatOwnsThisObject >> task
-        def context = Mock(TaskDependencyResolveContext)
+        def action = Mock(Action)
 
         when:
         var.attachProducer(owner)
-        def visited = var.maybeVisitBuildDependencies(context)
+        def producer = var.producer
 
         then:
-        visited
-        1 * context.add(task)
-        0 * context._
+        producer.known
+
+        when:
+        producer.visitProducerTasks(action)
+
+        then:
+        1 * action.execute(task)
+        0 * action._
     }
 
     def "can discard the producer task for a regular file"() {
@@ -323,14 +338,19 @@ class DefaultFilePropertyFactoryTest extends Specification {
         def task = Stub(Task)
         def owner = Stub(ModelObject)
         owner.taskThatOwnsThisObject >> task
-        def context = Mock(TaskDependencyResolveContext)
+        def action = Mock(Action)
 
         when:
         var.attachProducer(owner)
-        def visited = var.locationOnly.maybeVisitBuildDependencies(context)
+        def producer = var.locationOnly.producer
 
         then:
-        !visited
-        0 * context._
+        !producer.known
+
+        when:
+        producer.visitProducerTasks(action)
+
+        then:
+        0 * action._
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -748,10 +748,13 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         "RegularFileProperty"         | "objects.fileProperty()"              | "null"           | "null"
         "ListProperty<String>"        | "objects.listProperty(String)"        | "[]"             | "[]"
         "ListProperty<String>"        | "objects.listProperty(String)"        | "['abc']"        | ['abc']
+        "ListProperty<String>"        | "objects.listProperty(String)"        | "null"           | "null"
         "SetProperty<String>"         | "objects.setProperty(String)"         | "[]"             | "[]"
         "SetProperty<String>"         | "objects.setProperty(String)"         | "['abc']"        | ['abc']
+        "SetProperty<String>"         | "objects.setProperty(String)"         | "null"           | "null"
         "MapProperty<String, String>" | "objects.mapProperty(String, String)" | "[:]"            | [:]
         "MapProperty<String, String>" | "objects.mapProperty(String, String)" | "['abc': 'def']" | ['abc': 'def']
+        "MapProperty<String, String>" | "objects.mapProperty(String, String)" | "null"           | "null"
     }
 
     @Unroll

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -19,13 +19,11 @@ package org.gradle.api.internal.provider;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
 import org.gradle.api.Action;
-import org.gradle.api.Task;
 import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
 import org.gradle.api.internal.provider.Collectors.ElementsFromArray;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollection;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollectionProvider;
 import org.gradle.api.internal.provider.Collectors.SingleElement;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -34,18 +32,21 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 public abstract class AbstractCollectionProperty<T, C extends Collection<T>> extends AbstractProperty<C, CollectionSupplier<T, C>> implements CollectionPropertyInternal<T, C> {
     private static final CollectionSupplier<Object, Collection<Object>> NO_VALUE = new NoValueSupplier<>(Value.missing());
     private final Class<? extends Collection> collectionType;
     private final Class<T> elementType;
+    private final Supplier<ImmutableCollection.Builder<T>> collectionFactory;
     private final ValueCollector<T> valueCollector;
     private CollectionSupplier<T, C> defaultValue = emptySupplier();
 
-    AbstractCollectionProperty(PropertyHost host, Class<? extends Collection> collectionType, Class<T> elementType) {
+    AbstractCollectionProperty(PropertyHost host, Class<? extends Collection> collectionType, Class<T> elementType, Supplier<ImmutableCollection.Builder<T>> collectionFactory) {
         super(host);
         this.collectionType = collectionType;
         this.elementType = elementType;
+        this.collectionFactory = collectionFactory;
         valueCollector = new ValidatingValueCollector<>(collectionType, elementType, ValueSanitizers.forType(elementType));
         init(defaultValue, noValueSupplier());
     }
@@ -57,11 +58,6 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     private CollectionSupplier<T, C> noValueSupplier() {
         return Cast.uncheckedCast(NO_VALUE);
     }
-
-    /**
-     * Creates an immutable collection from the given current values of this property.
-     */
-    protected abstract ImmutableCollection.Builder<T> builder();
 
     /**
      * Creates an empty immutable collection.
@@ -111,23 +107,16 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     /**
-     * Unpacks this property into a list of element providers.
+     * Sets the value of this property the given value.
      */
-    public List<ProviderInternal<? extends Iterable<? extends T>>> getProviders() {
-        List<ProviderInternal<? extends Iterable<? extends T>>> sources = new ArrayList<>();
-        getSupplier().visit(sources);
-        return sources;
-    }
-
-    /**
-     * Sets the value of this property the given list of element providers.
-     */
-    public void providers(List<ProviderInternal<? extends Iterable<? extends T>>> providers) {
-        CollectionSupplier<T, C> value = defaultValue;
-        for (ProviderInternal<? extends Iterable<? extends T>> provider : providers) {
-            value = value.plus(new ElementsFromCollectionProvider<>(provider));
+    public void fromState(ExecutionTimeValue<? extends C> value) {
+        if (value.isMissing()) {
+            setSupplier(noValueSupplier());
+        } else if (value.isFixedValue()) {
+            setSupplier(new FixedSupplier<>(value.getFixedValue()));
+        } else {
+            setSupplier(new CollectingSupplier(new ElementsFromCollectionProvider<>(value.getChangingValue())));
         }
-        setSupplier(value);
     }
 
     @Override
@@ -206,6 +195,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
+    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(CollectionSupplier<T, C> value) {
+        return value.calculateExecutionTimeValue();
+    }
+
+    @Override
     public HasMultipleValues<T> convention(@Nullable Iterable<? extends T> elements) {
         if (elements == null) {
             setConvention(noValueSupplier());
@@ -251,21 +245,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+        public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.missing();
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return false;
+        public ValueProducer getProducer() {
+            return ValueProducer.unknown();
         }
     }
 
@@ -287,21 +273,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+        public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(emptyCollection());
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return false;
+        public ValueProducer getProducer() {
+            return ValueProducer.noProducer();
         }
     }
 
@@ -328,22 +306,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
-            sources.add(Providers.of(value));
+        public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(value);
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return false;
+        public ValueProducer getProducer() {
+            return ValueProducer.unknown();
         }
     }
 
@@ -362,7 +331,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public Value<C> calculateValue() {
             // TODO - don't make a copy when the collector already produces an immutable collection
-            ImmutableCollection.Builder<T> builder = builder();
+            ImmutableCollection.Builder<T> builder = collectionFactory.get();
             Value<Void> result = value.collectEntries(valueCollector, builder);
             if (result.isMissing()) {
                 return result.asType();
@@ -376,23 +345,77 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
-            value.visit(sources);
+        public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
+            List<ExecutionTimeValue<? extends Iterable<? extends T>>> values = new ArrayList<>();
+            value.calculateExecutionTimeValue(values::add);
+            boolean fixed = true;
+            boolean changingContent = false;
+            for (ExecutionTimeValue<? extends Iterable<? extends T>> value : values) {
+                if (value.isMissing()) {
+                    return ExecutionTimeValue.missing();
+                }
+                if (value.isChangingValue()) {
+                    fixed = false;
+                }
+                changingContent |= value.hasChangingContent();
+            }
+
+            if (fixed) {
+                ImmutableCollection.Builder<T> builder = collectionFactory.get();
+                for (ExecutionTimeValue<? extends Iterable<? extends T>> value : values) {
+                    builder.addAll(value.getFixedValue());
+                }
+                ExecutionTimeValue<C> mergedValue = ExecutionTimeValue.fixedValue(Cast.uncheckedNonnullCast(builder.build()));
+                if (changingContent) {
+                    return mergedValue.withChangingContent();
+                } else {
+                    return mergedValue;
+                }
+            }
+
+            // At least one of the values is a changing value
+            List<ProviderInternal<? extends Iterable<? extends T>>> providers = new ArrayList<>(values.size());
+            for (ExecutionTimeValue<? extends Iterable<? extends T>> value : values) {
+                providers.add(value.toProvider());
+            }
+            // TODO - CollectionSupplier could be replaced with ProviderInternal, so this type and the collection provider can be merged
+            return ExecutionTimeValue.changingValue(new CollectingProvider<>(AbstractCollectionProperty.this.getType(), providers, collectionFactory));
         }
 
         @Override
-        public boolean isValueProducedByTask() {
-            return value.isValueProducedByTask();
+        public ValueProducer getProducer() {
+            return value.getProducer();
+        }
+    }
+
+    private static class CollectingProvider<T, C extends Collection<? extends T>> extends AbstractMinimalProvider<C> {
+        private final Class<C> type;
+        private final List<ProviderInternal<? extends Iterable<? extends T>>> providers;
+        private final Supplier<ImmutableCollection.Builder<T>> collectionFactory;
+
+        public CollectingProvider(Class<C> type, List<ProviderInternal<? extends Iterable<? extends T>>> providers, Supplier<ImmutableCollection.Builder<T>> collectionFactory) {
+            this.type = type;
+            this.providers = providers;
+            this.collectionFactory = collectionFactory;
+        }
+
+        @Nullable
+        @Override
+        public Class<C> getType() {
+            return type;
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return value.maybeVisitBuildDependencies(context);
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-            value.visitProducerTasks(visitor);
+        protected Value<? extends C> calculateOwnValue() {
+            ImmutableCollection.Builder<T> builder = collectionFactory.get();
+            for (ProviderInternal<? extends Iterable<? extends T>> provider : providers) {
+                Value<? extends Iterable<? extends T>> value = provider.calculateValue();
+                if (value.isMissing()) {
+                    return Value.missing();
+                }
+                builder.addAll(value.get());
+            }
+            return Value.of(Cast.uncheckedNonnullCast(builder.build()));
         }
     }
 
@@ -425,28 +448,14 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
-            left.visit(sources);
-            right.visit(sources);
+        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
+            left.calculateExecutionTimeValue(visitor);
+            right.calculateExecutionTimeValue(visitor);
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            if (left.maybeVisitBuildDependencies(context)) {
-                return right.maybeVisitBuildDependencies(context);
-            }
-            return false;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-            left.visitProducerTasks(visitor);
-            right.visitProducerTasks(visitor);
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return left.isValueProducedByTask() || right.isValueProducedByTask();
+        public ValueProducer getProducer() {
+            return left.getProducer().plus(right.getProducer());
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -115,6 +115,20 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     protected abstract Value<? extends T> calculateOwnValue(S value);
 
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        ExecutionTimeValue<? extends T> value = calculateOwnExecutionTimeValue();
+        if (getProducerTasks().isEmpty()) {
+            return value;
+        } else {
+            return value.withChangingContent();
+        }
+    }
+
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue() {
+        return super.calculateExecutionTimeValue();
+    }
+
     /**
      * Returns a diagnostic string describing the current source of value of this property. Should not realize the value.
      */
@@ -138,11 +152,6 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         } else {
             getSupplier().visitProducerTasks(visitor);
         }
-    }
-
-    @Override
-    public boolean isValueProducedByTask() {
-        return getSupplier().isValueProducedByTask();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -17,12 +17,11 @@
 package org.gradle.api.internal.provider;
 
 import java.util.Collection;
-import java.util.List;
 
 interface CollectionSupplier<T, C extends Collection<? extends T>> extends ValueSupplier {
     Value<? extends C> calculateValue();
 
     CollectionSupplier<T, C> plus(Collector<T> collector);
 
-    void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources);
+    ExecutionTimeValue<? extends C> calculateExecutionTimeValue();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -17,8 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
-
-import java.util.List;
+import org.gradle.api.Action;
 
 /**
  * A supplier of zero or more values of type {@link T}.
@@ -28,5 +27,5 @@ public interface Collector<T> extends ValueSupplier {
 
     int size();
 
-    void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources);
+    void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -20,13 +20,21 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T>> implements ListProperty<T> {
+    private static final Supplier<ImmutableCollection.Builder<Object>> FACTORY = new Supplier<ImmutableCollection.Builder<Object>>() {
+        @Override
+        public ImmutableCollection.Builder<Object> get() {
+            return ImmutableList.builder();
+        }
+    };
     public DefaultListProperty(PropertyHost host, Class<T> elementType) {
-        super(host, List.class, elementType);
+        super(host, List.class, elementType, Cast.uncheckedNonnullCast(FACTORY));
     }
 
     @Override
@@ -37,11 +45,6 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     @Override
     public int getFactoryId() {
         return ManagedFactories.ListPropertyManagedFactory.FACTORY_ID;
-    }
-
-    @Override
-    protected ImmutableCollection.Builder<T> builder() {
-        return ImmutableList.builder();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -21,8 +21,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
-import org.gradle.api.Task;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -217,18 +215,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         return this;
     }
 
-    public List<? extends ProviderInternal<? extends Map<? extends K, ? extends V>>> getProviders() {
-        List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers = new ArrayList<>();
-        getSupplier().visit(providers);
-        return providers;
-    }
-
-    public void providers(List<? extends ProviderInternal<? extends Map<? extends K, ? extends V>>> providers) {
-        MapSupplier<K, V> value = defaultValue;
-        for (ProviderInternal<? extends Map<? extends K, ? extends V>> provider : providers) {
-            value = value.plus(new MapCollectors.EntriesFromMapProvider<>(provider));
+    public void fromState(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {
+        if (value.isMissing()) {
+            setSupplier(noValueSupplier());
+        } else if (value.isFixedValue()) {
+            setSupplier(new FixedSuppler<>(Cast.uncheckedNonnullCast(value.getFixedValue())));
+        } else {
+            setSupplier(new CollectingSupplier(new MapCollectors.EntriesFromMapProvider<>(value.getChangingValue())));
         }
-        setSupplier(value);
     }
 
     @Override
@@ -257,6 +251,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         } else {
             return new NoValueSupplier<>(result);
         }
+    }
+
+    @Override
+    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(MapSupplier<K, V> value) {
+        return value.calculateOwnExecutionTimeValue();
     }
 
     private class EntryProvider extends AbstractMinimalProvider<V> {
@@ -327,21 +326,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+        public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
+            return ExecutionTimeValue.missing();
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return false;
+        public ValueProducer getProducer() {
+            return ValueProducer.unknown();
         }
     }
 
@@ -368,21 +359,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+        public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(ImmutableMap.of());
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return false;
+        public ValueProducer getProducer() {
+            return ValueProducer.noProducer();
         }
     }
 
@@ -414,22 +397,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
-            sources.add(Providers.of(entries));
+        public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(entries);
         }
 
         @Override
-        public boolean isValueProducedByTask() {
-            return false;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-        }
-
-        @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return true;
+        public ValueProducer getProducer() {
+            return ValueProducer.unknown();
         }
     }
 
@@ -476,23 +450,70 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
-            collector.visit(sources);
+        public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
+            List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> values = new ArrayList<>();
+            collector.calculateExecutionTimeValue(values::add);
+            boolean fixed = true;
+            boolean changingContent = false;
+            for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
+                if (value.isMissing()) {
+                    return ExecutionTimeValue.missing();
+                }
+                if (value.isChangingValue()) {
+                    fixed = false;
+                } else if (value.hasChangingContent()) {
+                    changingContent = true;
+                }
+            }
+            if (fixed) {
+                Map<K, V> entries = new LinkedHashMap<>();
+                for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
+                    entries.putAll(value.getFixedValue());
+                }
+                ExecutionTimeValue<Map<K, V>> value = ExecutionTimeValue.fixedValue(ImmutableMap.copyOf(entries));
+                if (changingContent) {
+                    return value.withChangingContent();
+                } else {
+                    return value;
+                }
+            }
+            List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers = new ArrayList<>();
+            for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
+                providers.add(value.toProvider());
+            }
+            return ExecutionTimeValue.changingValue(new CollectingProvider<K, V>(providers));
         }
 
         @Override
-        public boolean isValueProducedByTask() {
-            return collector.isValueProducedByTask();
+        public ValueProducer getProducer() {
+            return collector.getProducer();
+        }
+    }
+
+    private static class CollectingProvider<K, V> extends AbstractMinimalProvider<Map<K, V>> {
+        private final List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers;
+
+        public CollectingProvider(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers) {
+            this.providers = providers;
+        }
+
+        @Nullable
+        @Override
+        public Class<Map<K, V>> getType() {
+            return Cast.uncheckedCast(Map.class);
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            return collector.maybeVisitBuildDependencies(context);
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-            collector.visitProducerTasks(visitor);
+        protected Value<? extends Map<K, V>> calculateOwnValue() {
+            Map<K, V> entries = new LinkedHashMap<>();
+            for (ProviderInternal<? extends Map<? extends K, ? extends V>> provider : providers) {
+                Value<? extends Map<? extends K, ? extends V>> value = provider.calculateValue();
+                if (value.isMissing()) {
+                    return Value.missing();
+                }
+                entries.putAll(value.get());
+            }
+            return Value.of(ImmutableMap.copyOf(entries));
         }
     }
 
@@ -529,28 +550,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
-            left.visit(sources);
-            right.visit(sources);
+        public void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor) {
+            left.calculateExecutionTimeValue(visitor);
+            right.calculateExecutionTimeValue(visitor);
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            if (left.maybeVisitBuildDependencies(context)) {
-                return right.maybeVisitBuildDependencies(context);
-            }
-            return false;
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-            left.visitProducerTasks(visitor);
-            right.visitProducerTasks(visitor);
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return left.isValueProducedByTask() || right.isValueProducedByTask();
+        public ValueProducer getProducer() {
+            return left.getProducer().plus(right.getProducer());
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -117,6 +117,12 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue() {
+        // Discard this property from a provider chain, as it does not contribute anything to the calculation.
+        return getSupplier().calculateExecutionTimeValue();
+    }
+
+    @Override
     protected Value<? extends T> calculateOwnValue(ProviderInternal<? extends T> value) {
         return value.calculateValue();
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -117,9 +117,9 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue() {
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ProviderInternal<? extends T> value) {
         // Discard this property from a provider chain, as it does not contribute anything to the calculation.
-        return getSupplier().calculateExecutionTimeValue();
+        return value.calculateExecutionTimeValue();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -20,18 +20,21 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>> implements SetProperty<T> {
+    private static final Supplier<ImmutableCollection.Builder<Object>> FACTORY = new Supplier<ImmutableCollection.Builder<Object>>() {
+        @Override
+        public ImmutableCollection.Builder<Object> get() {
+            return ImmutableSet.builder();
+        }
+    };
     public DefaultSetProperty(PropertyHost host, Class<T> elementType) {
-        super(host, Set.class, elementType);
-    }
-
-    @Override
-    protected ImmutableCollection.Builder<T> builder() {
-        return ImmutableSet.builder();
+        super(host, Set.class, elementType, Cast.uncheckedNonnullCast(FACTORY));
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -215,6 +215,15 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
             }
         }
 
+        @Override
+        public ExecutionTimeValue<T> calculateExecutionTimeValue() {
+            if (value != null) {
+                return ExecutionTimeValue.fixedValue(value.get());
+            } else {
+                return ExecutionTimeValue.changingValue(this);
+            }
+        }
+
         @Nullable
         private T obtainValueFromSource() {
             return instantiateValueSource(

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.internal.properties.GradleProperties;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
@@ -175,14 +174,13 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         }
 
         @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+        public ValueProducer getProducer() {
             // For now, assume value is never calculated from a task output
-            return true;
-        }
-
-        @Override
-        public boolean isValueProducedByTask() {
-            return value == null;
+            if (value != null) {
+                return ValueProducer.unknown();
+            } else {
+                return ValueProducer.externalValue();
+            }
         }
 
         @Override
@@ -218,7 +216,7 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         @Override
         public ExecutionTimeValue<T> calculateExecutionTimeValue() {
             if (value != null) {
-                return ExecutionTimeValue.fixedValue(value.get());
+                return ExecutionTimeValue.ofNullable(value.get());
             } else {
                 return ExecutionTimeValue.changingValue(this);
             }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -16,10 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Action;
-import org.gradle.api.Task;
 import org.gradle.api.Transformer;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
@@ -70,13 +67,8 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
     }
 
     @Override
-    public void visitProducerTasks(Action<? super Task> visitor) {
-        backingProvider().visitProducerTasks(visitor);
-    }
-
-    @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        return backingProvider().maybeVisitBuildDependencies(context);
+    public ValueProducer getProducer() {
+        return backingProvider().getProducer();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -75,14 +75,13 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
     }
 
     @Override
-    public boolean isValueProducedByTask() {
-        // Need the content in order to transform it to produce the value of this provider, so if the content is built by tasks, the value is also built by tasks
-        return backingProvider().isValueProducedByTask() || !getProducerTasks().isEmpty();
+    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+        return backingProvider().maybeVisitBuildDependencies(context);
     }
 
     @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        return backingProvider().maybeVisitBuildDependencies(context);
+    public ExecutionTimeValue<? extends S> calculateExecutionTimeValue() {
+        return backingProvider().calculateExecutionTimeValue();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
+import org.gradle.api.Action;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,5 +30,5 @@ public interface MapCollector<K, V> extends ValueSupplier {
 
     Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest);
 
-    void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources);
+    void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.provider;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,5 +26,5 @@ interface MapSupplier<K, V> extends ValueSupplier {
 
     MapSupplier<K, V> plus(MapCollector<K, V> collector);
 
-    void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources);
+    ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
@@ -16,10 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Action;
-import org.gradle.api.Task;
 import org.gradle.api.Transformer;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import javax.annotation.Nullable;
 
@@ -44,18 +41,8 @@ public class MappingProvider<OUT, IN> extends AbstractMinimalProvider<OUT> {
     }
 
     @Override
-    public boolean isValueProducedByTask() {
-        return provider.isValueProducedByTask();
-    }
-
-    @Override
-    public void visitProducerTasks(Action<? super Task> visitor) {
-        provider.visitProducerTasks(visitor);
-    }
-
-    @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        return provider.maybeVisitBuildDependencies(context);
+    public ValueProducer getProducer() {
+        return provider.getProducer();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
@@ -37,13 +36,13 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
     }
 
     @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        if (provider.isValueProducedByTask() || provider.isPresent()) {
-            // either the provider value will be used, or we don't know yet
-            return provider.maybeVisitBuildDependencies(context);
+    public ValueProducer getProducer() {
+        ValueProducer producer = provider.getProducer();
+        if (producer.isProducesDifferentValueOverTime() || provider.isPresent()) {
+            // Value is not available yet or is present
+            return provider.getProducer();
         } else {
-            // provider value will not be used, so there are no dependencies
-            return true;
+            return ValueProducer.unknown();
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-
 import javax.annotation.Nullable;
 
 class OrElseProvider<T> extends AbstractMinimalProvider<T> {
@@ -36,21 +34,12 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
-    public boolean isValueProducedByTask() {
-        // TODO - this isn't quite right. The value isn't produced by a task when left always has a value and its value is not produced by a task
-        return left.isValueProducedByTask() || right.isValueProducedByTask();
-    }
-
-    @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        if (left.isValueProducedByTask() && !left.maybeVisitBuildDependencies(context)) {
-            return false;
+    public ValueProducer getProducer() {
+        if (left.isPresent()) {
+            return left.getProducer();
+        } else {
+            return right.getProducer();
         }
-        if (!left.isValueProducedByTask() && left.isPresent()) {
-            return left.maybeVisitBuildDependencies(context);
-        }
-        // TODO - this isn't quite right. We shouldn't build right's inputs when left always has a value, but that value is produced by a task
-        return right.maybeVisitBuildDependencies(context);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -36,7 +36,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
     <S> ProviderInternal<S> map(Transformer<? extends S, ? super T> transformer);
 
     /**
-     * Calculates the value of this provider.
+     * Calculates the current value of this provider.
      */
     ValueSupplier.Value<? extends T> calculateValue();
 
@@ -46,7 +46,21 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
     ProviderInternal<T> asSupplier(DisplayName owner, Class<? super T> targetType, ValueSanitizer<? super T> sanitizer);
 
     /**
-     * Returns a copy of this provider with a final value.
+     * Returns a copy of this provider with a final value. The returned value is used to replace this provider by a property when the property is finalized.
      */
     ProviderInternal<T> withFinalValue();
+
+    /**
+     * Calculates the state of this provider that is required at execution time. The state is serialized to the instant execution cache, and recreated as a {@link Provider} implementation
+     * when the cache is read.
+     *
+     * <p>When the value and value content of this provider is known at the completion of configuration, then returns a fixed value or missing value.
+     * For example, a String @Input property of a task might have a value that is calculated at configuration time, but once configured does not change.
+     *
+     * <p>When the value or value content of this provider is not known until execution time then returns a {@link Provider} representing the calculation to perform at execution time.
+     * For example, the value content of an @InputFile property of a task is not known when that input file is the output of another a task.
+     * The provider returned by this method may or not be the same instance as this provider. Generally, it is better to simplify any provider chains to replace calculations with fixed values and to remove
+     * intermediate steps.
+     */
+    ExecutionTimeValue<? extends T> calculateExecutionTimeValue();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -93,8 +93,24 @@ public class Providers {
         }
 
         @Override
+        public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(value);
+        }
+
+        @Override
         public String toString() {
             return String.format("fixed(%s, %s)", getType(), value);
+        }
+    }
+
+    public static class FixedValueWithChangingContentProvider<T> extends FixedValueProvider<T> {
+        public FixedValueWithChangingContentProvider(T value) {
+            super(value);
+        }
+
+        @Override
+        public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+            return super.calculateExecutionTimeValue().withChangingContent();
         }
     }
 
@@ -125,6 +141,11 @@ public class Providers {
         @Override
         protected Value<T> calculateOwnValue() {
             return Value.missing();
+        }
+
+        @Override
+        public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.missing();
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TypeSanitizingTransformer.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TypeSanitizingTransformer.java
@@ -16,29 +16,29 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Transformer;
 import org.gradle.internal.Cast;
 import org.gradle.internal.DisplayName;
 
-class TypeSanitizingProvider<T> extends AbstractMappingProvider<T, T> {
+class TypeSanitizingTransformer<T> implements Transformer<T, T> {
     private final DisplayName owner;
     private final ValueSanitizer<? super T> sanitizer;
     private final Class<? super T> targetType;
 
-    public TypeSanitizingProvider(DisplayName owner, ValueSanitizer<? super T> sanitizer, Class<? super T> targetType, ProviderInternal<? extends T> delegate) {
-        super(Cast.uncheckedNonnullCast(targetType), delegate);
+    public TypeSanitizingTransformer(DisplayName owner, ValueSanitizer<? super T> sanitizer, Class<? super T> targetType) {
         this.owner = owner;
         this.sanitizer = sanitizer;
         this.targetType = targetType;
     }
 
     @Override
-    protected String getMapDescription() {
-        return "check-type";
+    public String toString() {
+        return "check-type()";
     }
 
     @Override
-    protected T mapValue(T v) {
-        v = Cast.uncheckedCast(sanitizer.sanitize(v));
+    public T transform(T t) {
+        T v = Cast.uncheckedCast(sanitizer.sanitize(t));
         if (targetType.isInstance(v)) {
             return v;
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -33,7 +33,7 @@ public interface ValueSupplier {
     /**
      * Visits the build dependencies of this supplier, if possible.
      *
-     * @return true if the dependencies have been added (possibly none), false if the build dependencies are unknown.
+     * @return true if the dependencies are konwn and have been added (possibly none), false if the build dependencies are unknown.
      */
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
 
@@ -56,6 +56,9 @@ public interface ValueSupplier {
 
     boolean isPresent();
 
+    /**
+     * Carries either a value or some diagnostic information about where the value would have come from, had it been present.
+     */
     interface Value<T> {
         Value<Object> MISSING = new Missing<>();
         Value<Void> SUCCESS = new Present<>(null);
@@ -102,7 +105,7 @@ public interface ValueSupplier {
     class Present<T> implements Value<T> {
         private final T result;
 
-        public Present(T result) {
+        private Present(T result) {
             this.result = result;
         }
 
@@ -150,11 +153,11 @@ public interface ValueSupplier {
     class Missing<T> implements Value<T> {
         private final List<DisplayName> path;
 
-        public Missing() {
+        private Missing() {
             this.path = ImmutableList.of();
         }
 
-        public Missing(List<DisplayName> path) {
+        private Missing(List<DisplayName> path) {
             this.path = path;
         }
 
@@ -212,6 +215,165 @@ public interface ValueSupplier {
             builder.addAll(path);
             builder.addAll(other.path);
             return new Missing<>(builder.build());
+        }
+    }
+
+    /**
+     * Represents either a missing value, a fixed value with fixed contents, a fixed value with changing contents, or a changing value (with changing contents).
+     */
+    abstract class ExecutionTimeValue<T> {
+        public boolean isMissing() {
+            return false;
+        }
+
+        public boolean isFixedValue() {
+            return false;
+        }
+
+        public boolean isChangingValue() {
+            return false;
+        }
+
+        /**
+         * A fixed value may have changing contents. For example, a task output file whose location is known at configuration time.
+         */
+        public boolean hasChangingContent() {
+            return false;
+        }
+
+        public T getFixedValue() throws IllegalStateException {
+            throw new IllegalStateException();
+        }
+
+        public ProviderInternal<T> getChangingValue() throws IllegalStateException {
+            throw new IllegalStateException();
+        }
+
+        public Value<T> toValue() throws IllegalStateException {
+            throw new IllegalStateException();
+        }
+
+        public abstract ProviderInternal<T> toProvider();
+
+        public abstract ExecutionTimeValue<T> withChangingContent();
+
+        public static <T> ExecutionTimeValue<T> missing() {
+            return new MissingExecutionTimeValue<>();
+        }
+
+        public static <T> ExecutionTimeValue<T> fixedValue(T value) {
+            assert value != null;
+            return new FixedExecutionTimeValue<>(value, false);
+        }
+
+        public static <T> ExecutionTimeValue<T> value(Value<T> value) {
+            if (value.isMissing()) {
+                return missing();
+            } else {
+                return fixedValue(value.get());
+            }
+        }
+
+        public static <T> ExecutionTimeValue<T> changingValue(ProviderInternal<T> provider) {
+            return new ChangingExecutionTimeValue<>(provider);
+        }
+    }
+
+    class MissingExecutionTimeValue<T> extends ExecutionTimeValue<T> {
+        @Override
+        public boolean isMissing() {
+            return true;
+        }
+
+        @Override
+        public ProviderInternal<T> toProvider() {
+            return Providers.notDefined();
+        }
+
+        @Override
+        public ExecutionTimeValue<T> withChangingContent() {
+            return this;
+        }
+
+        @Override
+        public Value<T> toValue() {
+            return Value.missing();
+        }
+    }
+
+    class FixedExecutionTimeValue<T> extends ExecutionTimeValue<T> {
+        private final T value;
+        private final boolean changingContent;
+
+        private FixedExecutionTimeValue(T value, boolean changingContent) {
+            this.value = value;
+            this.changingContent = changingContent;
+        }
+
+        @Override
+        public boolean isFixedValue() {
+            return true;
+        }
+
+        @Override
+        public boolean hasChangingContent() {
+            return changingContent;
+        }
+
+        @Override
+        public T getFixedValue() {
+            return value;
+        }
+
+        @Override
+        public Value<T> toValue() {
+            return Value.of(value);
+        }
+
+        @Override
+        public ProviderInternal<T> toProvider() {
+            if (changingContent) {
+                return new Providers.FixedValueWithChangingContentProvider<>(value);
+            }
+            return Providers.of(value);
+        }
+
+        @Override
+        public ExecutionTimeValue<T> withChangingContent() {
+            return new FixedExecutionTimeValue<>(value, true);
+        }
+    }
+
+    class ChangingExecutionTimeValue<T> extends ExecutionTimeValue<T> {
+        private final ProviderInternal<T> provider;
+
+        private ChangingExecutionTimeValue(ProviderInternal<T> provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public boolean isChangingValue() {
+            return true;
+        }
+
+        @Override
+        public boolean hasChangingContent() {
+            return true;
+        }
+
+        @Override
+        public ProviderInternal<T> getChangingValue() {
+            return provider;
+        }
+
+        @Override
+        public ProviderInternal<T> toProvider() {
+            return provider;
+        }
+
+        @Override
+        public ExecutionTimeValue<T> withChangingContent() {
+            return this;
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -23,6 +23,7 @@ import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.internal.provider.ValueSupplier;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
@@ -89,7 +90,10 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
             } else if (dependency instanceof ProviderInternal) {
                 // When a Provider is used as a task dependency (rather than as a task input), need to unpack the value
                 ProviderInternal<?> provider = (ProviderInternal<?>) dependency;
-                if (!provider.maybeVisitBuildDependencies(context)) {
+                ValueSupplier.ValueProducer producer = provider.getProducer();
+                if (producer.isKnown()) {
+                    producer.visitProducerTasks(context);
+                } else {
                     // The provider does not know how to produce the value, so use the value instead
                     queue.addFirst(provider.get());
                 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
@@ -16,12 +16,18 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.internal.artifacts.transform.TransformationDependency;
 
 import javax.annotation.Nullable;
 
-public interface TaskDependencyResolveContext {
+public interface TaskDependencyResolveContext extends Action<Task> {
+    @Override
+    default void execute(Task task) {
+        add(task);
+    }
+
     /**
      * Adds an object that can contribute tasks to the result. Supported types:
      *
@@ -45,7 +51,6 @@ public interface TaskDependencyResolveContext {
 
     /**
      * Visits a failure to visit the dependencies of an object.
-     * @param failure
      */
     void visitFailure(Throwable failure);
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -92,7 +92,7 @@ class DefaultPropertyTest extends PropertySpec<String> {
         }))
 
         expect:
-        propertyWithBadValue.toString() == "property(java.lang.String, check-type(provider(?)))"
+        propertyWithBadValue.toString() == "property(java.lang.String, map(java.lang.String provider(?) check-type()))"
         providerWithNoValue().toString() == "property(java.lang.String, undefined)"
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MappingProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MappingProviderTest.groovy
@@ -19,15 +19,15 @@ package org.gradle.api.internal.provider
 import org.gradle.api.provider.Provider
 import org.gradle.internal.state.ManagedFactory
 
-class AbstractMappingProviderTest extends ProviderSpec<String> {
+class MappingProviderTest extends ProviderSpec<String> {
     @Override
     Provider<String> providerWithValue(String value) {
-        return new TestProvider(Providers.of(value.replace("{", "").replace("}", "")))
+        return new MappingProvider(String, Providers.of(value.replace("{", "").replace("}", "")), { "{$it}" })
     }
 
     @Override
     Provider<String> providerWithNoValue() {
-        return new TestProvider(Providers.notDefined())
+        return new MappingProvider(String, Providers.notDefined(), { "{$it}" })
     }
 
     @Override
@@ -58,21 +58,5 @@ class AbstractMappingProviderTest extends ProviderSpec<String> {
     @Override
     ManagedFactory managedFactory() {
         return new ManagedFactories.ProviderManagedFactory()
-    }
-
-    class TestProvider extends AbstractMappingProvider<String, String> {
-        TestProvider(ProviderInternal<? extends String> provider) {
-            super(String, provider)
-        }
-
-        @Override
-        protected String getMapDescription() {
-            return "thing"
-        }
-
-        @Override
-        protected String mapValue(String v) {
-            return "{$v}"
-        }
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks
 import org.gradle.api.Buildable
 import org.gradle.api.Task
 import org.gradle.api.internal.provider.ProviderInternal
+import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.typeconversion.UnsupportedNotationException
@@ -153,7 +154,7 @@ class DefaultTaskDependencyTest extends Specification {
         def provider = Mock(ProviderInternal)
 
         given:
-        1 * provider.maybeVisitBuildDependencies(_) >> { TaskDependencyResolveContext context -> context.add(otherTask); return true }
+        1 * provider.producer >> ValueSupplier.ValueProducer.task(otherTask)
 
         when:
         dependency.add(provider)
@@ -166,7 +167,7 @@ class DefaultTaskDependencyTest extends Specification {
         def provider = Mock(ProviderInternal)
 
         given:
-        1 * provider.maybeVisitBuildDependencies(_) >> { return false }
+        1 * provider.producer >> ValueSupplier.ValueProducer.unknown()
         1 * provider.get() >> otherTask
 
         when:

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.api.internal.provider
 
-
+import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.Transformer
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
@@ -1901,90 +1900,56 @@ The value of this provider is derived from:
     }
 
     def "producer task for a property is not known when property has a fixed value"() {
-        def context = Mock(TaskDependencyResolveContext)
         def property = propertyWithNoValue()
         property.set(someValue())
 
-        when:
-        def known = property.maybeVisitBuildDependencies(context)
-
-        then:
-        !known
-        0 * context._
+        expect:
+        assertHasNoProducer(property)
     }
 
-    def "can define producer task for a property"() {
+    def "can attach a producer task to property"() {
         def task = Mock(Task)
-        def context = Mock(TaskDependencyResolveContext)
         def property = propertyWithNoValue()
         property.set(someValue())
+
+        expect:
+        assertHasNoProducer(property)
+
+        when:
         property.attachProducer(owner(task))
 
-        when:
-        def known = property.maybeVisitBuildDependencies(context)
-
         then:
-        known
-        1 * context.add(task)
-        0 * context._
+        assertHasProducer(property, task)
     }
 
-    def "has build dependencies when value is provider with producer task"() {
+    def "has producer task when value is provider with producer task"() {
         def task = Stub(Task)
         def provider = supplierWithProducer(task)
-        def context = Mock(TaskDependencyResolveContext)
-        def property = propertyWithNoValue()
-        property.set(provider)
-
-        when:
-        def known = property.maybeVisitBuildDependencies(context)
-
-        then:
-        known
-        1 * context.add(task)
-        0 * context._
-    }
-
-    def "has content producer when producer task attached"() {
-        def task = Mock(Task)
-        def property = propertyWithDefaultValue()
-
-        expect:
-        assertContentIsNotProducedByTask(property)
-        !property.valueProducedByTask
-
-        property.attachProducer(owner(task))
-
-        assertContentIsProducedByTask(property, task)
-        !property.valueProducedByTask
-    }
-
-    def "has content producer when value is provider with content producer"() {
-        def task = Mock(Task)
-        def provider = supplierWithProducer(task)
-
         def property = propertyWithNoValue()
         property.set(provider)
 
         expect:
-        assertContentIsProducedByTask(property, task)
-        !property.valueProducedByTask
+        assertHasProducer(property, task)
     }
 
     def "mapped value has changing execution time value when producer task attached to original property"() {
         def task = Mock(Task)
         def property = propertyWithDefaultValue()
         property.set(someValue())
-        def mapped = property.map { it }
+        def mapped = property.map { someOtherValue() }
 
         expect:
-        assertContentIsNotProducedByTask(mapped)
-        mapped.calculateExecutionTimeValue().isFixedValue()
+        assertHasNoProducer(mapped)
+        def value = mapped.calculateExecutionTimeValue()
+        value.isFixedValue()
+        value.fixedValue == someOtherValue()
 
         property.attachProducer(owner(task))
 
-        assertContentIsProducedByTask(mapped, task)
-        mapped.calculateExecutionTimeValue().isChangingValue()
+        assertHasProducer(mapped, task)
+        def value2 = mapped.calculateExecutionTimeValue()
+        value2.isChangingValue()
+        value2.changingValue.get() == someOtherValue()
     }
 
     def "mapped value has no execution time value when producer task attached to original property with no value"() {
@@ -1994,12 +1959,12 @@ The value of this provider is derived from:
         def mapped = property.map { it }
 
         expect:
-        assertContentIsNotProducedByTask(mapped)
+        assertHasNoProducer(mapped)
         mapped.calculateExecutionTimeValue().isMissing()
 
         property.attachProducer(owner(task))
 
-        assertContentIsProducedByTask(mapped, task)
+        assertHasProducer(mapped, task)
         mapped.calculateExecutionTimeValue().isMissing()
     }
 
@@ -2007,16 +1972,20 @@ The value of this provider is derived from:
         def task = Mock(Task)
         def property = propertyWithDefaultValue()
         property.set(someValue())
-        def mapped = property.map { it }.map { it }.map { it }
+        def mapped = property.map { it }.map { it }.map { someOtherValue() }
 
         expect:
-        assertContentIsNotProducedByTask(mapped)
-        mapped.calculateExecutionTimeValue().isFixedValue()
+        assertHasNoProducer(mapped)
+        def value = mapped.calculateExecutionTimeValue()
+        value.isFixedValue()
+        value.fixedValue == someOtherValue()
 
         property.attachProducer(owner(task))
 
-        assertContentIsProducedByTask(mapped, task)
-        mapped.calculateExecutionTimeValue().isChangingValue()
+        assertHasProducer(mapped, task)
+        def value2 = mapped.calculateExecutionTimeValue()
+        value2.isChangingValue()
+        value2.changingValue.get() == someOtherValue()
     }
 
     def "mapped value has value producer when value is provider with content producer"() {
@@ -2025,11 +1994,13 @@ The value of this provider is derived from:
 
         def property = propertyWithNoValue()
         property.set(provider)
-        def mapped = property.map { it }
+        def mapped = property.map { someOtherValue() }
 
         expect:
-        assertContentIsProducedByTask(mapped, task)
-        mapped.calculateExecutionTimeValue().isChangingValue()
+        assertHasProducer(mapped, task)
+        def value = mapped.calculateExecutionTimeValue()
+        value.isChangingValue()
+        value.changingValue.get() == someOtherValue()
     }
 
     def "fails when property has multiple producers attached"() {
@@ -2068,7 +2039,7 @@ The value of this provider is derived from:
         property.attachProducer(owner)
 
         when:
-        property.maybeVisitBuildDependencies(Stub(TaskDependencyResolveContext))
+        property.producer.visitProducerTasks(Stub(Action))
 
         then:
         def e =  thrown(IllegalStateException)
@@ -2099,18 +2070,6 @@ The value of this provider is derived from:
         property.set(someOtherValue())
         copy.getOrNull() == null
         copy2.get() == someValue()
-    }
-
-    void assertContentIsNotProducedByTask(ProviderInternal<?> provider) {
-        def producers = []
-        provider.visitProducerTasks { producers.add(it) }
-        assert producers.isEmpty()
-    }
-
-    void assertContentIsProducedByTask(ProviderInternal<?> provider, Task task) {
-        def producers = []
-        provider.visitProducerTasks { producers.add(it) }
-        assert producers == [task]
     }
 
     ModelObject owner() {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider
 
+import org.gradle.api.Task
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Provider
 import org.gradle.internal.state.Managed
@@ -450,4 +451,21 @@ abstract class ProviderSpec<T> extends Specification {
         }
     }
 
+    void assertHasNoProducer(ProviderInternal<?> provider) {
+        def producer = provider.producer
+        assert !producer.known
+        producer.visitProducerTasks { assert false }
+        producer.visitContentProducerTasks { assert false }
+    }
+
+    void assertHasProducer(ProviderInternal<?> provider, Task task) {
+        def producer = provider.producer
+        assert producer.known
+        def tasks = []
+        producer.visitProducerTasks { tasks.add(it) }
+        assert tasks == [task]
+        tasks.clear()
+        producer.visitContentProducerTasks { tasks.add(it) }
+        assert tasks == [task]
+    }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Action;
 import org.gradle.api.Task;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -55,19 +53,11 @@ public class ProviderTestUtil {
         }
 
         @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
+        public ValueProducer getProducer() {
             if (producer != null) {
-                visitor.execute(producer);
-            }
-        }
-
-        @Override
-        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-            if (producer != null) {
-                context.add(producer);
-                return true;
+                return ValueProducer.task(producer);
             } else {
-                return false;
+                return ValueProducer.unknown();
             }
         }
 

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
@@ -21,7 +21,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -35,8 +34,8 @@ public class ProviderTestUtil {
         return new TestProvider<>((Class<T>) values[0].getClass(), Arrays.asList(values), null);
     }
 
-    public static <T> ProviderInternal<T> withProducer(Class<T> type, Task producer) {
-        return new TestProvider<>(type, Collections.emptyList(), producer);
+    public static <T> ProviderInternal<T> withProducer(Class<T> type, Task producer, T... values) {
+        return new TestProvider<>(type, Arrays.asList(values), producer);
     }
 
     private static class TestProvider<T> extends AbstractMinimalProvider<T> {
@@ -69,6 +68,16 @@ public class ProviderTestUtil {
                 return true;
             } else {
                 return false;
+            }
+        }
+
+        @Override
+        public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+            ExecutionTimeValue<? extends T> value = super.calculateExecutionTimeValue();
+            if (producer != null) {
+                return value.withChangingContent();
+            } else {
+                return value;
             }
         }
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -37,7 +37,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.options.OptionValues
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.internal.reflect.TypeValidationContext
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
@@ -49,7 +48,6 @@ import static org.gradle.internal.reflect.TypeValidationContext.Severity.WARNING
 
 abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects missing annotations on Java properties"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -136,7 +134,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "task can have property with annotation @#annotation.simpleName"() {
         file("input.txt").text = "input"
         file("input").createDir()
@@ -183,7 +180,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects optional primitive type #type"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -211,7 +207,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         double  | 1
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "validates task caching annotations"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -245,7 +240,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects missing annotation on Groovy properties"() {
         groovyTaskSource << """
             import org.gradle.api.*
@@ -284,7 +278,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "no problems with Copy task"() {
         file("input.txt").text = "input"
 
@@ -301,7 +294,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         assertValidationSucceeds()
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "does not report missing properties for Provider types"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -371,7 +363,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "reports setters for property of mutable type #type"() {
         file("input.txt").text = "input"
 
@@ -411,7 +402,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         RegularFileProperty.name        | "getProject().getObjects().fileProperty().fileValue(new java.io.File(\"input.txt\"))"
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects problems with file inputs"() {
         file("input.txt").text = "input"
         file("input").createDir()
@@ -483,7 +473,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects problems on nested collections"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -596,7 +585,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects annotations on private getter methods"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -639,7 +627,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects annotations on non-property methods"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -676,7 +663,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "detects annotations on setter methods"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -731,7 +717,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "reports conflicting types when property is replaced"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -767,8 +752,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         )
     }
 
-
-    @ToBeFixedForInstantExecution(bottomSpecs = "ValidatePluginsIntegrationTest")
     def "reports both input and output annotation applied to the same property"() {
         javaTaskSource << """
             import java.io.File;

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
@@ -73,7 +73,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         return file(path)
     }
 
-    @ToBeFixedForInstantExecution
     def "supports recursive types"() {
         groovyTaskSource << """
             import org.gradle.api.*
@@ -102,7 +101,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "task cannot have property with annotation @#annotation.simpleName"() {
         javaTaskSource << """
             import org.gradle.api.*;
@@ -182,7 +180,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         )
     }
 
-    @ToBeFixedForInstantExecution
     def "can validate task classes using external types"() {
         buildFile << """
             ${jcenterRepository()}
@@ -215,7 +212,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         assertValidationSucceeds()
     }
 
-    @ToBeFixedForInstantExecution
     def "can validate task classes using types from other projects"() {
         settingsFile << """
             include 'lib'
@@ -270,7 +266,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         assertValidationSucceeds()
     }
 
-    @ToBeFixedForInstantExecution
     def "can validate properties of an artifact transform action"() {
         file("src/main/java/MyTransformAction.java") << """
             import org.gradle.api.*;
@@ -329,7 +324,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         )
     }
 
-    @ToBeFixedForInstantExecution
     def "can validate properties of an artifact transform parameters object"() {
         file("src/main/java/MyTransformParameters.java") << """
             import org.gradle.api.*;

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/AlreadyOnClasspathPluginUseIntegrationTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/AlreadyOnClasspathPluginUseIntegrationTest.groovy
@@ -174,7 +174,6 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
         operations.hasOperation("Apply plugin my-plugin to project ':a'")
     }
 
-    @ToBeFixedForInstantExecution
     def "can request plugin from TestKit injected classpath"() {
 
         given:
@@ -239,7 +238,6 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
         failureHasCause("Plugin request for plugin already on the classpath must not include a version")
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot request plugin version of plugin from TestKit injected classpath"() {
 
         given:
@@ -282,9 +280,9 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
         file("$projectPath/src/main/groovy/my/MyPlugin.groovy") << """
 
             package my
-            
+
             import org.gradle.api.*
-            
+
             class MyPlugin implements Plugin<Project> {
                 @Override
                 void apply(Project project) {
@@ -306,7 +304,7 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
 
             group = "com.acme"
             version = "1.0"
-            
+
             gradlePlugin {
                 plugins {
                     myPlugin {
@@ -326,21 +324,21 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
         """.stripIndent()
         if (testKitSpec) {
             file("src/test/groovy/my/MyPluginTest.groovy") << """
-    
+
                 package my
-                
+
                 import org.junit.*
                 import org.junit.rules.*
-                
+
                 import org.gradle.testkit.runner.*
-    
+
                 class MyPluginTest {
-                
+
                     @Rule public TemporaryFolder tmpDir = new TemporaryFolder()
-    
+
                     @Test
                     public void assertions() {
-                    
+
                         // given:
                         def rootDir = tmpDir.newFolder("root")
                         new File(rootDir, "settings.gradle").text = \"\"\"
@@ -354,7 +352,7 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
                         new File(rootDir, "a/build.gradle").text = \"\"\"
                             ${testKitSpec.childProjectBuildScript ?: ""}
                         \"\"\".stripIndent()
-    
+
                         //when:
                         def runner = GradleRunner.create()
                             .withGradleInstallation(new File("${distribution.gradleHomeDir.absolutePath.replace("\\", "\\\\")}"))
@@ -362,12 +360,12 @@ class AlreadyOnClasspathPluginUseIntegrationTest extends AbstractIntegrationSpec
                             .withProjectDir(rootDir)
                             .withArguments("help")
                         def result = runner.${testKitSpec.succeeds ? "build" : "buildAndFail"}()
-    
+
                         // then:
                         ${testKitSpec.testKitAssertions}
                     }
                 }
-    
+
             """.stripIndent()
         }
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -51,7 +51,6 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue('https://plugins.gradle.org/plugin/nebula.plugin-plugin')
-    @ToBeFixedForInstantExecution
     def 'nebula plugin plugin'() {
         when:
         buildFile << """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testkit.runner.enduser
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.testkit.runner.fixtures.PluginUnderTest
 
 class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest extends BaseTestKitEndUserIntegrationTest {
@@ -70,14 +70,12 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "can test plugin and custom task as external files by using default conventions from Java Gradle plugin development plugin"() {
         expect:
         succeeds 'test'
         executedAndNotSkipped ':test'
     }
 
-    @ToBeFixedForInstantExecution
     def "can override plugin metadata location"() {
         when:
         buildFile << """
@@ -91,7 +89,6 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
         executedAndNotSkipped ':test'
     }
 
-    @ToBeFixedForInstantExecution
     def "can use custom source set"() {
         when:
         file("src/test/groovy/Test.groovy").moveToDirectory(file("src/functionalTest/groovy"))

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -77,7 +77,6 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
 
     @Unroll
     @UsesSample("testKit/gradleRunner/automaticClasspathInjectionQuickstart")
-    @ToBeFixedForInstantExecution
     def "automaticClasspathInjectionQuickstart with #dsl dsl"() {
         expect:
         executer.inDirectory(sample.dir.file(dsl))
@@ -89,7 +88,6 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
 
     @Unroll
     @UsesSample("testKit/gradleRunner/automaticClasspathInjectionCustomTestSourceSet")
-    @ToBeFixedForInstantExecution
     def "automaticClasspathInjectionCustomTestSourceSet with #dsl dsl"() {
         expect:
         executer.inDirectory(sample.dir.file(dsl))


### PR DESCRIPTION

### Context

Improve the contract between provider implementations and instant execution, by moving some responsibilities from serialization to the provider implementations and by merging several API methods together. This means the same logic does not need to be implemented several times in a provider implementation (eg in the `map` provider) and also improves the serialized representation to be more efficient and removes some edge cases.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
