### PR TITLE
Ensure that generated Groovy plugin Adapters comply with Gradle checkstyle requirements

### DIFF
--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     integTestRuntimeOnly(project(":toolingApiBuilders"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":testingJunitPlatform"))
+    integTestRuntimeOnly(project(":codeQuality"))
 
     integTestRuntimeOnly(project(":kotlinDsl"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -20,8 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 
-import java.nio.file.Path
-
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String SAMPLE_TASK = "sampleTask"
@@ -81,7 +79,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
     @ToBeFixedForInstantExecution
     def "generated plugin adapter satisfies Gradle checkstyle requirements"() {
         when:
-        def checkstyleConfigDir = Path.of('../../config/checkstyle/').toAbsolutePath()
+        def checkstyleConfigDir = new File('../../config/checkstyle/').toPath().toAbsolutePath()
 
         buildFile << """
             plugins {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -20,6 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 
+import java.nio.file.Files
+import java.nio.file.Path
+
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String SAMPLE_TASK = "sampleTask"
@@ -74,6 +77,32 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("foo script plugin applied")
+    }
+
+    @ToBeFixedForInstantExecution
+    def "generated plugin adapter satisfies Gradle checkstyle requirements"() {
+        when:
+        def checkstyleConfigDir = Path.of('../../config/checkstyle/').toAbsolutePath()
+
+        buildFile << """
+            plugins {
+                id 'groovy-gradle-plugin'
+                id 'checkstyle'
+            }
+            ${mavenCentralRepository()}
+            checkstyle {
+                configDirectory = file('$checkstyleConfigDir')
+            }
+        """
+        file("src/main/groovy/foo.gradle") << """
+            plugins {
+                id 'base'
+            }
+            logger.lifecycle "foo script plugin applied"
+        """
+
+        then:
+        succeeds("checkstyleMain")
     }
 
     def "can apply a precompiled script plugin by id to a multi-project build from root"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 
-import java.nio.file.Files
 import java.nio.file.Path
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugin.devel.plugins
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.TextUtil
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -79,7 +80,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
     @ToBeFixedForInstantExecution
     def "generated plugin adapter satisfies Gradle checkstyle requirements"() {
         when:
-        def checkstyleConfigDir = new File('../../config/checkstyle/').toPath().toAbsolutePath()
+        def checkstyleConfigDir = TextUtil.normaliseFileSeparators(new File('../../config/checkstyle/').toPath().toAbsolutePath().toString())
 
         buildFile << """
             plugins {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
@@ -143,35 +143,48 @@ abstract class GeneratePluginAdaptersTask extends DefaultTask {
         StringBuilder applyPlugins = new StringBuilder();
         if (!pluginRequests.isEmpty()) {
             for (PluginRequest pluginRequest : pluginRequests) {
-                applyPlugins.append("target.getPluginManager().apply(\"").append(pluginRequest.getId().getId()).append("\"); ");
+                applyPlugins.append("        target.getPluginManager().apply(\"").append(pluginRequest.getId().getId()).append("\");\n");
             }
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(outputFile.toURI()))) {
-            writer.write("import " + targetClass + ";\n");
+            writer.write("/*\n" +
+                " * Copyright 2020 the original author or authors.\n" +
+                " *\n" +
+                " * Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                " * you may not use this file except in compliance with the License.\n" +
+                " * You may obtain a copy of the License at\n" +
+                " *\n" +
+                " *      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                " *\n" +
+                " * Unless required by applicable law or agreed to in writing, software\n" +
+                " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                " * See the License for the specific language governing permissions and\n" +
+                " * limitations under the License.\n" +
+                " */\n");
             writer.write("import org.gradle.util.GradleVersion;\n");
             writer.write("import org.gradle.groovy.scripts.BasicScript;\n");
             writer.write("import org.gradle.groovy.scripts.ScriptSource;\n");
             writer.write("import org.gradle.groovy.scripts.TextResourceScriptSource;\n");
             writer.write("import org.gradle.internal.resource.StringTextResource;\n");
-            writer.write("import org.gradle.internal.service.ServiceRegistry;\n");
             writer.write("/**\n");
             writer.write(" * Precompiled " + scriptPlugin.getId() + " script plugin.\n");
             writer.write(" **/\n");
             writer.write("public class " + scriptPlugin.getGeneratedPluginClassName() + " implements org.gradle.api.Plugin<" + targetClass + "> {\n");
-            writer.write("  private static final String MIN_SUPPORTED_GRADLE_VERSION = \"5.0\";\n");
-            writer.write("  public void apply(" + targetClass + " target) {\n");
-            writer.write("      assertSupportedByCurrentGradleVersion();\n");
-            writer.write("      " + applyPlugins + "\n");
-            writer.write("      try {\n");
-            writer.write("          Class<? extends BasicScript> precompiledScriptClass = Class.forName(\"" + scriptPlugin.getClassName() + "\").asSubclass(BasicScript.class);\n");
-            writer.write("          BasicScript script = precompiledScriptClass.getDeclaredConstructor().newInstance();\n");
-            writer.write("          script.setScriptSource(scriptSource(precompiledScriptClass));\n");
-            writer.write("          script.init(target, " + scriptPlugin.serviceRegistryAccessCode() + ");\n");
-            writer.write("          script.run();\n");
-            writer.write("      } catch (Exception e) {\n");
-            writer.write("          throw new RuntimeException(e);\n");
-            writer.write("      }\n");
+            writer.write("    private static final String MIN_SUPPORTED_GRADLE_VERSION = \"5.0\";\n");
+            writer.write("    public void apply(" + targetClass + " target) {\n");
+            writer.write("        assertSupportedByCurrentGradleVersion();\n");
+            writer.write("        " + applyPlugins + "\n");
+            writer.write("        try {\n");
+            writer.write("            Class<? extends BasicScript> precompiledScriptClass = Class.forName(\"" + scriptPlugin.getClassName() + "\").asSubclass(BasicScript.class);\n");
+            writer.write("            BasicScript script = precompiledScriptClass.getDeclaredConstructor().newInstance();\n");
+            writer.write("            script.setScriptSource(scriptSource(precompiledScriptClass));\n");
+            writer.write("            script.init(target, " + scriptPlugin.serviceRegistryAccessCode() + ");\n");
+            writer.write("            script.run();\n");
+            writer.write("        } catch (Exception e) {\n");
+            writer.write("            throw new RuntimeException(e);\n");
+            writer.write("        }\n");
             writer.write("  }\n");
             writer.write("  private static ScriptSource scriptSource(Class<?> scriptClass) {\n");
             writer.write("      return new TextResourceScriptSource(new StringTextResource(scriptClass.getSimpleName(), \"\"));\n");


### PR DESCRIPTION
While trying to dogfood precompiled Groovy plugins in Gradle build - https://github.com/gradle/gradle/pull/12781 - it turned out that the generated plugin adapter classes do not comply with Gradle checkstyle requirements and thus fail checkstyle checks when incorporated in Gradle build.

This change makes the generated adapter classes comply with Gradle checkstyle requirements.