### PR TITLE
Invalidate instant execution cache upon changes to `buildSrc` build logic inputs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -303,8 +303,11 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         );
     }
 
-    protected ProviderFactory createProviderFactory(ValueSourceProviderFactory valueSourceProviderFactory) {
-        return new DefaultProviderFactory(valueSourceProviderFactory);
+    protected ProviderFactory createProviderFactory(
+        Instantiator instantiator,
+        ValueSourceProviderFactory valueSourceProviderFactory
+    ) {
+        return instantiator.newInstance(DefaultProviderFactory.class, valueSourceProviderFactory);
     }
 
     protected ActorFactory createActorFactory() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
@@ -508,6 +508,62 @@ class InstantExecutionBuildOptionsIntegrationTest extends AbstractInstantExecuti
         "orElse"    | "Provider<String>" | "task input"
     }
 
+    def "can define and use custom value source in a Groovy script"() {
+
+        given:
+        def instant = newInstantExecutionFixture()
+        buildFile.text = """
+
+            import org.gradle.api.provider.*
+
+            abstract class IsSystemPropertySet implements ValueSource<Boolean, Parameters> {
+                interface Parameters extends ValueSourceParameters {
+                    Property<String> getPropertyName()
+                }
+                @Override Boolean obtain() {
+                    System.getProperty(parameters.getPropertyName().get()) != null
+                }
+            }
+
+            def isCi = providers.of(IsSystemPropertySet) {
+                parameters {
+                    propertyName = "ci"
+                }
+            }
+            if (isCi.get()) {
+                tasks.register("build") {
+                    doLast { println("ON CI") }
+                }
+            } else {
+                tasks.register("build") {
+                    doLast { println("NOT CI") }
+                }
+            }
+        """
+
+        when:
+        instantRun "build"
+
+        then:
+        output.count("NOT CI") == 1
+        instant.assertStateStored()
+
+        when:
+        instantRun "build"
+
+        then:
+        output.count("NOT CI") == 1
+        instant.assertStateLoaded()
+
+        when:
+        instantRun "build", "-Dci=true"
+
+        then:
+        output.count("ON CI") == 1
+        output.contains("because a build logic input of type 'IsSystemPropertySet' has changed")
+        instant.assertStateStored()
+    }
+
     private static String getGreetTask() {
         """
             abstract class Greet : DefaultTask() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
@@ -87,7 +87,12 @@ class InstantExecutionBuildOptionsIntegrationTest extends AbstractInstantExecuti
     enum SystemPropertySource {
         COMMAND_LINE,
         GRADLE_PROPERTIES,
-        GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR
+        GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR;
+
+        @Override
+        String toString() {
+            name().toLowerCase().replace('_', ' ')
+        }
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcChangesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcChangesIntegrationTest.groovy
@@ -63,8 +63,7 @@ class InstantExecutionBuildSrcChangesIntegrationTest extends AbstractInstantExec
         instant.assertStateLoaded()
 
         where:
-//        [language_, change_] << [BuildSrcLanguage.values(), BuildSrcChange.values()].combinations()
-        [language_, change_] << [[BuildSrcLanguage.KOTLIN], [BuildSrcChange.CHANGE_SOURCE]].combinations()
+        [language_, change_] << [BuildSrcLanguage.values(), BuildSrcChange.values()].combinations()
         language = language_ as BuildSrcLanguage
         change = change_ as BuildSrcChange
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintChecker.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintChecker.kt
@@ -17,6 +17,7 @@
 package org.gradle.instantexecution.fingerprint
 
 import org.gradle.api.Describable
+import org.gradle.api.internal.GeneratedSubclasses.unpackType
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -83,5 +84,5 @@ class InstantExecutionCacheFingerprintChecker(private val host: Host) {
     fun buildLogicInputHasChanged(valueSource: ValueSource<Any, ValueSourceParameters>): InvalidationReason =
         (valueSource as? Describable)?.let {
             it.displayName + " has changed"
-        } ?: "a build logic input of type '${valueSource.javaClass.simpleName}' has changed"
+        } ?: "a build logic input of type '${unpackType(valueSource).simpleName}' has changed"
 }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
@@ -41,7 +41,6 @@ import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.jetbrains.kotlin.backend.common.push
 import org.junit.Test
 import java.io.InputStream
 import java.io.OutputStream
@@ -109,11 +108,11 @@ class InstantExecutionFingerprintCheckerTest {
             PlaybackReadContext(values.toList())
 
         override fun writeSmallInt(value: Int) {
-            values.push(value)
+            values.add(value)
         }
 
         override suspend fun write(value: Any?) {
-            values.push(value)
+            values.add(value)
         }
 
         override val sharedIdentities: WriteIdentities

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
@@ -23,6 +23,8 @@ import org.gradle.api.provider.ValueSourceParameters;
 import org.gradle.api.provider.ValueSourceSpec;
 import org.gradle.internal.Try;
 
+import javax.annotation.Nullable;
+
 /**
  * Service to create providers from {@link ValueSource}s.
  *
@@ -61,6 +63,7 @@ public interface ValueSourceProviderFactory {
 
             Class<P> getValueSourceParametersType();
 
+            @Nullable
             P getValueSourceParameters();
         }
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider
 
+import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -86,13 +87,25 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
         ((Managed) provider).isImmutable()
     }
 
-    def "value source with no parameters"() {
+    def "parameterless value source can be used"() {
 
         given:
         def provider = createProviderOf(NoParameters) {}
 
         expect:
         provider.get() == 42
+    }
+
+    def "parameterless value source parameters cannot be configured"() {
+        when:
+        createProviderOf(NoParameters) {
+            it.parameters { }
+        }
+
+        then:
+        def e = thrown(GradleException)
+        e.message == 'Could not create provider for value source DefaultValueSourceProviderFactoryTest.NoParameters.'
+        e.cause.message == 'Value is null'
     }
 
     static abstract class EchoValueSource implements ValueSource<String, Parameters> {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -86,6 +86,15 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
         ((Managed) provider).isImmutable()
     }
 
+    def "value source with no parameters"() {
+
+        given:
+        def provider = createProviderOf(NoParameters) {}
+
+        expect:
+        provider.get() == 42
+    }
+
     static abstract class EchoValueSource implements ValueSource<String, Parameters> {
 
         interface Parameters extends ValueSourceParameters {
@@ -95,6 +104,14 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
         @Override
         String obtain() {
             return getParameters().getValue().getOrNull()
+        }
+    }
+
+    static abstract class NoParameters implements ValueSource<Integer, ValueSourceParameters.None> {
+
+        @Override
+        Integer obtain() {
+            return 42
         }
     }
 }


### PR DESCRIPTION
This PR only adds test coverage and improves the overall behaviour of value sources. The core functionality was already implemented.