### PR TITLE
Rename 'modularClasspathHandling' -> 'modularity'

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/jvm/ModularitySpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/jvm/ModularitySpec.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.jpms;
+package org.gradle.api.jvm;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
@@ -40,7 +40,7 @@ import org.gradle.api.tasks.Input;
  * @since 6.4
  */
 @Incubating
-public interface ModularClasspathHandling {
+public interface ModularitySpec {
 
     /**
      * Should a --module-path be inferred by analysing JARs and class folders on the classpath?

--- a/subprojects/core-api/src/main/java/org/gradle/api/jvm/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/jvm/package-info.java
@@ -18,6 +18,6 @@
  * Interfaces for configuring the Java Platform Module System (JPMS).
  */
 @NonNullApi
-package org.gradle.api.jpms;
+package org.gradle.api.jvm;
 
 import org.gradle.api.NonNullApi;

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -17,7 +17,7 @@ package org.gradle.process;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -157,5 +157,5 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      */
     @Incubating
     @Nested
-    ModularClasspathHandling getModularClasspathHandling();
+    ModularitySpec getModularity();
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -32,7 +32,7 @@ import org.gradle.cache.internal.DefaultCacheRepository
 import org.gradle.cache.internal.DefaultCacheScopeMapping
 import org.gradle.cache.internal.TestFileContentCacheFactory
 import org.gradle.internal.id.LongIdGenerator
-import org.gradle.internal.jpms.JavaModuleDetector
+import org.gradle.internal.jvm.JavaModuleDetector
 import org.gradle.internal.jvm.inspection.CachingJvmVersionDetector
 import org.gradle.internal.jvm.inspection.DefaultJvmVersionDetector
 import org.gradle.internal.logging.LoggingManagerInternal

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.cache.internal.TestFileContentCacheFactory
 import org.gradle.internal.Actions
 import org.gradle.internal.id.LongIdGenerator
-import org.gradle.internal.jpms.JavaModuleDetector
+import org.gradle.internal.jvm.JavaModuleDetector
 import org.gradle.internal.jvm.inspection.CachingJvmVersionDetector
 import org.gradle.internal.jvm.inspection.DefaultJvmVersionDetector
 import org.gradle.internal.remote.ObjectConnectionBuilder

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -24,13 +24,13 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.options.Option;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecResult;
@@ -111,7 +111,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     private final Property<String> mainModule;
     private final Property<String> mainClass;
     private final ConfigurableFileCollection classpath;
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
     private final Property<ExecResult> execResult;
 
     public JavaExec() {
@@ -119,13 +119,13 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         this.mainModule = objectFactory.property(String.class);
         this.mainClass = objectFactory.property(String.class);
         this.classpath = getFileCollectionFactory().configurableFiles("classpath");
-        this.modularClasspathHandling = objectFactory.newInstance(DefaultModularClasspathHandling.class);
+        this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         execResult = getObjectFactory().property(ExecResult.class);
 
         javaExecHandleBuilder = getDslExecActionFactory().newDecoratedJavaExecAction();
         javaExecHandleBuilder.getMainClass().convention(mainClass);
         javaExecHandleBuilder.getMainModule().convention(mainModule);
-        javaExecHandleBuilder.getModularClasspathHandling().getInferModulePath().convention(modularClasspathHandling.getInferModulePath());
+        javaExecHandleBuilder.getModularity().getInferModulePath().convention(modularity.getInferModulePath());
         javaExecHandleBuilder.setClasspath(classpath);
     }
 
@@ -514,8 +514,8 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/DefaultModularitySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/DefaultModularitySpec.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.jpms;
+package org.gradle.internal.jvm;
 
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
 import javax.inject.Inject;
 
-public class DefaultModularClasspathHandling implements ModularClasspathHandling {
+public class DefaultModularitySpec implements ModularitySpec {
 
     private Property<Boolean> inferModulePath;
 
     @Inject
-    public DefaultModularClasspathHandling(ObjectFactory objects) {
+    public DefaultModularitySpec(ObjectFactory objects) {
         inferModulePath = objects.property(Boolean.class).convention(false);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/JavaModuleDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/JavaModuleDetector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.jpms;
+package org.gradle.internal.jvm;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -163,7 +163,7 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.invocation.DefaultBuildInvocationDetails;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.sink.OutputEventListenerManager;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -54,7 +54,7 @@ import org.gradle.internal.filewatch.PendingChangesManager;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -58,7 +58,7 @@ import org.gradle.internal.file.JarCache;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.id.LongIdGenerator;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -76,7 +76,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -38,7 +38,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
@@ -20,7 +20,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaForkOptions;
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.reflect.Instantiator;
 
 /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.logging.LoggingManager;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.id.IdGenerator;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.remote.MessagingServer;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.io.StreamByteBuffer;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.process.ArgWriter;
 import org.gradle.internal.remote.Address;
@@ -105,7 +105,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
         if (useOptionsFile) {
             // Use an options file to pass across application classpath
             File optionsFile = temporaryFileProvider.createTemporaryFile("gradle-worker-classpath", "txt");
-            List<String> jvmArgs = writeOptionsFile(execSpec.getModularClasspathHandling().getInferModulePath().get(), workerMainClassPath, implementationModulePath, applicationClasspath, applicationModulePath, optionsFile);
+            List<String> jvmArgs = writeOptionsFile(execSpec.getModularity().getInferModulePath().get(), workerMainClassPath, implementationModulePath, applicationClasspath, applicationModulePath, optionsFile);
             execSpec.jvmArgs(jvmArgs);
         } else {
             // Use a dummy security manager, which hacks the application classpath into the system ClassLoader
@@ -135,7 +135,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
             }
 
             // Serialize the worker implementation classpath, this is consumed by GradleWorkerMain
-            if (execSpec.getModularClasspathHandling().getInferModulePath().get() || implementationModulePath == null) {
+            if (execSpec.getModularity().getInferModulePath().get() || implementationModulePath == null) {
                 outstr.writeInt(implementationClassPath.size());
                 for (URL entry : implementationClassPath) {
                     outstr.writeUTF(entry.toString());

--- a/subprojects/core/src/test/groovy/org/gradle/internal/jvm/JavaModuleDetectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/jvm/JavaModuleDetectorTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.jpms
+package org.gradle.internal.jvm
 
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.AbstractFileCollection

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.initialization.DefaultBuildCancellationToken
-import org.gradle.internal.jpms.JavaModuleDetector
+import org.gradle.internal.jvm.JavaModuleDetector
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.TestUtil
 import spock.lang.Issue
@@ -131,7 +131,7 @@ class JavaExecHandleBuilderTest extends Specification {
 
         when:
         // turn off module support:
-        builder.modularClasspathHandling.inferModulePath.set(false)
+        builder.modularity.inferModulePath.set(false)
 
         then:
         !builder.getAllArguments().contains('--module')
@@ -144,7 +144,7 @@ class JavaExecHandleBuilderTest extends Specification {
         builder.classpath(new File("file1.jar").canonicalFile)
 
         when:
-        builder.modularClasspathHandling.inferModulePath.set(true)
+        builder.modularity.inferModulePath.set(true)
         builder.getAllArguments()
 
         then:
@@ -175,7 +175,7 @@ class JavaExecHandleBuilderTest extends Specification {
         builder.classpath(libJar, moduleJar)
 
         when:
-        builder.modularClasspathHandling.inferModulePath.set(true)
+        builder.modularity.inferModulePath.set(true)
 
         then:
         builder.getAllArguments().findAll { !it.startsWith('-Duser.') } == ['-Dfile.encoding=UTF-8', '-cp', libJar.name, '--module-path', moduleJar.name, '--module', 'mainModule/mainClass']

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -78,6 +78,16 @@ In addition, there is a new `release` property (`java.release.set(...)` or `java
 Gradle versions from 6.0 to 6.3.x included could generate bad Gradle Module Metadata when publishing on an Ivy repository which had a custom repository layout.
 Starting from 6.4, Gradle will no longer publish Gradle Module Metadata if it detects that you are using a custom repository layout.
 
+=== New properties may shadow variables in build scripts
+
+This release introduces some new properties -- `mainClass`, `mainModule`, `modularity` -- in different places.
+Since these are very generic names, there is a chance that you use one of them in your build scripts as variable name.
+A new property might then shadow one of your variables in an undesired way, leading to a build failure where the property is accessed instead of the local variable with the same name.
+You can fix it by renaming the corresponding variable in the build script.
+
+Affected is configuration code inside the `application {}` and `java {}` configuration blocks, inside a java execution setup with `project.javaexec {}`, and inside various task configurations
+(`JavaExec`, `CreateStartScripts`, `JavaCompile`, `Test`, `Javadoc`).
+
 ==== Updates to bundled Gradle dependencies
 
 - Kotlin has been updated to https://github.com/JetBrains/kotlin/releases/tag/v1.3.71[Kotlin 1.3.71].

--- a/subprojects/docs/src/snippets/application/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/application/groovy/build.gradle
@@ -24,7 +24,7 @@ version = '1.0.2'
 
 // tag::inferModulePath[]
 java {
-    modularClasspathHandling.inferModulePath = true
+    modularity.inferModulePath = true
 }
 // end::inferModulePath[]
 

--- a/subprojects/docs/src/snippets/application/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/application/kotlin/build.gradle.kts
@@ -8,7 +8,7 @@ version = "1.0.2"
 
 // tag::inferModulePath[]
 java {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 // end::inferModulePath[]
 

--- a/subprojects/docs/src/snippets/java-library/module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-library/module/groovy/build.gradle
@@ -17,7 +17,7 @@ tasks.compileJava {
 
 // tag::inferModulePath[]
 java {
-    modularClasspathHandling.inferModulePath = true
+    modularity.inferModulePath = true
 }
 // end::inferModulePath[]
 

--- a/subprojects/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.compileJava {
 
 // tag::inferModulePath[]
 java {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 // end::inferModulePath[]
 

--- a/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
@@ -5,7 +5,7 @@ repositories {
     mavenCentral()
 }
 java {
-    modularClasspathHandling.inferModulePath = true
+    modularity.inferModulePath = true
 }
 
 // tag::patchArgs[]

--- a/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ repositories {
     mavenCentral()
 }
 java {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 
 // tag::patchArgs[]

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
@@ -57,7 +57,7 @@ class EclipseJavaModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
                 maven { url "${mavenRepo.uri}" }
             }
             $configLocation {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
             }
 
             dependencies {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -329,7 +329,7 @@ public class EclipseClasspath {
         boolean inferModulePath = false;
         Task compileJava = project.getTasks().findByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
         if (compileJava instanceof JavaCompile) {
-            inferModulePath = ((JavaCompile) compileJava).getModularClasspathHandling().getInferModulePath().get();
+            inferModulePath = ((JavaCompile) compileJava).getModularity().getInferModulePath().get();
         }
         ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, projectRegistry, new DefaultGradleApiSourcesResolver(project), inferModulePath);
         return classpathFactory.createEntries();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -33,7 +33,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.WarPlugin;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ear.EarPlugin;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
@@ -25,7 +25,7 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent;
 import org.gradle.plugins.ide.eclipse.model.FileReference;
 import org.gradle.plugins.ide.eclipse.model.WbDependentModule;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -31,7 +31,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.internal.Factory;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
 import org.gradle.plugins.ide.idea.model.IdeaModule;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -41,7 +41,7 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -133,7 +133,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
         """
         file("impl/build.gradle") << """
             compileJava {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
             }
         """
         succeeds "impl:${language.compileTaskName}"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/AbstractJavaModuleIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/AbstractJavaModuleIntegrationTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractJavaModuleIntegrationTest extends AbstractIntegrationSpec
                 maven { url '${mavenRepo.uri}' }
             }
             java {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
             }
         """
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -53,7 +53,7 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
         given:
         buildFile << """
             task run(type: JavaExec) {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
                 classpath = files(jar) + configurations.runtimeClasspath
                 mainModule.set('consumer')
             }
@@ -77,7 +77,7 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
         given:
         buildFile << """
             task run(type: JavaExec) {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
                 classpath = files(jar) + configurations.runtimeClasspath
                 mainModule.set('consumer')
                 mainClass.set('consumer.MainModule')
@@ -102,7 +102,7 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
                 dependsOn jar
                 doLast {
                     project.javaexec {
-                        modularClasspathHandling.inferModulePath.set(true)
+                        modularity.inferModulePath.set(true)
                         classpath = files(jar) + configurations.runtimeClasspath
                         mainModule.set('consumer')
                     }
@@ -131,7 +131,7 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
                 dependsOn jar
                 doLast {
                     project.javaexec {
-                        modularClasspathHandling.inferModulePath.set(true)
+                        modularity.inferModulePath.set(true)
                         classpath = files(jar) + configurations.runtimeClasspath
                         mainModule.set('consumer')
                         mainClass.set('consumer.MainModule')

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -35,7 +35,7 @@ import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.IncrementalCompilerFactory;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.CompilationSourceDirs;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.JavaRecompilationSpecProvider;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.tasks.CacheableTask;
@@ -50,8 +50,8 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal;
 import org.gradle.jvm.platform.JavaPlatform;
@@ -84,7 +84,7 @@ public class JavaCompile extends AbstractCompile {
     private final CompileOptions compileOptions;
     private JavaToolChain toolChain;
     private final FileCollection stableSources = getProject().files((Callable<Object[]>) () -> new Object[]{getSource(), getSources()});
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
 
     public JavaCompile() {
         Project project = getProject();
@@ -100,7 +100,7 @@ public class JavaCompile extends AbstractCompile {
             return version;
         }));
 
-        this.modularClasspathHandling = objects.newInstance(DefaultModularClasspathHandling.class);
+        this.modularity = objects.newInstance(DefaultModularitySpec.class);
     }
 
     /**
@@ -239,7 +239,7 @@ public class JavaCompile extends AbstractCompile {
     private DefaultJavaCompileSpec createSpec() {
         List<File> sourcesRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) getStableSources().getAsFileTree());
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
-        boolean isModule = JavaModuleDetector.isModuleSource(modularClasspathHandling.getInferModulePath().get(), sourcesRoots);
+        boolean isModule = JavaModuleDetector.isModuleSource(modularity.getInferModulePath().get(), sourcesRoots);
 
         final DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions).create();
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
@@ -272,8 +272,8 @@ public class JavaCompile extends AbstractCompile {
      */
     @Incubating
     @Nested
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -24,7 +24,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.CompilationSourceDirs;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -41,8 +41,8 @@ import org.gradle.api.tasks.javadoc.internal.JavadocSpec;
 import org.gradle.external.javadoc.MinimalJavadocOptions;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal;
 import org.gradle.jvm.platform.JavaPlatform;
 import org.gradle.jvm.platform.internal.DefaultJavaPlatform;
@@ -108,12 +108,12 @@ public class Javadoc extends SourceTask {
     private final StandardJavadocDocletOptions options = new StandardJavadocDocletOptions();
 
     private FileCollection classpath = getProject().files();
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
 
     private String executable;
 
     public Javadoc() {
-        this.modularClasspathHandling = getObjectFactory().newInstance(DefaultModularClasspathHandling.class);
+        this.modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
     }
 
     @TaskAction
@@ -133,7 +133,7 @@ public class Javadoc extends SourceTask {
 
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
         List<File> sourcesRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) getSource());
-        boolean isModule = JavaModuleDetector.isModuleSource(modularClasspathHandling.getInferModulePath().get(), sourcesRoots);
+        boolean isModule = JavaModuleDetector.isModuleSource(modularity.getInferModulePath().get(), sourcesRoots);
 
         options.classpath(new ArrayList<>(javaModuleDetector.inferClasspath(isModule, getClasspath()).getFiles()));
         options.modulePath(new ArrayList<>(javaModuleDetector.inferModulePath(isModule, getClasspath()).getFiles()));
@@ -324,8 +324,8 @@ public class Javadoc extends SourceTask {
      */
     @Incubating
     @Nested
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     /**

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
@@ -90,10 +90,10 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
                 $configModule
             }
             compileJava {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
             }
             startScripts {
-                modularClasspathHandling.inferModulePath.set(true)
+                modularity.inferModulePath.set(true)
             }
         """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -563,10 +563,10 @@ application {
     mainModule.set('org.gradle.test.main')
 }
 compileJava {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 startScripts {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 """
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -260,10 +260,10 @@ application {
     mainModule.set('main.test')
 }
 compileJava {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 startScripts {
-    modularClasspathHandling.inferModulePath.set(true)
+    modularity.inferModulePath.set(true)
 }
 """
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -142,7 +142,7 @@ public class ApplicationPlugin implements Plugin<Project> {
             run.getConventionMapping().map("jvmArgs", pluginConvention::getApplicationDefaultJvmArgs);
 
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
-            run.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
+            run.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
     }
 
@@ -164,7 +164,7 @@ public class ApplicationPlugin implements Plugin<Project> {
             startScripts.getConventionMapping().map("defaultJvmOpts", pluginConvention::getApplicationDefaultJvmArgs);
 
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
-            startScripts.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
+            startScripts.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -212,7 +212,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 compileTask.getOptions().getHeaderOutputDirectory().convention(target.getLayout().getBuildDirectory().dir(generatedHeadersDir));
                 JavaPluginExtension javaPluginExtension = target.getExtensions().getByType(JavaPluginExtension.class);
                 compileTask.getRelease().convention(javaPluginExtension.getRelease());
-                compileTask.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
+                compileTask.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -428,7 +428,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
                         return pluginConvention.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath();
                     }
                 });
-                test.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
+                test.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
             }
         });
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -21,7 +21,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Property;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 
 /**
  * Common configuration for Java based projects. This is added by the {@link JavaBasePlugin}.
@@ -129,5 +129,5 @@ public interface JavaPluginExtension {
      * @since 6.4
      */
     @Incubating
-    ModularClasspathHandling getModularClasspathHandling();
+    ModularitySpec getModularity();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -24,7 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponentContainer;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -33,7 +33,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
+import org.gradle.internal.jvm.DefaultModularitySpec;
 
 import java.util.regex.Pattern;
 
@@ -53,7 +53,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final SoftwareComponentContainer components;
     private final TaskContainer tasks;
     private final Project project;
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
     private final Property<Integer> release;
 
     public DefaultJavaPluginExtension(JavaPluginConvention convention,
@@ -64,7 +64,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         this.components = project.getComponents();
         this.tasks = project.getTasks();
         this.project = project;
-        this.modularClasspathHandling = project.getObjects().newInstance(DefaultModularClasspathHandling.class);
+        this.modularity = project.getObjects().newInstance(DefaultModularitySpec.class);
         this.release = project.getObjects().property(Integer.class);
         ((DefaultJavaPluginConvention) convention).internalReleaseFlagProperty(release);
     }
@@ -130,8 +130,8 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     }
 
     @Override
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     private static String validateFeatureName(String name) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -64,7 +64,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.TextUtil;
 
@@ -185,7 +185,7 @@ public class JvmPluginsHelper {
                 javadoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
                 javadoc.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
                 javadoc.setSource(sourceSet.getAllJava());
-                javadoc.getModularClasspathHandling().getInferModulePath().convention(javaPluginExtension.getModularClasspathHandling().getInferModulePath());
+                javadoc.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
             });
         }
     }
@@ -248,7 +248,7 @@ public class JvmPluginsHelper {
             if (!attributes.contains(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)) {
                 String libraryElements;
                 // If we are compiling a module, we require JARs of all dependencies as they may potentially include an Automatic-Module-Name
-                if (javaClasspathPackaging || JavaModuleDetector.isModuleSource(compileTaskProvider.get().getModularClasspathHandling().getInferModulePath().get(), CompilationSourceDirs.inferSourceRoots((FileTreeInternal) sourceSet.getJava().getAsFileTree()))) {
+                if (javaClasspathPackaging || JavaModuleDetector.isModuleSource(compileTaskProvider.get().getModularity().getInferModulePath().get(), CompilationSourceDirs.inferSourceRoots((FileTreeInternal) sourceSet.getJava().getAsFileTree()))) {
                    libraryElements = LibraryElements.JAR;
                 } else {
                     libraryElements = LibraryElements.CLASSES;

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.plugins.StartScriptGenerator;
 import org.gradle.api.internal.plugins.UnixStartScriptGenerator;
 import org.gradle.api.internal.plugins.WindowsStartScriptGenerator;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
@@ -34,8 +34,8 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.jvm.application.scripts.ScriptGenerator;
 import org.gradle.util.GUtil;
 
@@ -121,14 +121,14 @@ public class CreateStartScripts extends ConventionTask {
     private String optsEnvironmentVar;
     private String exitEnvironmentVar;
     private FileCollection classpath;
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
     private ScriptGenerator unixStartScriptGenerator = new UnixStartScriptGenerator();
     private ScriptGenerator windowsStartScriptGenerator = new WindowsStartScriptGenerator();
 
     public CreateStartScripts() {
         this.mainModule = getObjectFactory().property(String.class);
         this.mainClass = getObjectFactory().property(String.class);
-        this.modularClasspathHandling = getObjectFactory().newInstance(DefaultModularClasspathHandling.class);
+        this.modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
     }
 
     @Inject
@@ -314,8 +314,8 @@ public class CreateStartScripts extends ConventionTask {
      */
     @Incubating
     @Nested
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     public void setClasspath(@Nullable FileCollection classpath) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
@@ -160,13 +160,13 @@ class ApplicationPluginTest extends AbstractProjectBuilderSpec {
     void "module path handling is configured for all tasks"() {
         when:
         plugin.apply(project)
-        project.extensions.getByType(JavaPluginExtension).modularClasspathHandling.inferModulePath.set(true)
+        project.extensions.getByType(JavaPluginExtension).modularity.inferModulePath.set(true)
 
         then:
-        project.tasks.getByName("compileJava").modularClasspathHandling.inferModulePath.get()
-        project.tasks.getByName("compileTestJava").modularClasspathHandling.inferModulePath.get()
-        project.tasks.getByName("test").modularClasspathHandling.inferModulePath.get()
-        project.tasks.getByName("run").modularClasspathHandling.inferModulePath.get()
-        project.tasks.getByName("startScripts").modularClasspathHandling.inferModulePath.get()
+        project.tasks.getByName("compileJava").modularity.inferModulePath.get()
+        project.tasks.getByName("compileTestJava").modularity.inferModulePath.get()
+        project.tasks.getByName("test").modularity.inferModulePath.get()
+        project.tasks.getByName("run").modularity.inferModulePath.get()
+        project.tasks.getByName("startScripts").modularity.inferModulePath.get()
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -110,7 +110,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         builder.applicationClasspath(classPath);
         builder.applicationModulePath(modulePath);
         options.copyTo(builder.getJavaCommand());
-        builder.getJavaCommand().getModularClasspathHandling().getInferModulePath().set(modulePath.iterator().hasNext());
+        builder.getJavaCommand().getModularity().getInferModulePath().set(modulePath.iterator().hasNext());
         builder.getJavaCommand().jvmArgs("-Dorg.gradle.native=false");
         buildConfigAction.execute(builder);
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -39,7 +39,7 @@ import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult;
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultSerializer;
 import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
-import org.gradle.api.jpms.ModularClasspathHandling;
+import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
@@ -62,8 +62,8 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
-import org.gradle.internal.jpms.DefaultModularClasspathHandling;
-import org.gradle.internal.jpms.JavaModuleDetector;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -145,7 +145,7 @@ import static org.gradle.util.ConfigureUtil.configureUsing;
 public class Test extends AbstractTestTask implements JavaForkOptions, PatternFilterable {
 
     private final JavaForkOptions forkOptions;
-    private final ModularClasspathHandling modularClasspathHandling;
+    private final ModularitySpec modularity;
 
     private FileCollection testClassesDirs;
     private PatternFilterable patternSet;
@@ -160,7 +160,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         patternSet = getPatternSetFactory().create();
         forkOptions = getForkOptionsFactory().newDecoratedJavaForkOptions();
         forkOptions.setEnableAssertions(true);
-        modularClasspathHandling = getObjectFactory().newInstance(DefaultModularClasspathHandling.class);
+        modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
     }
 
     @Inject
@@ -591,8 +591,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      */
     @Incubating
     @Nested
-    public ModularClasspathHandling getModularClasspathHandling() {
-        return modularClasspathHandling;
+    public ModularitySpec getModularity() {
+        return modularity;
     }
 
     /**
@@ -605,7 +605,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         JavaForkOptions javaForkOptions = getForkOptionsFactory().newJavaForkOptions();
         copyTo(javaForkOptions);
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
-        boolean testIsModule = javaModuleDetector.isModule(modularClasspathHandling.getInferModulePath().get(), getTestClassesDirs());
+        boolean testIsModule = javaModuleDetector.isModule(modularity.getInferModulePath().get(), getTestClassesDirs());
         FileCollection classpath = javaModuleDetector.inferClasspath(testIsModule, getClasspath());
         FileCollection modulePath = javaModuleDetector.inferModulePath(testIsModule, getClasspath());
         return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());


### PR DESCRIPTION
Samples will be updated separately as we first need a new wrapper version that includes this change.

Package changed from `org.gradle.api.jpms` to `org.gradle.api.jvm` (which is **not** `org.gradle.jvm` that is used by the JVM software model in another subproject)