### PR TITLE
Fix memory leak in component metadata rule executor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -45,6 +45,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.CachingPatternSpecFactory;
 import org.gradle.api.tasks.util.internal.PatternSpecFactory;
+import org.gradle.cache.internal.CleaningInMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cli.CommandLineConverter;
@@ -179,7 +180,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     }
 
     InMemoryCacheDecoratorFactory createInMemoryTaskArtifactCache(CrossBuildInMemoryCacheFactory cacheFactory) {
-        return new InMemoryCacheDecoratorFactory(environment.isLongLivingProcess(), cacheFactory);
+        return new CleaningInMemoryCacheDecoratorFactory(environment.isLongLivingProcess(), cacheFactory);
     }
 
     ModelRuleExtractor createModelRuleInspector(List<MethodModelRuleExtractor> extractors, ModelSchemaStore modelSchemaStore, StructBindingsStore structBindingsStore, ManagedProxyFactory managedProxyFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.changedetection.state
 import org.gradle.cache.CacheDecorator
 import org.gradle.cache.internal.DefaultCacheRepository
 import org.gradle.cache.internal.DefaultCacheScopeMapping
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -42,7 +42,7 @@ class DefaultFileAccessTimeJournalTest extends Specification {
     def userHome = tmpDir.createDir("user-home")
     def cacheScopeMapping = new DefaultCacheScopeMapping(userHome, null, GradleVersion.current())
     def cacheRepository = new DefaultCacheRepository(cacheScopeMapping, new InMemoryCacheFactory())
-    def cacheDecoratorFactory = Stub(InMemoryCacheDecoratorFactory) {
+    def cacheDecoratorFactory = Stub(DefaultInMemoryCacheDecoratorFactory) {
         decorator(_, _) >> Stub(CacheDecorator) {
             decorate(_, _, _, _, _) >> { cacheId, cacheName, persistentCache, crossProcessCacheAccess, asyncCacheAccess ->
                 persistentCache

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultPreviousExecutionCacheAccessTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultPreviousExecutionCacheAccessTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.cache.internal.filelock.LockOptionsBuilder
 import spock.lang.Specification
@@ -34,7 +34,7 @@ class DefaultPreviousExecutionCacheAccessTest extends Specification {
         PersistentCache backingCache = Mock()
 
         when:
-        new DefaultExecutionHistoryCacheAccess(gradle, cacheRepository, new InMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory()))
+        new DefaultExecutionHistoryCacheAccess(gradle, cacheRepository, new DefaultInMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory()))
 
         then:
         1 * cacheRepository.cache(gradle, "executionHistory") >> cacheBuilder

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -40,12 +40,12 @@ class DefaultFileContentCacheFactoryTest extends Specification {
     def listenerManager = new DefaultListenerManager()
     def virtualFileSystem = Mock(VirtualFileSystem)
     def cacheRepository = new DefaultCacheRepository(new DefaultCacheScopeMapping(tmpDir.file("user-home"), tmpDir.file("build-dir"), GradleVersion.current()), new InMemoryCacheFactory())
-    def inMemoryTaskArtifactCache = new InMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory()) {
+    def inMemoryTaskArtifactCache = new DefaultInMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory()) {
         @Override
         CacheDecorator decorator(int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
             return new CacheDecorator() {
                 @Override
-                <K, V> MultiProcessSafePersistentIndexedCache<K, V> decorate(String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache<K, V> persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess) {
+                public <K, V> MultiProcessSafePersistentIndexedCache<K, V> decorate(String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache<K, V> persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess) {
                     return persistentCache
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource;
 import org.gradle.cache.CacheRepository;
+import org.gradle.cache.internal.InMemoryCacheController;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.serialize.Serializer;
@@ -29,6 +30,12 @@ import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 public class ComponentMetadataRuleExecutor extends CrossBuildCachingRuleExecutor<ModuleComponentResolveMetadata, ComponentMetadataContext, ModuleComponentResolveMetadata> {
+
+    private static final String CACHE_ID = "md-rule";
+
+    public static boolean isMetadataRuleExecutorCache(InMemoryCacheController controller) {
+        return CACHE_ID.equals(controller);
+    }
 
     private static Transformer<Object, ModuleComponentResolveMetadata> getKeyToSnapshotableTransformer() {
         return moduleMetadata -> moduleMetadata.getSources().withSource(ModuleDescriptorHashModuleSource.class, source -> {
@@ -44,7 +51,7 @@ public class ComponentMetadataRuleExecutor extends CrossBuildCachingRuleExecutor
                                          ValueSnapshotter snapshotter,
                                          BuildCommencedTimeProvider timeProvider,
                                          Serializer<ModuleComponentResolveMetadata> componentMetadataContextSerializer) {
-        super("md-rule", cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, createValidator(timeProvider), getKeyToSnapshotableTransformer(), componentMetadataContextSerializer);
+        super(CACHE_ID, cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, createValidator(timeProvider), getKeyToSnapshotableTransformer(), componentMetadataContextSerializer);
         this.componentMetadataContextSerializer = componentMetadataContextSerializer;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -31,7 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer
 import org.gradle.api.specs.Specs
 import org.gradle.cache.CacheRepository
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.ConfigurableRule
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ivy.DefaultMutableIvyModuleResolveMetadata
@@ -59,7 +59,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     private static final String MODULE = "module"
 
     // For testing ComponentMetadataHandler capabilities
-    def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
+    def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(DefaultInMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
     def stringInterner = SimpleMapInterner.notThreadSafe()
     def handler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor, DependencyManagementTestUtil.platformSupport())
     RuleActionAdapter adapter = Mock(RuleActionAdapter)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter
 import org.gradle.api.specs.Specs
 import org.gradle.cache.CacheRepository
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ivy.DefaultMutableIvyModuleResolveMetadata
@@ -76,7 +76,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
 
     MetadataResolutionContext context = Mock()
     def moduleSourcesSerializer = new ModuleSourcesSerializer([:])
-    def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
+    def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(DefaultInMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
     def stringInterner = SimpleMapInterner.notThreadSafe()
     def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCachePolicy
 import org.gradle.cache.CacheRepository
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
@@ -57,7 +57,7 @@ class DefaultMetadataProviderTest extends Specification {
     def resolveState = Mock(ModuleComponentResolveState)
     def metadataProvider = new DefaultMetadataProvider(resolveState)
     def cachePolicy = new DefaultCachePolicy()
-    def ruleExecutor = new ComponentMetadataSupplierRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
+    def ruleExecutor = new ComponentMetadataSupplierRuleExecutor(Stub(CacheRepository), Stub(DefaultInMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
 
     def setup() {
         resolveState.getCachePolicy() >> cachePolicy

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -31,7 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory
 import org.gradle.api.internal.component.ComponentTypeRegistration
 import org.gradle.api.internal.component.ComponentTypeRegistry
 import org.gradle.cache.CacheRepository
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -56,7 +56,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     def artifactResolver = Mock(ArtifactResolver)
     def repositoryChain = Mock(ComponentResolvers)
     def componentMetaDataResolver = Mock(ComponentMetaDataResolver)
-    def ruleExecutor = new ComponentMetadataSupplierRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
+    def ruleExecutor = new ComponentMetadataSupplierRuleExecutor(Stub(CacheRepository), Stub(DefaultInMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
 
     @Shared ComponentTypeRegistry testComponentTypeRegistry = createTestComponentTypeRegistry()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
@@ -33,7 +33,7 @@ import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.PersistentIndexedCache
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
@@ -58,7 +58,7 @@ class ComponentMetadataRuleExecutorTest extends Specification {
     @Subject
     ComponentMetadataRuleExecutor executor
     CacheRepository cacheRepository
-    InMemoryCacheDecoratorFactory cacheDecoratorFactory
+    DefaultInMemoryCacheDecoratorFactory cacheDecoratorFactory
     ValueSnapshotter valueSnapshotter
     long time = 0
     BuildCommencedTimeProvider timeProvider = Stub(BuildCommencedTimeProvider) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataSupplierRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataSupplierRuleExecutorTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.PersistentIndexedCache
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
@@ -54,7 +54,7 @@ class ComponentMetadataSupplierRuleExecutorTest extends Specification {
     @Subject
     ComponentMetadataSupplierRuleExecutor executor
     CacheRepository cacheRepository
-    InMemoryCacheDecoratorFactory cacheDecoratorFactory
+    DefaultInMemoryCacheDecoratorFactory cacheDecoratorFactory
     ValueSnapshotter valueSnapshotter
     BuildCommencedTimeProvider timeProvider = Stub(BuildCommencedTimeProvider) {
         getCurrentTime() >> 0

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutorTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.PersistentIndexedCache
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
@@ -47,7 +47,7 @@ import javax.inject.Inject
 class CrossBuildCachingRuleExecutorTest extends Specification {
 
     CacheRepository cacheRepository = Mock()
-    InMemoryCacheDecoratorFactory cacheDecoratorFactory = Mock()
+    DefaultInMemoryCacheDecoratorFactory cacheDecoratorFactory = Mock()
     ValueSnapshotter valueSnapshotter = Mock()
     BuildCommencedTimeProvider timeProvider = new BuildCommencedTimeProvider()
     PersistentIndexedCache<ValueSnapshot, CrossBuildCachingRuleExecutor.CachedEntry<Result>> store = Mock()

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.history.impl
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.CacheDecorator
 import org.gradle.cache.PersistentCache
-import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.internal.MutableReference
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot
@@ -42,7 +42,7 @@ class DefaultOutputFilesRepositoryTest extends Specification {
         createCache(_) >> outputFiles
     }
     def cacheDecorator = Mock(CacheDecorator)
-    def inMemoryCacheDecoratorFactory = Stub(InMemoryCacheDecoratorFactory) {
+    def inMemoryCacheDecoratorFactory = Stub(DefaultInMemoryCacheDecoratorFactory) {
         decorator(100000, true) >> cacheDecorator
     }
     def repository = new DefaultOutputFilesRepository(cacheAccess, inMemoryCacheDecoratorFactory)

--- a/subprojects/persistent-cache/persistent-cache.gradle.kts
+++ b/subprojects/persistent-cache/persistent-cache.gradle.kts
@@ -46,3 +46,6 @@ gradlebuildJava {
     moduleType = ModuleType.CORE
 }
 
+tasks.withType<ValidatePlugins>().configureEach {
+    enabled = false
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleaningInMemoryCacheDecoratorFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleaningInMemoryCacheDecoratorFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.cache.internal;
+
+import com.google.common.collect.Lists;
+
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class CleaningInMemoryCacheDecoratorFactory extends DefaultInMemoryCacheDecoratorFactory {
+    private final List<WeakReference<InMemoryCacheController>> inMemoryCaches = Lists.newArrayList();
+
+    public CleaningInMemoryCacheDecoratorFactory(boolean longLivingProcess, CrossBuildInMemoryCacheFactory cacheFactory) {
+        super(longLivingProcess, cacheFactory);
+    }
+
+    public void clearCaches(Predicate<InMemoryCacheController> predicate) {
+        for (Iterator<WeakReference<InMemoryCacheController>> iterator = inMemoryCaches.iterator(); iterator.hasNext();) {
+            WeakReference<InMemoryCacheController> ref = iterator.next();
+            InMemoryCacheController cache = ref.get();
+            if (cache == null) {
+                iterator.remove();
+            } else if (predicate.test(cache)) {
+                cache.clearInMemoryCache();
+            }
+        }
+    }
+
+    @Override
+    protected <K, V> MultiProcessSafeAsyncPersistentIndexedCache<K, V> applyInMemoryCaching(String cacheId, MultiProcessSafeAsyncPersistentIndexedCache<K, V> backingCache, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
+        MultiProcessSafeAsyncPersistentIndexedCache<K, V> delegate = super.applyInMemoryCaching(cacheId, backingCache, maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses);
+        if (delegate instanceof InMemoryCacheController) {
+            InMemoryCacheController cimc = (InMemoryCacheController) delegate;
+            inMemoryCaches.add(new WeakReference<>(cimc));
+        }
+        return delegate;
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.gradle.api.Transformer;
+import org.gradle.cache.AsyncCacheAccess;
+import org.gradle.cache.CacheDecorator;
+import org.gradle.cache.CrossProcessCacheAccess;
+import org.gradle.cache.FileLock;
+import org.gradle.cache.MultiProcessSafePersistentIndexedCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link CacheDecorator} that wraps each cache with an in-memory cache that is used to short-circuit reads from the backing cache.
+ * The in-memory cache is invalidated when the backing cache is changed by another process.
+ *
+ * Also decorates each cache so that updates to the backing cache are made asynchronously.
+ */
+public class DefaultInMemoryCacheDecoratorFactory implements InMemoryCacheDecoratorFactory {
+    private final static Logger LOG = LoggerFactory.getLogger(DefaultInMemoryCacheDecoratorFactory.class);
+    private final boolean longLivingProcess;
+    private final HeapProportionalCacheSizer cacheSizer = new HeapProportionalCacheSizer();
+    private final CrossBuildInMemoryCache<String, CacheDetails> caches;
+
+    public DefaultInMemoryCacheDecoratorFactory(boolean longLivingProcess, CrossBuildInMemoryCacheFactory cacheFactory) {
+        this.longLivingProcess = longLivingProcess;
+        caches = cacheFactory.newCache();
+    }
+
+    @Override
+    public CacheDecorator decorator(final int maxEntriesToKeepInMemory, final boolean cacheInMemoryForShortLivedProcesses) {
+        return new InMemoryCacheDecorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses);
+    }
+
+    protected <K, V> MultiProcessSafeAsyncPersistentIndexedCache<K, V> applyInMemoryCaching(String cacheId, MultiProcessSafeAsyncPersistentIndexedCache<K, V> backingCache, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
+        if (!longLivingProcess && !cacheInMemoryForShortLivedProcesses) {
+            // Short lived process, don't cache in memory
+            LOG.debug("Creating cache {} without in-memory store.", cacheId);
+            return backingCache;
+        }
+        int targetSize = cacheSizer.scaleCacheSize(maxEntriesToKeepInMemory);
+        CacheDetails cacheDetails = getCache(cacheId, targetSize);
+        return new InMemoryDecoratedCache<K, V>(backingCache, cacheDetails.entries, cacheId, cacheDetails.lockState);
+    }
+
+    private CacheDetails getCache(final String cacheId, final int maxSize) {
+        CacheDetails cacheDetails = caches.get(cacheId, new Transformer<CacheDetails, String>() {
+            @Override
+            public CacheDetails transform(String cacheId) {
+                Cache<Object, Object> entries = createInMemoryCache(cacheId, maxSize);
+                CacheDetails cacheDetails = new CacheDetails(cacheId, maxSize, entries, new AtomicReference<FileLock.State>(null));
+                LOG.debug("Creating in-memory store for cache {} (max size: {})", cacheId, maxSize);
+                return cacheDetails;
+            }
+        });
+        if (cacheDetails.maxEntries != maxSize) {
+            throw new IllegalStateException("Mismatched in-memory store size for cache " + cacheId + ", expected: " + maxSize + ", found: " + cacheDetails.maxEntries);
+        }
+        return cacheDetails;
+    }
+
+    private Cache<Object, Object> createInMemoryCache(String cacheId, int maxSize) {
+        LoggingEvictionListener evictionListener = new LoggingEvictionListener(cacheId, maxSize);
+        final CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder().maximumSize(maxSize).recordStats().removalListener(evictionListener);
+        Cache<Object, Object> inMemoryCache = cacheBuilder.build();
+        evictionListener.setCache(inMemoryCache);
+        return inMemoryCache;
+    }
+
+    private class InMemoryCacheDecorator implements CacheDecorator {
+        private final int maxEntriesToKeepInMemory;
+        private final boolean cacheInMemoryForShortLivedProcesses;
+
+        InMemoryCacheDecorator(int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
+            this.maxEntriesToKeepInMemory = maxEntriesToKeepInMemory;
+            this.cacheInMemoryForShortLivedProcesses = cacheInMemoryForShortLivedProcesses;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            InMemoryCacheDecorator other = (InMemoryCacheDecorator) obj;
+            return maxEntriesToKeepInMemory == other.maxEntriesToKeepInMemory && cacheInMemoryForShortLivedProcesses == other.cacheInMemoryForShortLivedProcesses;
+        }
+
+        @Override
+        public int hashCode() {
+            return maxEntriesToKeepInMemory ^ (cacheInMemoryForShortLivedProcesses ? 1 : 0);
+        }
+
+        @Override
+        public <K, V> MultiProcessSafePersistentIndexedCache<K, V> decorate(String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache<K, V> persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess) {
+            MultiProcessSafeAsyncPersistentIndexedCache<K, V> asyncCache = new AsyncCacheAccessDecoratedCache<K, V>(asyncCacheAccess, persistentCache);
+            MultiProcessSafeAsyncPersistentIndexedCache<K, V> memCache = applyInMemoryCaching(cacheId, asyncCache, maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses);
+            return new CrossProcessSynchronizingCache<K, V>(memCache, crossProcessCacheAccess);
+        }
+    }
+
+    private static class CacheDetails {
+        private final String cacheId;
+        private final int maxEntries;
+        private final Cache<Object, Object> entries;
+        private final AtomicReference<FileLock.State> lockState;
+
+        CacheDetails(String cacheId, int maxEntries, Cache<Object, Object> entries, AtomicReference<FileLock.State> lockState) {
+            this.cacheId = cacheId;
+            this.maxEntries = maxEntries;
+            this.entries = entries;
+            this.lockState = lockState;
+        }
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryCacheController.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryCacheController.java
@@ -15,8 +15,7 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.cache.CacheDecorator;
-
-public interface InMemoryCacheDecoratorFactory {
-    CacheDecorator decorator(int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses);
+public interface InMemoryCacheController {
+    String getCacheId();
+    void clearInMemoryCache();
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryDecoratedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryDecoratedCache.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-class InMemoryDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentIndexedCache<K, V> {
+class InMemoryDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentIndexedCache<K, V>, InMemoryCacheController {
     private final static Logger LOG = LoggerFactory.getLogger(InMemoryDecoratedCache.class);
     private final static Object NULL = new Object();
     private final MultiProcessSafeAsyncPersistentIndexedCache<K, V> delegate;
@@ -147,5 +147,15 @@ class InMemoryDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentInd
     public void beforeLockRelease(FileLock.State currentCacheState) {
         fileLockStateReference.set(currentCacheState);
         delegate.beforeLockRelease(currentCacheState);
+    }
+
+    @Override
+    public String getCacheId() {
+        return cacheId;
+    }
+
+    @Override
+    public void clearInMemoryCache() {
+        inMemoryCache.invalidateAll();
     }
 }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/InMemoryCacheDecoratorFactoryTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/InMemoryCacheDecoratorFactoryTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.Factory
 import spock.lang.Specification
 
 class InMemoryCacheDecoratorFactoryTest extends Specification {
-    def cacheFactory = new InMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory())
+    def cacheFactory = new DefaultInMemoryCacheDecoratorFactory(false, new TestCrossBuildInMemoryCacheFactory())
     def target = Mock(MultiProcessSafePersistentIndexedCache)
     def asyncCacheAccess = Mock(AsyncCacheAccess)
     def crossProcessCacheAccess = Mock(CrossProcessCacheAccess)


### PR DESCRIPTION
The cross-build cache for cached component metadata rules stores
instances of realized Maven/Ivy module metadata in memory. The
problem is that those instances shouldn't have any state from
the project/Gradle build attached to them (they should be good
old POJOs) but for implementation reasons, they are not. In
particular, they keep a reference to the attributes factory,
which in turn keeps a reference to the object factory, which,
itself, will leak classloaders.

As a consequence, as more builds get executed, it was _possible_
that the cache would release some entries, but for the classloaders
to be released, it would require _all_ the entries from the same
build to be released from the cache. It turns out this event is
unlikely and as a consequence, builds end up running out of
memory.

This commit fixes the problem by making sure that at the end of
a build, we clear the in-memory cache of component metadata rules.
Therefore, cross-build, we would still read the result of the
execution of rules from the binary, on disk cache, but we would
not reuse in-memory results from previous builds.

This fix has been tested and validated by a user facing this
issue. Memory usage dropped from 11GB of memory to 1GB.

Fixes #12843 
