### PR TITLE
Serialize test listeners and changes made by task graph whenReady listeners to instant execution cache

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -117,13 +117,13 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         graphNotifyOps.size() == 3
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildB:buildSrc)'
         graphNotifyOps[0].details.buildPath == ':buildB:buildSrc'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
         graphNotifyOps[1].details.buildPath == ":"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
         graphNotifyOps[2].displayName == "Notify task graph whenReady listeners (:buildB)"
         graphNotifyOps[2].details.buildPath == ":buildB"
-        graphNotifyOps[2].parentId == runTasksOps[2].id
+        graphNotifyOps[2].parentId == taskGraphOps[2].id
 
         where:
         settings                     | display
@@ -221,16 +221,16 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         graphNotifyOps.size() == 4
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
         graphNotifyOps[0].details.buildPath == ':buildSrc'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:buildB:buildSrc)"
         graphNotifyOps[1].details.buildPath == ":buildB:buildSrc"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
         graphNotifyOps[2].displayName == "Notify task graph whenReady listeners"
         graphNotifyOps[2].details.buildPath == ":"
-        graphNotifyOps[2].parentId == runTasksOps[2].id
+        graphNotifyOps[2].parentId == taskGraphOps[2].id
         graphNotifyOps[3].displayName == "Notify task graph whenReady listeners (:buildB)"
         graphNotifyOps[3].details.buildPath == ":buildB"
-        graphNotifyOps[3].parentId == runTasksOps[3].id
+        graphNotifyOps[3].parentId == taskGraphOps[3].id
 
         where:
         settings                     | display

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -120,10 +120,10 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         graphNotifyOps.size() == 2
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners'
         graphNotifyOps[0].details.buildPath == ':'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:${buildName})"
         graphNotifyOps[1].details.buildPath == ":${buildName}"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
 
         where:
         settings                     | buildName | dependencyName | display
@@ -198,10 +198,10 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         graphNotifyOps.size() == 2
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildB)'
         graphNotifyOps[0].details.buildPath == ':buildB'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
         graphNotifyOps[1].details.buildPath == ":"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
     }
 
     def assertChildrenNotIn(BuildOperationRecord origin, BuildOperationRecord op, List<BuildOperationRecord> allOps) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -88,10 +88,10 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         graphNotifyOps.size() == 2
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
         graphNotifyOps[0].details.buildPath == ':buildSrc'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
         graphNotifyOps[1].details.buildPath == ":"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
 
         def taskOps = ops.all(ExecuteTaskBuildOperationType)
         taskOps.size() > 1

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -212,13 +212,17 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.op(NotifyProjectAfterEvaluatedBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"]).parentId == notifications.op(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"]).id
         notifications.op(NotifyProjectAfterEvaluatedBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"]).parentId == notifications.op(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"]).id
 
-        notifications.op(RunRootBuildWorkBuildOperationType.Details).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 
-        // TODO - this is incorrect, these should be accounted as configuration time, not task execution time
-        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunRootBuildWorkBuildOperationType.Details).id
-        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
-        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
-        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ":a"]).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':buildSrc']).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':a:buildSrc']).id
+
+        notifications.op(RunRootBuildWorkBuildOperationType.Details).parentId == notifications.op(RunBuildBuildOperationType.Details).id
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
@@ -19,11 +19,9 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.execution.TaskExecutionGraph;
-import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
-import org.gradle.internal.InternalListener;
 
 import java.util.Collection;
 import java.util.Set;
@@ -37,19 +35,16 @@ public class SelectedTaskExecutionAction implements BuildExecutionAction {
             taskGraph.setContinueOnFailure(true);
         }
 
-        taskGraph.addTaskExecutionGraphListener(new BindAllReferencesOfProjectsToExecuteListener());
+        bindAllReferencesOfProject(taskGraph);
         taskGraph.execute(taskFailures);
     }
 
-    private static class BindAllReferencesOfProjectsToExecuteListener implements TaskExecutionGraphListener, InternalListener {
-        @Override
-        public void graphPopulated(TaskExecutionGraph graph) {
-            Set<Project> seen = Sets.newHashSet();
-            for (Task task : graph.getAllTasks()) {
-                if (seen.add(task.getProject())) {
-                    ProjectInternal projectInternal = (ProjectInternal) task.getProject();
-                    projectInternal.bindAllModelRules();
-                }
+    private void bindAllReferencesOfProject(TaskExecutionGraph graph) {
+        Set<Project> seen = Sets.newHashSet();
+        for (Task task : graph.getAllTasks()) {
+            if (seen.add(task.getProject())) {
+                ProjectInternal projectInternal = (ProjectInternal) task.getProject();
+                projectInternal.bindAllModelRules();
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -43,7 +43,7 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     void addNodes(Collection<? extends Node> nodes);
 
     /**
-     * Does the work to populate the task graph based on tasks that have been added. Does not fire events.
+     * Does the work to populate the task graph based on tasks that have been added. Fires events and no further tasks should be added.
      */
     void populate();
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
@@ -16,9 +16,7 @@
 package org.gradle.execution
 
 import org.gradle.StartParameter
-import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.tasks.TaskState
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import spock.lang.Specification
 
@@ -40,6 +38,7 @@ class SelectedTaskExecutionActionTest extends Specification {
 
         given:
         _ * startParameter.continueOnFailure >> false
+        _ * taskGraph.allTasks >> []
 
         when:
         action.execute(context, failures)
@@ -53,6 +52,7 @@ class SelectedTaskExecutionActionTest extends Specification {
 
         given:
         _ * startParameter.continueOnFailure >> true
+        _ * taskGraph.allTasks >> []
 
         when:
         action.execute(context, failures)
@@ -60,14 +60,5 @@ class SelectedTaskExecutionActionTest extends Specification {
         then:
         1 * taskGraph.setContinueOnFailure(true)
         1 * taskGraph.execute(failures)
-    }
-
-    def brokenTask(Throwable failure) {
-        Task task = Mock()
-        TaskState state = Mock()
-        _ * task.state >> state
-        _ * state.failure >> failure
-        _ * state.rethrowFailure() >> { throw failure }
-        return task
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -104,6 +104,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         given:
         taskGraph.addEntryTasks([a])
+        taskGraph.populate()
 
         when:
         taskGraph.execute(failures)
@@ -121,6 +122,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([a, b])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -138,6 +140,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([a, b])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -151,6 +154,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -165,6 +169,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([d])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -180,6 +185,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([d])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -194,6 +200,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([b, c, a])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -210,6 +217,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         taskGraph.addEntryTasks([c, b])
         taskGraph.addEntryTasks([d, a])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -227,6 +235,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         taskGraph.addEntryTasks([c])
         taskGraph.addEntryTasks([e])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -297,6 +306,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([b])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -312,6 +322,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([b])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -342,6 +353,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([c])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -357,6 +369,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         taskGraph.addTaskExecutionGraphListener(listener)
         taskGraph.addEntryTasks([a])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -383,6 +396,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         taskGraph.whenReady(closure)
         taskGraph.whenReady(action)
         taskGraph.addEntryTasks([a])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -413,6 +427,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         final Task b = task("b")
 
         taskGraph.addEntryTasks([a, b])
+        taskGraph.populate()
 
         when:
         taskGraph.execute(failures)
@@ -429,6 +444,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
         when:
         taskGraph.addEntryTasks([a, b])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:
@@ -492,6 +508,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         taskGraph.useFilter(spec)
         taskGraph.addEntryTasks([a, b])
+        taskGraph.populate()
 
         then:
         taskGraph.allTasks == [b]
@@ -517,6 +534,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         taskGraph.useFilter(spec)
         taskGraph.addEntryTasks([c])
+        taskGraph.populate()
 
         then:
         taskGraph.allTasks == [b, c]
@@ -543,6 +561,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
             }
         })
         taskGraph.addEntryTasks([a, c])
+        taskGraph.populate()
         taskGraph.execute(failures)
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1476,6 +1476,7 @@ Found the following transforms:
         outputContains("files: [test-api-1.3.jar.txt, test-impl2-1.3.jar.txt, test-2-0.1.jar.txt]")
     }
 
+    @ToBeFixedForInstantExecution
     def "user gets a reasonable error message when file dependency cannot be listed and continues with other inputs"() {
         given:
         buildFile << """
@@ -1595,24 +1596,26 @@ Found the following transforms:
 
             abstract class FailingTransform implements TransformAction<TransformParameters.None> {
                 void transform(TransformOutputs outputs) {
-                    ${switch (type) {
-                        case FileType.Missing:
-                            return """
+                    ${
+            switch (type) {
+                case FileType.Missing:
+                    return """
                                 outputs.${method}('this_file_does_not.exist').delete()
 
                             """
-                        case FileType.Directory:
-                            return """
+                case FileType.Directory:
+                    return """
                                 def output = outputs.${method}('directory')
                                 output.mkdirs()
                             """
-                        case FileType.RegularFile:
-                            return """
+                case FileType.RegularFile:
+                    return """
                                 def output = outputs.${method}('file')
                                 output.delete()
                                 output.text = 'some text'
                             """
-                    }}
+            }
+        }
                 }
             }
             ${declareTransformAction('FailingTransform')}
@@ -2049,8 +2052,8 @@ Found the following transforms:
 
     def "artifacts with same component id and extension, but different classifier remain distinguishable after transformation"() {
         def module = mavenRepo.module("test", "test", "1.3").publish()
-        module.getArtifactFile(classifier:"foo").text = "1234"
-        module.getArtifactFile(classifier:"bar").text = "5678"
+        module.getArtifactFile(classifier: "foo").text = "1234"
+        module.getArtifactFile(classifier: "bar").text = "5678"
 
         given:
         buildFile << """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -1044,4 +1044,31 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("thisTask = true")
         outputContains("bean.owner = true")
     }
+
+    def "captures changes applied in task graph whenReady listener"() {
+        buildFile << """
+            class SomeTask extends DefaultTask {
+                @Internal
+                String value
+
+                @TaskAction
+                void run() {
+                    println "value = " + value
+                }
+            }
+
+            task ok(type: SomeTask)
+
+            gradle.taskGraph.whenReady {
+                ok.value = 'value'
+            }
+        """
+
+        when:
+        instantRun "ok"
+        instantRun "ok"
+
+        then:
+        outputContains("value = value")
+    }
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
@@ -141,6 +141,10 @@ public class ListenerBroadcast<T> implements Dispatch<MethodInvocation> {
         broadcast.dispatch(event);
     }
 
+    public void visitListeners(Action<T> visitor) {
+        broadcast.visitListeners(visitor);
+    }
+
     /**
      * Returns a new {@link ListenerBroadcast} with the same {@link BroadcastDispatch} as this class.
      */

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -104,23 +104,23 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         then:
         DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
         result.assertTestClassesExecuted(
-                'org.gradle.ClassWithBrokenRunner',
-                'org.gradle.CustomException',
-                'org.gradle.BrokenTest',
-                'org.gradle.BrokenBefore',
-                'org.gradle.BrokenAfter',
-                'org.gradle.BrokenBeforeClass',
-                'org.gradle.BrokenAfterClass',
-                'org.gradle.BrokenBeforeAndAfter',
-                'org.gradle.BrokenConstructor',
-                'org.gradle.BrokenException',
-                'org.gradle.Unloadable',
-                'org.gradle.UnserializableException')
+            'org.gradle.ClassWithBrokenRunner',
+            'org.gradle.CustomException',
+            'org.gradle.BrokenTest',
+            'org.gradle.BrokenBefore',
+            'org.gradle.BrokenAfter',
+            'org.gradle.BrokenBeforeClass',
+            'org.gradle.BrokenAfterClass',
+            'org.gradle.BrokenBeforeAndAfter',
+            'org.gradle.BrokenConstructor',
+            'org.gradle.BrokenException',
+            'org.gradle.Unloadable',
+            'org.gradle.UnserializableException')
         result.testClass('org.gradle.ClassWithBrokenRunner').assertTestFailed('initializationError', equalTo('java.lang.UnsupportedOperationException: broken'))
         result.testClass('org.gradle.BrokenTest')
-                .assertTestCount(2, 2, 0)
-                .assertTestFailed('failure', equalTo('java.lang.AssertionError: failed'))
-                .assertTestFailed('broken', equalTo('java.lang.IllegalStateException: html: <> cdata: ]]>'))
+            .assertTestCount(2, 2, 0)
+            .assertTestFailed('failure', equalTo('java.lang.AssertionError: failed'))
+            .assertTestFailed('broken', equalTo('java.lang.IllegalStateException: html: <> cdata: ]]>'))
         result.testClass('org.gradle.BrokenBeforeClass').assertTestFailed('classMethod', equalTo('java.lang.AssertionError: failed'))
         result.testClass('org.gradle.BrokenAfterClass').assertTestFailed('classMethod', equalTo('java.lang.AssertionError: failed'))
         result.testClass('org.gradle.BrokenBefore').assertTestFailed('ok', equalTo('java.lang.AssertionError: failed'))
@@ -252,26 +252,26 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     def runsAllTestsInTheSameForkedJvm() {
         given:
         testDirectory.file('build.gradle').writelns(
-                "apply plugin: 'java'",
-                mavenCentralRepository(),
-                "dependencies { implementation 'junit:junit:4.12' }"
+            "apply plugin: 'java'",
+            mavenCentralRepository(),
+            "dependencies { implementation 'junit:junit:4.12' }"
         )
         testDirectory.file('src/test/java/org/gradle/AbstractTest.java').writelns(
-                "package org.gradle;",
-                "public abstract class AbstractTest {",
-                "    @org.junit.Test public void ok() {",
-                "        long time = java.lang.management.ManagementFactory.getRuntimeMXBean().getStartTime();",
-                "        System.out.println(String.format(\"VM START TIME = %s\", time));",
-                "    }",
-                "}")
+            "package org.gradle;",
+            "public abstract class AbstractTest {",
+            "    @org.junit.Test public void ok() {",
+            "        long time = java.lang.management.ManagementFactory.getRuntimeMXBean().getStartTime();",
+            "        System.out.println(String.format(\"VM START TIME = %s\", time));",
+            "    }",
+            "}")
         testDirectory.file('src/test/java/org/gradle/SomeTest.java').writelns(
-                "package org.gradle;",
-                "public class SomeTest extends AbstractTest {",
-                "}")
+            "package org.gradle;",
+            "public class SomeTest extends AbstractTest {",
+            "}")
         testDirectory.file('src/test/java/org/gradle/SomeTest2.java').writelns(
-                "package org.gradle;",
-                "public class SomeTest2 extends AbstractTest {",
-                "}")
+            "package org.gradle;",
+            "public class SomeTest2 extends AbstractTest {",
+            "}")
 
         when:
         executer.withTasks('test').run()
@@ -287,27 +287,27 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     def canSpecifyMaximumNumberOfTestClassesToExecuteInAForkedJvm() {
         given:
         testDirectory.file('build.gradle').writelns(
-                "apply plugin: 'java'",
-                mavenCentralRepository(),
-                "dependencies { implementation 'junit:junit:4.12' }",
-                "test.forkEvery = 1"
+            "apply plugin: 'java'",
+            mavenCentralRepository(),
+            "dependencies { implementation 'junit:junit:4.12' }",
+            "test.forkEvery = 1"
         )
         testDirectory.file('src/test/java/org/gradle/AbstractTest.java').writelns(
-                "package org.gradle;",
-                "public abstract class AbstractTest {",
-                "    @org.junit.Test public void ok() {",
-                "        long time = java.lang.management.ManagementFactory.getRuntimeMXBean().getStartTime();",
-                "        System.out.println(String.format(\"VM START TIME = %s\", time));",
-                "    }",
-                "}")
+            "package org.gradle;",
+            "public abstract class AbstractTest {",
+            "    @org.junit.Test public void ok() {",
+            "        long time = java.lang.management.ManagementFactory.getRuntimeMXBean().getStartTime();",
+            "        System.out.println(String.format(\"VM START TIME = %s\", time));",
+            "    }",
+            "}")
         testDirectory.file('src/test/java/org/gradle/SomeTest.java').writelns(
-                "package org.gradle;",
-                "public class SomeTest extends AbstractTest {",
-                "}")
+            "package org.gradle;",
+            "public class SomeTest extends AbstractTest {",
+            "}")
         testDirectory.file('src/test/java/org/gradle/SomeTest2.java').writelns(
-                "package org.gradle;",
-                "public class SomeTest2 extends AbstractTest {",
-                "}")
+            "package org.gradle;",
+            "public class SomeTest2 extends AbstractTest {",
+            "}")
 
         when:
         executer.withTasks('test').run()
@@ -318,26 +318,26 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         results1.assertIsFile()
         results2.assertIsFile()
         assertThat(results1.linesThat(containsString('VM START TIME =')).get(0), not(equalTo(results2.linesThat(
-                containsString('VM START TIME =')).get(0))))
+            containsString('VM START TIME =')).get(0))))
     }
 
     def canListenForTestResults() {
         given:
         testDirectory.file('src/main/java/AppException.java').writelns(
-                "public class AppException extends Exception { }"
+            "public class AppException extends Exception { }"
         )
 
         testDirectory.file('src/test/java/SomeTest.java').writelns(
-                "public class SomeTest {",
-                "@org.junit.Test public void fail() { org.junit.Assert.fail(\"message\"); }",
-                "@org.junit.Test public void knownError() { throw new RuntimeException(\"message\"); }",
-                "@org.junit.Test public void unknownError() throws AppException { throw new AppException(); }",
-                "}"
+            "public class SomeTest {",
+            "@org.junit.Test public void fail() { org.junit.Assert.fail(\"message\"); }",
+            "@org.junit.Test public void knownError() { throw new RuntimeException(\"message\"); }",
+            "@org.junit.Test public void unknownError() throws AppException { throw new AppException(); }",
+            "}"
         )
         testDirectory.file('src/test/java/SomeOtherTest.java').writelns(
-                "public class SomeOtherTest {",
-                "@org.junit.Test public void pass() { }",
-                "}"
+            "public class SomeOtherTest {",
+            "@org.junit.Test public void pass() { }",
+            "}"
         )
 
         testDirectory.file('build.gradle') << """
@@ -356,39 +356,47 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         """
 
         when:
-        ExecutionResult result = executer.withTasks("test").run()
+        def result = executer.withTasks("test").run()
 
         then:
-        assert containsLine(result.getOutput(), "START [Gradle Test Run :test] [Gradle Test Run :test]")
-        assert containsLine(result.getOutput(), "FINISH [Gradle Test Run :test] [Gradle Test Run :test] [FAILURE] [4]")
+        containsLine(result.getOutput(), "START [Gradle Test Run :test] [Gradle Test Run :test]")
+        containsLine(result.getOutput(), "FINISH [Gradle Test Run :test] [Gradle Test Run :test] [FAILURE] [4]")
 
-        assert containsLine(result.getOutput(), matchesRegexp("START \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\]"))
-        assert containsLine(result.getOutput(), matchesRegexp("FINISH \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\] \\[FAILURE\\] \\[4\\]"))
+        containsLine(result.getOutput(), matchesRegexp("START \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\]"))
+        containsLine(result.getOutput(), matchesRegexp("FINISH \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\] \\[FAILURE\\] \\[4\\]"))
 
-        assert containsLine(result.getOutput(), "START [Test class SomeOtherTest] [SomeOtherTest]")
-        assert containsLine(result.getOutput(), "FINISH [Test class SomeOtherTest] [SomeOtherTest] [SUCCESS] [1]")
-        assert containsLine(result.getOutput(), "START [Test pass(SomeOtherTest)] [pass]")
-        assert containsLine(result.getOutput(), "FINISH [Test pass(SomeOtherTest)] [pass] [SUCCESS] [1] [null]")
+        containsLine(result.getOutput(), "START [Test class SomeOtherTest] [SomeOtherTest]")
+        containsLine(result.getOutput(), "FINISH [Test class SomeOtherTest] [SomeOtherTest] [SUCCESS] [1]")
+        containsLine(result.getOutput(), "START [Test pass(SomeOtherTest)] [pass]")
+        containsLine(result.getOutput(), "FINISH [Test pass(SomeOtherTest)] [pass] [SUCCESS] [1] [null]")
 
-        assert containsLine(result.getOutput(), "START [Test class SomeTest] [SomeTest]")
-        assert containsLine(result.getOutput(), "FINISH [Test class SomeTest] [SomeTest] [FAILURE] [3]")
-        assert containsLine(result.getOutput(), "START [Test fail(SomeTest)] [fail]")
-        assert containsLine(result.getOutput(), "FINISH [Test fail(SomeTest)] [fail] [FAILURE] [1] [java.lang.AssertionError: message]")
-        assert containsLine(result.getOutput(), "START [Test knownError(SomeTest)] [knownError]")
-        assert containsLine(result.getOutput(), "FINISH [Test knownError(SomeTest)] [knownError] [FAILURE] [1] [java.lang.RuntimeException: message]")
-        assert containsLine(result.getOutput(), "START [Test unknownError(SomeTest)] [unknownError]")
-        assert containsLine(result.getOutput(), "FINISH [Test unknownError(SomeTest)] [unknownError] [FAILURE] [1] [AppException]")
+        containsLine(result.getOutput(), "START [Test class SomeTest] [SomeTest]")
+        containsLine(result.getOutput(), "FINISH [Test class SomeTest] [SomeTest] [FAILURE] [3]")
+        containsLine(result.getOutput(), "START [Test fail(SomeTest)] [fail]")
+        containsLine(result.getOutput(), "FINISH [Test fail(SomeTest)] [fail] [FAILURE] [1] [java.lang.AssertionError: message]")
+        containsLine(result.getOutput(), "START [Test knownError(SomeTest)] [knownError]")
+        containsLine(result.getOutput(), "FINISH [Test knownError(SomeTest)] [knownError] [FAILURE] [1] [java.lang.RuntimeException: message]")
+        containsLine(result.getOutput(), "START [Test unknownError(SomeTest)] [unknownError]")
+        containsLine(result.getOutput(), "FINISH [Test unknownError(SomeTest)] [unknownError] [FAILURE] [1] [AppException]")
+
+        when:
+        testDirectory.file('src/test/java/SomeOtherTest.java').delete()
+        result = executer.withTasks("test").run()
+
+        then:
+        result.assertNotOutput("SomeOtherTest")
+        containsLine(result.getOutput(), "START [Test class SomeTest] [SomeTest]")
     }
 
     def canListenForTestResultsWhenJUnit3IsUsed() {
         given:
         ignoreWhenJupiter()
         testDirectory.file('src/test/java/SomeTest.java').writelns(
-                "public class SomeTest extends junit.framework.TestCase {",
-                "public void testPass() { }",
-                "public void testFail() { junit.framework.Assert.fail(\"message\"); }",
-                "public void testError() { throw new RuntimeException(\"message\"); }",
-                "}"
+            "public class SomeTest extends junit.framework.TestCase {",
+            "public void testPass() { }",
+            "public void testFail() { junit.framework.Assert.fail(\"message\"); }",
+            "public void testError() { throw new RuntimeException(\"message\"); }",
+            "}"
         )
 
         testDirectory.file('build.gradle') << """

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -148,7 +148,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     private final ModularitySpec modularity;
 
     private FileCollection testClassesDirs;
-    private PatternFilterable patternSet;
+    private final PatternFilterable patternSet;
     private FileCollection classpath;
     private TestFramework testFramework;
     private boolean scanForTestClasses = true;

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -115,10 +115,10 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
         graphNotifyOps.size() == 2
         graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners'
         graphNotifyOps[0].details.buildPath == ':'
-        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[0].parentId == taskGraphOps[0].id
         graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:${buildName})"
         graphNotifyOps[1].details.buildPath == ":${buildName}"
-        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[1].parentId == taskGraphOps[1].id
 
         where:
         settings                     | buildName | dependencyName | display


### PR DESCRIPTION

### Context

Serialize listeners added directly to `Test` task instances to the instant execution cache. Also serialize the task graph after task graph `whenReady` has completed, so that changes made by listeners are captured.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
