### PR TITLE
Consistently use GE plugin 3.2.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import java.util.*
 import org.gradle.internal.os.OperatingSystem
+import java.util.Properties
 
 plugins {
     `java`
@@ -87,10 +87,6 @@ allprojects {
                 // This repository contains an older version which has been overwritten in Central
                 excludeModule("com.google.j2objc", "j2objc-annotations")
             }
-        }
-        maven {
-            name = "Gradle Enterprise Gradle plugin RC"
-            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local")
         }
         maven {
             name = "kotlinx"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,21 +20,11 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
-        maven { url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local") }
-    }
-
-    // No plugin marker for plugin RC - can be removed when going to a final version
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "com.gradle.enterprise") {
-                useModule("com.gradle:gradle-enterprise-gradle-plugin:${requested.version}")
-            }
-        }
     }
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.2-rc-1")
+    id("com.gradle.enterprise").version("3.2.1")
 }
 
 apply(from = "gradle/build-cache-configuration.settings.gradle.kts")


### PR DESCRIPTION
We still have been applying plugin 3.2-rc-1 to the build itself.