### PR TITLE
Let Java Modules run as Jar so that resources are accessible 

### DIFF
--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/groovy/build.gradle
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/groovy/build.gradle
@@ -26,16 +26,21 @@ subprojects {
             integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
         }
 
-        def integrationTest = tasks.register('integrationTest', Test) {
+        def integrationTestJarTask = tasks.register(sourceSets.integrationTest.jarTaskName, Jar) {
+            archiveClassifier = 'integration-tests'
+            from sourceSets.integrationTest.output
+        }
+        def integrationTestTask = tasks.register('integrationTest', Test) {
             description = 'Runs integration tests.'
             group = 'verification'
 
             testClassesDirs = sourceSets.integrationTest.output.classesDirs
-            classpath = sourceSets.integrationTest.runtimeClasspath
+            // Make sure we run the 'Jar' containing the tests (and not just the 'classes' folder) so that test resources are also part of the test module
+            classpath = configurations[sourceSets.integrationTest.runtimeClasspathConfigurationName] + files(integrationTestJarTask)
             shouldRunAfter('test')
         }
 
-        tasks.named('check') { dependsOn(integrationTest) }
+        tasks.named('check') { dependsOn(integrationTestTask) }
     }
 
     tasks.withType(Test).configureEach {

--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/build.gradle.kts
@@ -22,12 +22,17 @@ subprojects {
             "integrationTestRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine")
         }
 
+        val integrationTestJarTask = tasks.register<Jar>(integrationTest.jarTaskName) {
+            archiveClassifier.set("integration-tests")
+            from(integrationTest.output)
+        }
         val integrationTestTask = tasks.register<Test>("integrationTest") {
             description = "Runs integration tests."
             group = "verification"
 
             testClassesDirs = integrationTest.output.classesDirs
-            classpath = integrationTest.runtimeClasspath
+            // Make sure we run the 'Jar' containing the tests (and not just the 'classes' folder) so that test resources are also part of the test module
+            classpath = configurations[integrationTest.runtimeClasspathConfigurationName] + files(integrationTestJarTask)
             shouldRunAfter("test")
         }
 

--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/tests/checkTask.out
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/tests/checkTask.out
@@ -17,6 +17,7 @@
 > Task :application:compileIntegrationTestJava
 > Task :application:processIntegrationTestResources NO-SOURCE
 > Task :application:integrationTestClasses
+> Task :application:integrationTestJar
 > Task :application:integrationTest
 > Task :application:check
 > Task :list:compileTestJava
@@ -26,6 +27,7 @@
 > Task :list:compileIntegrationTestJava NO-SOURCE
 > Task :list:processIntegrationTestResources NO-SOURCE
 > Task :list:integrationTestClasses UP-TO-DATE
+> Task :list:integrationTestJar
 > Task :list:integrationTest NO-SOURCE
 > Task :list:check
 > Task :utilities:compileTestJava NO-SOURCE
@@ -35,8 +37,9 @@
 > Task :utilities:compileIntegrationTestJava
 > Task :utilities:processIntegrationTestResources NO-SOURCE
 > Task :utilities:integrationTestClasses
+> Task :utilities:integrationTestJar
 > Task :utilities:integrationTest
 > Task :utilities:check
 
 BUILD SUCCESSFUL in 0s
-14 actionable tasks: 14 executed
+17 actionable tasks: 17 executed

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/AbstractJavaModuleIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/AbstractJavaModuleIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.java.compile.jpms
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -58,8 +59,9 @@ abstract class AbstractJavaModuleIntegrationTest extends AbstractIntegrationSpec
         mavenRepo.module('org', name, '1.0').mainArtifact(content: autoModuleJar(name)).publish()
     }
 
-    protected consumingModuleClass(String... dependencies) {
-        file('src/main/java/consumer/MainModule.java').text = """
+    protected TestFile consumingModuleClass(String... dependencies) {
+        def file = file('src/main/java/consumer/MainModule.java')
+        file.text = """
             package consumer;
 
             public class MainModule {
@@ -71,13 +73,14 @@ abstract class AbstractJavaModuleIntegrationTest extends AbstractIntegrationSpec
                     return "protected name";
                 }
 
-                public static void main(String[] args) {
+                public static void main(String[] args) throws Exception {
                     new MainModule().run();
                     System.out.println("Module Name: " + MainModule.class.getModule().getName());
                     System.out.println("Module Version: " + MainModule.class.getModule().getDescriptor().version().get());
                 }
             }
         """
+        file
     }
 
     protected consumingModuleInfo(String... statements) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -72,6 +72,49 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
         outputContains("Module Version: 1.0-beta2")
     }
 
+    // This test demonstrated the current behavior for how a module compilation of sources in one 'source directory set' and be patched with the result of another.
+    // If we add higher level modeling concepts for the relationship between the compile steps on one source set, the '--patch-module' arguments could maybe be derived automatically.
+    def "runs a module accessing classes from separate compilation step using the module path with the application plugin"() {
+        given:
+        buildFile.text = buildFile.text.replace('java-library', 'application')
+        buildFile << """
+            apply plugin: 'groovy'
+            application {
+                mainClass.set('consumer.MainModule')
+                mainModule.set('consumer')
+            }
+            dependencies {
+                implementation localGroovy()
+            }
+            // compile Groovy first
+            compileGroovy {
+                classpath = sourceSets.main.compileClasspath
+            }
+            // We need to patch the previously compiled classes (by the Groovy compile) into the module
+            def patchArgs = ['--patch-module', "consumer=\${compileGroovy.destinationDirectory.getAsFile().get().path}"]
+            compileJava {
+                options.compilerArgs = patchArgs
+                classpath += files(sourceSets.main.groovy.classesDirectory)
+            }
+        """
+        publishJavaModule('moda')
+        consumingModuleInfo('requires moda')
+        file('src/main/groovy/consumer/GroovyInterface.groovy') << """
+            package consumer;
+
+            interface GroovyInterface { }
+        """
+        def mainClass = consumingModuleClass('moda.ModaClass')
+        mainClass.text = mainClass.text.replace('MainModule {', 'MainModule implements GroovyInterface {')
+
+        when:
+        succeeds ':run'
+
+        then:
+        outputContains("Module Name: consumer")
+        outputContains("Module Version: 1.0-beta2")
+    }
+
     def "runs a module using the module path with main class defined in compile task"() {
         given:
         buildFile << """

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/test/AbstractJavaModuleTestingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/test/AbstractJavaModuleTestingIntegrationTest.groovy
@@ -35,7 +35,7 @@ class AbstractJavaModuleTestingIntegrationTest extends AbstractJavaModuleIntegra
             public class MainModuleTest {
 
                 @Test
-                public void testMain() {
+                public void testMain() throws Exception {
                     $statement;
                 }
             }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -650,4 +650,25 @@ rootProject.name = 'sample'
         file('build/install/sample/').allDescendants() == ["not-the-root/bin/sample", "not-the-root/bin/sample.bat", "not-the-root/lib/sample.jar"] as Set
         assert file("build/install/sample/not-the-root/bin/sample").permissions == "rwxr-xr-x"
     }
+
+    @ToBeFixedForInstantExecution
+    def "runs the classes folder for traditional applications"() {
+        when:
+        succeeds("run")
+
+        then:
+        executed(':compileJava', ':processResources', ':classes', ':run')
+    }
+
+    @ToBeFixedForInstantExecution
+    def "runs the jar for modular applications"() {
+        given:
+        configureMainModule()
+
+        when:
+        succeeds("run")
+
+        then:
+        executed(':compileJava', ':processResources', ':classes', ':jar', ':run')
+    }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -660,6 +660,7 @@ rootProject.name = 'sample'
         executed(':compileJava', ':processResources', ':classes', ':run')
     }
 
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     @ToBeFixedForInstantExecution
     def "runs the jar for modular applications"() {
         given:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.distribution.Distribution;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.plugins.DistributionPlugin;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.internal.DefaultApplicationPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.tasks.JavaExec;
@@ -135,8 +136,14 @@ public class ApplicationPlugin implements Plugin<Project> {
             run.setDescription("Runs this project as a JVM application");
             run.setGroup(APPLICATION_GROUP);
 
-            JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-            run.setClasspath(javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath());
+            FileCollection runtimeClasspath = project.files().from((Callable<FileCollection>) () -> {
+                if (run.getMainModule().isPresent()) {
+                    return jarsOnlyRuntimeClasspath(project);
+                } else  {
+                    return runtimeClasspath(project);
+                }
+            });
+            run.setClasspath(runtimeClasspath);
             run.getMainModule().set(pluginExtension.getMainModule());
             run.getMainClass().set(pluginExtension.getMainClass());
             run.getConventionMapping().map("jvmArgs", pluginConvention::getApplicationDefaultJvmArgs);
@@ -150,7 +157,7 @@ public class ApplicationPlugin implements Plugin<Project> {
     private void addCreateScriptsTask(Project project, JavaApplication pluginExtension, ApplicationPluginConvention pluginConvention) {
         project.getTasks().register(TASK_START_SCRIPTS_NAME, CreateStartScripts.class, startScripts -> {
             startScripts.setDescription("Creates OS specific scripts to run the project as a JVM application.");
-            startScripts.setClasspath(project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles().plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
+            startScripts.setClasspath(jarsOnlyRuntimeClasspath(project));
 
             startScripts.getMainModule().set(pluginExtension.getMainModule());
             startScripts.getMainClass().set(pluginExtension.getMainClass());
@@ -166,6 +173,14 @@ public class ApplicationPlugin implements Plugin<Project> {
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             startScripts.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
+    }
+
+    private FileCollection runtimeClasspath(Project project) {
+        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+    }
+
+    private FileCollection jarsOnlyRuntimeClasspath(Project project) {
+        return project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles().plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
     }
 
     private CopySpec configureDistribution(Project project, Distribution mainDistribution, ApplicationPluginConvention pluginConvention) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
@@ -54,7 +54,7 @@ class ApplicationPluginTest extends AbstractProjectBuilderSpec {
         then:
         def task = project.tasks[ApplicationPlugin.TASK_RUN_NAME]
         task instanceof JavaExec
-        task.classpath.from as List == [project.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].runtimeClasspath]
+        task.classpath.from.files == [project.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].runtimeClasspath.files]
         task TaskDependencyMatchers.dependsOn('classes')
     }
 


### PR DESCRIPTION
This fixes the issue described here when using the `:run` task to run a Java Module:
https://github.com/gradle/gradle/issues/890#issuecomment-611222793

We also update the blackbox integration test samples to to run test modules as Jars.