### PR TITLE
Let Kotlin DSL model preparation task be registered on the root project only

### DIFF
--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinScriptingModelBuildersRegistrationAction.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinScriptingModelBuildersRegistrationAction.kt
@@ -33,8 +33,10 @@ class KotlinScriptingModelBuildersRegistrationAction : ProjectConfigureAction {
             register(KotlinDslScriptsModelBuilder)
             register(KotlinBuildScriptTemplateModelBuilder)
         }
-        project.tasks.apply {
-            register(KotlinDslModelsParameters.PREPARATION_TASK_NAME)
+        if (project.parent == null) {
+            project.tasks.apply {
+                register(KotlinDslModelsParameters.PREPARATION_TASK_NAME)
+            }
         }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r21/TaskVisibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r21/TaskVisibilityCrossVersionSpec.groovy
@@ -54,8 +54,8 @@ project(':b:c') {
     }
 
     def "task visibility is correct"() {
-        def publicTasks = rootProjectImplicitTasks - implicitInvisibleTasks + ['t2']
-        def publicSelectors = rootProjectImplicitSelectors - implicitInvisibleSelectors + ['t1', 't2']
+        def publicTasks = rootProjectImplicitTasks - rootProjectImplicitInvisibleTasks + ['t2']
+        def publicSelectors = rootProjectImplicitSelectors - rootProjectImplicitInvisibleSelectors + ['t1', 't2']
 
         when:
         BuildInvocations model = withConnection { connection ->

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -202,7 +202,9 @@ abstract class ToolingApiSpecification extends Specification {
      * Returns the set of implicit task names expected for any project for the target Gradle version.
      */
     Set<String> getImplicitTasks() {
-        if (targetVersion >= GradleVersion.version("6.0")) {
+        if (targetVersion >= GradleVersion.version("6.5")) {
+            return ['buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants']
+        } else if (targetVersion >= GradleVersion.version("6.0")) {
             return ['buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants', 'prepareKotlinBuildScriptModel']
         } else if (targetVersion >= GradleVersion.version("5.3")) {
             return ['buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'projects', 'properties', 'tasks', 'model', 'prepareKotlinBuildScriptModel']
@@ -226,26 +228,26 @@ abstract class ToolingApiSpecification extends Specification {
     }
 
     /**
-     * Returns the set of invisible implicit task names expected for any project for the target Gradle version.
+     * Returns the set of invisible implicit task names expected for a root project for the target Gradle version.
      */
-    Set<String> getImplicitInvisibleTasks() {
+    Set<String> getRootProjectImplicitInvisibleTasks() {
         return targetVersion >= GradleVersion.version("5.3") ? ['prepareKotlinBuildScriptModel'] : []
     }
 
     /**
-     * Returns the set of invisible implicit selector names expected for any project for the target Gradle version.
+     * Returns the set of invisible implicit selector names expected for a root project for the target Gradle version.
      *
-     * See {@link #getImplicitInvisibleTasks}.
+     * See {@link #getRootProjectImplicitInvisibleTasks}.
      */
-    Set<String> getImplicitInvisibleSelectors() {
-        return implicitInvisibleTasks
+    Set<String> getRootProjectImplicitInvisibleSelectors() {
+        return rootProjectImplicitInvisibleTasks
     }
 
     /**
      * Returns the set of implicit task names expected for a root project for the target Gradle version.
      */
     Set<String> getRootProjectImplicitTasks() {
-        return implicitTasks + ['init', 'wrapper']
+        return implicitTasks + ['init', 'wrapper'] + rootProjectImplicitInvisibleTasks
     }
 
     /**


### PR DESCRIPTION
# Context

Building TAPI models for Kotlin DSL scripts require a preparation task `:prepareKotlinBuildScriptModel`. That task is effectively doing something only on the root project but was registered to all projects. This is unnecessary and was creating noise in the IDE output panel on builds with a lot of subprojects. This PR makes it registered to the root project only.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
