### PR TITLE
Add additional assertions in interoperability tests for org.gradle.api.provider.Property

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyGroovyInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyGroovyInterOpIntegrationTest.groovy
@@ -44,6 +44,7 @@ abstract class AbstractPropertyGroovyInterOpIntegrationTest extends AbstractProp
                     project.tasks.register("someTask", SomeTask) { t ->
                         t.flag = true
                         t.message = "some value"
+                        t.number = 1.23d
                         t.list = [1, 2]
                         t.set = [1, 2]
                         t.map = [1: true, 2: false]
@@ -64,6 +65,7 @@ abstract class AbstractPropertyGroovyInterOpIntegrationTest extends AbstractProp
                     project.tasks.register("someTask", SomeTask) { t ->
                         t.flag = project.provider { true }
                         t.message = project.provider { "some value" }
+                        t.number = project.provider { 1.23d }
                         t.list = project.provider { [1, 2] }
                         t.set = project.provider { [1, 2] }
                         t.map = project.provider { [1: true, 2: false] }
@@ -85,6 +87,7 @@ abstract class AbstractPropertyGroovyInterOpIntegrationTest extends AbstractProp
                         def provider = project.provider { "some value" }
                         t.flag = provider.map { s -> !s.empty }
                         t.message = provider.map { s -> s }
+                        t.number = provider.map { s -> 1.23d }
                         t.list = provider.map { s -> [1, 2] }
                         t.set = provider.map { s -> [1, 2] }
                         t.map = provider.map { s -> [1: true, 2: false] }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyJavaInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyJavaInterOpIntegrationTest.groovy
@@ -46,6 +46,7 @@ abstract class AbstractPropertyJavaInterOpIntegrationTest extends AbstractProper
                     project.getTasks().register("someTask", SomeTask.class, t -> {
                         t.getFlag().set(true);
                         t.getMessage().set("some value");
+                        t.getNumber().set(1.23);
                         t.getList().set(Arrays.asList(1, 2));
                         t.getSet().set(Arrays.asList(1, 2));
                         Map<Integer, Boolean> map = new LinkedHashMap<>();
@@ -72,6 +73,7 @@ abstract class AbstractPropertyJavaInterOpIntegrationTest extends AbstractProper
                     project.getTasks().register("someTask", SomeTask.class, t -> {
                         t.getFlag().set(project.provider(() -> true));
                         t.getMessage().set(project.provider(() -> "some value"));
+                        t.getNumber().set(project.provider(() -> 1.23));
                         t.getList().set(project.provider(() -> Arrays.asList(1, 2)));
                         t.getSet().set(project.provider(() -> Arrays.asList(1, 2)));
                         t.getMap().set(project.provider(() -> {
@@ -102,6 +104,7 @@ abstract class AbstractPropertyJavaInterOpIntegrationTest extends AbstractProper
                         Provider<String> provider = project.provider(() -> "some value");
                         t.getFlag().set(provider.map(s -> !s.isEmpty()));
                         t.getMessage().set(provider.map(s -> s));
+                        t.getNumber().set(provider.map(s -> 1.23));
                         t.getList().set(provider.map(s -> Arrays.asList(1, 2)));
                         t.getSet().set(provider.map(s -> Arrays.asList(1, 2)));
                         t.getMap().set(provider.map(s -> {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyKotlinInterOpIntegrationTest.groovy
@@ -39,6 +39,7 @@ abstract class AbstractPropertyKotlinInterOpIntegrationTest extends AbstractProp
                     project.tasks.register("someTask", SomeTask::class.java) {
                         flag.set(true)
                         message.set("some value")
+                        number.set(1.23)
                         list.set(listOf(1, 2))
                         set.set(listOf(1, 2))
                         map.set(mapOf(1 to true, 2 to false))
@@ -59,6 +60,7 @@ abstract class AbstractPropertyKotlinInterOpIntegrationTest extends AbstractProp
                     project.tasks.register("someTask", SomeTask::class.java) {
                         flag.set(project.provider { true })
                         message.set(project.provider { "some value" })
+                        number.set(project.provider { 1.23 })
                         list.set(project.provider { listOf(1, 2) })
                         set.set(project.provider { listOf(1, 2) })
                         map.set(project.provider { mapOf(1 to true, 2 to false) })
@@ -80,6 +82,7 @@ abstract class AbstractPropertyKotlinInterOpIntegrationTest extends AbstractProp
                         val provider = project.provider { "some value" }
                         flag.set(provider.map { s -> !s.isEmpty() })
                         message.set(provider.map { s -> s })
+                        number.set(provider.map { s -> 1.23 })
                         list.set(provider.map { s -> listOf(1, 2) })
                         set.set(provider.map { s -> listOf(1, 2) })
                         map.set(provider.map { s -> mapOf(1 to true, 2 to false) })

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -47,6 +47,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = true")
         outputContains("message = some value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -68,6 +69,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = true")
         outputContains("message = some value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -89,6 +91,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = true")
         outputContains("message = some value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -128,6 +131,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
             tasks.someTask {
                 flag = true
                 message = "some value"
+                number = 1.23d
                 list = [1, 2]
                 set = [1, 2]
                 map = [1: true, 2: false]
@@ -139,6 +143,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = true")
         outputContains("message = some value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -175,6 +180,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
             tasks.withType(SomeTask::class.java).named("someTask").configure {
                 flag.set(true)
                 message.set("some value")
+                number.set(1.23)
                 list.set(listOf(1, 2))
                 set.set(listOf(1, 2))
                 map.set(mapOf(1 to true, 2 to false))
@@ -187,6 +193,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = true")
         outputContains("message = some value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -196,6 +203,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
             tasks.withType(SomeTask::class.java).named("someTask").configure {
                 flag.set(provider { false })
                 message.set(provider { "some new value" })
+                number.set(provider { 4.56 })
                 list.set(provider { listOf(3) })
                 set.set(provider { listOf(3) })
                 map.set(provider { mapOf(3 to true) })
@@ -206,6 +214,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = false")
         outputContains("message = some new value")
+        outputContains("number = 4.56")
         outputContains("list = [3]")
         outputContains("set = [3]")
         outputContains("map = {3=true}")
@@ -249,6 +258,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
                     project.getTasks().withType(SomeTask.class).configureEach(t -> {
                         t.getFlag().set(false);
                         t.getMessage().set("some other value");
+                        t.getNumber().set(1.23);
                         t.getList().set(Arrays.asList(1, 2));
                         t.getSet().set(Arrays.asList(1, 2));
                         Map<Integer, Boolean> map = new LinkedHashMap<>();
@@ -271,6 +281,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = false")
         outputContains("message = some other value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")
@@ -308,6 +319,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
                     project.tasks.withType(SomeTask::class.java).configureEach {
                         flag.set(false)
                         message.set("some other value")
+                        number.set(1.23)
                         list.set(listOf(1, 2))
                         set.set(listOf(1, 2))
                         map.set(mapOf(1 to true, 2 to false))
@@ -329,6 +341,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
         then:
         outputContains("flag = false")
         outputContains("message = some other value")
+        outputContains("number = 1.23")
         outputContains("list = [1, 2]")
         outputContains("set = [1, 2]")
         outputContains("map = {1=true, 2=false}")

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyGroovyInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyGroovyInterOpIntegrationTest.groovy
@@ -37,6 +37,8 @@ class ManagedPropertyGroovyInterOpIntegrationTest extends AbstractPropertyGroovy
                 @Internal
                 abstract Property<String> getMessage()
                 @Internal
+                abstract Property<Double> getNumber()
+                @Internal
                 abstract ListProperty<Integer> getList()
                 @Internal
                 abstract SetProperty<Integer> getSet()
@@ -47,6 +49,7 @@ class ManagedPropertyGroovyInterOpIntegrationTest extends AbstractPropertyGroovy
                 void run() {
                     System.out.println("flag = " + flag.get())
                     System.out.println("message = " + message.get())
+                    System.out.println("number = " + number.get())
                     System.out.println("list = " + list.get())
                     System.out.println("set = " + set.get())
                     System.out.println("map = " + map.get().toString())

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyJavaInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyJavaInterOpIntegrationTest.groovy
@@ -39,6 +39,9 @@ class ManagedPropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInte
                 public abstract Property<String> getMessage();
 
                 @Internal
+                public abstract Property<Double> getNumber();
+
+                @Internal
                 public abstract ListProperty<Integer> getList();
 
                 @Internal
@@ -51,6 +54,7 @@ class ManagedPropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInte
                 public void run() {
                     System.out.println("flag = " + getFlag().get());
                     System.out.println("message = " + getMessage().get());
+                    System.out.println("number = " + getNumber().get());
                     System.out.println("list = " + getList().get());
                     System.out.println("set = " + getSet().get());
                     System.out.println("map = " + getMap().get());

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyKotlinInterOpIntegrationTest.groovy
@@ -39,6 +39,8 @@ class ManagedPropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlin
                 @get:Internal
                 abstract val message: Property<String>
                 @get:Internal
+                abstract val number: Property<Double>
+                @get:Internal
                 abstract val list: ListProperty<Int>
                 @get:Internal
                 abstract val set: SetProperty<Int>
@@ -49,6 +51,7 @@ class ManagedPropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlin
                 fun run() {
                     println("flag = " + flag.get())
                     println("message = " + message.get())
+                    println("number = " + number.get())
                     println("list = " + list.get())
                     println("set = " + set.get())
                     println("map = " + map.get())

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyGroovyInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyGroovyInterOpIntegrationTest.groovy
@@ -42,6 +42,8 @@ class PropertyGroovyInterOpIntegrationTest extends AbstractPropertyGroovyInterOp
                 @Internal
                 final Property<String> message
                 @Internal
+                final Property<Double> number
+                @Internal
                 final ListProperty<Integer> list
                 @Internal
                 final SetProperty<Integer> set
@@ -52,6 +54,7 @@ class PropertyGroovyInterOpIntegrationTest extends AbstractPropertyGroovyInterOp
                 SomeTask(ObjectFactory objectFactory) {
                     flag = objectFactory.property(Boolean)
                     message = objectFactory.property(String)
+                    number = objectFactory.property(Double)
                     list = objectFactory.listProperty(Integer)
                     set = objectFactory.setProperty(Integer)
                     map = objectFactory.mapProperty(Integer, Boolean)
@@ -61,6 +64,7 @@ class PropertyGroovyInterOpIntegrationTest extends AbstractPropertyGroovyInterOp
                 void run() {
                     System.out.println("flag = " + flag.get())
                     System.out.println("message = " + message.get())
+                    System.out.println("number = " + number.get())
                     System.out.println("list = " + list.get())
                     System.out.println("set = " + set.get())
                     System.out.println("map = " + map.get().toString())

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyJavaInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyJavaInterOpIntegrationTest.groovy
@@ -39,6 +39,7 @@ class PropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInterOpInte
             public class SomeTask extends DefaultTask {
                 private final Property<Boolean> flag;
                 private final Property<String> message;
+                private final Property<Double> number;
                 private final ListProperty<Integer> list;
                 private final SetProperty<Integer> set;
                 private final MapProperty<Integer, Boolean> map;
@@ -47,6 +48,7 @@ class PropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInterOpInte
                 public SomeTask(ObjectFactory objectFactory) {
                     flag = objectFactory.property(Boolean.class);
                     message = objectFactory.property(String.class);
+                    number = objectFactory.property(Double.class);
                     list = objectFactory.listProperty(Integer.class);
                     set = objectFactory.setProperty(Integer.class);
                     map = objectFactory.mapProperty(Integer.class, Boolean.class);
@@ -60,6 +62,11 @@ class PropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInterOpInte
                 @Internal
                 public Property<String> getMessage() {
                     return message;
+                }
+
+                @Internal
+                public Property<Double> getNumber() {
+                    return number;
                 }
 
                 @Internal
@@ -81,6 +88,7 @@ class PropertyJavaInterOpIntegrationTest extends AbstractPropertyJavaInterOpInte
                 public void run() {
                     System.out.println("flag = " + flag.get());
                     System.out.println("message = " + message.get());
+                    System.out.println("number = " + number.get());
                     System.out.println("list = " + list.get());
                     System.out.println("set = " + set.get());
                     System.out.println("map = " + map.get());

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -44,6 +44,8 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlinInterOp
                 @Internal
                 val message = objectFactory.property(String::class.java)
                 @Internal
+                val number = objectFactory.property(Double::class.java)
+                @Internal
                 val list = objectFactory.listProperty(Int::class.java)
                 @Internal
                 val set = objectFactory.setProperty(Int::class.java)
@@ -54,6 +56,7 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlinInterOp
                 fun run() {
                     println("flag = " + flag.get())
                     println("message = " + message.get())
+                    println("number = " + number.get())
                     println("list = " + list.get())
                     println("set = " + set.get())
                     println("map = " + map.get())


### PR DESCRIPTION
### Context
Recently, I worked on a plugin written in Kotlin with a `Property<Int>` property (built with Gradle 6.3 and jvmTarget 1.8). When I used the plugin from Groovy build script, I got `> Cannot set the value of a property of type int using an instance of type java.lang.Integer.`
I wondered why this happens and found the corresponding integration tests. Initially, I added a `Property<Int>` property to the tests and expected them to fail. But they didn't. Turns out: The incompatibility exists only when Gradle <= v4.10.3 is used. With Gradle >= 5.0, the observed issue isn't present anymore.
Nevertheless, I think the added assertions are still useful. But I changed them to `java.lang.Double / kotlin.Double`, as Integer is already used for `ListProperty` and `SetProperty`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
