### PR TITLE
Use the configured Zinc version for the Scala runtime

### DIFF
--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -61,7 +61,9 @@ dependencies {
 }
 
 classycle {
-    excludePatterns.set(listOf("org/gradle/api/internal/tasks/scala/**"))
+    excludePatterns.set(listOf("org/gradle/api/internal/tasks/scala/**",
+        // Unable to change package of public API
+        "org/gradle/api/tasks/ScalaRuntime*"))
 }
 
 tasks.named<Test>("integTest") {

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaRuntime.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaRuntime.java
@@ -24,7 +24,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.internal.file.collections.LazilyInitializedFileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.language.scala.internal.toolchain.DefaultScalaToolProvider;
+import org.gradle.api.plugins.scala.ScalaPluginExtension;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -99,8 +99,10 @@ public class ScalaRuntime {
                     throw new AssertionError(String.format("Unexpectedly failed to parse version of Scala Jar file: %s in %s", scalaLibraryJar, project));
                 }
 
+                String zincVersion = project.getExtensions().getByType(ScalaPluginExtension.class).getZincVersion().get();
+
                 String scalaMajorMinorVersion = Joiner.on('.').join(Splitter.on('.').splitToList(scalaVersion).subList(0, 2));
-                DefaultExternalModuleDependency compilerBridgeJar = new DefaultExternalModuleDependency("org.scala-sbt", "compiler-bridge_" + scalaMajorMinorVersion, DefaultScalaToolProvider.DEFAULT_ZINC_VERSION);
+                DefaultExternalModuleDependency compilerBridgeJar = new DefaultExternalModuleDependency("org.scala-sbt", "compiler-bridge_" + scalaMajorMinorVersion, zincVersion);
                 compilerBridgeJar.setTransitive(false);
                 compilerBridgeJar.artifact(artifact -> {
                     artifact.setClassifier("sources");
@@ -108,7 +110,7 @@ public class ScalaRuntime {
                     artifact.setExtension("jar");
                     artifact.setName(compilerBridgeJar.getName());
                 });
-                DefaultExternalModuleDependency compilerInterfaceJar = new DefaultExternalModuleDependency("org.scala-sbt", "compiler-interface", DefaultScalaToolProvider.DEFAULT_ZINC_VERSION);
+                DefaultExternalModuleDependency compilerInterfaceJar = new DefaultExternalModuleDependency("org.scala-sbt", "compiler-interface", zincVersion);
                 return project.getConfigurations().detachedConfiguration(new DefaultExternalModuleDependency("org.scala-lang", "scala-compiler", scalaVersion), compilerBridgeJar, compilerInterfaceJar);
             }
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/ScalaRuntimeTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/ScalaRuntimeTest.groovy
@@ -32,31 +32,47 @@ class ScalaRuntimeTest extends AbstractProjectBuilderSpec {
         project.repositories {
             mavenCentral()
         }
-
         when:
         def classpath = project.scalaRuntime.inferScalaClasspath([new File("other.jar"), new File("scala-library-2.10.1.jar")])
-
         then:
-        classpath instanceof LazilyInitializedFileCollection
-        classpath.sourceCollections.size() == 1
+        assertHasCorrectDependencies(classpath, DefaultScalaToolProvider.DEFAULT_ZINC_VERSION)
+    }
+
+    def "inferred Scala class path contains 'scala-compiler' repository dependency and 'compiler-bridge' matching 'scala-library' Jar found on class path with specified zinc version"() {
+        project.repositories {
+            mavenCentral()
+        }
+        def useZincVersion = "1.3.4"
+        project.scala {
+            zincVersion = useZincVersion
+        }
+        when:
+        def classpath = project.scalaRuntime.inferScalaClasspath([new File("other.jar"), new File("scala-library-2.10.1.jar")])
+        then:
+        assertHasCorrectDependencies(classpath, useZincVersion)
+    }
+
+    private void assertHasCorrectDependencies(classpath, zincVersion) {
+        assert classpath instanceof LazilyInitializedFileCollection
+        assert classpath.sourceCollections.size() == 1
         with(classpath.sourceCollections[0]) {
-            it instanceof Configuration
-            it.state == Configuration.State.UNRESOLVED
-            it.dependencies.size() == 3
-            it.dependencies.any { d ->
+            assert it instanceof Configuration
+            assert it.state == Configuration.State.UNRESOLVED
+            assert it.dependencies.size() == 3
+            assert it.dependencies.any { d ->
                 d.group == "org.scala-lang" &&
-                d.name == "scala-compiler" &&
-                d.version == "2.10.1"
+                    d.name == "scala-compiler" &&
+                    d.version == "2.10.1"
             }
-            it.dependencies.any { d ->
+            assert it.dependencies.any { d ->
                 d.group == "org.scala-sbt" &&
-                d.name == "compiler-bridge_2.10" &&
-                d.version == DefaultScalaToolProvider.DEFAULT_ZINC_VERSION
+                    d.name == "compiler-bridge_2.10" &&
+                    d.version == zincVersion
             }
-            it.dependencies.any { d ->
+            assert it.dependencies.any { d ->
                 d.group == "org.scala-sbt" &&
-                d.name == "compiler-interface" &&
-                d.version == DefaultScalaToolProvider.DEFAULT_ZINC_VERSION
+                    d.name == "compiler-interface" &&
+                    d.version == zincVersion
             }
         }
     }


### PR DESCRIPTION
Prior to this change, the compiler-bridge and compiler-interface remained
at the Gradle defined default Zinc version. They now are properly
aligned to the user specified Zinc version.