### PR TITLE
Restore the ability to define JavaExec.main via task convention

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -28,6 +28,7 @@ import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
@@ -123,7 +124,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         execResult = getObjectFactory().property(ExecResult.class);
 
         javaExecHandleBuilder = getDslExecActionFactory().newDecoratedJavaExecAction();
-        javaExecHandleBuilder.getMainClass().convention(mainClass);
+        javaExecHandleBuilder.getMainClass().convention(getProviderFactory().provider(this::getMain)); // go through 'main' to keep this compatible with existing convention mappings
         javaExecHandleBuilder.getMainModule().convention(mainModule);
         javaExecHandleBuilder.getModularity().getInferModulePath().convention(modularity.getInferModulePath());
         javaExecHandleBuilder.setClasspath(classpath);
@@ -136,6 +137,11 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
 
     @Inject
     protected ExecActionFactory getExecActionFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected ProviderFactory getProviderFactory() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -237,6 +237,25 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         outputFile.text == "different"
     }
 
+    @ToBeFixedForInstantExecution
+    def "main class can be configured through a convention mapping"() {
+        given:
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                conventionMapping("main") { "driver.Driver" }
+            }
+        """
+
+        when:
+        run "run"
+
+        then:
+        executedAndNotSkipped ":run"
+    }
+
     private void assertOutputFileIs(String text) {
         assert file("out.txt").text == text
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
@@ -56,7 +56,7 @@ public class DefaultJavaApplication implements JavaApplication {
 
     @Override
     public String getMainClassName() {
-        return mainClass.get();
+        return mainClass.getOrNull();
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -244,6 +244,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         given:
         buildFile << """
             plugins {
+                id "application"
                 id "org.springframework.boot" version "${TestedVersions.springBoot}"
             }
         """.stripIndent()
@@ -257,13 +258,24 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         """.stripIndent()
 
         when:
-        def result = runner('build').build()
-        println(result.output)
+        def buildResult = runner('build').build()
 
         then:
-        result.task(':buildEnvironment').outcome == SUCCESS
+        buildResult.task(':build').outcome == SUCCESS
 
-        expectNoDeprecationWarnings(result)
+        // https://github.com/spring-projects/spring-boot/issues/20759
+        expectDeprecationWarnings(buildResult,
+            "Property 'mainClassName' is annotated with @Optional that is not allowed for @Internal properties. " +
+                "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+                "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+
+        when:
+        def runResult = runner('bootRun').build()
+
+        then:
+        runResult.task(':bootRun').outcome == SUCCESS
+
+        expectNoDeprecationWarnings(runResult)
     }
 
     @Issue('https://plugins.gradle.org/plugin/com.bmuschko.tomcat')


### PR DESCRIPTION
Fixes #12833
Fixes #12834
