### PR TITLE
Clean VFS when starting watching

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/WatchingVirtualFileSystem.java
@@ -200,6 +200,7 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
                     }
                 }
             });
+            getRoot().update(SnapshotHierarchy::empty);
             delegatingUpdateFunctionDecorator.setSnapshotDiffListener(snapshotDiffListener);
             long endTime = System.currentTimeMillis() - startTime;
             LOGGER.warn("Spent {} ms registering watches for file system events", endTime);


### PR DESCRIPTION
Fixes #12762 for now by emptying the VFS when we start watching in the `afterStart` hook.

We actually need to start watching before anything is added to the VFS. So let's find out separately what ends up there and then maybe use a different hook to start watching early enough.