### PR TITLE
Add some additional validation when Property.disallowUnsafeRead() is used

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -831,7 +831,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return findDomainObject(getName()) != null;
         }
 
@@ -854,7 +854,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return getOrNull() != null;
         }
 
@@ -867,7 +867,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         @Override
-        protected Value<I> calculateOwnValue() {
+        protected Value<I> calculateOwnValue(ValueConsumer consumer) {
             return Value.ofNullable(Cast.uncheckedCast(findByNameWithoutRules(getName())));
         }
     }
@@ -888,7 +888,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return findDomainObject(getName()) != null;
         }
 
@@ -916,7 +916,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         @Override
-        protected Value<? extends I> calculateOwnValue() {
+        protected Value<? extends I> calculateOwnValue(ValueConsumer consumer) {
             if (wasElementRemoved()) {
                 return Value.missing();
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultCacheableOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultCacheableOutputFilePropertySpec.java
@@ -47,11 +47,7 @@ public class DefaultCacheableOutputFilePropertySpec extends AbstractFileProperty
     @Override
     @Nullable
     public File getOutputFile() {
-        FileCollectionInternal files = getPropertyFiles();
-        if (files.isEmpty()) {
-            return null;
-        }
-        return files.getSingleFile();
+        return getPropertyFiles().getSingleFile();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -70,7 +70,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     }
 
     @Override
-    public boolean isPresent() {
+    public boolean calculatePresence(ValueConsumer consumer) {
         return true;
     }
 
@@ -85,7 +85,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     }
 
     @Override
-    protected Value<? extends T> calculateOwnValue() {
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
         synchronized (this) {
             if (instance == null) {
                 // TODO - extract some shared infrastructure to take care of instantiation (eg which services are visible, strict vs lenient, decorated or not?)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -221,7 +221,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !result
 
         and:
-        1 * provider.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of(a)
         0 * _
     }
 
@@ -241,7 +241,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         and:
         _ * provider.size() >> 2
-        1 * provider.calculateValue() >> ValueSupplier.Value.of([a, d])
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of([a, d])
         0 * _
     }
 
@@ -288,8 +288,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         result == iterationOrder(b, a, d, c)
 
         and:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         0 * _
     }
 
@@ -310,7 +310,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         and:
         _ * provider1.size() >> 2
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([a, d])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([a, d])
         0 * _
     }
 
@@ -422,7 +422,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(c)
         _ * provider1.type >> type
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(c)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(c)
         0 * _
 
         when:
@@ -449,7 +449,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(c)
         _ * provider1.elementType >> type
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([c])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([c])
         _ * provider1.size() >> 1
         0 * _
 
@@ -494,7 +494,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result == iterationOrder(c, a)
         _ * provider.type >> type
-        1 * provider.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of(a)
         0 * _
 
         when:
@@ -526,7 +526,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result == iterationOrder(c, a, b)
         _ * provider.size() >> 2
-        1 * provider.calculateValue() >> ValueSupplier.Value.of([a, b])
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of([a, b])
         0 * _
 
         when:
@@ -564,7 +564,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         result2 == iterationOrder(c, a, d)
-        1 * provider.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of(a)
         0 * _
     }
 
@@ -597,7 +597,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result2 == iterationOrder(c, a, b, d)
         _ * provider.size() >> 2
-        1 * provider.calculateValue() >> ValueSupplier.Value.of([a, b])
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of([a, b])
         0 * _
     }
 
@@ -675,7 +675,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         _ * provider1.type >> type
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(c)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(c)
         1 * action.execute(c)
         0 * _
 
@@ -704,7 +704,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         _ * provider1.elementType >> type
         _ * provider1.size() >> 1
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([c])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([c])
         1 * action.execute(c)
         0 * _
 
@@ -790,7 +790,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         toList(container)
 
         then:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         1 * action.execute(a)
         0 * _
 
@@ -805,7 +805,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         toList(container)
 
         then:
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(c)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(c)
         1 * action.execute(c)
         0 * _
 
@@ -821,7 +821,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         _ * provider3.size() >> 2
-        1 * provider3.calculateValue() >> ValueSupplier.Value.of([b, d])
+        1 * provider3.calculateValue(_) >> ValueSupplier.Value.of([b, d])
         1 * action.execute(b)
         1 * action.execute(d)
         0 * _
@@ -834,8 +834,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def providerOfIterable = Mock(CollectionProviderInternal)
 
         given:
-        _ * provider.calculateValue() >> ValueSupplier.Value.of(a)
-        _ * providerOfIterable.calculateValue() >> ValueSupplier.Value.of([b, c])
+        _ * provider.calculateValue(_) >> ValueSupplier.Value.of(a)
+        _ * providerOfIterable.calculateValue(_) >> ValueSupplier.Value.of([b, c])
         container.addLater(provider)
         container.addAllLater(providerOfIterable)
         toList(container)
@@ -888,10 +888,10 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         _ * provider1.type >> type
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         1 * action.execute(a)
         _ * provider2.type >> otherType
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         0 * _
 
         when:
@@ -925,12 +925,12 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         _ * provider1.elementType >> type
         _ * provider1.size() >> 2
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([a, c])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([a, c])
         1 * action.execute(a)
         1 * action.execute(c)
         _ * provider2.elementType >> otherType
         _ * provider2.size() >> 1
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of([d])
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of([d])
         0 * _
 
         when:
@@ -963,8 +963,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result = toList(filtered)
 
         then:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         and:
@@ -1002,8 +1002,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         _ * provider1.size() >> 1
         _ * provider2.size() >> 2
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([a])
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of([c, b])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([a])
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of([c, b])
         0 * _
 
         and:
@@ -1039,7 +1039,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         0 * provider1.get() >> a
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         and:
@@ -1078,7 +1078,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         _ * provider1.size() >> 1
         _ * provider2.size() >> 2
         0 * provider1.get()
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of([b, c])
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of([b, c])
         0 * _
 
         and:
@@ -1113,8 +1113,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result = toList(filtered)
 
         then:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         and:
@@ -1149,7 +1149,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result = toList(container)
 
         then:
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         and:
@@ -1197,10 +1197,10 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider1.present >> true
         _ * provider2.type >> type
-        _ * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        _ * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         _ * provider2.present >> true
         _ * provider3.type >> otherType
         container.addLater(provider1)
@@ -1242,7 +1242,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider2.type >> otherType
         container.addLater(provider1)
         container.addLater(provider2)
@@ -1268,7 +1268,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider1.get() >> a
         _ * provider1.present >> true
         _ * provider2.type >> otherType
@@ -1312,7 +1312,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider2.type >> otherType
         container.addLater(provider1)
         container.addLater(provider2)
@@ -1370,9 +1370,9 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider2.type >> otherType
-        _ * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        _ * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         container.addLater(provider1)
         container.addLater(provider2)
         container.whenObjectRemoved(action)
@@ -1387,7 +1387,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         didRetained
 
         and:
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         1 * action.execute(a)
         1 * action.execute(d)
         0 * _
@@ -1420,8 +1420,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         didRetained
 
         and:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         when:
@@ -1441,9 +1441,9 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider2.type >> otherType
-        _ * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        _ * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         container.addLater(provider1)
         container.addLater(provider2)
 
@@ -1457,7 +1457,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         didRetained
 
         and:
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(d)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(d)
         0 * _
 
         when:
@@ -1497,8 +1497,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         _ * provider1.size() >> 1
         _ * provider2.size() >> 2
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of([a])
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of([b, c])
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of([a])
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of([b, c])
         0 * _
 
         and:
@@ -1525,7 +1525,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.withType(type).iterator()
 
         then:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         0 * _
 
         when:
@@ -1533,7 +1533,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         0 * provider1.get()
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         0 * _
 
         and:
@@ -1548,9 +1548,9 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider2.type >> type
-        _ * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        _ * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         container.addLater(provider1)
         container.addLater(provider2)
         container.whenObjectRemoved(action)
@@ -1565,8 +1565,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         result == iterationOrder(b)
 
         and:
-        1 * provider1.calculateValue() >> ValueSupplier.Value.of(a)
-        1 * provider2.calculateValue() >> ValueSupplier.Value.of(b)
+        1 * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
+        1 * provider2.calculateValue(_) >> ValueSupplier.Value.of(b)
         1 * action.execute(a)
         0 * _
     }
@@ -1579,7 +1579,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         given:
         _ * provider1.type >> type
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of(a)
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of(a)
         _ * provider1.get() >> a
         _ * provider1.present >> true
         _ * provider2.type >> otherType

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -299,7 +299,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
     def callsRemoveActionWhenObjectRemovedUsingIteratorNoFlushAndLastElementIsUnrealized() {
         def action = Mock(Action)
         def provider = Mock(ProviderInternal)
-        _ * provider.calculateValue() >> ValueSupplier.Value.of("c")
+        _ * provider.calculateValue(_) >> ValueSupplier.Value.of("c")
 
         container.whenObjectRemoved(action)
         container.add("a")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractElementSourceTest.groovy
@@ -291,7 +291,7 @@ abstract class AbstractElementSourceTest extends Specification {
         }
 
         @Override
-        protected Value<T> calculateOwnValue() {
+        protected Value<T> calculateOwnValue(ValueConsumer consumer) {
             return Value.of(value)
         }
 
@@ -323,7 +323,7 @@ abstract class AbstractElementSourceTest extends Specification {
         }
 
         @Override
-        protected Value<? extends Set<T>> calculateOwnValue() {
+        protected Value<? extends Set<T>> calculateOwnValue(ValueConsumer consumer) {
             return Value.of(value)
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
@@ -30,9 +30,9 @@ class DefaultPendingSourceTest extends Specification {
 
     def setup() {
         pending.onRealize(realize)
-        _ * provider1.calculateValue() >> ValueSupplier.Value.of("provider1")
-        _ * provider2.calculateValue() >> ValueSupplier.Value.of("provider2")
-        _ * provider3.calculateValue() >> ValueSupplier.Value.of("provider3")
+        _ * provider1.calculateValue(_) >> ValueSupplier.Value.of("provider1")
+        _ * provider2.calculateValue(_) >> ValueSupplier.Value.of("provider2")
+        _ * provider3.calculateValue(_) >> ValueSupplier.Value.of("provider3")
     }
 
     def "realizes pending elements on flush"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ListElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ListElementSourceTest.groovy
@@ -495,7 +495,7 @@ class ListElementSourceTest extends AbstractIterationOrderRetainingElementSource
         }
 
         @Override
-        protected Value<List<T>> calculateOwnValue() {
+        protected Value<List<T>> calculateOwnValue(ValueConsumer consumer) {
             return Value.of(value)
         }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -319,7 +319,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         }
 
         @Override
-        public Set<FileSystemLocation> get() {
+        protected Value<Set<FileSystemLocation>> calculateOwnValue(ValueConsumer consumer) {
             // TODO - visit the contents of this collection instead.
             // This is just a super simple implementation for now
             Set<File> files = collection.getFiles();
@@ -327,7 +327,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             for (File file : files) {
                 builder.add(new DefaultFileSystemLocation(file));
             }
-            return builder.build();
+            return Value.of(builder.build());
         }
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -256,8 +256,8 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
                 }
 
                 @Override
-                protected Value<? extends T> calculateOwnValue() {
-                    return calculateOwnValueNoProducer();
+                protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+                    return calculateOwnValueNoProducer(consumer);
                 }
             };
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -85,9 +85,16 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
     @Override
     public void finalizeValue() {
-        if (state != State.Final) {
-            calculateFinalizedValue();
+        if (state == State.Final) {
+            return;
         }
+        if (disallowUnsafeRead) {
+            String reason = host.beforeRead(null);
+            if (reason != null) {
+                throw new IllegalStateException("Cannot finalize the value for " + displayNameForThisCollection() + " because " + reason + ".");
+            }
+        }
+        calculateFinalizedValue();
         state = State.Final;
         disallowChanges = true;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
@@ -217,7 +217,7 @@ public class DefaultBinaryCollection<T extends SoftwareComponent> implements Bin
         }
 
         @Override
-        protected Value<S> calculateOwnValue() {
+        protected Value<S> calculateOwnValue(ValueConsumer consumer) {
             if (ambiguous) {
                 throw new IllegalStateException("Found multiple elements");
             }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
@@ -109,7 +109,7 @@ class ValidatingMavenPublisherTest extends Specification {
     def "ignores project coordinates missing from POM file that could be taken from parent POM file"() {
         given:
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
-        def pomFile = createPomFile(makeProjectIdentity(null, "artifact", null), new Action<XmlProvider>() {
+        def pomFile = createPomFile(makeProjectIdentity("group", "artifact", "version"), new Action<XmlProvider>() {
             void execute(XmlProvider xml) {
                 xml.asNode().appendNode("parent")
             }
@@ -243,9 +243,9 @@ class ValidatingMavenPublisherTest extends Specification {
 
     private def makeProjectIdentity(def groupId, def artifactId, def version) {
         return Stub(MavenProjectIdentity) {
-            getGroupId() >> Providers.of(groupId)
-            getArtifactId() >> Providers.of(artifactId)
-            getVersion() >> Providers.of(version)
+            getGroupId() >> Providers.ofNullable(groupId)
+            getArtifactId() >> Providers.ofNullable(artifactId)
+            getVersion() >> Providers.ofNullable(version)
         }
     }
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -236,6 +236,7 @@ task thing(type: SomeTask) {
 
         then:
         failure.assertHasDescription("Execution failed for task ':thing'.")
+        failure.assertHasCause("Failed to calculate the value of task ':thing' property 'prop'.")
         failure.assertHasCause("broken")
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -184,7 +184,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
     @Override
     protected CollectionSupplier<T, C> finalValue(CollectionSupplier<T, C> value) {
-        Value<? extends C> result = calculateOwnValue(value);
+        Value<? extends C> result = value.calculateValue();
         if (!result.isMissing()) {
             return new FixedSupplier<>(result.get());
         } else if (result.getPathToOrigin().isEmpty()) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCombiningProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCombiningProvider.java
@@ -36,17 +36,17 @@ public abstract class AbstractCombiningProvider<OUT, BASE, IN> extends AbstractM
     }
 
     @Override
-    public boolean isPresent() {
-        return left.isPresent() && right.isPresent();
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return left.calculatePresence(consumer) && right.calculatePresence(consumer);
     }
 
     @Override
-    protected Value<OUT> calculateOwnValue() {
-        Value<? extends BASE> leftValue = left.calculateValue();
+    protected Value<OUT> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends BASE> leftValue = left.calculateValue(consumer);
         if (leftValue.isMissing()) {
             return leftValue.asType();
         }
-        Value<? extends IN> rightValue = right.calculateValue();
+        Value<? extends IN> rightValue = right.calculateValue(consumer);
         if (rightValue.isMissing()) {
             return rightValue.asType();
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -71,7 +71,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public boolean isPresent() {
-        return calculatePresence(ValueConsumer.Lenient);
+        return calculatePresence(ValueConsumer.IgnoreUnsafeRead);
     }
 
     @Override
@@ -81,7 +81,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public T get() {
-        Value<? extends T> value = calculateOwnValue(ValueConsumer.Lenient);
+        Value<? extends T> value = calculateOwnValue(ValueConsumer.IgnoreUnsafeRead);
         if (value.isMissing()) {
             TreeFormatter formatter = new TreeFormatter();
             formatter.node("Cannot query the value of ").append(getDisplayName().getDisplayName()).append(" because it has no value available.");
@@ -100,12 +100,12 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public T getOrNull() {
-        return calculateOwnValue(ValueConsumer.Lenient).orNull();
+        return calculateOwnValue(ValueConsumer.IgnoreUnsafeRead).orNull();
     }
 
     @Override
     public T getOrElse(T defaultValue) {
-        return calculateOwnValue(ValueConsumer.Lenient).orElse(defaultValue);
+        return calculateOwnValue(ValueConsumer.IgnoreUnsafeRead).orElse(defaultValue);
     }
 
     @Override
@@ -136,7 +136,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        return ExecutionTimeValue.value(calculateOwnValue(ValueConsumer.Lenient));
+        return ExecutionTimeValue.value(calculateOwnValue(ValueConsumer.IgnoreUnsafeRead));
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProviderWithValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProviderWithValue.java
@@ -23,25 +23,12 @@ import org.gradle.api.provider.Provider;
  */
 public abstract class AbstractProviderWithValue<T> extends AbstractMinimalProvider<T> {
     @Override
-    protected Value<? extends T> calculateOwnValue() {
-        return Value.of(get());
-    }
-
-    @Override
-    public abstract T get();
-
-    @Override
-    public T getOrNull() {
-        return get();
-    }
-
-    @Override
-    public T getOrElse(T defaultValue) {
-        return get();
-    }
-
-    @Override
     public boolean isPresent() {
+        return true;
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
         return true;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.provider;
 import java.util.Collection;
 
 interface CollectionSupplier<T, C extends Collection<? extends T>> extends ValueSupplier {
-    Value<? extends C> calculateValue();
+    Value<? extends C> calculateValue(ValueConsumer consumer);
 
     CollectionSupplier<T, C> plus(Collector<T> collector);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -23,7 +23,7 @@ import org.gradle.api.Action;
  * A supplier of zero or more values of type {@link T}.
  */
 public interface Collector<T> extends ValueSupplier {
-    Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> dest);
+    Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> dest);
 
     int size();
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -38,12 +38,12 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
             collector.add(element, collection);
             return Value.present();
         }
@@ -89,13 +89,13 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
-            return provider.isPresent();
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return provider.calculatePresence(consumer);
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
-            Value<? extends T> value = provider.calculateValue();
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
+            Value<? extends T> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
             }
@@ -156,12 +156,12 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
             collector.addAll(value, collection);
             return Value.present();
         }
@@ -207,13 +207,13 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
-            return provider.isPresent();
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return provider.calculatePresence(consumer);
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
-            Value<? extends Iterable<? extends T>> value = provider.calculateValue();
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
+            Value<? extends Iterable<? extends T>> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
             }
@@ -271,12 +271,12 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
             for (T t : value) {
                 collector.add(t, dest);
             }
@@ -316,17 +316,17 @@ public class Collectors {
         }
 
         @Override
-        public boolean isPresent() {
-            return delegate.isPresent();
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return delegate.calculatePresence(consumer);
         }
 
         public void collectInto(ImmutableCollection.Builder<T> builder) {
-            collectEntries(valueCollector, builder);
+            collectEntries(ValueConsumer.Lenient, valueCollector, builder);
         }
 
         @Override
-        public Value<Void> collectEntries(ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
-            return delegate.collectEntries(collector, dest);
+        public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
+            return delegate.collectEntries(consumer, collector, dest);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -321,7 +321,7 @@ public class Collectors {
         }
 
         public void collectInto(ImmutableCollection.Builder<T> builder) {
-            collectEntries(ValueConsumer.Lenient, valueCollector, builder);
+            collectEntries(ValueConsumer.IgnoreUnsafeRead, valueCollector, builder);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -242,7 +242,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     @Override
     protected MapSupplier<K, V> finalValue(MapSupplier<K, V> value) {
-        Value<? extends Map<K, V>> result = calculateOwnValue(value);
+        Value<? extends Map<K, V>> result = value.calculateValue();
         if (!result.isMissing()) {
             Map<K, V> entries = result.get();
             return new FixedSuppler<>(entries);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -123,13 +123,13 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected Value<? extends T> calculateOwnValue(ProviderInternal<? extends T> value) {
-        return value.calculateValue();
+    protected Value<? extends T> calculateValueFrom(ProviderInternal<? extends T> value, ValueConsumer consumer) {
+        return value.calculateValue(consumer);
     }
 
     @Override
-    protected ProviderInternal<? extends T> finalValue(ProviderInternal<? extends T> value) {
-        return value.withFinalValue();
+    protected ProviderInternal<? extends T> finalValue(ProviderInternal<? extends T> value, ValueConsumer consumer) {
+        return value.withFinalValue(consumer);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -61,7 +61,7 @@ public class DefaultProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
-    protected Value<? extends T> calculateOwnValue() {
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
         try {
             return Value.ofNullable(value.call());
         } catch (Exception e) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -200,7 +200,7 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         }
 
         @Override
-        protected Value<? extends T> calculateOwnValue() {
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
             synchronized (this) {
                 if (value == null) {
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -37,17 +37,17 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
     }
 
     @Override
-    public boolean isPresent() {
-        return backingProvider().isPresent();
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return backingProvider(consumer).calculatePresence(consumer);
     }
 
     @Override
-    protected Value<? extends S> calculateOwnValue() {
-        Value<? extends T> value = provider.calculateValue();
+    protected Value<? extends S> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends T> value = provider.calculateValue(consumer);
         if (value.isMissing()) {
             return value.asType();
         }
-        return doMapValue(value.get()).calculateValue();
+        return doMapValue(value.get()).calculateValue(consumer);
     }
 
     private ProviderInternal<? extends S> doMapValue(T value) {
@@ -58,8 +58,8 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         return Providers.internal(result);
     }
 
-    public ProviderInternal<? extends S> backingProvider() {
-        Value<? extends T> value = provider.calculateValue();
+    private ProviderInternal<? extends S> backingProvider(ValueConsumer consumer) {
+        Value<? extends T> value = provider.calculateValue(consumer);
         if (value.isMissing()) {
             return Providers.notDefined();
         }
@@ -68,12 +68,12 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public ValueProducer getProducer() {
-        return backingProvider().getProducer();
+        return backingProvider(ValueConsumer.Lenient).getProducer();
     }
 
     @Override
     public ExecutionTimeValue<? extends S> calculateExecutionTimeValue() {
-        return backingProvider().calculateExecutionTimeValue();
+        return backingProvider(ValueConsumer.Lenient).calculateExecutionTimeValue();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -68,12 +68,12 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public ValueProducer getProducer() {
-        return backingProvider(ValueConsumer.Lenient).getProducer();
+        return backingProvider(ValueConsumer.IgnoreUnsafeRead).getProducer();
     }
 
     @Override
     public ExecutionTimeValue<? extends S> calculateExecutionTimeValue() {
-        return backingProvider(ValueConsumer.Lenient).calculateExecutionTimeValue();
+        return backingProvider(ValueConsumer.IgnoreUnsafeRead).calculateExecutionTimeValue();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -26,9 +26,9 @@ import java.util.Map;
  */
 public interface MapCollector<K, V> extends ValueSupplier {
 
-    Value<Void> collectEntries(MapEntryCollector<K, V> collector, Map<K, V> dest);
+    Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest);
 
-    Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest);
+    Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest);
 
     void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -36,18 +36,18 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
 
         @Override
-        public Value<Void> collectEntries(MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
             collector.add(key, value, dest);
             return Value.present();
         }
 
         @Override
-        public Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
+        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
             collector.add(key, dest);
             return Value.present();
         }
@@ -90,13 +90,13 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isPresent() {
-            return providerOfValue.isPresent();
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return providerOfValue.calculatePresence(consumer);
         }
 
         @Override
-        public Value<Void> collectEntries(MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            Value<? extends V> value = providerOfValue.calculateValue();
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+            Value<? extends V> value = providerOfValue.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
             }
@@ -105,8 +105,8 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
-            if (providerOfValue.isPresent()) {
+        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
+            if (providerOfValue.calculatePresence(consumer)) {
                 collector.add(key, dest);
                 return Value.present();
             } else {
@@ -141,18 +141,18 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
 
         @Override
-        public Value<Void> collectEntries(MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
             collector.addAll(entries.entrySet(), dest);
             return Value.present();
         }
 
         @Override
-        public Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
+        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
             collector.addAll(entries.keySet(), dest);
             return Value.present();
         }
@@ -177,13 +177,13 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isPresent() {
-            return providerOfEntries.isPresent();
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return providerOfEntries.calculatePresence(consumer);
         }
 
         @Override
-        public Value<Void> collectEntries(MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            Value<? extends Map<? extends K, ? extends V>> value = providerOfEntries.calculateValue();
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+            Value<? extends Map<? extends K, ? extends V>> value = providerOfEntries.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
             }
@@ -192,14 +192,13 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectKeys(ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
-            Map<? extends K, ? extends V> entries = providerOfEntries.getOrNull();
-            if (entries != null) {
-                collector.addAll(entries.keySet(), dest);
-                return Value.present();
-            } else {
-                return Value.missing();
+        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
+            Value<? extends Map<? extends K, ? extends V>> value = providerOfEntries.calculateValue(consumer);
+            if (value.isMissing()) {
+                return value.asType();
             }
+            collector.addAll(value.get().keySet(), dest);
+            return Value.present();
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import java.util.Set;
 
 interface MapSupplier<K, V> extends ValueSupplier {
-    Value<? extends Map<K, V>> calculateValue();
+    Value<? extends Map<K, V>> calculateValue(ValueConsumer consumer);
 
-    Value<? extends Set<K>> calculateKeys();
+    Value<? extends Set<K>> calculateKeys(ValueConsumer consumer);
 
     MapSupplier<K, V> plus(MapCollector<K, V> collector);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
@@ -46,13 +46,13 @@ public class MappingProvider<OUT, IN> extends AbstractMinimalProvider<OUT> {
     }
 
     @Override
-    public boolean isPresent() {
-        return provider.isPresent();
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return provider.calculatePresence(consumer);
     }
 
     @Override
-    protected Value<OUT> calculateOwnValue() {
-        Value<? extends IN> value = provider.calculateValue();
+    protected Value<OUT> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends IN> value = provider.calculateValue(consumer);
         if (value.isMissing()) {
             return value.asType();
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -62,8 +62,12 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
     }
 
     @Override
-    public T get() {
-        T value = provider.getOrNull();
-        return value != null ? value : fallbackValue;
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends T> value = provider.calculateValue(consumer);
+        if (value.isMissing()) {
+            return Value.of(fallbackValue);
+        } else {
+            return value;
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -43,17 +43,17 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
-    public boolean isPresent() {
-        return left.isPresent() || right.isPresent();
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return left.calculatePresence(consumer) || right.calculatePresence(consumer);
     }
 
     @Override
-    protected Value<? extends T> calculateOwnValue() {
-        Value<? extends T> leftValue = left.calculateValue();
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends T> leftValue = left.calculateValue(consumer);
         if (!leftValue.isMissing()) {
             return leftValue;
         }
-        Value<? extends T> rightValue = right.calculateValue();
+        Value<? extends T> rightValue = right.calculateValue(consumer);
         if (!rightValue.isMissing()) {
             return rightValue;
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -38,7 +38,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
     /**
      * Calculates the current value of this provider.
      */
-    ValueSupplier.Value<? extends T> calculateValue();
+    ValueSupplier.Value<? extends T> calculateValue(ValueConsumer consumer);
 
     /**
      * Returns a view of this provider that can be used to supply a value to a {@link org.gradle.api.provider.Property} instance.
@@ -48,7 +48,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
     /**
      * Returns a copy of this provider with a final value. The returned value is used to replace this provider by a property when the property is finalized.
      */
-    ProviderInternal<T> withFinalValue();
+    ProviderInternal<T> withFinalValue(ValueConsumer consumer);
 
     /**
      * Calculates the state of this provider that is required at execution time. The state is serialized to the instant execution cache, and recreated as a {@link Provider} implementation

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -54,6 +54,9 @@ public class Providers {
     }
 
     public static <T> ProviderInternal<T> of(T value) {
+        if (value == null) {
+            throw new IllegalArgumentException();
+        }
         return new FixedValueProvider<>(value);
     }
 
@@ -83,12 +86,12 @@ public class Providers {
         }
 
         @Override
-        public T get() {
-            return value;
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+            return Value.of(value);
         }
 
         @Override
-        public ProviderInternal<T> withFinalValue() {
+        public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
             return this;
         }
 
@@ -123,7 +126,7 @@ public class Providers {
         }
 
         @Override
-        public Value<? extends T> calculateValue() {
+        public Value<? extends T> calculateValue(ValueConsumer consumer) {
             return value;
         }
 
@@ -139,7 +142,7 @@ public class Providers {
         }
 
         @Override
-        protected Value<T> calculateOwnValue() {
+        protected Value<T> calculateOwnValue(ValueConsumer consumer) {
             return Value.missing();
         }
 
@@ -159,12 +162,17 @@ public class Providers {
         }
 
         @Override
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return false;
+        }
+
+        @Override
         public ProviderInternal<T> asSupplier(DisplayName owner, Class<? super T> targetType, ValueSanitizer<? super T> sanitizer) {
             return this;
         }
 
         @Override
-        public ProviderInternal<T> withFinalValue() {
+        public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
             return this;
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -59,9 +59,9 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
     }
 
     @Override
-    protected Value<? extends OUT> calculateOwnValue() {
+    protected Value<? extends OUT> calculateOwnValue(ValueConsumer consumer) {
         beforeRead();
-        Value<? extends IN> value = provider.calculateValue();
+        Value<? extends IN> value = provider.calculateValue(consumer);
         return mapValue(value);
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -37,7 +37,7 @@ public interface ValueSupplier {
     boolean calculatePresence(ValueConsumer consumer);
 
     enum ValueConsumer {
-        Strict, Lenient
+        DisallowUnsafeRead, IgnoreUnsafeRead
     }
 
     /**

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -34,7 +34,11 @@ public interface ValueSupplier {
      */
     ValueProducer getProducer();
 
-    boolean isPresent();
+    boolean calculatePresence(ValueConsumer consumer);
+
+    enum ValueConsumer {
+        Strict, Lenient
+    }
 
     /**
      * Carries information about the producer of a value.
@@ -218,7 +222,9 @@ public interface ValueSupplier {
         }
 
         static <T> Value<T> of(T value) {
-            assert value != null;
+            if (value == null) {
+                throw new IllegalArgumentException();
+            }
             return new Present<>(value);
         }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
@@ -144,7 +144,7 @@ class AbstractMinimalProviderTest extends ProviderSpec<String> {
         }
 
         @Override
-        protected Value calculateOwnValue() {
+        protected Value calculateOwnValue(ValueConsumer consumer) {
             return Value.ofNullable(value)
         }
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -139,17 +139,13 @@ class DefaultPropertyTest extends PropertySpec<String> {
     }
 
     def "can set value to a provider whose type is compatible"() {
-        def supplier = Mock(ProviderInternal)
-        def provider = Mock(ProviderInternal)
+        def supplier = supplierWithValues(1, 2, 3)
 
         given:
-        provider.asSupplier(_, _, _) >> supplier
-        supplier.calculateValue() >>> [1, 2, 3].collect { ValueSupplier.Value.ofNullable(it) }
-
         def property = propertyWithDefaultValue(Number)
 
         when:
-        property.set(provider)
+        property.set(supplier)
 
         then:
         property.get() == 1

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -18,11 +18,13 @@ package org.gradle.api.internal.provider
 
 import com.google.common.collect.ImmutableMap
 import org.gradle.api.Task
+import org.gradle.api.provider.Property
 import org.gradle.internal.Describables
 import org.gradle.internal.state.ManagedFactory
 import org.gradle.util.TestUtil
 import org.gradle.util.TextUtil
 import org.spockframework.util.Assert
+import spock.lang.Unroll
 
 class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
@@ -115,7 +117,7 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         given:
         def provider = Stub(ProviderInternal)
         provider.type >> null
-        provider.calculateValue() >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
+        provider.calculateValue(_) >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
 
         when:
         property.setFromAnyValue(provider)
@@ -144,8 +146,8 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         given:
         def provider = Stub(ProviderInternal)
         provider.type >> Map
-        provider.calculateValue() >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
-        provider.present >> true
+        provider.calculateValue(_) >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
+        provider.calculatePresence(_) >> true
         and:
         property.set(provider)
 
@@ -240,8 +242,8 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         given:
         def provider = Stub(ProviderInternal)
         _ * provider.type >> Map
-        _ * provider.present >> true
-        _ * provider.calculateValue() >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
+        _ * provider.calculatePresence(_) >> true
+        _ * provider.calculateValue(_) >>> [['k1': 'v1'], ['k2': 'v2']].collect { ValueSupplier.Value.of(it) }
         and:
         property.putAll(provider)
 
@@ -278,25 +280,25 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         when:
         property.present
         then:
-        1 * valueProvider.present >> true
-        1 * putProvider.present >> true
-        1 * putAllProvider.present >> true
+        1 * valueProvider.calculatePresence(_) >> true
+        1 * putProvider.calculatePresence(_) >> true
+        1 * putAllProvider.calculatePresence(_) >> true
         0 * _
 
         when:
         property.get()
         then:
-        1 * valueProvider.calculateValue() >> ValueSupplier.Value.of(['k1': 'v1'])
-        1 * putProvider.calculateValue() >> ValueSupplier.Value.of('v2')
-        1 * putAllProvider.calculateValue() >> ValueSupplier.Value.of(['k3': 'v3'])
+        1 * valueProvider.calculateValue(_) >> ValueSupplier.Value.of(['k1': 'v1'])
+        1 * putProvider.calculateValue(_) >> ValueSupplier.Value.of('v2')
+        1 * putAllProvider.calculateValue(_) >> ValueSupplier.Value.of(['k3': 'v3'])
         0 * _
 
         when:
         property.getOrNull()
         then:
-        1 * valueProvider.calculateValue() >> ValueSupplier.Value.of(['k1': 'v1'])
-        1 * putProvider.calculateValue() >> ValueSupplier.Value.of('v2')
-        1 * putAllProvider.calculateValue() >> ValueSupplier.Value.of(['k3': 'v3'])
+        1 * valueProvider.calculateValue(_) >> ValueSupplier.Value.of(['k1': 'v1'])
+        1 * putProvider.calculateValue(_) >> ValueSupplier.Value.of('v2')
+        1 * putAllProvider.calculateValue(_) >> ValueSupplier.Value.of(['k3': 'v3'])
         0 * _
     }
 
@@ -942,14 +944,21 @@ The value of this property is derived from: <source>""")
 
         when:
         def result = p.get()
-        def result2 = property.get()
 
         then:
-        1 * provider.calculateValue() >> ValueSupplier.Value.of("value")
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of("value")
         0 * _
 
         and:
         result == (['k1'] as Set)
+
+        when:
+        def result2 = property.get()
+
+        then:
+        0 * _
+
+        and:
         result2 == [k1: "value"]
     }
 
@@ -968,15 +977,73 @@ The value of this property is derived from: <source>""")
 
         when:
         def result = p.get()
-        def result2 = property.get()
 
         then:
-        1 * provider.calculateValue() >> ValueSupplier.Value.of("value")
+        1 * provider.calculateValue(_) >> ValueSupplier.Value.of("value")
         0 * _
 
         and:
         result == "value"
+
+        when:
+        def result2 = property.get()
+
+        then:
+        0 * _
+
+        and:
         result2 == [k1: "value"]
+    }
+
+    @Unroll
+    def "finalizes upstream properties when value read using #method and disallow unsafe reads"() {
+        def a = property()
+        def b = property()
+        def c = valueProperty()
+        def property = property()
+        property.disallowUnsafeRead()
+
+        property.putAll(a)
+
+        a.putAll(b)
+        a.attachOwner(owner(), displayName("<a>"))
+
+        b.attachOwner(owner(), displayName("<b>"))
+
+        property.put("c", c)
+        c.set("c")
+        c.attachOwner(owner(), displayName("<c>"))
+
+        given:
+        property."$method"()
+
+        when:
+        a.set([a: 'a'])
+
+        then:
+        def e1 = thrown(IllegalStateException)
+        e1.message == 'The value for <a> is final and cannot be changed any further.'
+
+        when:
+        b.set([b: 'b'])
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set('c2')
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
+    }
+
+    Property<String> valueProperty() {
+        return new DefaultProperty<String>(host, String)
     }
 
     private ProviderInternal<String> brokenValueSupplier() {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.internal.DisplayName
 import org.gradle.internal.state.Managed
 import org.gradle.internal.state.ModelObject
 import org.gradle.util.TextUtil
+import spock.lang.Unroll
 
 import java.util.concurrent.Callable
 
@@ -674,6 +675,109 @@ The value of this provider is derived from:
         def e3 = thrown(AbstractProperty.PropertyQueryException)
         e3.message == "Failed to calculate the value of <property>."
         e3.cause.message == "broken!"
+    }
+
+    def "does not finalize upstream property on finalize"() {
+        def upstream = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+        property.set(upstream)
+        upstream.set(someValue())
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream.set(someOtherValue())
+
+        then:
+        property.get() == someValue()
+        upstream.get() == someOtherValue()
+    }
+
+    def "does not finalize upstream property with no value on finalize"() {
+        def upstream = propertyWithNoValue()
+        def property = propertyWithDefaultValue()
+        property.set(upstream)
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream.set(someOtherValue())
+
+        then:
+        property.orNull == null
+        upstream.get() == someOtherValue()
+    }
+
+    def "does not finalize mapped upstream property on finalize"() {
+        def upstream = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+        upstream.set(someValue())
+        property.set(upstream.map { someOtherValue() })
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream.set(someOtherValue2())
+
+        then:
+        property.get() == someOtherValue()
+        upstream.get() == someOtherValue2()
+    }
+
+    def "does not finalize flatMapped upstream property on finalize"() {
+        def upstream = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+        upstream.set(someValue())
+        property.set(upstream.flatMap { supplierWithValues(someOtherValue()) })
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream.set(someOtherValue2())
+
+        then:
+        property.get() == someOtherValue()
+        upstream.get() == someOtherValue2()
+    }
+
+    def "does not finalize orElse upstream property on finalize"() {
+        def upstream = propertyWithNoValue()
+        def property = propertyWithDefaultValue()
+        property.set(upstream.orElse(someValue()))
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream.set(someOtherValue())
+
+        then:
+        property.get() == someValue()
+        upstream.get() == someOtherValue()
+    }
+
+    def "does not finalize orElse upstream properties on finalize"() {
+        def upstream1 = propertyWithNoValue()
+        def upstream2 = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+        property.set(upstream1.orElse(upstream2))
+        upstream2.set(someValue())
+
+        given:
+        property.finalizeValue()
+
+        when:
+        upstream1.set(someOtherValue())
+        upstream2.set(someOtherValue())
+
+        then:
+        property.get() == someValue()
+        upstream1.get() == someOtherValue()
+        upstream2.get() == someOtherValue()
     }
 
     def "replaces provider with fixed value on next query of value when value implicitly finalized"() {
@@ -1876,7 +1980,7 @@ The value of this property is derived from:
         0 * host._
     }
 
-    def "cannot set value after value read when unsafe read disallowed"() {
+    def "finalizes value after read when unsafe read disallowed"() {
         given:
         def property = propertyWithDefaultValue()
         property.disallowUnsafeRead()
@@ -1949,6 +2053,225 @@ The value of this property is derived from:
 
         and:
         1 * host.beforeRead(null) >> null
+    }
+
+    @Unroll
+    def "finalizes upstream property when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithNoValue()
+        def c = propertyWithNoValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b)
+        property.disallowUnsafeRead()
+
+        b.set(c)
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.set(someValue())
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property."$method"()
+
+        when:
+        b.set(someOtherValue())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
+    }
+
+    @Unroll
+    def "finalizes upstream property with no value when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithNoValue()
+        def c = propertyWithNoValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b)
+        property.disallowUnsafeRead()
+
+        b.set(c)
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property."$method"()
+
+        when:
+        b.set(someOtherValue())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["getOrNull", "finalizeValue", "isPresent"]
+    }
+
+    @Unroll
+    def "finalizes upstream mapped property when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithDefaultValue()
+        def c = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b.map { someOtherValue2() })
+        property.disallowUnsafeRead()
+
+        b.set(c.map { someOtherValue() })
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.set(someValue())
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property."$method"()
+
+        when:
+        b.set(someOtherValue3())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue3())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
+    }
+
+    @Unroll
+    def "finalizes upstream flatmapped property when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithDefaultValue()
+        def c = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b.flatMap { supplierWithValues(someOtherValue2()) })
+        property.disallowUnsafeRead()
+
+        b.set(c.flatMap { supplierWithValues(someOtherValue()) })
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.set(someValue())
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property."$method"()
+
+        when:
+        b.set(someOtherValue3())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue3())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
+    }
+
+    @Unroll
+    def "finalizes upstream orElse fixed value property when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithNoValue()
+        def c = propertyWithNoValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b.orElse(someOtherValue2()))
+        property.disallowUnsafeRead()
+
+        b.set(c)
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property.get()
+
+        when:
+        b.set(someOtherValue3())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue3())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
+    }
+
+    @Unroll
+    def "finalizes upstream orElse properties when value read using #method and unsafe read disallowed"() {
+        def b = propertyWithNoValue()
+        def c = propertyWithDefaultValue()
+        def property = propertyWithDefaultValue()
+
+        property.set(b.orElse(c))
+        property.disallowUnsafeRead()
+
+        b.attachOwner(owner(), displayName("<b>"))
+
+        c.set(someValue())
+        c.attachOwner(owner(), displayName("<c>"))
+        c.disallowUnsafeRead()
+
+        given:
+        property."$method"()
+
+        when:
+        b.set(someOtherValue3())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <b> is final and cannot be changed any further.'
+
+        when:
+        c.set(someOtherValue3())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <c> is final and cannot be changed any further.'
+
+        where:
+        method << ["get", "finalizeValue", "isPresent"]
     }
 
     def "reports the source of property value when value is missing and source is known"() {
@@ -2337,13 +2660,13 @@ The value of this provider is derived from:
         }
 
         @Override
-        protected Value<? extends T> calculateOwnValue() {
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
             return Value.missing()
         }
 
         @Override
-        Value<? extends T> calculateValue() {
-            return Value.missing().pushWhenMissing(displayName)
+        protected DisplayName getDeclaredDisplayName() {
+            return displayName
         }
     }
 

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -445,7 +445,7 @@ abstract class ProviderSpec<T> extends Specification {
             }
 
             @Override
-            protected ValueSupplier.Value<T> calculateOwnValue() {
+            protected ValueSupplier.Value<T> calculateOwnValue(ValueSupplier.ValueConsumer consumer) {
                 throw new RuntimeException("broken!")
             }
         }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderTestUtil.java
@@ -83,12 +83,12 @@ public class ProviderTestUtil {
         }
 
         @Override
-        public boolean isPresent() {
+        public boolean calculatePresence(ValueConsumer consumer) {
             return values.hasNext();
         }
 
         @Override
-        protected Value<? extends T> calculateOwnValue() {
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
             return values.hasNext() ? Value.of(values.next()) : Value.missing();
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -81,7 +81,7 @@ public class DefaultArtifactPublicationSet {
         }
 
         @Override
-        protected Value<Set<PublishArtifact>> calculateOwnValue() {
+        protected Value<Set<PublishArtifact>> calculateOwnValue(ValueConsumer consumer) {
             if (defaultArtifacts == null) {
                 defaultArtifacts = Sets.newLinkedHashSet();
                 currentDefault = null;


### PR DESCRIPTION

### Context

When `disallowUnsafeRead()` is used on a property instance:
- Disallow explicit finalization of the property's value until the value can be read.
- Finalize all upstream properties whose values are used to calculate the property value.
- If any upstream property represents a task output, disallow read of the property's value until the producing task has completed.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
