### PR TITLE
Make `ProgressLoggingFixture` compatible with instant execution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InstantExecutionRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
+import org.gradle.internal.logging.LoggingOutputInternal
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
 import org.junit.runner.RunWith
@@ -555,6 +556,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
             FileSystemOperations,
             ObjectFactory,
             ProviderFactory,
+            LoggingOutputInternal // for internal use
         ].collect { it.name }
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.services
 
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.logging.LoggingOutput
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
@@ -32,7 +33,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InstantExecutionRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
-import org.gradle.internal.logging.LoggingOutputInternal
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
 import org.junit.runner.RunWith
@@ -556,7 +556,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
             FileSystemOperations,
             ObjectFactory,
             ProviderFactory,
-            LoggingOutputInternal // for internal use
+            LoggingOutput
         ].collect { it.name }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -18,13 +18,13 @@ package org.gradle.api.services.internal;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
+import org.gradle.api.logging.LoggingOutput;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.internal.Try;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.isolated.IsolationScheme;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.logging.LoggingOutputInternal;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.state.Managed;
@@ -97,10 +97,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
                 ServiceLookup instantiationServices = isolationScheme.servicesForImplementation(
                     isolatedParameters,
                     internalServices,
-                    ImmutableList.of(
-                        // Required by ProgressLoggingFixture
-                        LoggingOutputInternal.class
-                    ),
+                    ImmutableList.of(LoggingOutput.class),
                     serviceType -> false
                 );
                 try {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -125,7 +125,13 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         return doRegister(name, implementationType, isolationScheme.parameterTypeFor(implementationType), parameters, maxUsages <= 0 ? null : maxUsages);
     }
 
-    private <T extends BuildService<P>, P extends BuildServiceParameters> BuildServiceProvider<T, P> doRegister(String name, Class<T> implementationType, Class<P> parameterType, P parameters, @Nullable Integer maxParallelUsages) {
+    private <T extends BuildService<P>, P extends BuildServiceParameters> BuildServiceProvider<T, P> doRegister(
+        String name,
+        Class<T> implementationType,
+        Class<P> parameterType,
+        P parameters,
+        @Nullable Integer maxParallelUsages
+    ) {
         BuildServiceProvider<T, P> provider = new BuildServiceProvider<>(name, implementationType, parameters, isolationScheme, instantiatorFactory.injectScheme(), isolatableFactory, services);
 
         DefaultServiceRegistration<T, P> registration = specInstantiator.newInstance(DefaultServiceRegistration.class, name, parameters, provider);

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(testLibrary("jetty"))
     implementation(testLibrary("littleproxy"))
     implementation(library("gcs"))
+    implementation(library("inject"))
     implementation(library("commons_httpclient"))
     implementation(library("joda"))
     implementation(library("jackson_core"))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
@@ -78,14 +78,15 @@ class ProgressLoggingFixture extends InitScriptExecuterFixture {
                 }
 
                 @Inject
-                protected abstract LoggingOutputInternal getLoggingOutputInternal()
+                protected abstract LoggingOutput getLoggingOutput()
 
                 OutputProgressService() {
-                    loggingOutputInternal.addOutputEventListener(this)
+                    (loggingOutput as LoggingOutputInternal).addOutputEventListener(this)
                 }
 
+                @Override
                 synchronized void close() {
-                    loggingOutputInternal.removeOutputEventListener(this)
+                    (loggingOutput as LoggingOutputInternal).removeOutputEventListener(this)
                 }
 
                 void onOutput(OutputEvent event) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -125,7 +125,14 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
         private final Object params;
         private final Spec<Class<?>> whiteListPolicy;
 
-        public ServicesForIsolatedObject(Class<?> interfaceType, Class<?> noParamsType, @Nullable Object params, ServiceLookup allServices, Collection<? extends Class<?>> additionalWhiteListedServices, Spec<Class<?>> whiteListPolicy) {
+        public ServicesForIsolatedObject(
+            Class<?> interfaceType,
+            Class<?> noParamsType,
+            @Nullable Object params,
+            ServiceLookup allServices,
+            Collection<? extends Class<?>> additionalWhiteListedServices,
+            Spec<Class<?>> whiteListPolicy
+        ) {
             this.interfaceType = interfaceType;
             this.noParamsType = noParamsType;
             this.additionalWhiteListedServices = additionalWhiteListedServices;


### PR DESCRIPTION
By capturing the output events from a build service, this requires making `LoggingOutputInternal` available for injection.