### PR TITLE
Restore TestKit multi-version compatibility tests

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.fixtures.CustomDaemonDirectory
+import org.gradle.testkit.runner.fixtures.CustomEnvironmentVariables
 import org.gradle.testkit.runner.fixtures.Debug
 import org.gradle.testkit.runner.fixtures.InjectsPluginClasspath
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
@@ -65,6 +66,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
     public static final GradleVersion MIN_TESTED_VERSION = TestKitFeature.RUN_BUILDS.since
     public static final GradleVersion CUSTOM_DAEMON_DIR_SUPPORT_VERSION = GradleVersion.version("2.2")
     public static final GradleVersion NO_SOURCE_TASK_OUTCOME_SUPPORT_VERSION = GradleVersion.version("3.4")
+    public static final GradleVersion ENVIRONMENT_VARIABLES_SUPPORT_VERSION = GradleVersion.version("3.5")
 
     // Context set by multi run infrastructure
     public static GradleVersion gradleVersion
@@ -361,6 +363,9 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
                     return false
                 }
                 if (testDetails.getAnnotation(WithNoSourceTaskOutcome) && gradleVersion < NO_SOURCE_TASK_OUTCOME_SUPPORT_VERSION) {
+                    return false
+                }
+                if (testDetails.getAnnotation(CustomEnvironmentVariables) && gradleVersion < ENVIRONMENT_VARIABLES_SUPPORT_VERSION) {
                     return false
                 }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -40,6 +40,7 @@ import org.gradle.testkit.runner.fixtures.Debug
 import org.gradle.testkit.runner.fixtures.InjectsPluginClasspath
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
+import org.gradle.testkit.runner.fixtures.InspectsGroupedOutput
 import org.gradle.testkit.runner.fixtures.NoDebug
 import org.gradle.testkit.runner.fixtures.NonCrossVersion
 import org.gradle.testkit.runner.fixtures.WithNoSourceTaskOutcome
@@ -67,6 +68,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
     public static final GradleVersion CUSTOM_DAEMON_DIR_SUPPORT_VERSION = GradleVersion.version("2.2")
     public static final GradleVersion NO_SOURCE_TASK_OUTCOME_SUPPORT_VERSION = GradleVersion.version("3.4")
     public static final GradleVersion ENVIRONMENT_VARIABLES_SUPPORT_VERSION = GradleVersion.version("3.5")
+    public static final GradleVersion INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION = GradleVersion.version("5.0")
 
     // Context set by multi run infrastructure
     public static GradleVersion gradleVersion
@@ -366,6 +368,9 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
                     return false
                 }
                 if (testDetails.getAnnotation(CustomEnvironmentVariables) && gradleVersion < ENVIRONMENT_VARIABLES_SUPPORT_VERSION) {
+                    return false
+                }
+                if (testDetails.getAnnotation(InspectsGroupedOutput) && gradleVersion < INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION) {
                     return false
                 }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
+import org.gradle.testkit.runner.fixtures.InspectsGroupedOutput
+import org.gradle.util.GradleVersion
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -83,13 +85,16 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
     }
 
     @InspectsBuildOutput
+    @InspectsGroupedOutput
     @InspectsExecutedTasks
     def "exposes result when build is expected to fail but does not"() {
         given:
         buildScript helloWorldTask()
 
         when:
-        def runner = runner('helloWorld', '--warning-mode=none')
+        def runner = gradleVersion >= GradleVersion.version("4.5")
+            ? runner('helloWorld', '--warning-mode=none')
+            : runner('helloWorld')
         runner.buildAndFail()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testkit.runner
 import org.gradle.testkit.runner.fixtures.InjectsPluginClasspath
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.PluginUnderTest
+import org.gradle.util.GradleVersion
 import org.gradle.util.UsesNativeServices
 
 import static org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading.IMPLEMENTATION_CLASSPATH_PROP_KEY
@@ -56,7 +57,7 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
             |Plugin [id: 'com.company.helloworld'] was not found in any of the following sources:
             |
             |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Plugin Repositories (plugin dependency must include a version number for this source)
+            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
         """.stripMargin().trim())
     }
 
@@ -79,7 +80,7 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
             |
             |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
             |- Gradle TestKit (classpath: ${explicitClasspath*.absolutePath.join(File.pathSeparator)})
-            |- Plugin Repositories (plugin dependency must include a version number for this source)
+            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
         """.stripMargin().trim())
     }
 
@@ -120,4 +121,9 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
         t.message == "Plugin metadata file '${pluginUnderTest.metadataFile.toURI().toURL()}' does not contain expected property named '$IMPLEMENTATION_CLASSPATH_PROP_KEY'".toString()
     }
 
+    private static String getPluginRepositoriesDisplayName() {
+        return gradleVersion >= GradleVersion.version("4.4")
+            ? "Plugin Repositories"
+            : "Gradle Central Plugin Repository"
+    }
 }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerDaemonIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerDaemonIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.testkit.runner
 
 import org.gradle.integtests.fixtures.executer.DaemonGradleExecuter
 import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.testkit.runner.fixtures.CustomDaemonDirectory
 import org.gradle.testkit.runner.fixtures.NoDebug
 import org.junit.Rule
 
 @NoDebug
+@LeaksFileHandles
 class GradleRunnerDaemonIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     def setup() {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerDaemonIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerDaemonIntegrationTest.groovy
@@ -76,6 +76,7 @@ class GradleRunnerDaemonIntegrationTest extends BaseGradleRunnerIntegrationTest 
             .usingProjectDirectory(testDirectory)
             .withGradleUserHomeDir(testKitDir)
             .withDaemonBaseDir(defaultDaemonDir) // simulate default, our fixtures deviate from the default
+            .withWarningMode(null)
             .run()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.testkit.runner
 
+import org.gradle.testkit.runner.fixtures.CustomEnvironmentVariables
 import org.gradle.testkit.runner.fixtures.Debug
 import org.gradle.testkit.runner.fixtures.NoDebug
 
 class GradleRunnerEnvironmentVariablesIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
+    @CustomEnvironmentVariables
     @NoDebug //avoid in-process execution so that we can set the env variable
     def "user can provide env vars"() {
         given:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -168,9 +168,10 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
 
         and:
         def output = OutputScrapingExecutionResult.from(t.message, "")
+        def taskHeader = gradleVersion >= GradleVersion.version("4.0") ? "> Task :helloWorld" : ":helloWorld"
         output.normalizedOutput == """An error occurred executing build with args '${runner.arguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
 
-> Task :helloWorld
+$taskHeader
 Hello world!
 """
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -168,9 +168,8 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
 
         and:
         def output = OutputScrapingExecutionResult.from(t.message, "")
-        def taskHeader = gradleVersion >= GradleVersion.version("4.0") ? "> Task :helloWorld" : ":helloWorld"
+        def taskHeader = gradleVersion >= GradleVersion.version("4.0") ? "\n> Task :helloWorld" : ":helloWorld"
         output.normalizedOutput == """An error occurred executing build with args '${runner.arguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
-
 $taskHeader
 Hello world!
 """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.testkit.runner.fixtures.InjectsPluginClasspath
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
 import org.gradle.testkit.runner.fixtures.PluginUnderTest
+import org.gradle.util.GradleVersion
 import org.gradle.util.UsesNativeServices
 import spock.lang.Unroll
 
@@ -49,7 +50,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
             |Plugin [id: '$plugin.id'] was not found in any of the following sources:
             |
             |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Plugin Repositories (plugin dependency must include a version number for this source)
+            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
         """.stripMargin().trim())
     }
 
@@ -67,7 +68,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
             |
             |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
             |- Gradle TestKit (classpath: ${expectedClasspath*.absolutePath.join(File.pathSeparator)})
-            |- Plugin Repositories (plugin dependency must include a version number for this source)
+            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
         """.stripMargin().trim())
     }
 
@@ -110,9 +111,9 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
         then:
         // This is how the class not being visible will manifest
         execFailure(result).assertThatCause(
-                anyOf(
-                        containsString("Could not get unknown property 'org' for task ':echo1' of type org.gradle.api.DefaultTask."),
-                        containsString("Could not find property 'org' on task ':echo1'.")))
+            anyOf(
+                containsString("Could not get unknown property 'org' for task ':echo1' of type org.gradle.api.DefaultTask."),
+                containsString("Could not find property 'org' on task ':echo1'.")))
     }
 
     def "injected classes are inherited by child projects of project that applies plugin"() {
@@ -148,9 +149,9 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
         then:
         // This is how the class not being visible will manifest
         execFailure(result).assertThatCause(
-                anyOf(
-                        containsString("Could not get unknown property 'org' for task ':echo1' of type org.gradle.api.DefaultTask."),
-                        containsString("Could not find property 'org' on task ':echo1'.")))
+            anyOf(
+                containsString("Could not get unknown property 'org' for task ':echo1' of type org.gradle.api.DefaultTask."),
+                containsString("Could not find property 'org' on task ':echo1'.")))
     }
 
     def "injected classes are not visible to projects at run time that are not child projects of applying project"() {
@@ -379,4 +380,9 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
         result.output.contains('Hello world!1')
     }
 
+    private static String getPluginRepositoriesDisplayName() {
+        return gradleVersion >= GradleVersion.version("4.4")
+            ? "Plugin Repositories"
+            : "Gradle Central Plugin Repository"
+    }
 }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
@@ -56,7 +56,7 @@ class GradleRunnerResultIntegrationTest extends BaseGradleRunnerIntegrationTest 
         given:
         buildFile << """
            task empty {
-                inputs.files(project.layout.files()).skipWhenEmpty()
+                inputs.files(project.files()).skipWhenEmpty()
                 doLast{}
            }
         """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/CustomEnvironmentVariables.java
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/CustomEnvironmentVariables.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface CustomEnvironmentVariables {
+}

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/InspectsGroupedOutput.java
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/InspectsGroupedOutput.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface InspectsGroupedOutput {
+}

--- a/subprojects/test-kit/test-kit.gradle.kts
+++ b/subprojects/test-kit/test-kit.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
@@ -46,10 +45,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
-tasks.register<IntegrationTest>("crossVersionTests") {
-    description = "Runs the TestKit version compatibility tests"
-    systemProperties["org.gradle.integtest.testkit.compatibility"] = "all"
-    systemProperties["org.gradle.integtest.executer"] = "forking"
+tasks.integMultiVersionTest {
+    systemProperty("org.gradle.integtest.testkit.compatibility", "all")
+    // TestKit multi version tests are not using JUnit categories
+    (options as JUnitOptions).includeCategories.clear()
 }
 
 testFilesCleanup {


### PR DESCRIPTION
They were not running for a long while ... at least since Gradle 3.5.

The ad-hoc `:testKit:crossVersionTests` task was running tests from the `test` source set instead of from the `integTest` source set.

This PR prefers using `integMultiVersionTest` as those compatibility tests aren't "cross version tests". This requires disabling the JUnit category filter set by the `IntegrationTestsPlugin` because the TestKit compatibility tests are not using `@ContextualMultiVersionTest` but a dedicated runner.

The TestKit compatibility tests then run as part of the `Ready for Release` CI pipeline in the `AllVersionsIntegMultiVersion` jobs:
- https://builds.gradle.org/viewLog.html?buildId=33855718&tab=queuedBuildOverviewTab

Unsurprisingly, some tests are now failing.
- https://e.grdev.net/s/ggbnwzlhkl2ie/tests/failed

All failing tests were failing because of test problems, not production code problems.
This PR fixes those tests so they can work across tested versions.

The calculation of the minimum tested versions has also been refined as it was incorrectly ignoring annotations on spock features functions, producing tests that wouldn't work.