### PR TITLE
Revert changes to buildId for publications

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -456,22 +456,6 @@ Gradle 6.4 takes a first step in improving those error messages by making them m
                                 hfi1vdp51SUqS9SXyd8U8JJAV1h4ThiOvrAQ6e2isLCgoLCwoKCgoKCgoGAYGM7ppODN4jfM+Aok
                                 sRq1uwAAAABJRU5ErkJggg==">
 
-### Gradle module metadata can be made reproducible
-
-The Gradle Module Metadata file contains a build identifier field which defaults to a unique ID generated during build execution.
-This results in the generated file being different at each build execution.
-
-This value can now be configured to something else at the publication level, allowing users to opt-in for a reproducible Gradle Module Metadata file.
-
-```groovy
-main(MavenPublication) {
-    from components.java
-    buildIdentifier = 'unused'
-}
-```
-
-See the documentation for more information on [Gradle Module Metadata generation](userguide/publishing_gradle_module_metadata.html#sub:gmm-reproducible).
-
 <a name="precompiled-groovy-dsl"></a>
 ## Precompiled Groovy DSL script plugins
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
@@ -123,28 +123,6 @@ The following rules are enforced:
 
 These rules ensure the quality of the metadata produced, and help confirm that consumption will not be problematic.
 
-[[sub:gmm-reproducible]]
-== Making Gradle Module Metadata reproducible
-
-By default, the Gradle Module Metadata file contains a unique id from the build that generated it.
-This means that the file will always be different.
-
-Users can choose to replace this unique id by something else through the configuration of the `buildIdentifier` in their `publication`:
-
-.Configure the build identifier of a publication
-====
-include::sample[dir="snippets/userguide/publishing/javaLibrary/groovy",files="build.gradle[tags=configure-build-id]"]
-include::sample[dir="snippets/userguide/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=configure-build-id]"]
-====
-
-With the changes above, the generated Gradle Module Metadata file will always be the same, allowing downstream tasks to consider it up-to-date.
-
-[NOTE]
-====
-The task generating the module metadata files is currently never marked `UP-TO-DATE` by Gradle due to the way it is implemented.
-However, if the build identifier is configured to not depend on the build invocation anymore, and no build inputs nor build scripts changed, the task is effectively up-to-date (it always produces the same output).
-====
-
 [[sub:disabling-gmm-publication]]
 == Disabling Gradle Module Metadata publication
 

--- a/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/groovy/build.gradle
@@ -41,14 +41,3 @@ tasks.withType(GenerateMavenPom).all {
     destination = "$buildDir/poms/${publicationName}-pom.xml"
 }
 // end::configure-generate-task[]
-
-// tag::configure-build-id[]
-publishing {
-    publications {
-        main(MavenPublication) {
-            from components.java
-            buildIdentifier = 'unused'
-        }
-    }
-}
-// end::configure-build-id[]

--- a/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/publishing/javaLibrary/kotlin/build.gradle.kts
@@ -41,14 +41,3 @@ tasks.withType<GenerateMavenPom>().configureEach {
     destination = file("$buildDir/poms/$publicationName-pom.xml")
 }
 // end::configure-generate-task[]
-
-// tag::configure-build-id[]
-publishing {
-    publications {
-        create<MavenPublication>("main") {
-            from(components["java"])
-            buildIdentifier.set("unused")
-        }
-    }
-}
-// end::configure-build-id[]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -43,15 +43,6 @@ class GradleModuleMetadata {
     }
 
     @Nullable
-    CreatedBy getCreatedBy() {
-        def createdBy = values.createdBy
-        if (createdBy == null) {
-            return null
-        }
-        return new CreatedBy(createdBy.gradle.version, createdBy.gradle.buildId)
-    }
-
-    @Nullable
     Coords getComponent() {
         def comp = values.component
         if (comp == null || comp.url) {
@@ -440,17 +431,6 @@ class GradleModuleMetadata {
                 assert actualAttributes == expectedAttributes
                 this
             }
-        }
-    }
-
-    @EqualsAndHashCode
-    static class CreatedBy {
-        final String gradleVersion
-        final String buildId
-
-        CreatedBy(String gradleVersion, String buildId) {
-            this.gradleVersion = gradleVersion
-            this.buildId = buildId
         }
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -932,43 +932,4 @@ class TestCapability implements Capability {
         false   | false
         true    | true
     }
-
-    @ToBeFixedForInstantExecution
-    def 'can configure the build identifier'() {
-        given:
-        settingsFile << "rootProject.name = 'root'"
-        buildFile << """
-            apply plugin: 'ivy-publish'
-
-            group = 'group'
-            version = '1.0'
-
-            def comp = new TestComponent()
-            comp.usages.add(new TestUsage(
-                    name: 'api',
-                    usage: objects.named(Usage, 'api'),
-                    dependencies: configurations.implementation.allDependencies,
-                    attributes: testAttributes))
-
-            publishing {
-                repositories {
-                    ivy { url "${ivyRepo.uri}" }
-                }
-                publications {
-                    ivy(IvyPublication) {
-                        from comp
-                        buildIdentifier = 'magic'
-                    }
-                }
-            }
-        """
-
-        when:
-        succeeds 'publish'
-
-        then:
-        def module = ivyRepo.module('group', 'root', '1.0')
-        module.assertPublished()
-        module.parsedModuleMetadata.createdBy.buildId == 'magic'
-    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -49,7 +49,6 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
@@ -126,7 +125,6 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final Set<String> silencedVariants = new HashSet<>();
-    private final Property<String> buildIdentifier;
     private IvyArtifact ivyDescriptorArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
     private SingleOutputTaskIvyArtifact gradleModuleDescriptorArtifact;
@@ -157,17 +155,11 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         this.publishableArtifacts = new CompositePublicationArtifactSet<>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         this.ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
         this.descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
-        this.buildIdentifier = objectFactory.property(String.class);
     }
 
     @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public Property<String> getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -888,41 +888,4 @@ class TestCapability implements Capability {
         variant.dependencyConstraints[0].strictly == '1.1'
         variant.dependencyConstraints[0].rejectsVersion == []
     }
-
-    @ToBeFixedForInstantExecution
-    def 'can configure the build identifier'() {
-        settingsFile << "rootProject.name = 'root'"
-        buildFile << """
-            apply plugin: 'maven-publish'
-
-            group = 'group'
-            version = '1.0'
-
-            def comp = new TestComponent()
-            comp.usages.add(new TestUsage(
-                    name: 'api',
-                    usage: objects.named(Usage, 'api'),
-                    attributes: testAttributes))
-
-            publishing {
-                repositories {
-                    maven { url "${mavenRepo.uri}" }
-                }
-                publications {
-                    maven(MavenPublication) {
-                        from comp
-                        buildIdentifier = 'magic'
-                    }
-                }
-            }
-        """
-
-        when:
-        succeeds 'publish'
-
-        then:
-        def module = mavenRepo.module('group', 'root', '1.0')
-        module.assertPublished()
-        module.parsedModuleMetadata.createdBy.buildId == 'magic'
-    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -56,7 +56,6 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
@@ -153,7 +152,6 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final PlatformSupport platformSupport;
     private final Set<String> silencedVariants = new HashSet<>();
-    private final Property<String> buildIdentifier;
     private MavenArtifact pomArtifact;
     private SingleOutputTaskMavenArtifact moduleMetadataArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
@@ -183,17 +181,11 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         derivedArtifacts = new DefaultPublicationArtifactSet<>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
         publishableArtifacts = new CompositePublicationArtifactSet<>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         pom = instantiator.newInstance(DefaultMavenPom.class, this, instantiator, objectFactory);
-        this.buildIdentifier = objectFactory.property(String.class);
     }
 
     @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public Property<String> getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.publish;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
-import org.gradle.api.provider.Property;
 
 /**
  * A publication is a description of a consumable representation of one or more artifacts, and possibly associated metadata.
@@ -26,15 +24,4 @@ import org.gradle.api.provider.Property;
  * @since 1.3
  */
 public interface Publication extends Named {
-
-    /**
-     * A {@link Property} that allows to configure the build identifier value mapped to the Gradle Module Metadata file.
-     * <p>
-     * If this value is not configured, it will default to the internal build identifier, different for each build invocation.
-     *
-     * @return a {@code String} property
-     * @since 6.4
-     */
-    @Incubating
-    Property<String> getBuildIdentifier();
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -141,7 +141,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(publication.getCoordinates(), publication.getAttributes(), component, componentCoordinates, owners, jsonWriter);
-        writeCreator(publication, jsonWriter);
+        writeCreator(jsonWriter);
         writeVariants(publication, component, componentCoordinates, jsonWriter, checker);
         jsonWriter.endObject();
     }
@@ -259,7 +259,7 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeCreator(PublicationInternal publication, JsonWriter jsonWriter) throws IOException {
+    private void writeCreator(JsonWriter jsonWriter) throws IOException {
         jsonWriter.name("createdBy");
         jsonWriter.beginObject();
         jsonWriter.name("gradle");
@@ -267,7 +267,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.name("version");
         jsonWriter.value(GradleVersion.current().getVersion());
         jsonWriter.name("buildId");
-        jsonWriter.value(publication.getBuildIdentifier().getOrElse(buildInvocationScopeId.getId().asString()));
+        jsonWriter.value(buildInvocationScopeId.getId().asString());
         jsonWriter.endObject();
         jsonWriter.endObject();
     }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.provider.Property
 import org.gradle.api.publish.Publication
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.util.TestUtil
@@ -97,11 +96,6 @@ class DefaultPublicationContainerTest extends Specification {
 
         TestPublication(name) {
             this.name = name
-        }
-
-        @Override
-        Property<String> getBuildIdentifier() {
-            return null;
         }
     }
 }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -36,8 +36,6 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.internal.component.external.model.ImmutableCapability
@@ -72,7 +70,6 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "1.2")
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     def generator = new GradleModuleMetadataWriter(new BuildInvocationScopeId(buildId), projectDependencyResolver, TestUtil.checksumService)
-    def buildIdentifier = new DefaultProperty(Mock(PropertyHost), String)
 
     def "fails to write file for component with no variants"() {
         def writer = new StringWriter()
@@ -1131,7 +1128,6 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         publication.component >> component
         publication.coordinates >> coords
         publication.versionMappingStrategy >> mappingStrategyInternal
-        publication.buildIdentifier >> buildIdentifier
         return publication
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
