### PR TITLE
Make publication build identifier configurable

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -482,6 +482,22 @@ To strike a balance between the security risks and the needs of people who may f
 
 We recommend plugin maintainers avoid logging sensitive information if possible, and if it's not possible, that all sensitive information be logged exclusively at the `DEBUG` log level.
 
+## Gradle module metadata can be made reproducible
+
+The Gradle Module Metadata file contains a build identifier field which defaults to a unique ID generated during build execution.
+This results in the generated file being different at each build execution.
+
+This value can now be configured to something else at the publication level, allowing users to opt-in for a reproducible Gradle Module Metadata file.
+
+```groovy
+main(MavenPublication) {
+    from components.java
+    buildIdentifier = 'unused'
+}
+```
+
+See the documentation for more information on [Gradle Module Metadata generation](userguide/publishing_gradle_module_metadata.html#sub:gmm-reproducible).
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
@@ -123,6 +123,28 @@ The following rules are enforced:
 
 These rules ensure the quality of the metadata produced, and help confirm that consumption will not be problematic.
 
+[[sub:gmm-reproducible]]
+== Making Gradle Module Metadata reproducible
+
+By default, the Gradle Module Metadata file contains a unique id from the build that generated it.
+This means that the file will always be different.
+
+Users can choose to replace this unique id by something else through the configuration of the `buildIdentifier` in their `publication`:
+
+.Configure the build identifier of a publication
+====
+include::sample[dir="snippets/userguide/publishing/javaLibrary/groovy",files="build.gradle[tags=configure-build-id]"]
+include::sample[dir="snippets/userguide/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=configure-build-id]"]
+====
+
+With the changes above, the generated Gradle Module Metadata file will always be the same, allowing downstream tasks to consider it up-to-date.
+
+[NOTE]
+====
+The task generating the module metadata files is currently never marked `UP-TO-DATE` by Gradle due to the way it is implemented.
+However, if the build identifier is configured to not depend on the build invocation anymore, and no build inputs nor build scripts changed, the task is effectively up-to-date (it always produces the same output).
+====
+
 [[sub:disabling-gmm-publication]]
 == Disabling Gradle Module Metadata publication
 

--- a/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/groovy/build.gradle
@@ -41,3 +41,14 @@ tasks.withType(GenerateMavenPom).all {
     destination = "$buildDir/poms/${publicationName}-pom.xml"
 }
 // end::configure-generate-task[]
+
+// tag::configure-build-id[]
+publishing {
+    publications {
+        main(MavenPublication) {
+            from components.java
+            buildIdentifier = 'unused'
+        }
+    }
+}
+// end::configure-build-id[]

--- a/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/kotlin/build.gradle.kts
@@ -41,3 +41,14 @@ tasks.withType<GenerateMavenPom>().configureEach {
     destination = file("$buildDir/poms/$publicationName-pom.xml")
 }
 // end::configure-generate-task[]
+
+// tag::configure-build-id[]
+publishing {
+    publications {
+        create<MavenPublication>("main") {
+            from(components["java"])
+            buildIdentifier.set("unused")
+        }
+    }
+}
+// end::configure-build-id[]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -43,6 +43,15 @@ class GradleModuleMetadata {
     }
 
     @Nullable
+    CreatedBy getCreatedBy() {
+        def createdBy = values.createdBy
+        if (createdBy == null) {
+            return null
+        }
+        return new CreatedBy(createdBy.gradle.version, createdBy.gradle.buildId)
+    }
+
+    @Nullable
     Coords getComponent() {
         def comp = values.component
         if (comp == null || comp.url) {
@@ -431,6 +440,17 @@ class GradleModuleMetadata {
                 assert actualAttributes == expectedAttributes
                 this
             }
+        }
+    }
+
+    @EqualsAndHashCode
+    static class CreatedBy {
+        final String gradleVersion
+        final String buildId
+
+        CreatedBy(String gradleVersion, String buildId) {
+            this.gradleVersion = gradleVersion
+            this.buildId = buildId
         }
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -932,4 +932,43 @@ class TestCapability implements Capability {
         false   | false
         true    | true
     }
+
+    @ToBeFixedForInstantExecution
+    def 'can configure the build identifier'() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                        buildIdentifier = 'magic'
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.createdBy.buildId == 'magic'
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -49,6 +49,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
@@ -125,6 +126,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final Set<String> silencedVariants = new HashSet<>();
+    private final Property<String> buildIdentifier;
     private IvyArtifact ivyDescriptorArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
     private SingleOutputTaskIvyArtifact gradleModuleDescriptorArtifact;
@@ -155,11 +157,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         this.publishableArtifacts = new CompositePublicationArtifactSet<>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         this.ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
         this.descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
+        this.buildIdentifier = objectFactory.property(String.class);
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Property<String> getBuildIdentifier() {
+        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -888,4 +888,41 @@ class TestCapability implements Capability {
         variant.dependencyConstraints[0].strictly == '1.1'
         variant.dependencyConstraints[0].rejectsVersion == []
     }
+
+    @ToBeFixedForInstantExecution
+    def 'can configure the build identifier'() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'),
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                        buildIdentifier = 'magic'
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.createdBy.buildId == 'magic'
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -56,6 +56,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
@@ -152,6 +153,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final PlatformSupport platformSupport;
     private final Set<String> silencedVariants = new HashSet<>();
+    private final Property<String> buildIdentifier;
     private MavenArtifact pomArtifact;
     private SingleOutputTaskMavenArtifact moduleMetadataArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
@@ -181,11 +183,17 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         derivedArtifacts = new DefaultPublicationArtifactSet<>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
         publishableArtifacts = new CompositePublicationArtifactSet<>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         pom = instantiator.newInstance(DefaultMavenPom.class, this, instantiator, objectFactory);
+        this.buildIdentifier = objectFactory.property(String.class);
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Property<String> getBuildIdentifier() {
+        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.publish;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.provider.Property;
 
 /**
  * A publication is a description of a consumable representation of one or more artifacts, and possibly associated metadata.
@@ -24,4 +26,15 @@ import org.gradle.api.Named;
  * @since 1.3
  */
 public interface Publication extends Named {
+
+    /**
+     * A {@link Property} that allows to configure the build identifier value mapped to the Gradle Module Metadata file.
+     * <p>
+     * If this value is not configured, it will default to the internal build identifier, different for each build invocation.
+     *
+     * @return a {@code String} property
+     * @since 6.4
+     */
+    @Incubating
+    Property<String> getBuildIdentifier();
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -141,7 +141,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(publication.getCoordinates(), publication.getAttributes(), component, componentCoordinates, owners, jsonWriter);
-        writeCreator(jsonWriter);
+        writeCreator(publication, jsonWriter);
         writeVariants(publication, component, componentCoordinates, jsonWriter, checker);
         jsonWriter.endObject();
     }
@@ -259,7 +259,7 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeCreator(JsonWriter jsonWriter) throws IOException {
+    private void writeCreator(PublicationInternal publication, JsonWriter jsonWriter) throws IOException {
         jsonWriter.name("createdBy");
         jsonWriter.beginObject();
         jsonWriter.name("gradle");
@@ -267,7 +267,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.name("version");
         jsonWriter.value(GradleVersion.current().getVersion());
         jsonWriter.name("buildId");
-        jsonWriter.value(buildInvocationScopeId.getId().asString());
+        jsonWriter.value(publication.getBuildIdentifier().getOrElse(buildInvocationScopeId.getId().asString()));
         jsonWriter.endObject();
         jsonWriter.endObject();
     }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.provider.Property
 import org.gradle.api.publish.Publication
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.util.TestUtil
@@ -96,6 +97,11 @@ class DefaultPublicationContainerTest extends Specification {
 
         TestPublication(name) {
             this.name = name
+        }
+
+        @Override
+        Property<String> getBuildIdentifier() {
+            return null;
         }
     }
 }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -36,6 +36,8 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.internal.component.external.model.ImmutableCapability
@@ -70,6 +72,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "1.2")
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     def generator = new GradleModuleMetadataWriter(new BuildInvocationScopeId(buildId), projectDependencyResolver, TestUtil.checksumService)
+    def buildIdentifier = new DefaultProperty(Mock(PropertyHost), String)
 
     def "fails to write file for component with no variants"() {
         def writer = new StringWriter()
@@ -1128,6 +1131,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         publication.component >> component
         publication.coordinates >> coords
         publication.versionMappingStrategy >> mappingStrategyInternal
+        publication.buildIdentifier >> buildIdentifier
         return publication
     }
 


### PR DESCRIPTION
This allows to set a user defined value or a constant in case that
information is not needed and having a stable .module output is
preferred.

Documentation still needs to be added.