### PR TITLE
Remove workaround for buildscript.sourceFile path

### DIFF
--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -18,12 +18,7 @@
 
 // As this script is also accessed from the buildSrc project,
 // we can't use rootProject for the path as both builds share the same config directory.
-// Work around https://github.com/gradle/kotlin-dsl/issues/736, remove this once fixed
-val effectiveRootDir: File =
-    if (rootDir.name == "buildSrc") rootDir.parentFile
-    else rootDir
-
-val codeQualityConfigDir = effectiveRootDir.resolve("config")
+val codeQualityConfigDir = buildscript.sourceFile!!.parentFile.parentFile.parentFile.resolve("config")
 
 configureCheckstyle(codeQualityConfigDir)
 configureCodenarc(codeQualityConfigDir)


### PR DESCRIPTION
The issue was fixed and the workaround is no longer needed.
https://github.com/gradle/kotlin-dsl-samples/issues/736

On the other hand, the current workaround makes sense from the readability perspective - when you see the directory structure and the context, it does not look like a workaround. Maybe just the workaround comment should be removed instead.