### PR TITLE
Remove module version convention

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
@@ -315,14 +315,13 @@ For more details on declaring module dependencies, please refer to https://www.o
 
 The Java module system supports additional more fine granular encapsulation concepts than Gradle itself currently does.
 For example, you explicitly need to declare which packages are part of your API and which are only visible inside your module.
-Some of these capabilities might be added to Gradle itself in future version.
+Some of these capabilities might be added to Gradle itself in future versions.
 For now, please refer to https://www.oracle.com/corporate/features/understanding-java-9-modules.html[documentation on the Java Module System] to learn how to use these features in Java Modules.
 
 === Declaring module versions
 
 Java Modules also have a version that is encoded as part of the module identity in the `module-info.class` file.
 This version can be inspected when a module is running.
-If the gradle project has a version configured, this version is used by default.
 
 .Declare the module version in the build script or directly as compile task option
 ====

--- a/subprojects/docs/src/snippets/java-library/module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-library/module/groovy/build.gradle
@@ -7,11 +7,11 @@ repositories {
 }
 
 // tag::declareVersion[]
-version = '1.1'
+version = '1.2'
 
 tasks.compileJava {
-    // if set, the following takes precedence over the version defined above
-    options.javaModuleVersion = '1.2'
+    // use the project's version or define one directly
+    options.javaModuleVersion = provider { project.version }
 }
 // end::declareVersion[]
 

--- a/subprojects/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
@@ -7,11 +7,11 @@ repositories {
 }
 
 // tag::declareVersion[]
-version = "1.1"
+version = "1.2"
 
 tasks.compileJava {
-    // if set, the following takes precedence over the version defined above
-    options.javaModuleVersion.set("1.2")
+    // use the project's version or define one directly
+    options.javaModuleVersion.set(provider { project.version as String })
 }
 // end::declareVersion[]
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -25,6 +25,10 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
             dependencies {
                 implementation 'org:moda:1.0'
             }
+            tasks.withType(JavaCompile).configureEach {
+                // use the project's version as module version
+                options.javaModuleVersion = provider { project.version }
+            }
         """
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -91,16 +91,7 @@ public class JavaCompile extends AbstractCompile {
         ObjectFactory objects = project.getObjects();
         compileOptions = objects.newInstance(CompileOptions.class);
         CompilerForkUtils.doNotCacheIfForkingViaExecutable(compileOptions, getOutputs());
-
-        compileOptions.getJavaModuleVersion().convention(project.provider(() -> {
-            String version = project.getVersion().toString();
-            if (Project.DEFAULT_VERSION.equals(version)) {
-                return null;
-            }
-            return version;
-        }));
-
-        this.modularity = objects.newInstance(DefaultModularitySpec.class);
+        modularity = objects.newInstance(DefaultModularitySpec.class);
     }
 
     /**

--- a/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCachedCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCachedCompileIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.compile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
 
 abstract class AbstractCachedCompileIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
     def setup() {
@@ -40,6 +41,29 @@ abstract class AbstractCachedCompileIntegrationTest extends AbstractIntegrationS
         compileIsNotCached()
 
         when:
+        expectDeprecationWarnings()
+        withBuildCache().succeeds 'clean', compilationTask
+
+        then:
+        compileIsCached()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/12860")
+    def 'compilation is cached if the project version changes'() {
+        when:
+        buildFile << '''
+            version = '1.0-a'
+        '''
+        expectDeprecationWarnings()
+        withBuildCache().run compilationTask
+
+        then:
+        compileIsNotCached()
+
+        when:
+        buildFile << '''
+            version = '1.0-b'
+        '''
         expectDeprecationWarnings()
         withBuildCache().succeeds 'clean', compilationTask
 


### PR DESCRIPTION
This was set to the project version by default. This breaks the cache
of a compile task even if the version is not used.
We now never set any version be default, but document how to use the
project version as the version of your Java module.

Fixes: https://github.com/gradle/gradle/issues/12860
