### PR TITLE
Detect long command lines properly for Linux

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
@@ -25,7 +25,8 @@ public class LongCommandLineDetectionUtil {
     public static final int MAX_COMMAND_LINE_LENGTH_WINDOWS = 32767;
     // Derived from default when running getconf ARG_MAX in OSX
     public static final int MAX_COMMAND_LINE_LENGTH_OSX = 262144;
-    public static final int MAX_COMMAND_LINE_LENGTH_NIX = 2097152;
+    // Dervied from MAX_ARG_STRLEN as per http://man7.org/linux/man-pages/man2/execve.2.html
+    public static final int MAX_COMMAND_LINE_LENGTH_NIX = 131072;
     private static final String WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE = "The filename or extension is too long";
     private static final String NIX_LONG_COMMAND_EXCEPTION_MESSAGE = "error=7, Argument list too long";
 


### PR DESCRIPTION
Long command lines for Linux systems are derived from MAX_ARG_STRLEN (131072 by default)

<!--- The issue this PR addresses -->
Fixes #12453 
And [KT-34487](https://youtrack.jetbrains.com/issue/KT-34487) as a bonus!

### Context
We have Windows and macOS lengths. Let's do Linux now too!

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
