### PR TITLE
Report instant execution deserialization problems

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -29,7 +29,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
 
         given:
         def instant = newInstantExecutionFixture()
-        def stateSerializationProblems = withStateSerializationProblems()
+        def stateSerializationProblems = withStateSerializationProblems().store
         def stateSerializationErrors = withStateSerializationErrors()
         def errorSpec = problems.newErrorSpec(stateSerializationErrors.first()) {
             withUniqueProblems(stateSerializationProblems)
@@ -77,7 +77,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         then:
         executed(':taskWithStateSerializationProblems', ':a', ':b')
         problems.assertFailureHasProblems(failure) {
-            withUniqueProblems(taskExecutionProblems + stateSerializationProblems)
+            withUniqueProblems(taskExecutionProblems + stateSerializationProblems.store)
             withProblemsWithStackTraceCount(2)
         }
 
@@ -89,7 +89,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         executed(':taskWithStateSerializationProblems', ':a', ':b')
         instantExecution.assertStateStored()
         problems.assertResultHasProblems(result) {
-            withUniqueProblems(taskExecutionProblems + stateSerializationProblems)
+            withUniqueProblems(taskExecutionProblems + stateSerializationProblems.store)
             withProblemsWithStackTraceCount(2)
         }
 
@@ -100,7 +100,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         executed(':taskWithStateSerializationProblems', ':a', ':b')
         instantExecution.assertStateLoaded()
         problems.assertFailureHasProblems(failure) {
-            withUniqueProblems(taskExecutionProblems)
+            withUniqueProblems(taskExecutionProblems + stateSerializationProblems.load)
             withProblemsWithStackTraceCount(2)
         }
     }
@@ -108,7 +108,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
     def "problems are reported and fail the build when failOnProblems is false but maxProblems is reached"() {
 
         given:
-        def stateSerializationProblems = withStateSerializationProblems()
+        def stateSerializationProblems = withStateSerializationProblems().store
         def taskExecutionProblems = withTaskExecutionProblems()
 
         when:
@@ -139,7 +139,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
 
         given:
         settingsFile << "rootProject.name = 'test'"
-        def expectedProblems = withStateSerializationProblems()
+        def expectedProblems = withStateSerializationProblems().store
         buildFile << """
             taskWithStateSerializationProblems.doFirst { throw new Exception("BOOM") }
         """
@@ -177,7 +177,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         ]
     }
 
-    private List<String> withStateSerializationProblems() {
+    private Map<String, List<String>> withStateSerializationProblems() {
         buildFile << """
             task taskWithStateSerializationProblems {
                 inputs.property 'brokenProperty', project
@@ -185,8 +185,14 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
             }
         """
         return [
-            "input property 'brokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with instant execution.",
-            "input property 'otherBrokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with instant execution.",
+            store: [
+                "input property 'brokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with instant execution.",
+                "input property 'otherBrokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with instant execution.",
+            ],
+            load: [
+                "input property 'brokenProperty' of ':taskWithStateSerializationProblems': cannot deserialize object of type '${Project.name}' as these are not supported with instant execution.",
+                "input property 'otherBrokenProperty' of ':taskWithStateSerializationProblems': cannot deserialize object of type '${Project.name}' as these are not supported with instant execution."
+            ]
         ]
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -135,9 +135,18 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         }
 
         when:
+        problems.withDoNotFailOnProblems()
         instantRun "broken"
 
         then:
+        problems.assertResultHasProblems(result) {
+            withUniqueProblems(
+                "field 'badReference' from type 'SomeTask': cannot deserialize object of type '${baseType.name}' as these are not supported with instant execution.",
+                "field 'badReference' from type 'SomeBean': cannot deserialize object of type '${baseType.name}' as these are not supported with instant execution."
+            )
+        }
+
+        and:
         outputContains("this.reference = null")
         outputContains("bean.reference = null")
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -103,16 +103,19 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
             class SomeTask extends DefaultTask {
                 private final ${baseType.name} badReference
                 private final bean = new SomeBean()
+                private final sameBean = new SomeBean()
 
                 SomeTask() {
                     badReference = ${reference}
                     bean.badReference = ${reference}
+                    sameBean.badReference = ${reference}
                 }
 
                 @TaskAction
                 void run() {
                     println "this.reference = " + badReference
                     println "bean.reference = " + bean.badReference
+                    println "sameBean.reference = " + sameBean.badReference
                 }
             }
 
@@ -128,6 +131,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
 
         then:
         problems.assertResultHasProblems(result) {
+            withTotalProblemsCount(3)
             withUniqueProblems(
                 "field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.",
                 "field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution."
@@ -140,6 +144,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
 
         then:
         problems.assertResultHasProblems(result) {
+            withTotalProblemsCount(3)
             withUniqueProblems(
                 "field 'badReference' from type 'SomeTask': cannot deserialize object of type '${baseType.name}' as these are not supported with instant execution.",
                 "field 'badReference' from type 'SomeBean': cannot deserialize object of type '${baseType.name}' as these are not supported with instant execution."
@@ -149,6 +154,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         and:
         outputContains("this.reference = null")
         outputContains("bean.reference = null")
+        outputContains("sameBean.reference = null")
 
         where:
         concreteType                          | baseType                       | reference
@@ -210,16 +216,19 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
             class SomeTask extends DefaultTask {
                 private final ${baseType.name} badField
                 private final bean = new SomeBean()
+                private final sameBean = new SomeBean()
 
                 SomeTask() {
                     badField = ${reference}
                     bean.badField = ${reference}
+                    sameBean.badField = ${reference}
                 }
 
                 @TaskAction
                 void run() {
                     println "this.reference = " + badField
                     println "bean.reference = " + bean.badField
+                    println "sameBean.reference = " + sameBean.badField
                 }
             }
 
@@ -235,6 +244,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
 
         then:
         problems.assertResultHasProblems(result) {
+            withTotalProblemsCount(3)
             withUniqueProblems(
                 "field 'badField' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution.",
                 "field 'badField' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with instant execution."
@@ -247,6 +257,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
 
         then:
         problems.assertResultHasProblems(result) {
+            withTotalProblemsCount(6)
             withUniqueProblems(
                 "field 'badField' from type 'SomeTask': cannot deserialize object of type '${baseType.name}' as these are not supported with instant execution.",
                 "field 'badField' from type 'SomeTask': value '$deserializedValue' is not assignable to '${baseType.name}'",
@@ -258,6 +269,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         and:
         outputContains("this.reference = null")
         outputContains("bean.reference = null")
+        outputContains("sameBean.reference = null")
 
         where:
         concreteType         | baseType      | reference                                    | deserializedValue

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -103,19 +103,19 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
             class SomeTask extends DefaultTask {
                 private final ${baseType.name} badReference
                 private final bean = new SomeBean()
-                private final sameBean = new SomeBean()
+                private final beanWithSameType = new SomeBean()
 
                 SomeTask() {
                     badReference = ${reference}
                     bean.badReference = ${reference}
-                    sameBean.badReference = ${reference}
+                    beanWithSameType.badReference = ${reference}
                 }
 
                 @TaskAction
                 void run() {
                     println "this.reference = " + badReference
                     println "bean.reference = " + bean.badReference
-                    println "sameBean.reference = " + sameBean.badReference
+                    println "beanWithSameType.reference = " + beanWithSameType.badReference
                 }
             }
 
@@ -154,7 +154,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         and:
         outputContains("this.reference = null")
         outputContains("bean.reference = null")
-        outputContains("sameBean.reference = null")
+        outputContains("beanWithSameType.reference = null")
 
         where:
         concreteType                          | baseType                       | reference
@@ -216,19 +216,19 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
             class SomeTask extends DefaultTask {
                 private final ${baseType.name} badField
                 private final bean = new SomeBean()
-                private final sameBean = new SomeBean()
+                private final beanWithSameType = new SomeBean()
 
                 SomeTask() {
                     badField = ${reference}
                     bean.badField = ${reference}
-                    sameBean.badField = ${reference}
+                    beanWithSameType.badField = ${reference}
                 }
 
                 @TaskAction
                 void run() {
                     println "this.reference = " + badField
                     println "bean.reference = " + bean.badField
-                    println "sameBean.reference = " + sameBean.badField
+                    println "beanWithSameType.reference = " + beanWithSameType.badField
                 }
             }
 
@@ -269,7 +269,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         and:
         outputContains("this.reference = null")
         outputContains("bean.reference = null")
-        outputContains("sameBean.reference = null")
+        outputContains("beanWithSameType.reference = null")
 
         where:
         concreteType         | baseType      | reference                                    | deserializedValue

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -311,7 +311,8 @@ class DefaultInstantExecution internal constructor(
         decoder,
         service(),
         beanConstructors,
-        logger
+        logger,
+        problems::onProblem
     )
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -48,10 +48,10 @@ inline fun <reified T> ownerServiceCodec() =
 internal
 inline fun <reified T : Any> unsupported(): Codec<T> = codec(
     encode = { value ->
-        logUnsupported(T::class, value.javaClass)
+        logUnsupported("serialize", T::class, value.javaClass)
     },
     decode = {
-        logUnsupported(T::class)
+        logUnsupported("deserialize", T::class)
         null
     }
 )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -172,7 +172,11 @@ class DefaultReadContext(
     private
     val constructors: BeanConstructors,
 
-    override val logger: Logger
+    override val logger: Logger,
+
+    private
+    val problemHandler: (PropertyProblem) -> Unit
+
 ) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, Decoder by decoder {
 
     override val sharedIdentities = ReadIdentities()
@@ -274,7 +278,7 @@ class DefaultReadContext(
         DefaultReadIsolate(owner)
 
     override fun onProblem(problem: PropertyProblem) {
-        // ignore problems
+        problemHandler(problem)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
@@ -38,9 +38,11 @@ fun IsolateContext.logPropertyInfo(action: String, value: Any?) {
 }
 
 
-fun IsolateContext.logUnsupported(baseType: KClass<*>, actualType: Class<*>) {
+fun IsolateContext.logUnsupported(action: String, baseType: KClass<*>, actualType: Class<*>) {
     logPropertyProblem {
-        text("cannot serialize object of type ")
+        text("cannot ")
+        text(action)
+        text(" object of type ")
         reference(GeneratedSubclasses.unpack(actualType))
         text(", a subtype of ")
         reference(baseType)
@@ -49,9 +51,11 @@ fun IsolateContext.logUnsupported(baseType: KClass<*>, actualType: Class<*>) {
 }
 
 
-fun IsolateContext.logUnsupported(baseType: KClass<*>) {
+fun IsolateContext.logUnsupported(action: String, baseType: KClass<*>) {
     logPropertyProblem {
-        text("cannot serialize object of type ")
+        text("cannot ")
+        text(action)
+        text(" object of type ")
         reference(baseType)
         text(" as these are not supported with instant execution.")
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -48,7 +48,7 @@ class BeanPropertyReader(
 
     private
     val fieldSetters = relevantStateOf(beanType).map {
-        FieldSetter(it.field, it.unsupportedFieldType, setterFor(it.field))
+        FieldSetter(it.field.name, it.unsupportedFieldType, setterFor(it.field))
     }
 
     private
@@ -65,11 +65,10 @@ class BeanPropertyReader(
 
     override suspend fun ReadContext.readStateOf(bean: Any) {
         for (fieldSetter in fieldSetters) {
-            val field = fieldSetter.field
-            val fieldName = field.name
+            val fieldName = fieldSetter.fieldName
             val setter = fieldSetter.setter
             fieldSetter.unsupportedFieldType?.let {
-                reportUnsupportedFieldType(it, "deserialize", field.name)
+                reportUnsupportedFieldType(it, "deserialize", fieldName)
             }
             readPropertyValue(PropertyKind.Field, fieldName) { fieldValue ->
                 setter(bean, fieldValue)
@@ -114,7 +113,7 @@ class BeanPropertyReader(
 
 private
 class FieldSetter(
-    val field: Field,
+    val fieldName: String,
     val unsupportedFieldType: KClass<*>?,
     val setter: ReadContext.(Any, Any?) -> Unit
 )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -80,8 +80,8 @@ fun WriteContext.reportFieldProblems(field: Field, fieldName: String, fieldType:
             unsupportedFieldDeclaredTypes
                 .firstOrNull { it.java.isAssignableFrom(fieldType) }
                 ?.let { unsupported ->
-                    if (fieldValue == null) logUnsupported(unsupported)
-                    else logUnsupported(unsupported, fieldValue::class.java)
+                    if (fieldValue == null) logUnsupported("serialize", unsupported)
+                    else logUnsupported("serialize", unsupported, fieldValue::class.java)
                 }
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -22,14 +22,12 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.instantexecution.InstantExecutionError
 import org.gradle.instantexecution.InstantExecutionProblemsException
 import org.gradle.instantexecution.extensions.maybeUnwrapInvocationTargetException
-import org.gradle.instantexecution.problems.DisableInstantExecutionFieldTypeCheck
 import org.gradle.instantexecution.problems.PropertyKind
 import org.gradle.instantexecution.problems.propertyDescriptionFor
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logPropertyInfo
-import org.gradle.instantexecution.serialization.logUnsupported
 import java.io.IOException
 import java.lang.reflect.Field
 import java.util.concurrent.Callable
@@ -50,7 +48,7 @@ class BeanPropertyWriter(
         for (field in relevantFields) {
             val fieldName = field.name
             val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
-            reportFieldProblems(field, fieldName, field.type, fieldValue)
+            reportFieldProblems("serialize", field, fieldValue)
             writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
         }
     }
@@ -69,21 +67,6 @@ class BeanPropertyWriter(
         is Function0<*> -> fieldValue.invoke()
         is Lazy<*> -> fieldValue.value
         else -> fieldValue ?: conventionalValueOf(bean, fieldName)
-    }
-}
-
-
-private
-fun WriteContext.reportFieldProblems(field: Field, fieldName: String, fieldType: Class<*>, fieldValue: Any?) {
-    if (!field.isAnnotationPresent(DisableInstantExecutionFieldTypeCheck::class.java)) {
-        withPropertyTrace(PropertyKind.Field, fieldName) {
-            unsupportedFieldDeclaredTypes
-                .firstOrNull { it.java.isAssignableFrom(fieldType) }
-                ?.let { unsupported ->
-                    if (fieldValue == null) logUnsupported("serialize", unsupported)
-                    else logUnsupported("serialize", unsupported, fieldValue::class.java)
-                }
-        }
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -48,8 +48,8 @@ class BeanPropertyWriter(
             val field = relevantField.field
             val fieldName = field.name
             val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
-            relevantField.problemReporter?.apply {
-                report("serialize", fieldValue)
+            relevantField.unsupportedFieldType?.let {
+                reportUnsupportedFieldType(it, "serialize", field.name, fieldValue)
             }
             writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -29,7 +29,6 @@ import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import java.io.IOException
-import java.lang.reflect.Field
 import java.util.concurrent.Callable
 import java.util.function.Supplier
 
@@ -45,10 +44,13 @@ class BeanPropertyWriter(
      * Serializes a bean by serializing the value of each of its fields.
      */
     override suspend fun WriteContext.writeStateOf(bean: Any) {
-        for (field in relevantFields) {
+        for (relevantField in relevantFields) {
+            val field = relevantField.field
             val fieldName = field.name
             val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
-            reportFieldProblems("serialize", field, fieldValue)
+            relevantField.problemReporter?.apply {
+                report("serialize", fieldValue)
+            }
             writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
@@ -30,7 +30,7 @@ object TaskReferenceCodec : Codec<Task> {
         if (value === isolate.owner.delegate) {
             writeBoolean(true)
         } else {
-            logUnsupported(Task::class, value.javaClass)
+            logUnsupported("serialize", Task::class, value.javaClass)
             writeBoolean(false)
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
@@ -36,5 +36,10 @@ object TaskReferenceCodec : Codec<Task> {
     }
 
     override suspend fun ReadContext.decode(): Task? =
-        isolate.owner.delegate.takeIf { readBoolean() } as Task?
+        if (readBoolean()) {
+            isolate.owner.delegate as Task
+        } else {
+            logUnsupported("deserialize", Task::class)
+            null
+        }
 }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -381,7 +381,8 @@ class UserTypesCodecTest {
             decoder = KryoBackedDecoder(inputStream),
             instantiatorFactory = TestUtil.instantiatorFactory(),
             constructors = BeanConstructors(TestCrossBuildInMemoryCacheFactory()),
-            logger = mock()
+            logger = mock(),
+            problemHandler = {}
         )
 
     private


### PR DESCRIPTION
They were going into the void. Also refine how problems are reported when deserializing the cached state.