### PR TITLE
Apply the 'classycle' plugin consistently to all projects

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/Classycle.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/Classycle.kt
@@ -125,6 +125,7 @@ fun GroovyBuilderScope.withFilesetOf(classesDirs: FileCollection, excludePattern
             excludePatterns.forEach { excludePattern ->
                 "exclude"("name" to excludePattern)
             }
+            "exclude"("name" to "META-INF/**")
         }
     }
 

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/ClassyclePlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/ClassyclePlugin.kt
@@ -50,7 +50,6 @@ open class ClassyclePlugin : Plugin<Project> {
             )
             classycle { dependsOn(sourceSetTask) }
             tasks.named("check") { dependsOn(sourceSetTask) }
-            tasks.named("codeQuality") { dependsOn(sourceSetTask) }
         }
     }
 }

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     id("gradlebuild.gradle-distribution")
     id("gradlebuild.incubation-report")
     id("gradlebuild.task-properties-validation")
+    id("gradlebuild.classycle")
 }
 
 apply(from = "$rootDir/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -87,7 +87,7 @@ fun Project.configureCodenarc(codeQualityConfigDir: File) {
 
 
 fun Project.configureCodeQualityTasks() {
-    val codeQualityTasks = tasks.matching { it is CodeNarc || it is Checkstyle }
+    val codeQualityTasks = tasks.matching { it is CodeNarc || it is Checkstyle || it.name == "classycle" }
     tasks.register("codeQuality").configure {
         dependsOn(codeQualityTasks)
     }

--- a/subprojects/antlr/antlr.gradle.kts
+++ b/subprojects/antlr/antlr.gradle.kts
@@ -43,3 +43,7 @@ dependencies {
     testImplementation(testFixtures(project(":core")))
     testRuntimeOnly(project(":runtimeApiInfo"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/plugins/antlr/internal/*"))
+}

--- a/subprojects/base-annotations/base-annotations.gradle.kts
+++ b/subprojects/base-annotations/base-annotations.gradle.kts
@@ -17,7 +17,6 @@ plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 description = "Common shared annotations"

--- a/subprojects/base-services-groovy/base-services-groovy.gradle.kts
+++ b/subprojects/base-services-groovy/base-services-groovy.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    // gradlebuild.classycle <- DynamicObjectAware and DynamicObjectUtil should move to org.gradle.internal.metaobject (but it breaks third-party plugins)
 }
 
 dependencies {

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -7,7 +7,6 @@
 
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedInWorkers()

--- a/subprojects/bootstrap/bootstrap.gradle.kts
+++ b/subprojects/bootstrap/bootstrap.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedForStartup()

--- a/subprojects/build-cache-base/build-cache-base.gradle.kts
+++ b/subprojects/build-cache-base/build-cache-base.gradle.kts
@@ -17,7 +17,6 @@ plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/build-cache-http/build-cache-http.gradle.kts
+++ b/subprojects/build-cache-http/build-cache-http.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.classycle
 }
 
 description = "Package build cache results"

--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/build-init/build-init.gradle.kts
+++ b/subprojects/build-init/build-init.gradle.kts
@@ -18,7 +18,6 @@ import java.util.*
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/build-option/build-option.gradle.kts
+++ b/subprojects/build-option/build-option.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedInWorkers()

--- a/subprojects/build-profile/build-profile.gradle.kts
+++ b/subprojects/build-profile/build-profile.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-implementation-java`
-    gradlebuild.classycle
 }
 
 description = "Provides high-level insights into a Gradle build (--profile)"

--- a/subprojects/build-scan-performance/build-scan-performance.gradle.kts
+++ b/subprojects/build-scan-performance/build-scan-performance.gradle.kts
@@ -18,7 +18,6 @@ import org.gradle.testing.performance.generator.tasks.JvmProjectGeneratorTask
  */
 plugins {
     gradlebuild.internal.java
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/cli/cli.gradle.kts
+++ b/subprojects/cli/cli.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 description = "Utilities for parsing command line arguments"

--- a/subprojects/code-quality/code-quality.gradle.kts
+++ b/subprojects/code-quality/code-quality.gradle.kts
@@ -42,3 +42,7 @@ dependencies {
     testFixturesImplementation(project(":coreApi"))
     testFixturesImplementation(project(":baseServices"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/plugins/quality/internal/*"))
+}

--- a/subprojects/core-api/core-api.gradle.kts
+++ b/subprojects/core-api/core-api.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     testFixturesImplementation(project(":baseServices"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}
+
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -149,6 +149,10 @@ dependencies {
     crossVersionTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}
+
 tasks.test {
     setForkEvery(200)
 }

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -123,6 +123,10 @@ dependencies {
     crossVersionTestRuntimeOnly(project(":maven"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}
+
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }

--- a/subprojects/diagnostics/diagnostics.gradle.kts
+++ b/subprojects/diagnostics/diagnostics.gradle.kts
@@ -64,6 +64,13 @@ dependencies {
 
 }
 
+classycle {
+    excludePatterns.set(listOf(
+        "org/gradle/api/reporting/model/internal/*",
+        "org/gradle/api/reporting/dependencies/internal/*",
+        "org/gradle/api/plugins/internal/*"))
+}
+
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }

--- a/subprojects/ear/ear.gradle.kts
+++ b/subprojects/ear/ear.gradle.kts
@@ -41,3 +41,7 @@ dependencies {
 
     testRuntimeOnly(project(":runtimeApiInfo"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/plugins/ear/internal/*"))
+}

--- a/subprojects/execution/execution.gradle.kts
+++ b/subprojects/execution/execution.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 description = "Execution engine that takes a unit of work and makes it happen"

--- a/subprojects/file-collections/file-collections.gradle.kts
+++ b/subprojects/file-collections/file-collections.gradle.kts
@@ -15,8 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    // Some cycles have been inherited from the time these classes were in :core
-    // gradlebuild.classycle
 }
 
 dependencies {
@@ -56,4 +54,9 @@ dependencies {
 
     integTestRuntimeOnly(project(":apiMetadata"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
+}
+
+classycle {
+    // Some cycles have been inherited from the time these classes were in :core
+    excludePatterns.set(listOf("org/gradle/api/internal/file/collections/"))
 }

--- a/subprojects/files/files.gradle.kts
+++ b/subprojects/files/files.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.classycle
     gradlebuild.`strict-compile`
 }
 

--- a/subprojects/hashing/hashing.gradle.kts
+++ b/subprojects/hashing/hashing.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.classycle
     gradlebuild.`strict-compile`
 }
 

--- a/subprojects/ide-native/ide-native.gradle.kts
+++ b/subprojects/ide-native/ide-native.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/ide-play/ide-play.gradle.kts
+++ b/subprojects/ide-play/ide-play.gradle.kts
@@ -16,7 +16,6 @@ import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 val integTestRuntimeResources by configurations.creating {

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -66,6 +66,15 @@ dependencies {
     integTestRuntimeOnly(project(":testKit"))
 }
 
+classycle {
+    excludePatterns.set(listOf(
+        "org/gradle/plugins/ide/internal/*",
+        "org/gradle/plugins/ide/eclipse/internal/*",
+        "org/gradle/plugins/ide/idea/internal/*",
+        "org/gradle/plugins/ide/eclipse/model/internal/*",
+        "org/gradle/plugins/ide/idea/model/internal/*"))
+}
+
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -86,3 +86,7 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDsl"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/instantexecution/**"))
+}

--- a/subprojects/integ-test/integ-test.gradle.kts
+++ b/subprojects/integ-test/integ-test.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.internal.java
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -81,6 +81,10 @@ dependencies {
     testRuntimeOnly(project(":workers"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}
+
 val generatedResourcesDir = gradlebuildJava.generatedResourcesDir
 
 val prepareVersionsInfo = tasks.register<PrepareVersionsInfo>("prepareVersionsInfo") {

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -16,7 +16,6 @@
 import accessors.java
 plugins {
     gradlebuild.internal.java
-    gradlebuild.classycle
 }
 
 val reports by configurations.creating

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.internal.java
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -17,7 +17,6 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -51,3 +51,9 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
+
+classycle {
+    excludePatterns.set(listOf(
+        "org/gradle/internal/jacoco/*",
+        "org/gradle/testing/jacoco/plugins/*"))
+}

--- a/subprojects/javascript/javascript.gradle.kts
+++ b/subprojects/javascript/javascript.gradle.kts
@@ -41,3 +41,7 @@ dependencies {
 
     testRuntimeOnly(project(":runtimeApiInfo"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/plugins/javascript/coffeescript/**"))
+}

--- a/subprojects/jvm-services/jvm-services.gradle.kts
+++ b/subprojects/jvm-services/jvm-services.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 description = "JVM invocation and inspection abstractions"

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/kotlin/dsl/plugins/base/**"))
+}
 
 // plugins ------------------------------------------------------------
 

--- a/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
@@ -46,3 +46,7 @@ dependencies {
     testImplementation(project(":kotlinDslTestFixtures"))
     testImplementation(testLibrary("mockito_kotlin2"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/**"))
+}

--- a/subprojects/kotlin-dsl-tooling-models/kotlin-dsl-tooling-models.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-models/kotlin-dsl-tooling-models.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-kotlin`
-    gradlebuild.classycle
     gradlebuild.`strict-compile`
 }
 

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -106,6 +106,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/kotlin/dsl/**"))
+}
+
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 

--- a/subprojects/language-groovy/language-groovy.gradle.kts
+++ b/subprojects/language-groovy/language-groovy.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/language-jvm/language-jvm.gradle.kts
+++ b/subprojects/language-jvm/language-jvm.gradle.kts
@@ -1,7 +1,6 @@
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -17,7 +17,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/language-scala/language-scala.gradle.kts
+++ b/subprojects/language-scala/language-scala.gradle.kts
@@ -45,3 +45,10 @@ dependencies {
 
     compileOnly("org.scala-sbt:zinc_2.12:1.3.5")
 }
+
+classycle {
+    excludePatterns.set(listOf(
+        "org/gradle/api/internal/tasks/scala/**",
+        "org/gradle/language/scala/internal/toolchain/**"))
+}
+

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/logging/logging.gradle.kts
+++ b/subprojects/logging/logging.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 description = "Logging infrastructure"

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -75,6 +75,12 @@ dependencies {
     testFixturesImplementation(project(":dependencyManagement"))
 }
 
+classycle {
+    excludePatterns.set(listOf(
+        "org/gradle/api/publication/maven/internal/**",
+        "org/gradle/api/artifacts/maven/**"))
+}
+
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }

--- a/subprojects/messaging/messaging.gradle.kts
+++ b/subprojects/messaging/messaging.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedInWorkers()

--- a/subprojects/model-core/model-core.gradle.kts
+++ b/subprojects/model-core/model-core.gradle.kts
@@ -17,7 +17,6 @@
 import build.kotlinVersion
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/model-groovy/model-groovy.gradle.kts
+++ b/subprojects/model-groovy/model-groovy.gradle.kts
@@ -20,7 +20,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/native/native.gradle.kts
+++ b/subprojects/native/native.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 description = "This project contains various native operating system integration utilities"

--- a/subprojects/normalization-java/normalization-java.gradle.kts
+++ b/subprojects/normalization-java/normalization-java.gradle.kts
@@ -17,7 +17,6 @@ description = "API extraction for Java"
 
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
     gradlebuild.`publish-public-libraries`
     gradlebuild.`strict-compile`
 }

--- a/subprojects/persistent-cache/persistent-cache.gradle.kts
+++ b/subprojects/persistent-cache/persistent-cache.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/platform-base/platform-base.gradle.kts
+++ b/subprojects/platform-base/platform-base.gradle.kts
@@ -33,3 +33,7 @@ dependencies {
     testFixturesApi(testFixtures(project(":modelCore")))
     testFixturesApi(testFixtures(project(":diagnostics")))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 val integTestRuntimeResources by configurations.creating {

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -19,7 +19,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/plugin-use/plugin-use.gradle.kts
+++ b/subprojects/plugin-use/plugin-use.gradle.kts
@@ -17,7 +17,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -86,6 +86,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/**"))
+}
+
 val wrapperJarDir = file("$buildDir/generated-resources/wrapper-jar")
 evaluationDependsOn(":wrapper")
 val wrapperJar by tasks.registering(Copy::class) {

--- a/subprojects/process-services/process-services.gradle.kts
+++ b/subprojects/process-services/process-services.gradle.kts
@@ -21,3 +21,7 @@ dependencies {
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/process/internal/**"))
+}

--- a/subprojects/publish/publish.gradle.kts
+++ b/subprojects/publish/publish.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/reporting/reporting.gradle.kts
+++ b/subprojects/reporting/reporting.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     add("reports", "jquery:jquery.min:3.4.1@js")
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/reporting/internal/**"))
+}
+
 val generatedResourcesDir = gradlebuildJava.generatedResourcesDir
 
 val reportResources by tasks.registering(Copy::class) {

--- a/subprojects/resources-gcs/resources-gcs.gradle.kts
+++ b/subprojects/resources-gcs/resources-gcs.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/resources-http/resources-http.gradle.kts
+++ b/subprojects/resources-http/resources-http.gradle.kts
@@ -19,7 +19,6 @@ plugins {
     // @SuppressWarnings("deprecation"), used in org.gradle.internal.resource.transport.http.HttpClientHelper.AutoClosedHttpResponse
     // in the context of a delegation pattern
     // gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/resources-s3/resources-s3.gradle.kts
+++ b/subprojects/resources-s3/resources-s3.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/resources-sftp/resources-sftp.gradle.kts
+++ b/subprojects/resources-sftp/resources-sftp.gradle.kts
@@ -19,7 +19,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/resources/resources.gradle.kts
+++ b/subprojects/resources/resources.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 description = "A set of general-purpose resource abstractions"

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.internal.java
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/internal/tasks/scala/**"))
+}
+
 tasks.named<Test>("integTest") {
     jvmArgs("-XX:MaxPermSize=1500m") // AntInProcessScalaCompilerIntegrationTest needs lots of permgen
 }

--- a/subprojects/security/security.gradle.kts
+++ b/subprojects/security/security.gradle.kts
@@ -44,5 +44,8 @@ dependencies {
     testFixturesImplementation(testLibrary("jetty"))
     testFixturesImplementation(testFixtures(project(":core")))
     testFixturesImplementation(project(":internalIntegTesting"))
+}
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/plugins/signing/type/pgp/**"))
 }

--- a/subprojects/signing/.gitignore
+++ b/subprojects/signing/.gitignore
@@ -1,2 +1,0 @@
-build
-.gradle

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -42,3 +42,7 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
     testRuntimeOnly(testFixtures(project(":security")))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/plugins/signing/**"))
+}

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -19,7 +19,6 @@ import accessors.java
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.classycle
     gradlebuild.`strict-compile`
 }
 

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.internal.kotlin
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/test-kit/test-kit.gradle.kts
+++ b/subprojects/test-kit/test-kit.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/testkit/runner/internal/**"))
+}
+
 tasks.integMultiVersionTest {
     systemProperty("org.gradle.integtest.testkit.compatibility", "all")
     // TestKit multi version tests are not using JUnit categories

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -60,3 +60,7 @@ dependencies {
 
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
+}

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -15,9 +15,7 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    // TODO: re-enable if we are ready to do breaking changes, because this subproject includes classes migrated from the "plugins" subproject
     // id "gradlebuild.strict-compile"
-    // id "gradlebuild.classycle"
 }
 
 gradlebuildJava.usedInWorkers()
@@ -66,6 +64,10 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
 
     integTestRuntimeOnly(project(":testingJunitPlatform"))
+}
+
+classycle {
+    excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }
 
 tasks.named<Test>("test").configure {

--- a/subprojects/testing-native/testing-native.gradle.kts
+++ b/subprojects/testing-native/testing-native.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
+++ b/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     gradlebuild.distribution.`plugins-implementation-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -90,6 +90,10 @@ dependencies {
     integTestRuntimeOnly(project(":apiMetadata"))
 }
 
+classycle {
+    excludePatterns.set(listOf("org/gradle/tooling/**"))
+}
+
 apply(from = "buildship.gradle")
 
 tasks.withType<IntegrationTest>().configureEach {

--- a/subprojects/tooling-native/tooling-native.gradle.kts
+++ b/subprojects/tooling-native/tooling-native.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/version-control/version-control.gradle.kts
+++ b/subprojects/version-control/version-control.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
     gradlebuild.`strict-compile`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/worker-processes/worker-processes.gradle.kts
+++ b/subprojects/worker-processes/worker-processes.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-implementation-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedInWorkers()

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 dependencies {

--- a/subprojects/wrapper/wrapper.gradle.kts
+++ b/subprojects/wrapper/wrapper.gradle.kts
@@ -18,7 +18,6 @@ import java.util.jar.Attributes
 
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.classycle
 }
 
 gradlebuildJava.usedInWorkers()


### PR DESCRIPTION
Existing cycles are now explicitly excluded in the corresponding build scripts and are thus more visible. They may or may not be improved on when working on the corresponding project.

Whether or not we want to keep this check in the future, or want to replaces with a different tool, is another question. This PR is only to have a more consistent build setup, where all quality checks are applied by default and exceptions are more clearly visible.