### PR TITLE
Fix an issue using task property instances to set worker action parameters when instant execution is enabled

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionWorkerApiIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionWorkerApiIntegrationTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.tasks.TasksWithInputsAndOutputs
+import spock.lang.Unroll
+
+import javax.inject.Inject
+
+class InstantExecutionWorkerApiIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
+    @Unroll
+    def "task can wire input #type with fixed value to worker action parameter property"() {
+        buildFile << """
+            import ${Inject.name}
+
+            abstract class UsesWorker extends DefaultTask {
+                @Input
+                abstract ${type} getValue()
+
+                @Inject
+                abstract WorkerExecutor getExecutor()
+
+                @TaskAction
+                def go() {
+                    def flag = value
+                    executor.noIsolation().submit(SomeWorkAction) {
+                        value = flag
+                    }
+                }
+            }
+
+            interface SomeParams extends WorkParameters {
+                ${type} getValue()
+            }
+
+            abstract class SomeWorkAction implements WorkAction<SomeParams> {
+                void execute() {
+                    println("value = \${parameters.value.get()}")
+                }
+            }
+
+            task worker(type: UsesWorker) {
+                value = ${initialValue}
+            }
+        """
+
+        when:
+        instantRun("worker")
+        instantRun("worker")
+
+        then:
+        outputContains("value = ${expectedOutput}")
+
+        where:
+        type                           | initialValue   | expectedOutput
+        "Property<Boolean>"            | "true"         | "true"
+        "ListProperty<Integer>"        | "[1, 2]"       | "[1, 2]"
+        "SetProperty<Integer>"         | "[1, 2, 1]"    | "[1, 2]"
+        "MapProperty<String, Integer>" | "[a: 1, b: 2]" | "[a:1, b:2]"
+    }
+}

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -458,14 +458,23 @@ abstract class ProviderSpec<T> extends Specification {
         producer.visitContentProducerTasks { assert false }
     }
 
-    void assertHasProducer(ProviderInternal<?> provider, Task task) {
+    void assertHasKnownProducer(ProviderInternal<?> provider) {
+        def producer = provider.producer
+        assert producer.known
+        producer.visitProducerTasks { assert false }
+        producer.visitContentProducerTasks { assert false }
+    }
+
+    void assertHasProducer(ProviderInternal<?> provider, Task task, Task... additional) {
+        def expected = [task] + (additional as List)
+
         def producer = provider.producer
         assert producer.known
         def tasks = []
         producer.visitProducerTasks { tasks.add(it) }
-        assert tasks == [task]
+        assert tasks == expected
         tasks.clear()
         producer.visitContentProducerTasks { tasks.add(it) }
-        assert tasks == [task]
+        assert tasks == expected
     }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
@@ -32,8 +32,19 @@ public class ProviderTestUtil {
         return new TestProvider<>((Class<T>) values[0].getClass(), Arrays.asList(values), null);
     }
 
+    public static <T> ProviderInternal<T> withChangingExecutionTimeValues(T... values) {
+        assert values.length > 0;
+        return new TestProviderWithChangingValue<>((Class<T>) values[0].getClass(), Arrays.asList(values), null);
+    }
+
     public static <T> ProviderInternal<T> withProducer(Class<T> type, Task producer, T... values) {
-        return new TestProvider<>(type, Arrays.asList(values), producer);
+        Class<T> valueType = values.length == 0 ? type : (Class<T>) values[0].getClass();
+        return new TestProvider<>(valueType, Arrays.asList(values), producer);
+    }
+
+    public static <T> ProviderInternal<T> withProducerAndChangingExecutionTimeValue(Class<T> type, Task producer, T... values) {
+        Class<T> valueType = values.length == 0 ? type : (Class<T>) values[0].getClass();
+        return new TestProviderWithChangingValue<>(valueType, Arrays.asList(values), producer);
     }
 
     private static class TestProvider<T> extends AbstractMinimalProvider<T> {
@@ -79,6 +90,17 @@ public class ProviderTestUtil {
         @Override
         protected Value<? extends T> calculateOwnValue() {
             return values.hasNext() ? Value.of(values.next()) : Value.missing();
+        }
+    }
+
+    private static class TestProviderWithChangingValue<T> extends TestProvider<T> {
+        public TestProviderWithChangingValue(Class<T> type, List<T> values, Task producer) {
+            super(type, values, producer);
+        }
+
+        @Override
+        public ExecutionTimeValue<T> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.changingValue(this);
         }
     }
 }


### PR DESCRIPTION

### Context

Improves `Property` serialization to capture and restore type information, so that runtime type checks work correctly for state loaded from the instant execution cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
