### PR TITLE
Fix invalid caching of exclusion

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -54,7 +54,6 @@ class EdgeState implements DependencyGraphEdge {
     private final DependencyMetadata dependencyMetadata;
     private final NodeState from;
     private final ResolveState resolveState;
-    private final ExcludeSpec transitiveExclusions;
     private final List<NodeState> targetNodes = Lists.newLinkedList();
     private final boolean isTransitive;
     private final boolean isConstraint;
@@ -63,6 +62,7 @@ class EdgeState implements DependencyGraphEdge {
     private SelectorState selector;
     private ModuleVersionResolveException targetNodeSelectionFailure;
     private ImmutableAttributes cachedAttributes;
+    private ExcludeSpec transitiveExclusions;
     private ExcludeSpec cachedEdgeExclusions;
     private ExcludeSpec cachedExclusions;
 
@@ -414,5 +414,17 @@ class EdgeState implements DependencyGraphEdge {
 
     DependencyState getDependencyState() {
         return dependencyState;
+    }
+
+    public void updateTransitiveExcludes(ExcludeSpec newResolutionFilter) {
+        if (isConstraint) {
+            // Constraint do not carry excludes on a path
+            return;
+        }
+        transitiveExclusions = newResolutionFilter;
+        cachedExclusions = null;
+        for (NodeState targetNode : targetNodes) {
+            targetNode.updateTransitiveExcludes();
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -305,6 +305,12 @@ public class NodeState implements DependencyGraphNode {
         // (it used to be) because if the filters are _equivalent_, we would
         // revisit all dependencies and possibly change the classpath order!
         boolean sameDependencies = dependencies(newResolutionFilter).equals(oldStates);
+        if (sameDependencies) {
+            // While there will be no change to this node, there might be changes to the nodes it brings as the exclude change could concern them
+            for (EdgeState outgoingEdge : outgoingEdges) {
+                outgoingEdge.updateTransitiveExcludes(newResolutionFilter);
+            }
+        }
         if (LOGGER.isDebugEnabled()) {
             if (sameDependencies) {
                 LOGGER.debug("Filter {} excludes same dependencies as previous {}. Dependencies left = {}", newResolutionFilter, previousTraversalExclusions, oldStates);
@@ -1148,5 +1154,12 @@ public class NodeState implements DependencyGraphNode {
             resolvedVariantCapabilities
         );
         return cachedVariantResult;
+    }
+
+    public void updateTransitiveExcludes() {
+        cachedModuleResolutionFilter = null;
+        if (isSelected()) {
+            resolveState.onMoreSelected(this);
+        }
     }
 }


### PR DESCRIPTION
When the exclusion set changes but  does not impact the current node,
the engine still need to ensure that nodes lower down the graph are not
impacted either.