### PR TITLE
Deprecate internal `AbstractTask`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.tasks
 
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.internal.TaskInternal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -80,7 +82,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        succeeds ":emptyOptions", ":nothing",":withAction", ":withOptions", ":withOptionsAndAction"
+        succeeds ":emptyOptions", ":nothing", ":withAction", ":withOptions", ":withOptionsAndAction"
     }
 
     def "can define tasks in nested blocks"() {
@@ -123,7 +125,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             ":withAction", ":withOptions", ":withOptionsAndAction", ":all"
     }
 
-    def "can configure tasks when the are defined"() {
+    def "can configure tasks when they are defined"() {
         buildFile << """
             task withDescription { description = 'value' }
             task(asMethod)\n{ description = 'value' }
@@ -143,6 +145,58 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds "all"
+    }
+
+    def "can define task using type Task"() {
+        buildFile << """
+            task thing(type: Task) { t ->
+                assert t instanceof DefaultTask
+                doFirst { println("thing") }
+            }
+        """
+
+        expect:
+        succeeds("thing")
+    }
+
+    def "creating a task of type AbstractTask is deprecated"() {
+        buildFile << """
+            task thing(type: ${AbstractTask.name}) { t ->
+                assert t instanceof DefaultTask
+                doFirst { println("thing") }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Registering a task with type AbstractTask has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
+        succeeds("thing")
+    }
+
+    def "creating a task of type TaskInternal is deprecated"() {
+        buildFile << """
+            task thing(type: ${TaskInternal.name}) { t ->
+                assert t instanceof DefaultTask
+                doFirst { println("thing") }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Registering a task with type TaskInternal has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
+        succeeds("thing")
+    }
+
+    def "creating a task that is a subtype of AbstractTask is deprecated"() {
+        buildFile << """
+            class CustomTask extends ${AbstractTask.name} {
+            }
+            task thing(type: CustomTask) { t ->
+                doFirst { println("thing") }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Registering a task with a subtype of AbstractTask has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
+        succeeds("thing")
     }
 
     def "does not hide local methods and variables"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -195,7 +195,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Registering a task with a subtype of AbstractTask has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
+        executer.expectDocumentedDeprecationWarning("Registering a task with a type that directly extends AbstractTask has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
         succeeds("thing")
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -372,10 +372,10 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         // Problem is exposed by Java compiler
         file("buildSrc/src/main/java/AbstractCustomTask.java") << """
             import org.gradle.api.file.ConfigurableFileCollection;
-            import org.gradle.api.internal.AbstractTask;
+            import org.gradle.api.DefaultTask;
             import org.gradle.api.tasks.InputFiles;
 
-            abstract class AbstractCustomTask extends AbstractTask {
+            abstract class AbstractCustomTask extends DefaultTask {
                 private final ConfigurableFileCollection sourceFiles = getProject().files();
 
                 @InputFiles

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -98,6 +98,10 @@ import java.util.concurrent.Callable;
 
 import static org.gradle.util.GUtil.uncheckedCall;
 
+/**
+ * @deprecated This class will be removed in Gradle 7.0. Please use {@link org.gradle.api.DefaultTask} instead.
+ */
+@Deprecated
 public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     private static final Logger BUILD_LOGGER = Logging.getLogger(Task.class);
     private static final ThreadLocal<TaskInfo> NEXT_INSTANCE = new ThreadLocal<TaskInfo>();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -20,10 +20,12 @@ import org.gradle.api.Describable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.AbstractTask;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.api.tasks.TaskInstantiationException;
 import org.gradle.internal.Describables;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.util.NameValidator;
 
@@ -59,9 +61,21 @@ public class TaskFactory implements ITaskFactory {
         NameValidator.validate(identity.name, "task name", "");
 
         final Class<? extends AbstractTask> implType;
-        if (identity.type.isAssignableFrom(DefaultTask.class)) {
+        if (identity.type == Task.class) {
+            implType = DefaultTask.class;
+        } else if (DefaultTask.class.isAssignableFrom(identity.type)) {
+            implType = identity.type.asSubclass(AbstractTask.class);
+        } else if (identity.type == AbstractTask.class || identity.type == TaskInternal.class) {
+            DeprecationLogger.deprecate("Registering a task with type " + identity.type.getSimpleName())
+                .willBecomeAnErrorInGradle7()
+                .withUpgradeGuideSection(6, "abstract_task_deprecated")
+                .nagUser();
             implType = DefaultTask.class;
         } else {
+            DeprecationLogger.deprecate("Registering a task with a subtype of AbstractTask")
+                .willBecomeAnErrorInGradle7()
+                .withUpgradeGuideSection(6, "abstract_task_deprecated")
+                .nagUser();
             implType = identity.type.asSubclass(AbstractTask.class);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -72,7 +72,7 @@ public class TaskFactory implements ITaskFactory {
                 .nagUser();
             implType = DefaultTask.class;
         } else {
-            DeprecationLogger.deprecate("Registering a task with a subtype of AbstractTask")
+            DeprecationLogger.deprecate("Registering a task with a type that directly extends AbstractTask")
                 .willBecomeAnErrorInGradle7()
                 .withUpgradeGuideSection(6, "abstract_task_deprecated")
                 .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -42,6 +42,18 @@ Some plugins will break with this new version of Gradle, for example because the
 
 - Kotlin has been updated to https://github.com/JetBrains/kotlin/releases/tag/v1.3.72[Kotlin 1.3.72].
 
+=== Deprecations
+
+[[abstract_task_deprecated]]
+==== Internal class AbstractTask is deprecated
+
+`AbstractTask` is an internal class which is visible on the public API, as a superclass of public type `DefaultTask`.
+`AbstractTask` will be removed in Gradle 7.0, and the following are deprecated in Gradle 6.5:
+
+- Registering a task whose type is `AbstractTask` or `TaskInternal`. You can remove the task type from the task registration and Gradle will use `DefaultTask` instead.
+- Registering a task whose type is a subclass of `AbstractTask` but not a subclass of `DefaultTask`. You can change the task type to extend `DefaultTask` instead.
+- Using the class `AbstractTask` from plugin code or build scripts. You can change the code to use `DefaultTask` instead.
+
 [[changes_6.4]]
 == Upgrading from 6.3
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Deprecate `AbstractTask` so that it can be removed in Gradle 7.0. `AbstractTask` is an internal type that is exposed on the public via `DefaultTask` and this results in many internal types leaking onto the public API. This change is a step towards addressing this problem.

Also deprecate registering a task using a task type that is not a subtype of `DefaultTask`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
