### PR TITLE
Added more detail around configurations (#12861)

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -36,6 +36,14 @@ Every Gradle project provides the task `dependencies` to render the so-called _d
 By default the dependency report renders dependencies for all configurations.
 To focus on the information about one configuration, provide the optional parameter `--configuration`.
 
+For example, to show dependencies that would be on the test runtime classpath in a Java project, run:
+
+----
+gradle -q dependencies --configuration testRuntimeClasspath
+----
+
+TIP: To see a list of all the pre-defined configurations added by the `java` plugin, see <<java_plugin.adoc#sec:java_plugin_and_dependency_management,the documentation for the Java Plugin>>.
+
 .Declaring the JGit dependency with a custom configuration
 ====
 include::sample[dir="snippets/userguide/dependencyManagement/inspectingDependencies/dependenciesReport/groovy",files="build.gradle[tags=dependency-declaration]"]
@@ -87,6 +95,19 @@ Given a dependency in the dependency graph you can identify the selection reason
 > gradle -q dependencyInsight --dependency commons-codec --configuration scm
 include::{samplesPath}/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out[]
 ----
+
+Note that omitting the `--configuration` parameter in a project that has no configurations will lead to an error:
+----
+> Dependency insight report cannot be generated because the input configuration was not specified. 
+  It can be specified from the command line, e.g: ':dependencyInsight --configuration someConf --dependency someDep'
+----
+
+The most common cases in which this can happen are:
+
+* for a newly initialized general purpose Gradle build: try applying a plugin like `java` that adds pre-defined configurations to the project
+* for the top-level project of a <<multi_project_builds.adoc#,multi-project>>: make sure to run the `dependencyInsight` task against a module, e.g. `gradle -q my-module:dependencyInsight --dependency commons-codec
+
+For more information about configurations, see the documentation on declaring dependencies, which describes <<declaring_dependencies.adoc#sec:what-are-dependency-configurations, what dependency configurations are>>.
 
 [[sec:resolving-version-conflict]]
 == Resolving version conflicts


### PR DESCRIPTION
Added example for `gradle dependencies` specifying a pre-defined configuration with link to where to find pre-defined configurations for Java projects.
Added explanation as to why omitting the `--configuration` flag to `dependencyInsight` would lead to an error and how to solve these cases.

Signed-off-by: Frans Flippo <frans@assisisolutions.com>

<!--- The issue this PR addresses -->
Fixes #12861?

### Context
Adds more context around configurations with references to the user guide pages describing relevant topics. This information might not be known to developers new to Gradle and this points them in the right direction.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [N/A] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
