### PR TITLE
Build Init plugin: use configuration avoidance for task registration

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -232,7 +232,7 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
 
         then: 'testsJar task configuration is generated'
         buildFile.text.contains(TextUtil.toPlatformLineSeparators('''
-            task testsJar(type: Jar) {
+            tasks.register('testsJar', Jar) {
                 archiveClassifier = 'tests'
                 from(sourceSets.test.output)
             }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1542,7 +1542,7 @@ public class BuildScriptBuilder {
 
         @Override
         public String taskRegistration(String taskName, String taskType) {
-            return "task " + taskName + "(type: " + taskType + ")";
+            return "tasks.register('" + taskName + "', " + taskType + ")";
         }
 
         @Override

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
@@ -243,7 +243,7 @@ dependencies {
  */
 
 // Compile stuff
-task compile(type: JavaCompile) {
+tasks.register('compile', JavaCompile) {
     classpath = 12
 }
 
@@ -271,7 +271,7 @@ artifacts {
 
 allprojects {
     // Compile stuff
-    task compile(type: JavaCompile) {
+    tasks.register('compile', JavaCompile) {
         // Set a property
         foo.bar = 'bazar'
 


### PR DESCRIPTION
Signed-off-by: Erhard Pointl <epeee@users.noreply.github.com>

<!--- The issue this PR addresses -->
Fixes #8170

### Context
A first part to generate builds that use configuration avoidance API. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
