### PR TITLE
Run JVM test classes in a reproducible order

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.TestResources
+import org.junit.Rule
+
+import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
+import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
+
+@TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE_JUPITER })
+class DefaultTestOrderingIntegrationTest extends MultiVersionIntegrationSpec {
+
+    @Rule public final TestResources resources = new TestResources(temporaryFolder)
+
+    def setup() {
+        executer.noExtraLogging()
+        executer.withRepositoryMirrors()
+    }
+
+    private void addEmptyTestClass(String testName) {
+        file("src/test/java/${testName}.java") << """
+import org.junit.*;
+public class ${testName} {
+    @Test public void test() {}
+}
+"""
+    }
+
+    def "test classes are scanned and run in deterministic order by default"() {
+        addEmptyTestClass("AdTest")
+        addEmptyTestClass("AATest")
+        addEmptyTestClass("AyTest")
+        addEmptyTestClass("AÆTest")
+        addEmptyTestClass("ACTest")
+        addEmptyTestClass("AÄTest")
+        addEmptyTestClass("AZTest")
+        addEmptyTestClass("AbTest")
+
+        String expectedTestMessages = """
+executed Test test(AATest)
+executed Test test(ACTest)
+executed Test test(AZTest)
+executed Test test(AbTest)
+executed Test test(AdTest)
+executed Test test(AyTest)
+executed Test test(AÄTest)
+executed Test test(AÆTest)
+"""
+
+        file("build.gradle") << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'junit:junit:4.12' }
+            test.beforeTest { println "executed " + it }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        outputContains(expectedTestMessages)
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScanner.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScanner.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.testing.detection;
 import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.ReproducibleFileVisitor;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
@@ -72,7 +73,7 @@ public class DefaultTestClassScanner implements Runnable {
         });
     }
 
-    private abstract class ClassFileVisitor extends EmptyFileVisitor {
+    private abstract class ClassFileVisitor extends EmptyFileVisitor implements ReproducibleFileVisitor {
         @Override
         public void visitFile(FileVisitDetails fileDetails) {
             if (isClass(fileDetails) && !isAnonymousClass(fileDetails)) {
@@ -89,6 +90,11 @@ public class DefaultTestClassScanner implements Runnable {
         private boolean isClass(FileVisitDetails fileVisitDetails) {
             String fileName = fileVisitDetails.getFile().getName();
             return fileName.endsWith(".class") && !"module-info.class".equals(fileName);
+        }
+
+        @Override
+        public boolean isReproducibleFileOrder() {
+            return true;
         }
     }
 


### PR DESCRIPTION
(From commit message:)

This addresses part of #8520. (It fixes the title of the issue, but the issue author had additional requests not supported here.)

Ideally, we would support running test classes in a stable but
non-obvious ordering that doesn't encourage a reliance on the
order in which tests are run. The ordering here (which is easier
to achieve) is stable but also obvious. This is still preferable
to having non-deterministic ordering; it fixes the issue of having
a set of tests pass pre-merge CI for one commit and then fail in
other commits due to running in a different order.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
**My specific situation:**
The current situation in which this is particularly important for me is that we are converting many JUnit 4 tests in a legacy codebase, originally in test suites, into JUnit 5 tests where suites are not supported. Our CI system automatically converts these JUnit 5 tests into "autosuites" of tests that are run together, to considerably reduce overhead time. (This is similar to grouping the tests into reasonably sized modules and then running all the tests in each module, though in our case we also share e.g. initial database setup among the tests. It's also worth noting that our CI system has its own parallelism, so we aren't using Gradle's test-class-level parallelism.) Some of these tests were originally written in ways that affected static state, and so some of these tests will fail if run in the "wrong" relative order. Previously this order was fixed by the test suites.

My current options to get test classes running in a deterministic order are to make configuration changes that require some custom code that ends up relying on internal Gradle classes, or to run the JUnit Platform Console Launcher manually (which preserves the order of classes passed in via `--select-classes`) and lose Gradle's test reporting. I've chosen the former, though it adds some risk/effort to Gradle upgrades.

**Broader design considerations:**
This affects the test class scanner, which feeds into the test class processor, which may collect the classes and then reorder them. This is fine; certain processors will want to "degrade" to the test scanner-provided ordering if they don't have anything interesting to do, and it looks like the [RunPreviousFailedFirstTestClassProcessor](https://github.com/gradle/gradle/blob/241d20ca8855f4f5d8b78f90d201df84c8b70e43/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessor.java#L34) and [proposed RunSortedBySizeTestClassProcessor](https://github.com/gradle/gradle/pull/12012/files#diff-f7e3dca231ee35d0b9a3895bdbe8431c) already do so.

I understand that there are also proponents of making test ordering more random, to help flush out these badly-behaving tests more quickly. My experience is that while such testing can also be useful, it hurts devX in routine pre-merge CI builds for a large multi-dev project, where the person inconvenienced by the test failures is rarely the person who caused (or knows how to fix) the faulty test. In any case, the current default behavior is not quite random and not quite deterministic.

Another possible approach would be to make the test class ordering deterministic but non-obvious, an approach favored by JUnit 5 in many situations. (It should also be stable when adding or removing individual tests.) This would require a larger change than this PR currently proposes.

I'd also be happy to make this configurable, though I suspect that some sort of deterministic behavior should be the default.

I'm not sure where (or if) this behavior should be documented. Deterministic test ordering can't be guaranteed with certain implementations of parallelized tests, for example.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
