### PR TITLE
Some fixes for instant execution undeclared system property detection

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -34,6 +34,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.scopes.BuildTreeScopeServices;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 import java.io.File;
@@ -42,6 +43,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.Map;
 
+@ServiceScope(ServiceScope.Value.BuildTree)
 public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppable {
     private final IncludedBuildFactory includedBuildFactory;
     private final IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder;

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.initialization.buildsrc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class BuildSrcIdentityIntegrationTest extends AbstractIntegrationSpec {
@@ -45,7 +44,6 @@ class BuildSrcIdentityIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "Task.getProject() during execution")
     def "includes build identifier in dependency report with #display"() {
         file("buildSrc/settings.gradle") << """
             $settings

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.changedetection.state;
 
-import com.google.common.io.ByteStreams;
+import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
@@ -67,13 +67,7 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
         if (!isClassFile(zipEntry.getName())) {
             return null;
         }
-        byte[] content;
-        if (zipEntry.size() >= 0) {
-            content = new byte[zipEntry.size()];
-            ByteStreams.readFully(zipEntry.getInputStream(), content);
-        } else {
-            content = ByteStreams.toByteArray(zipEntry.getInputStream());
-        }
+        byte[] content = zipEntry.getContent();
         return hashClassBytes(content);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceHasher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.internal.hash.HashCode;
 
 import javax.annotation.Nullable;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/RuntimeClasspathResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/RuntimeClasspathResourceHasher.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.io.ByteStreams;
+import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -18,6 +18,10 @@ package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.compress.utils.Lists;
+import org.gradle.api.internal.file.archive.FileZipInput;
+import org.gradle.api.internal.file.archive.StreamZipInput;
+import org.gradle.api.internal.file.archive.ZipEntry;
+import org.gradle.api.internal.file.archive.ZipInput;
 import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.IoActions;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/FileZipInput.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/FileZipInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.file.archive;
 
 import com.google.common.collect.AbstractIterator;
 import org.gradle.api.JavaVersion;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/JdkZipEntry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/JdkZipEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.file.archive;
 
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Supplier;
 
@@ -37,6 +40,18 @@ class JdkZipEntry implements ZipEntry {
     @Override
     public String getName() {
         return entry.getName();
+    }
+
+    @Override
+    public byte[] getContent() throws IOException {
+        int size = size();
+        if (size >= 0) {
+            byte[] content = new byte[size];
+            ByteStreams.readFully(getInputStream(), content);
+            return content;
+        } else {
+            return ByteStreams.toByteArray(getInputStream());
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/StreamZipInput.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/StreamZipInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.file.archive;
 
 import com.google.common.collect.AbstractIterator;
 import org.gradle.api.UncheckedIOException;
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.function.Supplier;
 import java.util.zip.ZipInputStream;
 
-class StreamZipInput implements ZipInput {
+public class StreamZipInput implements ZipInput {
 
     private final ZipInputStream in;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.file.archive;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 public interface ZipEntry {
@@ -24,6 +25,14 @@ public interface ZipEntry {
 
     String getName();
 
+    /**
+     * This method or {@link #getInputStream()} can be called at most once per entry.
+     */
+    byte[] getContent() throws IOException;
+
+    /**
+     * This method or {@link #getContent()} can be called at most once per entry.
+     */
     InputStream getInputStream();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipInput.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.file.archive;
 
 import java.io.Closeable;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.execution;
 
-import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
 
 
 public interface TaskExecutionAccessListener {
@@ -24,10 +24,10 @@ public interface TaskExecutionAccessListener {
     /**
      * Called when accessing the project during task execution.
      */
-    void onProjectAccess(String invocationDescription, Task task);
+    void onProjectAccess(String invocationDescription, TaskInternal task);
 
     /**
      * Called when accessing task dependencies during task execution.
      */
-    void onTaskDependenciesAccess(String invocationDescription, Task task);
+    void onTaskDependenciesAccess(String invocationDescription, TaskInternal task);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.GradleInternal;
  *
  * A root build may contain zero or more nested builds, such as `buildSrc` or included builds.
  *
- * This listener type is available to session services up to global services.
+ * This listener type is available to services from build tree up to global services.
  */
 public interface RootBuildLifecycleListener {
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.classpath;
 
-import com.google.common.io.ByteStreams;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.changedetection.state.FileZipInput;
-import org.gradle.api.internal.changedetection.state.ZipEntry;
-import org.gradle.api.internal.changedetection.state.ZipInput;
+import org.gradle.api.internal.file.archive.FileZipInput;
+import org.gradle.api.internal.file.archive.ZipEntry;
+import org.gradle.api.internal.file.archive.ZipInput;
 import org.gradle.internal.file.FileMetadataSnapshot;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
@@ -109,13 +108,7 @@ public class ClasspathWalker {
 
         @Override
         public byte[] getContent() throws IOException {
-            if (entry.size() >= 0) {
-                byte[] content = new byte[entry.size()];
-                ByteStreams.readFully(entry.getInputStream(), content);
-                return content;
-            } else {
-                return ByteStreams.toByteArray(entry.getInputStream());
-            }
+            return entry.getContent();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DecoratingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DecoratingTransformer.java
@@ -23,13 +23,19 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 public class DecoratingTransformer {
     private static final Type SYSTEM_TYPE = Type.getType(System.class);
     private static final Type STRING_TYPE = Type.getType(String.class);
-    private static final Type CLASS_TYPE = Type.getType(Class.class);
     private static final Type INSTRUMENTED_TYPE = Type.getType(Instrumented.class);
+    private static final Attributes.Name DIGEST_ATTRIBUTE = new Attributes.Name("SHA1-Digest");
 
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
@@ -48,11 +54,27 @@ public class DecoratingTransformer {
                 reader.accept(new InstrumentingVisitor(classWriter), 0);
                 byte[] bytes = classWriter.toByteArray();
                 builder.put(entry.getName(), bytes);
-            } else if (!entry.getName().equals("META-INF/MANIFEST.MF")) {
+            } else if (entry.getName().equals("META-INF/MANIFEST.MF")) {
+                // Remove the signature from the manifest, as the classes may have been instrumented
+                Manifest manifest = new Manifest(new ByteArrayInputStream(entry.getContent()));
+                manifest.getMainAttributes().remove(Attributes.Name.SIGNATURE_VERSION);
+                Iterator<Map.Entry<String, Attributes>> entries = manifest.getEntries().entrySet().iterator();
+                while (entries.hasNext()) {
+                    Map.Entry<String, Attributes> manifestEntry = entries.next();
+                    Attributes attributes = manifestEntry.getValue();
+                    attributes.remove(DIGEST_ATTRIBUTE);
+                    if (attributes.isEmpty()) {
+                        entries.remove();
+                    }
+                }
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                manifest.write(outputStream);
+                builder.put(entry.getName(), outputStream.toByteArray());
+            } else if (!entry.getName().startsWith("META-INF/") || !entry.getName().endsWith(".SF")) {
+                // Discard signature files, as the classes may have been instrumented
+                // Else, copy resource
                 builder.put(entry.getName(), entry.getContent());
             }
-            // Else - discard the manifest
-            // TODO - filter the manifest to remove digests for instrumented classes
         }));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DecoratingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DecoratingTransformer.java
@@ -49,10 +49,10 @@ public class DecoratingTransformer {
                 byte[] bytes = classWriter.toByteArray();
                 builder.put(entry.getName(), bytes);
             } else if (!entry.getName().equals("META-INF/MANIFEST.MF")) {
-                // Discard the manifest
-                // TODO - filter the manifest to remove digests for instrumented classes
                 builder.put(entry.getName(), entry.getContent());
             }
+            // Else - discard the manifest
+            // TODO - filter the manifest to remove digests for instrumented classes
         }));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -45,7 +45,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
     private static final CacheVersionMapping CACHE_VERSION_MAPPING = introducedIn("3.1-rc-1")
         .incrementedIn("3.2-rc-1")
         .incrementedIn("3.5-rc-1")
-        .changedTo(5, "6.5-rc-1")
+        .changedTo(7, "6.5-rc-1")
         .build();
     @VisibleForTesting
     static final String CACHE_NAME = "jars";

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.api.internal.changedetection.state.ResourceHasher;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
-import org.gradle.api.internal.changedetection.state.RuntimeClasspathResourceHasher;
 import org.gradle.api.internal.changedetection.state.ZipHasher;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.FileType;
@@ -85,7 +84,7 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         this.zipHasherConfigurationHash = hasher.hash();
     }
 
-    public static ClasspathFingerprintingStrategy runtimeClasspath(ResourceFilter classpathResourceFilter, RuntimeClasspathResourceHasher runtimeClasspathResourceHasher, ResourceSnapshotterCacheService cacheService, StringInterner stringInterner) {
+    public static ClasspathFingerprintingStrategy runtimeClasspath(ResourceFilter classpathResourceFilter, ResourceHasher runtimeClasspathResourceHasher, ResourceSnapshotterCacheService cacheService, StringInterner stringInterner) {
         return new ClasspathFingerprintingStrategy("CLASSPATH", USE_FILE_HASH, runtimeClasspathResourceHasher, classpathResourceFilter, cacheService, stringInterner);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
@@ -33,6 +33,7 @@ public @interface ServiceScope {
     enum Value {
         Global,
         UserHome,
+        BuildTree,
         Build
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import org.gradle.api.internal.file.archive.ZipEntry
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.FileMetadata

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath
+
+import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+class ClasspathBuilderTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(ClasspathBuilderTest)
+    def builder = new ClasspathBuilder()
+
+    def "creates an empty jar"() {
+        def file = tmpDir.file("thing.zip")
+
+        when:
+        builder.jar(file) {}
+
+        then:
+        def zip = new ZipTestFixture(file)
+        zip.hasDescendants()
+    }
+
+    def "can construct jar with entries"() {
+        def file = tmpDir.file("thing.zip")
+
+        when:
+        builder.jar(file) {
+            it.put("a.class", "bytes".bytes)
+            it.put("dir/b.class", "bytes".bytes)
+        }
+
+        then:
+        def zip = new ZipTestFixture(file)
+        zip.hasDescendants("a.class", "dir/b.class")
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -107,12 +107,12 @@ class RuntimeShadedJarCreator {
     private void writeServiceFiles(ClasspathBuilder.EntryBuilder builder, Map<String, List<String>> services) throws IOException {
         for (Map.Entry<String, List<String>> service : services.entrySet()) {
             String allProviders = Joiner.on("\n").join(service.getValue());
-            writeEntry(builder, SERVICES_DIR_PREFIX + service.getKey(), allProviders.getBytes(Charsets.UTF_8));
+            builder.put(SERVICES_DIR_PREFIX + service.getKey(), allProviders.getBytes(Charsets.UTF_8));
         }
     }
 
     private void writeIdentifyingMarkerFile(ClasspathBuilder.EntryBuilder builder) throws IOException {
-        writeEntry(builder, GradleRuntimeShadedJarDetector.MARKER_FILENAME, new byte[0]);
+        builder.put(GradleRuntimeShadedJarDetector.MARKER_FILENAME, new byte[0]);
     }
 
     private void processEntry(ClasspathBuilder.EntryBuilder builder, ClasspathEntryVisitor.Entry entry, final Set<String> seenPaths, Map<String, List<String>> services) throws IOException {
@@ -192,18 +192,14 @@ class RuntimeShadedJarCreator {
         if (remapper.keepOriginalResource(path)) {
             // we're writing 2 copies of the resource: one relocated, the other not, in order to support `getResource/getResourceAsStream` with
             // both absolute and relative paths
-            writeEntry(builder, name, resource);
+            builder.put(name, resource);
         }
 
         String remappedResourceName = path != null ? remapper.maybeRelocateResource(path) : null;
         if (remappedResourceName != null) {
             String newFileName = remappedResourceName + name.substring(i);
-            writeEntry(builder, newFileName, resource);
+            builder.put(newFileName, resource);
         }
-    }
-
-    private void writeEntry(ClasspathBuilder.EntryBuilder builder, String name, byte[] content) throws IOException {
-        builder.put(name, content);
     }
 
     private void processClassFile(ClasspathBuilder.EntryBuilder builder, ClasspathEntryVisitor.Entry entry) throws IOException {
@@ -219,7 +215,7 @@ class RuntimeShadedJarCreator {
         String remappedClassName = remapper.maybeRelocateResource(className);
         String newFileName = (remappedClassName == null ? className : remappedClassName).concat(".class");
 
-        writeEntry(builder, newFileName, remappedClass);
+        builder.put(newFileName, remappedClass);
     }
 
     private byte[] remapClass(String className, byte[] bytes) {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionUndeclaredBuildInputsIntegrationTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.integtests.fixtures.instantexecution.HasInstantExecutionProblemsSpec
+
+abstract class AbstractInstantExecutionUndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    abstract void pluginDefinition()
+
+    void additionalProblems(HasInstantExecutionProblemsSpec spec) {
+    }
+
+    def "reports undeclared use of system property prior to task execution from plugin"() {
+        pluginDefinition()
+        buildFile << """
+            apply plugin: SneakyPlugin
+        """
+        def fixture = newInstantExecutionFixture()
+
+        when:
+        run("thing")
+
+        then:
+        outputContains("apply CI = null")
+        outputContains("task CI = null")
+
+        when:
+        problems.withDoNotFailOnProblems()
+        instantRun("thing")
+
+        then:
+        fixture.assertStateStored()
+        problems.assertResultHasProblems(result) {
+            additionalProblems(it)
+            withProblem("unknown property: read system property 'CI' from 'SneakyPlugin'")
+        }
+        outputContains("apply CI = null")
+        outputContains("task CI = null")
+
+        when:
+        instantRun("thing", "-DCI=true")
+
+        then:
+        fixture.assertStateLoaded()
+        problems.assertResultHasProblems(result)
+        outputContains("task CI = true")
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -45,6 +45,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         and:
         instant.assertStateStoreFailed()
         problems.assertFailureHasError(failure, errorSpec)
+        failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(9)
         failure.assertHasCause("BOOM")
@@ -59,6 +60,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         and:
         instant.assertStateStoreFailed()
         problems.assertFailureHasError(failure, errorSpec)
+        failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(9)
         failure.assertHasCause("BOOM")
@@ -80,6 +82,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
             withUniqueProblems(taskExecutionProblems + stateSerializationProblems.store)
             withProblemsWithStackTraceCount(2)
         }
+        failure.assertHasFailures(1)
 
         when:
         problems.withDoNotFailOnProblems()
@@ -157,6 +160,40 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         and:
         failure.assertHasDescription("Execution failed for task ':taskWithStateSerializationProblems'.")
         failure.assertHasCause("java.lang.Exception: BOOM")
+    }
+
+    def "report does not include configuration and runtime problems from buildSrc"() {
+        file("buildSrc/build.gradle") << """
+            // These should not be reported, as neither of these are serialized
+            gradle.buildFinished { }
+            classes.doLast { t -> t.project }
+        """
+        file("build.gradle") << """
+            gradle.addListener(new BuildAdapter())
+            task broken {
+                inputs.property('p', project)
+            }
+        """
+
+        when:
+        instantFails("broken")
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withProblem("input property 'p' of ':broken': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
+            withProblem("unknown property: registration of listener on 'Gradle.addListener' is unsupported")
+        }
+        failure.assertHasFailures(1)
+
+        when:
+        problems.withDoNotFailOnProblems()
+        instantRun("broken")
+
+        then:
+        problems.assertResultHasProblems(result) {
+            withProblem("input property 'p' of ':broken': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
+            withProblem("unknown property: registration of listener on 'Gradle.addListener' is unsupported")
+        }
     }
 
     private List<String> withStateSerializationErrors() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import org.gradle.integtests.fixtures.instantexecution.HasInstantExecutionProblemsSpec
+
+class InstantExecutionUndeclaredBuildInputsKotlinBuildSrcIntegrationTest extends AbstractInstantExecutionUndeclaredBuildInputsIntegrationTest {
+    @Override
+    void pluginDefinition() {
+        file("buildSrc/build.gradle.kts").text = KotlinDslTestUtil.kotlinDslBuildSrcScript
+        file("buildSrc/src/main/kotlin/SneakyPlugin.kt") << """
+            import ${Project.name}
+            import ${Plugin.name}
+
+            class SneakyPlugin: Plugin<Project> {
+                override fun apply(project: Project) {
+                    val ci = System.getProperty("CI")
+                    println("apply CI = " + ci)
+                    project.tasks.register("thing") {
+                        doLast {
+                            val ci2 = System.getProperty("CI")
+                            println("task CI = " + ci2)
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    @Override
+    void additionalProblems(HasInstantExecutionProblemsSpec spec) {
+        spec.withProblem("unknown property: read system property 'kotlin.gradle.test.report.memory.usage' from 'org.jetbrains.kotlin.gradle.plugin.KotlinGradleBuildServices'")
+        spec.withProblem("unknown property: read system property 'idea.active' from 'org.jetbrains.kotlin.gradle.plugin.statistics.DefaultKotlinBuildStatsService'")
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class InstantExecutionUndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest extends AbstractInstantExecutionUndeclaredBuildInputsIntegrationTest {
+    @Override
+    void pluginDefinition() {
+        file("buildSrc/src/main/groovy/SneakyPlugin.groovy") << """
+            import ${Project.name}
+            import ${Plugin.name}
+            import ${CompileStatic.name}
+
+            @CompileStatic
+            class SneakyPlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    def ci = System.getProperty("CI")
+                    println("apply CI = " + ci)
+                    project.tasks.register("thing") { t ->
+                        t.doLast {
+                            def ci2 = System.getProperty("CI")
+                            println("task CI = " + ci2)
+                        }
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
@@ -18,47 +18,46 @@ package org.gradle.instantexecution.initialization
 
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.ProjectEvaluationListener
-import org.gradle.api.Task
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener
 import org.gradle.api.internal.GeneratedSubclasses
+import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.instantexecution.problems.InstantExecutionProblems
 import org.gradle.instantexecution.problems.PropertyProblem
 import org.gradle.instantexecution.problems.PropertyTrace
 import org.gradle.instantexecution.problems.StructuredMessage
 import org.gradle.internal.InternalListener
+import org.gradle.internal.service.scopes.ServiceScope
 
 
-class InstantExecutionProblemsListener internal constructor(
+@ServiceScope(ServiceScope.Value.Build)
+interface InstantExecutionProblemsListener : TaskExecutionAccessListener, BuildScopeListenerRegistrationListener
 
-    private
-    val startParameter: InstantExecutionStartParameter,
 
+class DefaultInstantExecutionProblemsListener internal constructor(
     private
     val problems: InstantExecutionProblems
 
-) : TaskExecutionAccessListener, BuildScopeListenerRegistrationListener {
+) : InstantExecutionProblemsListener {
 
-    override fun onProjectAccess(invocationDescription: String, task: Task) {
+    override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
         onTaskExecutionAccessProblem(invocationDescription, task)
     }
 
-    override fun onTaskDependenciesAccess(invocationDescription: String, task: Task) {
+    override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal) {
         onTaskExecutionAccessProblem(invocationDescription, task)
     }
 
     private
-    fun onTaskExecutionAccessProblem(invocationDescription: String, task: Task) {
-        if (startParameter.isEnabled) {
-            val exception = InvalidUserCodeException(
-                "Invocation of '$invocationDescription' by $task at execution time is unsupported."
-            )
-            problems.onProblem(taskExecutionAccessProblem(
-                PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.path),
-                invocationDescription,
-                exception
-            ))
-        }
+    fun onTaskExecutionAccessProblem(invocationDescription: String, task: TaskInternal) {
+        val exception = InvalidUserCodeException(
+            "Invocation of '$invocationDescription' by $task at execution time is unsupported."
+        )
+        problems.onProblem(taskExecutionAccessProblem(
+            PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path),
+            invocationDescription,
+            exception
+        ))
     }
 
     private
@@ -74,7 +73,7 @@ class InstantExecutionProblemsListener internal constructor(
         )
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (startParameter.isEnabled && listener !is InternalListener && listener !is ProjectEvaluationListener) {
+        if (listener !is InternalListener && listener !is ProjectEvaluationListener) {
             val exception = InvalidUserCodeException(
                 "Listener registration '$invocationDescription' by $invocationSource is unsupported."
             )
@@ -101,4 +100,16 @@ class InstantExecutionProblemsListener internal constructor(
             },
             exception
         )
+}
+
+
+class NoOpInstantExecutionProblemsListener : InstantExecutionProblemsListener {
+    override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
+    }
+
+    override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal) {
+    }
+
+    override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
+    }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
@@ -24,8 +24,10 @@ import org.gradle.instantexecution.TooManyInstantExecutionProblemsException
 import org.gradle.instantexecution.extensions.getBroadcaster
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+@ServiceScope(ServiceScope.Value.BuildTree)
 class InstantExecutionProblems(
 
     private
@@ -98,7 +100,9 @@ class InstantExecutionProblems(
     inner class BuildFinishedProblemsHandler : BuildAdapter() {
 
         override fun buildFinished(result: BuildResult) {
-            if (problems.isEmpty()) return
+            if (result.gradle?.parent != null || problems.isEmpty()) {
+                return
+            }
             report.writeReportFiles(problems)
             when {
                 isConsoleSummaryRequested -> {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
@@ -179,8 +179,12 @@ final class InstantExecutionProblemsFixture {
         HasInstantExecutionProblemsSpec spec
     ) {
         // assert !(result instanceof ExecutionFailure)
-        assertHasConsoleSummary(result.output, spec)
-        assertProblemsHtmlReport(result.output, rootDir, spec)
+        if (spec.hasProblems()) {
+            assertHasConsoleSummary(result.output, spec)
+            assertProblemsHtmlReport(result.output, rootDir, spec)
+        } else {
+            assertNoProblemsSummary(result.output)
+        }
     }
 
     HasInstantExecutionProblemsSpec newProblemsSpec(
@@ -419,6 +423,11 @@ class HasInstantExecutionProblemsSpec {
     HasInstantExecutionProblemsSpec withUniqueProblems(Iterable<String> uniqueProblems) {
         this.uniqueProblems.clear()
         this.uniqueProblems.addAll(uniqueProblems)
+        return this
+    }
+
+    HasInstantExecutionProblemsSpec withProblem(String problem) {
+        uniqueProblems.add(problem)
         return this
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.performance.measure.MeasuredOperation
 import org.mortbay.jetty.Handler
 import org.mortbay.jetty.servlet.Context
 import org.mortbay.jetty.webapp.WebAppContext
-import spock.lang.Ignore
 
 import javax.servlet.Filter
 import javax.servlet.FilterChain
@@ -36,7 +35,6 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import java.util.concurrent.atomic.AtomicInteger
 
-@Ignore
 class ParallelDownloadsPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest implements WithExternalRepository {
     private final static String TEST_PROJECT_NAME = 'springBootApp'
 


### PR DESCRIPTION

### Context

- Fix instrumentation to better handle jar manifests.
- Improve instant execution problem reporting so that problems from buildSrc and the main build are grouped together into a single stream of problems and into a single report and build failure.
- Don't treat listener registration or project access by tasks in buildSrc as an instant execution problem, but do treat undeclared system property reads in buildSrc as problems.
- Continue to reuse logic for visiting the classes and resources of a classpath in more places and remove some duplication.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
