### PR TITLE
Revert changes to internal handling of JavaExec.classpath

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -20,7 +20,6 @@ import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.jvm.ModularitySpec;
@@ -110,7 +109,6 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     private final JavaExecAction javaExecHandleBuilder;
     private final Property<String> mainModule;
     private final Property<String> mainClass;
-    private final ConfigurableFileCollection classpath;
     private final ModularitySpec modularity;
     private final Property<ExecResult> execResult;
 
@@ -118,7 +116,6 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         ObjectFactory objectFactory = getObjectFactory();
         mainModule = objectFactory.property(String.class);
         mainClass = objectFactory.property(String.class);
-        classpath = objectFactory.fileCollection();
         modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         execResult = objectFactory.property(ExecResult.class);
 
@@ -126,7 +123,6 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         javaExecHandleBuilder.getMainClass().convention(getProviderFactory().provider(this::getMain)); // go through 'main' to keep this compatible with existing convention mappings
         javaExecHandleBuilder.getMainModule().convention(mainModule);
         javaExecHandleBuilder.getModularity().getInferModulePath().convention(modularity.getInferModulePath());
-        javaExecHandleBuilder.setClasspath(classpath);
     }
 
     @Inject
@@ -489,7 +485,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec setClasspath(FileCollection classpath) {
-        this.classpath.setFrom(classpath);
+        javaExecHandleBuilder.setClasspath(classpath);
         return this;
     }
 
@@ -498,7 +494,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec classpath(Object... paths) {
-        classpath.from(paths);
+        javaExecHandleBuilder.classpath(paths);
         return this;
     }
 
@@ -507,7 +503,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public FileCollection getClasspath() {
-        return classpath;
+        return javaExecHandleBuilder.getClasspath();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -343,6 +343,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
 
     @Override
     public JavaExecHandleBuilder setClasspath(FileCollection classpath) {
+        // we need to create a new file collection container to avoid cycles. See: https://github.com/gradle/gradle/issues/8755
         ConfigurableFileCollection newClasspath = fileCollectionFactory.configurableFiles("classpath");
         newClasspath.setFrom(classpath);
         this.classpath = newClasspath;

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.file
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -158,6 +159,35 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             task merge(type: LegacyTask) {
                 inFiles += files1
                 inFiles += files2
+                outFile = file("merge.txt")
+            }
+        """
+        file('a.txt').text = 'a'
+        file('b.txt').text = 'b'
+
+        when:
+        run("merge")
+
+        then:
+        file("merge.txt").text == 'a,b'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/12832")
+    @Ignore // This currently causes a stack overflow error
+    def "can compose and filter a file collection that includes the collection it replaces"() {
+        taskTypeWithInputFileCollection()
+        buildFile << """
+            class LegacyTask extends InputFilesTask {
+                void setInFiles(def c) {
+                    inFiles.from = c
+                }
+            }
+
+            def files1 = files('a.txt')
+            def files2 = files('b.txt')
+            task merge(type: LegacyTask) {
+                inFiles = files1
+                inFiles = files(inFiles, files2).filter { f -> f.name.endsWith('.txt') }
                 outFile = file("merge.txt")
             }
         """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -256,6 +256,28 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":run"
     }
 
+
+    @ToBeFixedForInstantExecution
+    @Issue("https://github.com/gradle/gradle/issues/12832")
+    def "classpath can be replaced with a file collection including the replaced value"() {
+        given:
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                classpath = files(classpath, "someOtherFile.jar").filter { true }
+                mainClass = "driver.Driver"
+            }
+        """
+
+        when:
+        run "run"
+
+        then:
+        executedAndNotSkipped ":run"
+    }
+
     private void assertOutputFileIs(String text) {
         assert file("out.txt").text == text
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -239,13 +239,17 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue('https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-gradle-plugin')
-    @ToBeFixedForInstantExecution(because = ":buildEnvironment")
+    @ToBeFixedForInstantExecution(because = "plugin uses task conventions")
     def 'spring boot plugin'() {
         given:
         buildFile << """
             plugins {
                 id "application"
                 id "org.springframework.boot" version "${TestedVersions.springBoot}"
+            }
+
+            bootRun {
+                sourceResources sourceSets.main
             }
         """.stripIndent()
 


### PR DESCRIPTION
This suffers from: https://github.com/gradle/gradle/issues/8755
The revert fixes:  https://github.com/gradle/gradle/issues/12832
