### PR TITLE
Report more dependency management types as unsupported by instant execution

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -41,6 +41,7 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
 import org.gradle.api.attributes.AttributesSchema
@@ -68,6 +69,7 @@ import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
 import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult
+import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -194,5 +196,6 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.resolvedArtifacts.first()"
         DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute()"
         DefaultComponentArtifactsResult       | ComponentResult                | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute().components.first()"
+        DefaultResolvedVariantResult          | ResolvedVariantResult          | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary, SourcesArtifact).execute().components.first().getArtifacts(SourcesArtifact).first().variant"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
@@ -64,6 +65,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationRe
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
+import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -188,5 +190,6 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultDependencyLockingHandler       | DependencyLockingHandler       | "project.dependencyLocking"
         DefaultResolvedDependency             | ResolvedDependency             | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.firstLevelModuleDependencies.first()"
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.resolvedArtifacts.first()"
+        DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute()"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
+import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
@@ -66,6 +67,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultRe
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
+import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -191,5 +193,6 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultResolvedDependency             | ResolvedDependency             | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.firstLevelModuleDependencies.first()"
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.resolvedArtifacts.first()"
         DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute()"
+        DefaultComponentArtifactsResult       | ComponentResult                | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute().components.first()"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
+import org.gradle.api.artifacts.result.ArtifactResult
 import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
@@ -69,6 +70,7 @@ import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
 import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult
+import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
@@ -196,6 +198,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.resolvedArtifacts.first()"
         DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute()"
         DefaultComponentArtifactsResult       | ComponentResult                | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute().components.first()"
+        DefaultResolvedArtifactResult         | ArtifactResult                 | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary, SourcesArtifact).execute().components.first().getArtifacts(SourcesArtifact).first()"
         DefaultResolvedVariantResult          | ResolvedVariantResult          | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary, SourcesArtifact).execute().components.first().getArtifacts(SourcesArtifact).first().variant"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.instantexecution
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
@@ -55,6 +56,7 @@ import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
 import org.gradle.api.internal.artifacts.DefaultResolvedDependency
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.ConfigurationArtifactView
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.LenientResolutionResult
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
@@ -196,6 +198,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
         DefaultDependencyLockingHandler       | DependencyLockingHandler       | "project.dependencyLocking"
         DefaultResolvedDependency             | ResolvedDependency             | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.firstLevelModuleDependencies.first()"
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.12') }.resolvedConfiguration.resolvedArtifacts.first()"
+        ConfigurationArtifactView             | ArtifactView                   | "project.configurations.maybeCreate('some').incoming.artifactView {}"
         DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute()"
         DefaultComponentArtifactsResult       | ComponentResult                | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary).execute().components.first()"
         DefaultResolvedArtifactResult         | ArtifactResult                 | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.12').withArtifacts(JvmLibrary, SourcesArtifact).execute().components.first().getArtifacts(SourcesArtifact).first()"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -66,7 +66,7 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
 }
 
 
-internal
+private
 class ConsumerProvidedVariantSpec(
     val node: TransformationNode,
     val variantDisplayName: DisplayName,
@@ -74,7 +74,7 @@ class ConsumerProvidedVariantSpec(
 )
 
 
-internal
+private
 class CollectingArtifactVisitor : ArtifactVisitor {
     val elements = mutableListOf<Any>()
     val failures = mutableListOf<Throwable>()
@@ -114,7 +114,7 @@ class CollectingArtifactVisitor : ArtifactVisitor {
 }
 
 
-internal
+private
 class FixedArtifactCollection(
     private val artifactFiles: FileCollection,
     private val elements: List<Any>,

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.component.Artifact
@@ -37,6 +38,7 @@ import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.readList
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.internal.DisplayName
+import java.io.File
 import java.util.concurrent.Callable
 
 
@@ -55,7 +57,7 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
         @Suppress("implicit_cast_to_any")
         val files = fileCollectionFactory.resolving(elements.map {
             when (it) {
-                is ResolvedArtifactResult -> it.file
+                is ResolvedArtifactResultSpec -> it.file
                 is ConsumerProvidedVariantSpec -> Callable { it.node.transformedSubject.get().files }
                 else -> throw IllegalArgumentException("Unexpected element $it in artifact collection")
             }
@@ -64,6 +66,15 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
         return FixedArtifactCollection(files, elements, failures)
     }
 }
+
+
+private
+class ResolvedArtifactResultSpec(
+    val id: ComponentArtifactIdentifier,
+    val variantAttributes: AttributeContainer,
+    val variantDisplayName: DisplayName,
+    val file: File
+)
 
 
 private
@@ -95,7 +106,7 @@ class CollectingArtifactVisitor : ArtifactVisitor {
     }
 
     override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, artifact: ResolvableArtifact) {
-        elements.add(DefaultResolvedArtifactResult(artifact.id, variantAttributes, variantName, Artifact::class.java, artifact.file))
+        elements.add(ResolvedArtifactResultSpec(artifact.id, variantAttributes, variantName, artifact.file))
     }
 
     override fun endVisitCollection(source: FileCollectionInternal.Source) {
@@ -132,7 +143,7 @@ class FixedArtifactCollection(
         val result = mutableSetOf<ResolvedArtifactResult>()
         for (element in elements) {
             when (element) {
-                is ResolvedArtifactResult -> result.add(element)
+                is ResolvedArtifactResultSpec -> result.add(DefaultResolvedArtifactResult(element.id, element.variantAttributes, element.variantDisplayName, Artifact::class.java, element.file))
                 is ConsumerProvidedVariantSpec -> {
                     for (output in element.node.transformedSubject.get().files) {
                         val resolvedArtifact: ResolvableArtifact = element.node.inputArtifact.transformedTo(output)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BindingsBackedCodec.kt
@@ -41,23 +41,23 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
             )
 
         private
-        const val NULL_VALUE: Byte = -1
+        const val NULL_VALUE: Int = -1
     }
 
     private
     val encodings = HashMap<Class<*>, TaggedEncoding>()
 
     override suspend fun WriteContext.encode(value: Any?) = when (value) {
-        null -> writeByte(NULL_VALUE)
+        null -> writeSmallInt(NULL_VALUE)
         else -> taggedEncodingFor(value.javaClass).run {
-            writeByte(tag)
+            writeSmallInt(tag)
             encoding.run { encode(value) }
         }
     }
 
-    override suspend fun ReadContext.decode() = when (val tag = readByte()) {
+    override suspend fun ReadContext.decode() = when (val tag = readSmallInt()) {
         NULL_VALUE -> null
-        else -> bindings[tag.toInt()].decoding.run { decode() }
+        else -> bindings[tag].decoding.run { decode() }
     }
 
     private
@@ -77,14 +77,14 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
 
     private
     data class TaggedEncoding(
-        val tag: Byte,
+        val tag: Int,
         val encoding: Encoding
     )
 }
 
 
 data class Binding(
-    val tag: Byte,
+    val tag: Int,
     val encoding: EncodingProducer,
     val decoding: Decoding
 ) {
@@ -140,11 +140,9 @@ class BindingsBuilder {
         bind(codec, codec)
 
     fun bind(encodingProducer: EncodingProducer, decoding: Decoding) {
-        val tag = bindings.size
-        require(tag < Byte.MAX_VALUE)
         bindings.add(
             Binding(
-                tag = tag.toByte(),
+                tag = bindings.size,
                 encoding = encodingProducer,
                 decoding = decoding
             )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -37,6 +37,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
+import org.gradle.api.artifacts.result.ArtifactResult
 import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
@@ -116,5 +117,6 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<ResolvedArtifact>())
     bind(unsupported<ArtifactResolutionResult>())
     bind(unsupported<ComponentResult>())
+    bind(unsupported<ArtifactResult>())
     bind(unsupported<ResolvedVariantResult>())
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -39,6 +39,7 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
 import org.gradle.api.attributes.AttributesSchema
@@ -115,4 +116,5 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<ResolvedArtifact>())
     bind(unsupported<ArtifactResolutionResult>())
     bind(unsupported<ComponentResult>())
+    bind(unsupported<ResolvedVariantResult>())
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -37,6 +37,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.result.ArtifactResolutionResult
+import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
@@ -113,4 +114,5 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<ResolvedDependency>())
     bind(unsupported<ResolvedArtifact>())
     bind(unsupported<ArtifactResolutionResult>())
+    bind(unsupported<ComponentResult>())
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.Project
 import org.gradle.api.Script
+import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraintSet
@@ -115,6 +116,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<DependencyLockingHandler>())
     bind(unsupported<ResolvedDependency>())
     bind(unsupported<ResolvedArtifact>())
+    bind(unsupported<ArtifactView>())
     bind(unsupported<ArtifactResolutionResult>())
     bind(unsupported<ComponentResult>())
     bind(unsupported<ArtifactResult>())

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -36,6 +36,7 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
@@ -111,4 +112,5 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<DependencyLockingHandler>())
     bind(unsupported<ResolvedDependency>())
     bind(unsupported<ResolvedArtifact>())
+    bind(unsupported<ArtifactResolutionResult>())
 }


### PR DESCRIPTION
- `ArtifactView`
- `ArtifactResolutionResult`
- `ComponentResult`
- `ArtifactResult`
- `ResolvedVariantResult`
