### PR TITLE
Fix cacheability of precompiled Groovy plugin tasks

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
@@ -138,7 +138,7 @@ abstract class GeneratePluginAdaptersTask extends DefaultTask {
 
     private void generateScriptPluginAdapter(PrecompiledGroovyScript scriptPlugin, PluginRequests pluginRequests) {
         String targetClass = scriptPlugin.getTargetClassName();
-        File outputFile = getPluginAdapterSourcesOutputDirectory().file(scriptPlugin.getGeneratedPluginClassName() + ".java").get().getAsFile();
+        File outputFile = getPluginAdapterSourcesOutputDirectory().file(scriptPlugin.getPluginAdapterClassName() + ".java").get().getAsFile();
 
         StringBuilder applyPlugins = new StringBuilder();
         if (!pluginRequests.isEmpty()) {
@@ -157,7 +157,7 @@ abstract class GeneratePluginAdaptersTask extends DefaultTask {
             writer.println("/**");
             writer.println(" * Precompiled " + scriptPlugin.getId() + " script plugin.");
             writer.println(" **/");
-            writer.println("public class " + scriptPlugin.getGeneratedPluginClassName() + " implements org.gradle.api.Plugin<" + targetClass + "> {");
+            writer.println("public class " + scriptPlugin.getPluginAdapterClassName() + " implements org.gradle.api.Plugin<" + targetClass + "> {");
             writer.println("    private static final String MIN_SUPPORTED_GRADLE_VERSION = \"5.0\";");
             writer.println("    public void apply(" + targetClass + " target) {");
             writer.println("        assertSupportedByCurrentGradleVersion();");

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
@@ -59,7 +59,7 @@ class PrecompiledGroovyPluginsPlugin implements Plugin<Project> {
 
         TaskProvider<ExtractPluginRequestsTask> extractPluginRequests = tasks.register("extractPluginRequests", ExtractPluginRequestsTask.class, task -> {
             task.getScriptPlugins().convention(scriptPlugins);
-            task.getScriptFiles().from(task.getScriptPlugins().map(list -> list.stream().map(p -> p.getSource().getResource().getFile()).collect(Collectors.toSet())));
+            task.getScriptFiles().from(scriptPluginFiles.getFiles());
             task.getExtractedPluginRequestsClassesDirectory().convention(buildDir.dir("groovy-dsl-plugins/plugin-requests"));
         });
 
@@ -71,7 +71,7 @@ class PrecompiledGroovyPluginsPlugin implements Plugin<Project> {
 
         TaskProvider<CompileGroovyScriptPluginsTask> precompilePlugins = tasks.register("compileGroovyPlugins", CompileGroovyScriptPluginsTask.class, task -> {
             task.getScriptPlugins().convention(scriptPlugins);
-            task.getScriptFiles().from(task.getScriptPlugins().map(list -> list.stream().map(p -> p.getSource().getResource().getFile()).collect(Collectors.toSet())));
+            task.getScriptFiles().from(scriptPluginFiles.getFiles());
             task.getPrecompiledGroovyScriptsOutputDirectory().convention(buildDir.dir("groovy-dsl-plugins/output/plugin-classes"));
 
             SourceDirectorySet javaSource = pluginSourceSet.getJava();

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
@@ -34,7 +34,7 @@ class PrecompiledGroovyScriptTest extends Specification {
     def "creates valid java classname '#javaClass' from script filename based plugin id: #filename"() {
         expect:
         def script = new PrecompiledGroovyScript(new File("/foo/bar/$filename"))
-        script.generatedPluginClassName == javaClass
+        script.pluginAdapterClassName == javaClass
 
         where:
         filename                     | javaClass


### PR DESCRIPTION
Class files for compiled Groovy plugin scripts were depending on absolute paths.
Generated Plugin adapters depend on the class name of the compiled script file, but not on the class files themselves. This is because the adapter class is compiled together with the Java source set and Groovy plugin sources can depend on Java classes.
This created a situation where:
1) both tasks - `compilePlugins` and `generateAdapters` are cached with some absolute-path dependent generated class name
2) on another machine, with a different directory structure, a build is started, artifacts are pulled from the cache - everything works
3) if a script source is now modified, `generateAdapters` task would be pulled from cache. While `compilePlugins`  task would create classes with different names because of different absolute paths of their source files. 

The adapter would still compile fine, but it would fail at runtime. An existing test missed the runtime part of this scenario - it only checked that the tasks would be cached, but it did not try to execute the result.

This change makes the classes of precompiled Groovy scripts depend on their source file name only. File name in this case is where plugin ID is derived from. Plugin IDs have to be unique anyway.