### PR TITLE
Set up timeout for DistributionLocatorIntegrationTest

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DistributionLocatorIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DistributionLocatorIntegrationTest.groovy
@@ -25,7 +25,8 @@ import spock.lang.Specification
 
 @Requires(TestPrecondition.ONLINE)
 class DistributionLocatorIntegrationTest extends Specification {
-
+    private static final int CONNECTION_TIMEOUT_SECONDS = 60 * 1000
+    private static final int READ_TIMEOUT_SECONDS = 60 * 1000
     def locator = new DistributionLocator()
     def distributions = new ReleasedVersionDistributions()
 
@@ -44,6 +45,8 @@ class DistributionLocatorIntegrationTest extends Specification {
 
     void urlExist(URI url) {
         HttpURLConnection connection = url.toURL().openConnection()
+        connection.setConnectTimeout(CONNECTION_TIMEOUT_SECONDS)
+        connection.setReadTimeout(READ_TIMEOUT_SECONDS)
         connection.requestMethod = "HEAD"
         connection.connect()
         assert connection.responseCode == 200


### PR DESCRIPTION
Sometimes the build hangs at connection.read, so we set timeout.

```
"Test worker" #14 prio=5 os_prio=0 cpu=6437.50ms elapsed=9907.46s tid=0x00000143452b5800 nid=0x1ea8 runnable  [0x0000001bdc3fa000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.ch.SocketDispatcher.read0(java.base@14/Native Method)
	at sun.nio.ch.SocketDispatcher.read(java.base@14/SocketDispatcher.java:46)
	at sun.nio.ch.NioSocketImpl.tryRead(java.base@14/NioSocketImpl.java:261)
	at sun.nio.ch.NioSocketImpl.implRead(java.base@14/NioSocketImpl.java:312)
	at sun.nio.ch.NioSocketImpl.read(java.base@14/NioSocketImpl.java:350)
	at sun.nio.ch.NioSocketImpl$1.read(java.base@14/NioSocketImpl.java:803)
	at java.net.Socket$SocketInputStream.read(java.base@14/Socket.java:982)
	at sun.security.ssl.SSLSocketInputRecord.read(java.base@14/SSLSocketInputRecord.java:457)
	at sun.security.ssl.SSLSocketInputRecord.decodeInputRecord(java.base@14/SSLSocketInputRecord.java:237)
    ...
	at org.gradle.integtests.DistributionLocatorIntegrationTest.$spock_feature_0_0(DistributionLocatorIntegrationTest.groovy:34)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@14/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@14/NativeMethodAccessorImpl.java:62)
```