### PR TITLE
Fix StackOverflowError when fileCollection += is used from the Groovy DSL

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -23,7 +23,6 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -117,11 +116,11 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
 
     public JavaExec() {
         ObjectFactory objectFactory = getObjectFactory();
-        this.mainModule = objectFactory.property(String.class);
-        this.mainClass = objectFactory.property(String.class);
-        this.classpath = getFileCollectionFactory().configurableFiles("classpath");
-        this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
-        execResult = getObjectFactory().property(ExecResult.class);
+        mainModule = objectFactory.property(String.class);
+        mainClass = objectFactory.property(String.class);
+        classpath = objectFactory.fileCollection();
+        modularity = objectFactory.newInstance(DefaultModularitySpec.class);
+        execResult = objectFactory.property(ExecResult.class);
 
         javaExecHandleBuilder = getDslExecActionFactory().newDecoratedJavaExecAction();
         javaExecHandleBuilder.getMainClass().convention(getProviderFactory().provider(this::getMain)); // go through 'main' to keep this compatible with existing convention mappings
@@ -147,11 +146,6 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
 
     @Inject
     protected DslExecActionFactory getDslExecActionFactory() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected FileCollectionFactory getFileCollectionFactory() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
@@ -15,23 +15,24 @@
  */
 package org.gradle.api.internal.file;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
-import org.gradle.util.GUtil;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
+/**
+ * An immutable sequence of file collections.
+ */
 public class UnionFileCollection extends CompositeFileCollection {
-    private final Set<FileCollection> source;
+    private final ImmutableSet<FileCollection> source;
 
     public UnionFileCollection(FileCollection... source) {
-        this(Arrays.asList(source));
+        this.source = ImmutableSet.copyOf(source);
     }
 
     public UnionFileCollection(Iterable<? extends FileCollection> source) {
-        this.source = GUtil.addToCollection(new LinkedHashSet<FileCollection>(), source);
+        this.source = ImmutableSet.copyOf(source);
     }
 
     @Override
@@ -41,10 +42,6 @@ public class UnionFileCollection extends CompositeFileCollection {
 
     public Set<FileCollection> getSources() {
         return source;
-    }
-
-    public void addToUnion(FileCollection collection) {
-        source.add(collection);
     }
 
     @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
@@ -47,16 +47,6 @@ class UnionFileCollectionTest extends Specification {
         collection.files == [file1, file2, file3] as LinkedHashSet
     }
 
-    def canAddCollection() {
-        def source1 = new TestFileCollection(file1)
-        def source2 = new TestFileCollection(file2)
-
-        expect:
-        def collection = new UnionFileCollection([source1])
-        collection.addToUnion(source2)
-        collection.files == [file1, file2] as LinkedHashSet
-    }
-
     def dependsOnUnionOfDependenciesOfSourceCollections() {
         def task1 = Stub(Task)
         def task2 = Stub(Task)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -293,6 +293,66 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         files.empty
     }
 
+    def canAppendContentsToEmptyCollectionUsingPlusOperator() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def src = containing(file1, file2)
+
+        when:
+        collection.from = collection + src
+        def files = collection.files
+
+        then:
+        files as List == [file1, file2]
+    }
+
+    def canAppendContentsToCollectionUsingPlusOperator() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def src = containing(file2)
+
+        when:
+        collection.from = "src1"
+        collection.from = collection + src
+        def files = collection.files
+
+        then:
+        _ * fileResolver.resolve("src1") >> file1
+        files as List == [file1, file2]
+    }
+
+    def canPrependContentsToEmptyCollectionUsingPlusOperator() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def src = containing(file1, file2)
+
+        when:
+        collection.from = src + collection
+        def files = collection.files
+
+        then:
+        files as List == [file1, file2]
+    }
+
+    def canPrependContentsToCollectionUsingPlusOperator() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def src = containing(file1)
+
+        when:
+        collection.from = "src2"
+        collection.from = src + collection
+        def files = collection.files
+
+        then:
+        _ * fileResolver.resolve("src2") >> file2
+        files as List == [file1, file2]
+    }
+
     def elementsProviderTracksChangesToContent() {
         given:
         def file1 = new File("1")

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -18,8 +18,8 @@ package org.gradle.api.tasks.testing;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Transformer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.BinaryResultBackedTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider;
@@ -78,27 +78,27 @@ public class TestReport extends DefaultTask {
      * Returns the set of binary test results to include in the report.
      */
     @PathSensitive(PathSensitivity.NONE)
-    @InputFiles @SkipWhenEmpty
+    @InputFiles
+    @SkipWhenEmpty
     public FileCollection getTestResultDirs() {
-        UnionFileCollection dirs = new UnionFileCollection();
+        ConfigurableFileCollection dirs = getObjectFactory().fileCollection();
         for (Object result : results) {
             addTo(result, dirs);
         }
         return dirs;
     }
 
-    private void addTo(Object result, UnionFileCollection dirs) {
-        ObjectFactory objects = getObjectFactory();
+    private void addTo(Object result, ConfigurableFileCollection dirs) {
         if (result instanceof Test) {
             Test test = (Test) result;
-            dirs.addToUnion(objects.fileCollection().from(test.getBinaryResultsDirectory()).builtBy(test));
+            dirs.from(test.getBinaryResultsDirectory());
         } else if (result instanceof Iterable<?>) {
             Iterable<?> iterable = (Iterable<?>) result;
             for (Object nested : iterable) {
                 addTo(nested, dirs);
             }
         } else {
-            dirs.addToUnion(objects.fileCollection().from(result));
+            dirs.from(result);
         }
     }
 


### PR DESCRIPTION

### Context

This is a fix so that += works from the Groovy DSL for a property of type `ConfigurableFileCollection` with a fixed value and a legacy setter (that is, a setter that simply calls `setFrom()` on the file collection with its argument).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
