### PR TITLE
Apply 'strict-compile' plugin to all subprojects

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/strict-compile.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/strict-compile.gradle.kts
@@ -19,21 +19,8 @@ import org.gradle.plugins.strictcompile.StrictCompileExtension
 
 val strictCompile = extensions.create<StrictCompileExtension>("strictCompile")
 
-afterEvaluate {
+val strictCompilerArgs = listOf("-Werror", "-Xlint:all", "-Xlint:-options", "-Xlint:-serial", "-Xlint:-classfile")
 
-    val strictCompilerArgs = listOf("-Werror", "-Xlint:all", "-Xlint:-options", "-Xlint:-serial", "-Xlint:-classfile")
-
-    val ignoreDeprecationsArg = "-Xlint:-deprecation"
-
-    val compilerArgs =
-        if (strictCompile.ignoreDeprecations) strictCompilerArgs + ignoreDeprecationsArg
-        else strictCompilerArgs
-
-    tasks.withType<JavaCompile>().configureEach {
-        options.compilerArgs.addAll(compilerArgs)
-    }
-
-    tasks.withType<GroovyCompile>().configureEach {
-        options.compilerArgs.addAll(compilerArgs)
-    }
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.addAll(strictCompilerArgs)
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -135,7 +135,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         options.isIncremental = true
         options.forkOptions.jvmArgs?.add("-XX:+HeapDumpOnOutOfMemoryError")
         options.forkOptions.memoryMaximumSize = "1g"
-        options.compilerArgs = mutableListOf("-Xlint:-options", "-Xlint:-path")
+        options.compilerArgs.addAll(mutableListOf("-Xlint:-options", "-Xlint:-path"))
         if (!jdkForCompilation.current) {
             options.forkOptions.javaHome = jdkForCompilation.javaHome
         }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/strictcompile/StrictCompileExtension.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/strictcompile/StrictCompileExtension.kt
@@ -15,11 +15,38 @@
  */
 package org.gradle.plugins.strictcompile
 
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.kotlin.dsl.*
+
 
 /**
  * Strict compilation options honored by [gradlebuild.Strict_compile_gradle].
  */
-open class StrictCompileExtension {
+open class StrictCompileExtension(val tasks: TaskContainer) {
 
-    var ignoreDeprecations = false
+    fun ignoreDeprecations() {
+        tasks.withType<JavaCompile>().configureEach {
+            options.compilerArgs.add("-Xlint:-deprecation")
+        }
+    }
+
+    fun ignoreRawTypes() {
+        tasks.withType<JavaCompile>().configureEach {
+            options.compilerArgs.add("-Xlint:-rawtypes")
+        }
+    }
+
+    fun ignoreUnchecked() {
+        tasks.withType<JavaCompile>().configureEach {
+            options.compilerArgs.add("-Xlint:-unchecked")
+        }
+    }
+
+    fun ignoreParameterizedVarargType() {
+        tasks.withType<JavaCompile>().configureEach {
+            // There is no way to ignore this warning, so we need to turn off "-Werror" completely
+            options.compilerArgs = options.compilerArgs - "-Werror"
+        }
+    }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/strictcompile/StrictCompileExtension.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/strictcompile/StrictCompileExtension.kt
@@ -37,12 +37,6 @@ open class StrictCompileExtension(val tasks: TaskContainer) {
         }
     }
 
-    fun ignoreUnchecked() {
-        tasks.withType<JavaCompile>().configureEach {
-            options.compilerArgs.add("-Xlint:-unchecked")
-        }
-    }
-
     fun ignoreParameterizedVarargType() {
         tasks.withType<JavaCompile>().configureEach {
             // There is no way to ignore this warning, so we need to turn off "-Werror" completely

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     id("gradlebuild.gradle-distribution")
     id("gradlebuild.incubation-report")
     id("gradlebuild.task-properties-validation")
+    id("gradlebuild.strict-compile")
     id("gradlebuild.classycle")
 }
 

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -34,8 +34,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.plugins.JavaPlugin.COMPILE_CONFIGURATION_NAME;
-
 /**
  * A plugin for adding Antlr support to {@link JavaPlugin java projects}.
  */
@@ -65,7 +63,9 @@ public class AntlrPlugin implements Plugin<Project> {
             }
         });
 
-        project.getConfigurations().getByName(COMPILE_CONFIGURATION_NAME).extendsFrom(antlrConfiguration);
+        @SuppressWarnings("deprecation")
+        Configuration compileConfiguration = project.getConfigurations().getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME);
+        compileConfiguration.extendsFrom(antlrConfiguration);
 
         // Wire the antlr configuration into all antlr tasks
         project.getTasks().withType(AntlrTask.class).configureEach(new Action<AntlrTask>() {

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
@@ -42,6 +42,7 @@ public interface AntlrSourceVirtualDirectory {
      * @param configureClosure The closure to use to configure the Antlr source.
      * @return this
      */
+    @SuppressWarnings("rawtypes")
     AntlrSourceVirtualDirectory antlr(Closure configureClosure);
 
     /**

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
@@ -44,6 +44,7 @@ public class AntlrSourceVirtualDirectoryImpl implements AntlrSourceVirtualDirect
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public AntlrSourceVirtualDirectory antlr(Closure configureClosure) {
         ConfigureUtil.configure(configureClosure, getAntlr());
         return this;

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarDelegate.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarDelegate.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class GrammarDelegate {
     public static List<GrammarDelegate> extractGrammarDelegates(GrammarFile antlrGrammarFile) {
         List<GrammarDelegate> grammarDelegates = new ArrayList<GrammarDelegate>();
-        Enumeration grammarFileGrammars = antlrGrammarFile.getGrammars().elements();
+        Enumeration<?> grammarFileGrammars = antlrGrammarFile.getGrammars().elements();
         while (grammarFileGrammars.hasMoreElements()) {
             grammarDelegates.add(new GrammarDelegate(grammarFileGrammars.nextElement()));
         }
@@ -127,18 +127,18 @@ public class GrammarDelegate {
         return vocabName;
     }
 
-    private static final Class ANTLR_GRAMMAR_CLASS;
-    private static final Class ANTLR_OPTION_CLASS;
+    private static final Class<?> ANTLR_GRAMMAR_CLASS;
+    private static final Class<?> ANTLR_OPTION_CLASS;
 
     static {
         ANTLR_GRAMMAR_CLASS = loadAntlrClass("antlr.preprocessor.Grammar");
         ANTLR_OPTION_CLASS = loadAntlrClass("antlr.preprocessor.Option");
     }
 
-    public static final Class[] NO_ARG_SIGNATURE = new Class[0];
+    public static final Class<?>[] NO_ARG_SIGNATURE = new Class<?>[0];
     public static final Object[] NO_ARGS = new Object[0];
 
-    private static Class loadAntlrClass(String className) {
+    private static Class<?> loadAntlrClass(String className) {
         try {
             return Class.forName(className, true, GrammarDelegate.class.getClassLoader());
         } catch (ClassNotFoundException e) {

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/KotlinCompatibilityTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/KotlinCompatibilityTest.java
@@ -259,14 +259,14 @@ public class KotlinCompatibilityTest {
         // We avoid using reflect, since that leads to class loading exceptions
         return !m.getModifiers().contains(JavaModifier.STATIC)
             && (accessorType == PropertyAccessorType.GET_GETTER || accessorType == PropertyAccessorType.IS_GETTER)
-            && m.getParameters().size() == 0
-            && (accessorType != PropertyAccessorType.IS_GETTER || m.getReturnType().isEquivalentTo(Boolean.TYPE) || m.getReturnType().isEquivalentTo(Boolean.class));
+            && m.getRawParameterTypes().size() == 0
+            && (accessorType != PropertyAccessorType.IS_GETTER || m.getRawReturnType().isEquivalentTo(Boolean.TYPE) || m.getRawReturnType().isEquivalentTo(Boolean.class));
     }
 
     private static boolean isSetter(JavaMethod m, PropertyAccessorType accessorType) {
         return !m.getModifiers().contains(JavaModifier.STATIC)
             && accessorType == PropertyAccessorType.SETTER
-            && m.getParameters().size() == 1;
+            && m.getRawParameterTypes().size() == 1;
     }
 
     private static class GradlePublicApi extends DescribedPredicate<JavaClass> {

--- a/subprojects/base-annotations/base-annotations.gradle.kts
+++ b/subprojects/base-annotations/base-annotations.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 description = "Common shared annotations"

--- a/subprojects/base-services-groovy/base-services-groovy.gradle.kts
+++ b/subprojects/base-services-groovy/base-services-groovy.gradle.kts
@@ -25,3 +25,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":core")))
 }
+
+strictCompile {
+    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: org.gradle.api.specs.AndSpec.and()
+}

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/api/InvalidActionClosureException.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/api/InvalidActionClosureException.java
@@ -17,6 +17,7 @@
 package org.gradle.api;
 
 import groovy.lang.Closure;
+import org.gradle.internal.Cast;
 import org.gradle.util.CollectionUtils;
 
 import java.util.List;
@@ -36,12 +37,7 @@ public class InvalidActionClosureException extends GradleException {
     }
 
     private static String toMessage(Closure<?> closure, Object argument) {
-        List<Object> classNames = CollectionUtils.collect(closure.getParameterTypes(), new Transformer<Object, Class>() {
-            @Override
-            public Object transform(Class clazz) {
-                return clazz.getName();
-            }
-        });
+        List<Object> classNames = CollectionUtils.collect(Cast.<Class<?>[]>uncheckedNonnullCast(closure.getParameterTypes()), Class::getName);
         return String.format(
                 "The closure '%s' is not valid as an action for argument '%s'. It should accept no parameters, or one compatible with type '%s'. It accepts (%s).",
                 closure, argument, argument.getClass().getName(), CollectionUtils.join(", ", classNames)

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/api/internal/coerce/StringToEnumTransformer.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/api/internal/coerce/StringToEnumTransformer.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.coerce;
 
 import org.codehaus.groovy.reflection.CachedClass;
+import org.gradle.internal.Cast;
 import org.gradle.util.GUtil;
 
 public class StringToEnumTransformer implements MethodArgumentsTransformer, PropertySetTransformer {
@@ -28,7 +29,7 @@ public class StringToEnumTransformer implements MethodArgumentsTransformer, Prop
         boolean needsTransform = false;
         for (int i = 0; i < args.length; i++) {
             Object arg = args[i];
-            Class type = types[i].getTheClass();
+            Class<?> type = types[i].getTheClass();
             if (type.isInstance(arg) || arg == null) {
                 // Can use arg without conversion
                 continue;
@@ -45,9 +46,9 @@ public class StringToEnumTransformer implements MethodArgumentsTransformer, Prop
         Object[] transformed = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             Object arg = args[i];
-            Class type = types[i].getTheClass();
+            Class<?> type = types[i].getTheClass();
             if (type.isEnum() && arg instanceof CharSequence) {
-                transformed[i] = toEnumValue(type, arg);
+                transformed[i] = toEnumValue(Cast.uncheckedNonnullCast(type), arg);
             } else {
                 transformed[i] = args[i];
             }
@@ -68,8 +69,8 @@ public class StringToEnumTransformer implements MethodArgumentsTransformer, Prop
     @Override
     public Object transformValue(Class<?> type, Object value) {
         if (value instanceof CharSequence && type.isEnum()) {
-            @SuppressWarnings("unchecked") Class<? extends Enum> enumType = (Class<? extends Enum>) type;
-            return toEnumValue(enumType, value);
+            @SuppressWarnings("unchecked") Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>) type;
+            return toEnumValue(Cast.uncheckedNonnullCast(enumType), value);
         }
 
         return value;

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/AndSpec.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/AndSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.specs;
 import com.google.common.collect.ObjectArrays;
 import groovy.lang.Closure;
 import org.gradle.api.specs.internal.ClosureSpec;
+import org.gradle.internal.Cast;
 
 /**
  * A {@link org.gradle.api.specs.CompositeSpec} which requires all its specs to be true in order to evaluate to true.
@@ -26,12 +27,14 @@ import org.gradle.api.specs.internal.ClosureSpec;
  * @param <T> The target type for this Spec
  */
 public class AndSpec<T> extends CompositeSpec<T> {
-    public static final AndSpec<?> EMPTY = new AndSpec<Object>();
+    public static final AndSpec<?> EMPTY = new AndSpec<>();
 
     public AndSpec() {
         super();
     }
 
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public AndSpec(Spec<? super T>... specs) {
         super(specs);
     }
@@ -51,6 +54,7 @@ public class AndSpec<T> extends CompositeSpec<T> {
         return true;
     }
 
+    @SuppressWarnings("varargs")
     public AndSpec<T> and(Spec<? super T>... specs) {
         if (specs.length == 0) {
             return this;
@@ -71,14 +75,12 @@ public class AndSpec<T> extends CompositeSpec<T> {
      *
      * @since 4.3
      */
-    @SuppressWarnings("unchecked")
     public AndSpec<T> and(Spec<? super T> spec) {
-        return and(new Spec[]{spec});
+        return and(Cast.<Spec<? super T>[]>uncheckedNonnullCast(new Spec<?>[]{spec}));
     }
 
-    @SuppressWarnings("unchecked")
-    public AndSpec<T> and(Closure spec) {
-        return and(new ClosureSpec<T>(spec));
+    public AndSpec<T> and(Closure<T> spec) {
+        return and(new ClosureSpec<>(spec));
     }
 
     public static <T> AndSpec<T> empty() {

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/Specs.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/Specs.java
@@ -51,14 +51,15 @@ public class Specs {
         return Cast.uncheckedCast(SATISFIES_NONE);
     }
 
-    public static <T> Spec<T> convertClosureToSpec(final Closure closure) {
-        return new ClosureSpec<T>(closure);
+    public static <T> Spec<T> convertClosureToSpec(final Closure<?> closure) {
+        return new ClosureSpec<>(closure);
     }
 
     /**
      * Returns a spec that selects the intersection of those items selected by the given specs. Returns a spec that selects everything when no specs provided.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Spec<T> intersect(Spec<? super T>... specs) {
         if (specs.length == 0) {
             return satisfyAll();
@@ -80,7 +81,7 @@ public class Specs {
     }
 
     private static <T> Spec<T> doIntersect(Collection<? extends Spec<? super T>> specs) {
-        List<Spec<? super T>> filtered = new ArrayList<Spec<? super T>>(specs.size());
+        List<Spec<? super T>> filtered = new ArrayList<>(specs.size());
         for (Spec<? super T> spec : specs) {
             if (spec == SATISFIES_NONE) {
                 return satisfyNone();
@@ -95,13 +96,14 @@ public class Specs {
         if (filtered.size() == 1) {
             return Cast.uncheckedCast(filtered.get(0));
         }
-        return new AndSpec<T>(filtered);
+        return new AndSpec<>(filtered);
     }
 
     /**
      * Returns a spec that selects the union of those items selected by the provided spec. Selects everything when no specs provided.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Spec<T> union(Spec<? super T>... specs) {
         if (specs.length == 0) {
             return satisfyAll();
@@ -139,7 +141,7 @@ public class Specs {
             return Cast.uncheckedCast(filtered.get(0));
         }
 
-        return new OrSpec<T>(filtered);
+        return new OrSpec<>(filtered);
     }
 
     /**
@@ -153,10 +155,10 @@ public class Specs {
             return satisfyAll();
         }
         if (spec instanceof NotSpec) {
-            NotSpec<? super T> notSpec = (NotSpec<? super T>) spec;
-            return Cast.uncheckedCast(notSpec.getSourceSpec());
+            NotSpec<? super T> notSpec = Cast.uncheckedNonnullCast(spec);
+            return Cast.uncheckedNonnullCast(notSpec.getSourceSpec());
         }
-        return new NotSpec<T>(spec);
+        return new NotSpec<>(spec);
     }
 
 }

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/ExpressionReplacingVisitorSupport.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/ExpressionReplacingVisitorSupport.java
@@ -405,7 +405,7 @@ public class ExpressionReplacingVisitorSupport extends StatementReplacingVisitor
     }
 
     @Override
-    protected void visitListOfExpressions(List exprs) {
+    protected void visitListOfExpressions(List<? extends Expression> exprs) {
         throw new UnsupportedOperationException("visitListOfExpressions");
     }
 

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -33,10 +33,6 @@ dependencies {
     jmh("com.google.guava:guava:27.1-android")
 }
 
-strictCompile {
-    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: org.gradle.api.specs.AndSpec.and()
-}
-
 jmh {
     include = listOf("HashingAlgorithmsBenchmark")
 }

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -33,6 +33,10 @@ dependencies {
     jmh("com.google.guava:guava:27.1-android")
 }
 
+strictCompile {
+    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: org.gradle.api.specs.AndSpec.and()
+}
+
 jmh {
     include = listOf("HashingAlgorithmsBenchmark")
 }

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/CachedConstructorsBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/CachedConstructorsBenchmark.java
@@ -30,17 +30,17 @@ import java.util.Random;
 @State(Scope.Benchmark)
 public class CachedConstructorsBenchmark {
 
-    private final static Class<?>[] CLAZZ_ARRAY = new Class[]{ArrayList.class, LinkedList.class, String.class, HashMap.class};
+    private final static Class<?>[] CLAZZ_ARRAY = new Class<?>[]{ArrayList.class, LinkedList.class, String.class, HashMap.class};
     private final static int ARR_LEN = 1024;
     private final static Random RANDOM = new Random();
-    public static final Class[] EMPTY = new Class[0];
+    public static final Class<?>[] EMPTY = new Class<?>[0];
 
     private final DirectInstantiator.ConstructorCache cache = new DirectInstantiator.ConstructorCache();
     private Class<?>[] randomClasses;
 
     @Setup(Level.Iteration)
     public void configClasses() {
-        randomClasses = new Class[ARR_LEN];
+        randomClasses = new Class<?>[ARR_LEN];
         for (int i = 0; i < randomClasses.length; i++) {
             randomClasses[i] = CLAZZ_ARRAY[RANDOM.nextInt(CLAZZ_ARRAY.length)];
         }

--- a/subprojects/base-services/src/main/java/org/gradle/api/specs/CompositeSpec.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/specs/CompositeSpec.java
@@ -29,7 +29,7 @@ import java.util.List;
  * @param <T> The target type for this Spec
  */
 public abstract class CompositeSpec<T> implements Spec<T> {
-    private static final Spec<?>[] EMPTY = new Spec[0];
+    private static final Spec<?>[] EMPTY = new Spec<?>[0];
 
     private final Spec<? super T>[] specs;
 
@@ -90,7 +90,7 @@ public abstract class CompositeSpec<T> implements Spec<T> {
             return false;
         }
 
-        CompositeSpec that = (CompositeSpec) o;
+        CompositeSpec<?> that = (CompositeSpec<?>) o;
         return Arrays.equals(specs, that.specs);
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -126,7 +126,7 @@ public abstract class Actions {
                 return false;
             }
 
-            CompositeAction that = (CompositeAction) o;
+            CompositeAction<?> that = (CompositeAction<?>) o;
 
             if (!actions.equals(that.actions)) {
                 return false;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
@@ -38,7 +38,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
      * Creates an empty action set.
      */
     public static <T> ImmutableActionSet<T> empty() {
-        return Cast.uncheckedCast(EMPTY);
+        return Cast.uncheckedNonnullCast(EMPTY);
     }
 
     /**
@@ -62,7 +62,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
 
     private static <T> void unpackAction(Action<? super T> action, ImmutableSet.Builder<Action<? super T>> builder) {
         if (action instanceof ImmutableActionSet) {
-            ImmutableActionSet<T> immutableSet = (ImmutableActionSet<T>) action;
+            ImmutableActionSet<T> immutableSet = Cast.uncheckedNonnullCast(action);
             immutableSet.unpackInto(builder);
         } else {
             builder.add(action);
@@ -79,15 +79,15 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
             return this;
         }
         if (action instanceof SingletonSet) {
-            SingletonSet<T> singletonSet = (SingletonSet) action;
+            SingletonSet<T> singletonSet = Cast.uncheckedNonnullCast(action);
             return addOne(singletonSet.singleAction);
         }
         if (action instanceof SetWithFewActions) {
-            SetWithFewActions<T> compositeSet = (SetWithFewActions<T>) action;
+            SetWithFewActions<T> compositeSet = Cast.uncheckedNonnullCast(action);
             return addAll(compositeSet);
         }
         if (action instanceof SetWithManyActions) {
-            SetWithManyActions<T> compositeSet = (SetWithManyActions) action;
+            SetWithManyActions<T> compositeSet = Cast.uncheckedNonnullCast(action);
             return addAll(compositeSet);
         }
         return addOne(action);
@@ -133,7 +133,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
             return this;
         }
         if (isEmpty()) {
-            return (ImmutableActionSet<T>) sibling;
+            return Cast.uncheckedNonnullCast(sibling);
         }
         return add(sibling);
     }
@@ -191,7 +191,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
             if (action.equals(singleAction)) {
                 return this;
             }
-            return new SetWithFewActions<T>(new Action[]{singleAction, action});
+            return new SetWithFewActions<T>(Cast.<Action<? super T>[]>uncheckedNonnullCast(new Action<?>[]{singleAction, action}));
         }
 
         @Override
@@ -202,7 +202,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
             }
             if (source.actions.length < FEW_VALUES && !source.contains(singleAction)) {
                 // Adding a small set with no duplicates
-                Action<? super T>[] newActions = new Action[source.actions.length + 1];
+                Action<? super T>[] newActions = Cast.uncheckedNonnullCast(new Action<?>[source.actions.length + 1]);
                 newActions[0] = singleAction;
                 System.arraycopy(source.actions, 0, newActions, 1, source.actions.length);
                 return new SetWithFewActions<T>(newActions);
@@ -232,10 +232,10 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
     }
 
     private static class SetWithFewActions<T> extends ImmutableActionSet<T> {
-        private final Action<? super T> actions[];
+        private final Action<? super T>[] actions;
 
         SetWithFewActions(ImmutableSet<Action<? super T>> set) {
-            actions = set.toArray(new Action[set.size()]);
+            actions = Cast.uncheckedNonnullCast(set.toArray(new Action<?>[set.size()]));
         }
 
         SetWithFewActions(Action<? super T>[] actions) {
@@ -255,7 +255,7 @@ public abstract class ImmutableActionSet<T> implements Action<T>, InternalListen
             }
             if (actions.length < FEW_VALUES) {
                 // Adding an action that is not a duplicate
-                Action<? super T>[] newActions = new Action[actions.length + 1];
+                Action<? super T>[] newActions = Cast.uncheckedNonnullCast(new Action<?>[actions.length + 1]);
                 System.arraycopy(actions, 0, newActions, 0, actions.length);
                 newActions[actions.length] = action;
                 return new SetWithFewActions<T>(newActions);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -145,7 +145,7 @@ public abstract class ClassLoaderUtils {
             try {
                 MethodHandles.Lookup lookup = getLookupForClassLoader(classLoader);
                 MethodHandle methodHandle = lookup.findVirtual(ClassLoader.class, methodName, methodType);
-                return (T) methodHandle.bindTo(classLoader).invokeWithArguments(arguments);
+                return Cast.uncheckedNonnullCast(methodHandle.bindTo(classLoader).invokeWithArguments(arguments));
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
@@ -162,15 +162,15 @@ public abstract class ClassLoaderUtils {
     }
 
     private static class ReflectionClassDefiner implements ClassDefiner {
-        private final JavaMethod<ClassLoader, Class> defineClassMethod;
+        private final JavaMethod<ClassLoader, Class<?>> defineClassMethod;
 
         private ReflectionClassDefiner() {
-            defineClassMethod = JavaMethod.of(ClassLoader.class, Class.class, "defineClass", String.class, byte[].class, int.class, int.class);
+            defineClassMethod = Cast.uncheckedNonnullCast(JavaMethod.of(ClassLoader.class, Class.class, "defineClass", String.class, byte[].class, int.class, int.class));
         }
 
         @Override
         public <T> Class<T> defineClass(ClassLoader classLoader, String className, byte[] classBytes) {
-            return Cast.uncheckedCast(defineClassMethod.invoke(classLoader, className, classBytes, 0, classBytes.length));
+            return Cast.uncheckedNonnullCast(defineClassMethod.invoke(classLoader, className, classBytes, 0, classBytes.length));
         }
 
         @Override
@@ -180,7 +180,7 @@ public abstract class ClassLoaderUtils {
     }
 
     private static class LookupClassDefiner extends AbstractClassLoaderLookuper implements ClassDefiner {
-        private MethodType defineClassMethodType = MethodType.methodType(Class.class, new Class[]{String.class, byte[].class, int.class, int.class});
+        private MethodType defineClassMethodType = MethodType.methodType(Class.class, new Class<?>[]{String.class, byte[].class, int.class, int.class});
 
         @Override
         @SuppressWarnings("unchecked")
@@ -221,8 +221,8 @@ public abstract class ClassLoaderUtils {
     }
 
     private static class LookupPackagesFetcher extends AbstractClassLoaderLookuper implements ClassLoaderPackagesFetcher {
-        private MethodType getPackagesMethodType = MethodType.methodType(Package[].class, new Class[]{});
-        private MethodType getDefinedPackageMethodType = MethodType.methodType(Package.class, new Class[]{String.class});
+        private MethodType getPackagesMethodType = MethodType.methodType(Package[].class, new Class<?>[]{});
+        private MethodType getDefinedPackageMethodType = MethodType.methodType(Package.class, new Class<?>[]{String.class});
 
         @Override
         public Package[] getPackages(ClassLoader classLoader) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -79,7 +79,7 @@ public class ClasspathUtil {
 
     public static File getClasspathForClass(String targetClassName) {
         try {
-            Class clazz = Class.forName(targetClassName);
+            Class<?> clazz = Class.forName(targetClassName);
             if (clazz.getClassLoader() == null) {
                 return null;
             } else {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -18,6 +18,7 @@ package org.gradle.internal.classpath;
 
 import org.gradle.api.specs.NotSpec;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.util.CollectionUtils;
 
@@ -83,6 +84,7 @@ public class DefaultClassPath implements ClassPath, Serializable {
     /**
      * @deprecated Only here for the Kotlin DSL, use {@link #of(File...)} instead.
      */
+    @Deprecated
     public DefaultClassPath(File... files) {
         this(new ImmutableUniqueList<File>(Arrays.asList(files)));
     }
@@ -235,7 +237,7 @@ public class DefaultClassPath implements ClassPath, Serializable {
             if (index >= size) {
                 throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
             }
-            return (T) asArray[index];
+            return Cast.uncheckedNonnullCast(asArray[index]);
         }
 
         @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.graph;
 
+import org.gradle.internal.Cast;
 import org.gradle.util.GUtil;
 
 import java.util.ArrayDeque;
@@ -60,8 +61,8 @@ public class CachingDirectedGraphWalker<N, T> {
     /**
      * Adds some start nodes.
      */
-    public CachingDirectedGraphWalker add(Iterable<? extends N> values) {
-        GUtil.addToCollection(startNodes, values);
+    public CachingDirectedGraphWalker<?, ?> add(Iterable<? extends N> values) {
+        GUtil.addToCollection(startNodes, Cast.<Iterable<? extends N>[]>uncheckedNonnullCast(new Iterable<?>[]{values}));
         return this;
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -119,7 +119,7 @@ public class DirectInstantiator implements Instantiator {
             }));
         }
 
-        private boolean isMatch(Class<?>[] argumentTypes, Class[] parameterTypes) {
+        private boolean isMatch(Class<?>[] argumentTypes, Class<?>[] parameterTypes) {
             for (int i = 0; i < argumentTypes.length; i++) {
                 Class<?> argumentType = argumentTypes[i];
                 Class<?> parameterType = parameterTypes[i];

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
@@ -73,7 +73,7 @@ public class JavaMethod<T, R> {
         method.setAccessible(true);
     }
 
-    private static Method findMethod(Class origTarget, Class target, String name, boolean allowStatic, Class<?>[] paramTypes) {
+    private static Method findMethod(Class<?> origTarget, Class<?> target, String name, boolean allowStatic, Class<?>[] paramTypes) {
         for (Method method : target.getDeclaredMethods()) {
             if (!allowStatic && Modifier.isStatic(method.getModifiers())) {
                 continue;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.internal.Cast;
+
 import java.lang.reflect.Method;
 
 /**
@@ -26,7 +28,7 @@ class DefaultServiceMethodFactory implements ServiceMethodFactory {
     DefaultServiceMethodFactory() {
         ServiceMethodFactory factory;
         try {
-            factory = ((Class<ServiceMethodFactory>) Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory")).getConstructor().newInstance();
+            factory = Cast.uncheckedNonnullCast(Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").getConstructor().newInstance());
         } catch (Exception e) {
             factory = new ReflectionBasedServiceMethodFactory();
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
@@ -22,7 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 
 class MethodHandleBasedServiceMethod extends AbstractServiceMethod {
-    private final static MethodHandles.Lookup LOOKUP = (MethodHandles.Lookup) MethodHandles.publicLookup();
+    private final static MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
     private final MethodHandle method;
 
     MethodHandleBasedServiceMethod(Method target) throws IllegalAccessException {

--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -143,7 +143,7 @@ public abstract class CollectionUtils {
     /**
      * Returns a sorted copy of the provided collection of things. Uses the natural ordering of the things.
      */
-    public static <T extends Comparable> List<T> sort(Iterable<T> things) {
+    public static <T extends Comparable<T>> List<T> sort(Iterable<T> things) {
         List<T> copy = toMutableList(things);
         Collections.sort(copy);
         return copy;

--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.io.StreamByteBuffer;
 
@@ -58,40 +59,40 @@ public class GUtil {
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
     private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
 
-    public static <T extends Collection> T flatten(Object[] elements, T addTo, boolean flattenMaps) {
+    public static <T extends Collection<?>> T flatten(Object[] elements, T addTo, boolean flattenMaps) {
         return flatten(asList(elements), addTo, flattenMaps);
     }
 
-    public static <T extends Collection> T flatten(Object[] elements, T addTo) {
+    public static <T extends Collection<?>> T flatten(Object[] elements, T addTo) {
         return flatten(asList(elements), addTo);
     }
 
-    public static <T extends Collection> T flatten(Collection elements, T addTo) {
+    public static <T extends Collection<?>> T flatten(Collection<?> elements, T addTo) {
         return flatten(elements, addTo, true);
     }
 
-    public static <T extends Collection> T flattenElements(Object... elements) {
+    public static <T extends Collection<?>> T flattenElements(Object... elements) {
         Collection<T> out = new LinkedList<T>();
         flatten(elements, out, true);
-        return (T) out;
+        return Cast.uncheckedNonnullCast(out);
     }
 
-    public static <T extends Collection> T flatten(Collection elements, T addTo, boolean flattenMapsAndArrays) {
+    public static <T extends Collection<?>> T flatten(Collection<?> elements, T addTo, boolean flattenMapsAndArrays) {
         return flatten(elements, addTo, flattenMapsAndArrays, flattenMapsAndArrays);
     }
 
-    public static <T extends Collection> T flatten(Collection elements, T addTo, boolean flattenMaps, boolean flattenArrays) {
-        Iterator iter = elements.iterator();
+    public static <T extends Collection<?>> T flatten(Collection<?> elements, T addTo, boolean flattenMaps, boolean flattenArrays) {
+        Iterator<?> iter = elements.iterator();
         while (iter.hasNext()) {
             Object element = iter.next();
             if (element instanceof Collection) {
-                flatten((Collection) element, addTo, flattenMaps, flattenArrays);
+                flatten((Collection<?>) element, addTo, flattenMaps, flattenArrays);
             } else if ((element instanceof Map) && flattenMaps) {
-                flatten(((Map) element).values(), addTo, flattenMaps, flattenArrays);
+                flatten(((Map<?, ?>) element).values(), addTo, flattenMaps, flattenArrays);
             } else if ((element.getClass().isArray()) && flattenArrays) {
                 flatten(asList((Object[]) element), addTo, flattenMaps, flattenArrays);
             } else {
-                addTo.add(element);
+                (Cast.<Collection<Object>>uncheckedNonnullCast(addTo)).add(element);
             }
         }
         return addTo;
@@ -103,15 +104,15 @@ public class GUtil {
      * @param input any object
      * @return collection of flattened input or single input wrapped in a collection.
      */
-    public static Collection collectionize(Object input) {
+    public static Collection<?> collectionize(Object input) {
         if (input == null) {
             return emptyList();
         } else if (input instanceof Collection) {
-            Collection out = new LinkedList();
-            flatten((Collection) input, out, false, true);
+            Collection<?> out = new LinkedList<Object>();
+            flatten((Collection<?>) input, out, false, true);
             return out;
         } else if (input.getClass().isArray()) {
-            Collection out = new LinkedList();
+            Collection<?> out = new LinkedList<Object>();
             flatten(asList((Object[]) input), out, false, true);
             return out;
         } else {
@@ -119,12 +120,12 @@ public class GUtil {
         }
     }
 
-    public static List flatten(Collection elements, boolean flattenMapsAndArrays) {
-        return flatten(elements, new ArrayList(), flattenMapsAndArrays);
+    public static List<Object> flatten(Collection<Object> elements, boolean flattenMapsAndArrays) {
+        return flatten(elements, new ArrayList<Object>(), flattenMapsAndArrays);
     }
 
-    public static List flatten(Collection elements) {
-        return flatten(elements, new ArrayList());
+    public static List<Object> flatten(Collection<Object> elements) {
+        return flatten(elements, new ArrayList<Object>());
     }
 
     public static String asPath(Iterable<?> collection) {
@@ -184,8 +185,8 @@ public class GUtil {
         };
     }
 
-    public static Map addMaps(Map map1, Map map2) {
-        HashMap map = new HashMap();
+    public static <K, V> Map<K, V> addMaps(Map<K, V> map1, Map<K, V> map2) {
+        HashMap<K, V> map = new HashMap<K, V>();
         map.putAll(map1);
         map.putAll(map2);
         return map;
@@ -256,8 +257,8 @@ public class GUtil {
         }
     }
 
-    public static Map map(Object... objects) {
-        Map map = new HashMap();
+    public static Map<Object, Object> map(Object... objects) {
+        Map<Object, Object> map = new HashMap<Object, Object>();
         assert objects.length % 2 == 0;
         for (int i = 0; i < objects.length; i += 2) {
             map.put(objects[i], objects[i + 1]);

--- a/subprojects/base-services/src/main/java/org/gradle/util/internal/LimitedDescription.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/internal/LimitedDescription.java
@@ -26,12 +26,12 @@ import java.util.List;
  */
 public class LimitedDescription {
 
-    private final LinkedList content;
+    private final LinkedList<String> content;
     private final int maxItems;
 
     public LimitedDescription(int maxItems) {
         this.maxItems = maxItems;
-        this.content = new LinkedList();
+        this.content = new LinkedList<String>();
     }
 
     public LimitedDescription append(String line) {
@@ -41,14 +41,14 @@ public class LimitedDescription {
         }
         return this;
     }
-    
+
     public String toString() {
         if (content.size() == 0) {
             return "<<empty>>";
         }
 
         StringBuilder out = new StringBuilder();
-        List reversed = Lists.reverse(content);
+        List<String> reversed = Lists.reverse(content);
         for (Object item : reversed) {
             out.append(item).append("\n");
         }

--- a/subprojects/build-cache-base/build-cache-base.gradle.kts
+++ b/subprojects/build-cache-base/build-cache-base.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/build-cache-http/build-cache-http.gradle.kts
+++ b/subprojects/build-cache-http/build-cache-http.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -150,7 +150,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
                     return;
                 }
                 try {
-                    handle((T) next);
+                    handle(Cast.uncheckedNonnullCast(next));
                 } catch (Exception e) {
                     failure.set(e);
                     break;

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl;
+import org.gradle.internal.Cast;
 import org.gradle.internal.file.PathToFileResolver;
 
 import javax.annotation.Nullable;
@@ -185,7 +186,7 @@ public class BuildScriptBuilder {
             return new LiteralValue(expression);
         }
         if (expression instanceof Map) {
-            return new MapLiteralValue(expressionMap((Map<String, ?>) expression));
+            return new MapLiteralValue(expressionMap(Cast.uncheckedNonnullCast(expression)));
         }
         throw new IllegalArgumentException("Don't know how to treat " + expression + " as an expression.");
     }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/TemplateOperationFactory.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/TemplateOperationFactory.java
@@ -35,7 +35,7 @@ public class TemplateOperationFactory {
     private final String templatepackage;
     private final PathToFileResolver fileResolver;
     private final DocumentationRegistry documentationRegistry;
-    private final Map defaultBindings;
+    private final Map<String, String> defaultBindings;
 
     public TemplateOperationFactory(String templatepackage, PathToFileResolver fileResolver, DocumentationRegistry documentationRegistry) {
         this.documentationRegistry = documentationRegistry;
@@ -46,7 +46,7 @@ public class TemplateOperationFactory {
 
     private Map<String, String> loadDefaultBindings() {
         String now = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(new Date());
-        Map<String, String> map = new LinkedHashMap<String, String>(3);
+        Map<String, String> map = new LinkedHashMap<>(3);
         map.put("genDate", now);
         map.put("genUser", System.getProperty("user.name"));
         map.put("genGradleVersion", GradleVersion.current().toString());
@@ -59,10 +59,10 @@ public class TemplateOperationFactory {
 
     public class TemplateOperationBuilder {
         private File target;
-        private Map<String, String> bindings =  new HashMap<String, String>();
+        final private Map<String, String> bindings =  new HashMap<>();
         private URL templateUrl;
 
-        public TemplateOperationBuilder(Map defaultBindings) {
+        public TemplateOperationBuilder(Map<String, String> defaultBindings) {
             this.bindings.putAll(defaultBindings);
         }
 
@@ -103,7 +103,7 @@ public class TemplateOperationFactory {
 
         public TemplateOperation create() {
             final Set<Map.Entry<String, String>> entries = bindings.entrySet();
-            Map wrappedBindings = new HashMap(entries.size());
+            Map<String, TemplateValue> wrappedBindings = new HashMap<>(entries.size());
             for (Map.Entry<String, String> entry : entries) {
                 if (entry.getValue() == null) {
                     throw new IllegalArgumentException("Null value provided for binding '" + entry.getKey() + "'.");

--- a/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -51,6 +51,7 @@ public class ProfileEventAdapter implements InternalBuildListener, ProjectEvalua
 
     // BuildListener
     @Override
+    @SuppressWarnings("deprecation")
     public void buildStarted(Gradle gradle) {
         long now = clock.getCurrentTime();
         buildProfile = new BuildProfile(gradle.getStartParameter());
@@ -106,14 +107,14 @@ public class ProfileEventAdapter implements InternalBuildListener, ProjectEvalua
 
     // TaskListenerInternal
     @Override
-    public void beforeExecute(TaskIdentity taskIdentity) {
+    public void beforeExecute(TaskIdentity<?> taskIdentity) {
         long now = clock.getCurrentTime();
         ProjectProfile projectProfile = buildProfile.getProjectProfile(taskIdentity.getProjectPath());
         projectProfile.getTaskProfile(taskIdentity.getTaskPath()).setStart(now);
     }
 
     @Override
-    public void afterExecute(TaskIdentity taskIdentity, TaskState state) {
+    public void afterExecute(TaskIdentity<?> taskIdentity, TaskState state) {
         long now = clock.getCurrentTime();
         ProjectProfile projectProfile = buildProfile.getProjectProfile(taskIdentity.getProjectPath());
         TaskExecution taskExecution = projectProfile.getTaskProfile(taskIdentity.getTaskPath());

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
@@ -307,11 +307,11 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         }
 
         @Override
-        public void beforeExecute(TaskIdentity taskIdentity) {
+        public void beforeExecute(TaskIdentity<?> taskIdentity) {
         }
 
         @Override
-        public void afterExecute(TaskIdentity taskIdentity, org.gradle.api.tasks.TaskState state) {
+        public void afterExecute(TaskIdentity<?> taskIdentity, org.gradle.api.tasks.TaskState state) {
             Throwable failure = state.getFailure();
             taskCompleted(taskIdentity.getTaskPath(), failure);
         }

--- a/subprojects/core-api/core-api.gradle.kts
+++ b/subprojects/core-api/core-api.gradle.kts
@@ -16,7 +16,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    // gradlebuild.`strict-compile`
 }
 
 dependencies {
@@ -46,6 +45,11 @@ dependencies {
 
 classycle {
     excludePatterns.set(listOf("org/gradle/**"))
+}
+
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: ArtifactResolutionQuery, RepositoryContentDescriptor, HasMultipleValues
 }
 
 testFilesCleanup {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.TransformSpec;
-import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.plugins.ExtensionAware;
@@ -451,7 +450,8 @@ public interface DependencyHandler extends ExtensionAware {
      * @since 3.5
      */
     @Deprecated
-    void registerTransform(Action<? super VariantTransform> registrationAction);
+    @SuppressWarnings("deprecation")
+    void registerTransform(Action<? super org.gradle.api.artifacts.transform.VariantTransform> registrationAction);
 
     /**
      * Registers an <a href="https://docs.gradle.org/current/userguide/artifact_transforms.html">artifact transform</a>.

--- a/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildListener.java
@@ -25,5 +25,6 @@ public interface InternalBuildListener extends BuildListener, InternalListener {
      *
      * @param gradle The build which is being started. Never null.
      */
+    @SuppressWarnings("deprecation")
     void buildStarted(Gradle gradle);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/FlatteningNotationParser.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/FlatteningNotationParser.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.typeconversion;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.util.GUtil;
 
@@ -44,7 +45,7 @@ public class FlatteningNotationParser<N, T> implements NotationParser<N, Set<T>>
 
     @Override
     public Set<T> parseNotation(N notation) {
-        Collection<N> notations = GUtil.collectionize(notation);
+        Collection<N> notations = Cast.uncheckedNonnullCast(GUtil.collectionize(notation));
         if (notations.isEmpty()) {
             return Collections.emptySet();
         }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.typeconversion;
 
 import org.gradle.api.Describable;
+import org.gradle.internal.Cast;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -114,7 +115,7 @@ public class NotationParserBuilder<N, T> {
         if (!notationType.isAssignableFrom(String.class)) {
             throw new IllegalArgumentException(String.format("Cannot convert from String when notation is %s.", notationType.getSimpleName()));
         }
-        NotationConverter notationParser = new CharSequenceNotationParser();
+        NotationConverter<String, T> notationParser = Cast.uncheckedNonnullCast(new CharSequenceNotationParser());
         fromCharSequence(notationParser);
         return this;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/TypeInfo.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/TypeInfo.java
@@ -16,15 +16,17 @@
 
 package org.gradle.internal.typeconversion;
 
+import org.gradle.internal.Cast;
+
 /**
  * Type literal, useful for nested Generics.
  */
 public class TypeInfo<T> {
     private final Class<T> targetType;
 
-    public TypeInfo(Class targetType) {
+    public TypeInfo(Class<?> targetType) {
         assert targetType != null;
-        this.targetType = targetType;
+        this.targetType = Cast.uncheckedNonnullCast(targetType);
     }
 
     public Class<T> getTargetType() {

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -149,6 +149,10 @@ dependencies {
     crossVersionTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -151,6 +151,7 @@ dependencies {
 
 strictCompile {
     ignoreRawTypes() // raw types used in public API
+    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
 }
 
 classycle {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -44,6 +44,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
     private final DefaultDomainObjectSet<T> backingSet;
     private final CollectionCallbackActionDecorator callbackActionDecorator;
 
+    @SafeVarargs
     public static <T> CompositeDomainObjectSet<T> create(Class<T> type, DomainObjectCollection<? extends T>... collections) {
         return create(type, CollectionCallbackActionDecorator.NOOP, collections);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
@@ -26,12 +26,12 @@ public class TaskExecutionStatisticsEventAdapter implements TaskListenerInternal
     private int upToDateTaskCount;
 
     @Override
-    public void beforeExecute(TaskIdentity taskIdentity) {
+    public void beforeExecute(TaskIdentity<?> taskIdentity) {
         // do nothing
     }
 
     @Override
-    public void afterExecute(TaskIdentity taskIdentity, TaskState state) {
+    public void afterExecute(TaskIdentity<?> taskIdentity, TaskState state) {
         TaskStateInternal stateInternal = (TaskStateInternal) state;
         if (stateInternal.isActionable()) {
             switch (stateInternal.getOutcome()) {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskListenerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskListenerInternal.java
@@ -25,7 +25,7 @@ public interface TaskListenerInternal {
      *
      * @param taskIdentity The identity of the task about to be executed. Never null.
      */
-    void beforeExecute(TaskIdentity taskIdentity);
+    void beforeExecute(TaskIdentity<?> taskIdentity);
 
     /**
      * This method is call immediately after a task has been executed. It is always called, regardless of whether the
@@ -35,6 +35,6 @@ public interface TaskListenerInternal {
      * @param state The task state. If the task failed with an exception, the exception is available in this
      * state. Never null.
      */
-    void afterExecute(TaskIdentity taskIdentity, TaskState state);
+    void afterExecute(TaskIdentity<?>  taskIdentity, TaskState state);
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -18,6 +18,7 @@ package org.gradle.initialization;
 import org.gradle.api.Project;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.properties.GradleProperties;
+import org.gradle.internal.Cast;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.GUtil;
 import org.gradle.util.SetSystemProperties;
@@ -69,7 +70,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromInstallationPropertiesFile() {
-        writePropertyFile(gradleInstallationHomeDir, GUtil.map("settingsProp", "settings value"));
+        writePropertyFile(gradleInstallationHomeDir, Cast.uncheckedNonnullCast(Cast.uncheckedNonnullCast(GUtil.map("settingsProp", "settings value"))));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -78,7 +79,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromUserPropertiesFile() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("userProp", "user value"));
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("userProp", "user value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -87,7 +88,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromSettingsPropertiesFile() {
-        writePropertyFile(settingsDir, GUtil.map("settingsProp", "settings value"));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("settingsProp", "settings value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -96,9 +97,9 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromEnvironmentVariablesWithPrefix() {
-        envProperties = GUtil.map(
+        envProperties = Cast.uncheckedNonnullCast(GUtil.map(
             ENV_PROJECT_PROPERTIES_PREFIX + "envProp", "env value",
-            "ignoreMe", "ignored");
+            "ignoreMe", "ignored"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -107,9 +108,9 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromSystemPropertiesWithPrefix() {
-        systemProperties = GUtil.map(
+        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(
             SYSTEM_PROJECT_PROPERTIES_PREFIX + "systemProp", "system value",
-            "ignoreMe", "ignored");
+            "ignoreMe", "ignored"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -118,7 +119,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromStartParameter() {
-        startParameter.setProjectProperties(GUtil.map("paramProp", "param value"));
+        startParameter.setProjectProperties(Cast.uncheckedNonnullCast(GUtil.map("paramProp", "param value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -127,8 +128,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void projectPropertiesHavePrecedenceOverInstallationPropertiesFile() {
-        writePropertyFile(gradleInstallationHomeDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
+        writePropertyFile(gradleInstallationHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -137,8 +138,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void projectPropertiesHavePrecedenceOverSettingsPropertiesFile() {
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -147,8 +148,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void userPropertiesFileHasPrecedenceOverSettingsPropertiesFile() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -157,9 +158,9 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void userPropertiesFileHasPrecedenceOverProjectProperties() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -168,10 +169,10 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void environmentVariablesHavePrecedenceOverProjectProperties() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
-        envProperties = GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value");
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -180,11 +181,11 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void systemPropertiesHavePrecedenceOverEnvironmentVariables() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
-        envProperties = GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value");
-        systemProperties = GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value");
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
+        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -193,12 +194,12 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void startParameterPropertiesHavePrecedenceOverSystemProperties() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));
-        Map<String, String> projectProperties = GUtil.map("prop", "project value");
-        envProperties = GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value");
-        systemProperties = GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value");
-        startParameter.setProjectProperties(GUtil.map("prop", "param value"));
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
+        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
+        startParameter.setProjectProperties(Cast.uncheckedNonnullCast(GUtil.map("prop", "param value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -208,10 +209,10 @@ public class DefaultGradlePropertiesLoaderTest {
     @Test
     public void loadSetsSystemProperties() {
         startParameter.setSystemPropertiesArgs(WrapUtil.toMap("systemPropArgKey", "systemPropArgValue"));
-        writePropertyFile(gradleUserHomeDir, GUtil.map(SYSTEM_PROP_PREFIX + ".userSystemProp", "userSystemValue"));
-        writePropertyFile(settingsDir, GUtil.map(
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROP_PREFIX + ".userSystemProp", "userSystemValue")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map(
             SYSTEM_PROP_PREFIX + ".userSystemProp", "settingsSystemValue",
-            SYSTEM_PROP_PREFIX + ".settingsSystemProp2", "settingsSystemValue2"));
+            SYSTEM_PROP_PREFIX + ".settingsSystemProp2", "settingsSystemValue2")));
 
         loadProperties();
 
@@ -234,10 +235,10 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void reloadsProperties() {
-        writePropertyFile(settingsDir, GUtil.map("prop1", "value", "prop2", "value"));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop1", "value", "prop2", "value")));
 
         File otherSettingsDir = tmpDir.createDir("otherSettingsDir");
-        writePropertyFile(otherSettingsDir, GUtil.map("prop1", "otherValue"));
+        writePropertyFile(otherSettingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop1", "otherValue")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
         assertEquals("value", properties.get("prop1"));
@@ -257,9 +258,9 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void startParameterSystemPropertiesHavePrecedenceOverPropertiesFiles() {
-        writePropertyFile(gradleUserHomeDir, GUtil.map("systemProp.prop", "user value"));
-        writePropertyFile(settingsDir, GUtil.map("systemProp.prop", "settings value"));
-        systemProperties = GUtil.map("prop", "system value");
+        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("systemProp.prop", "user value")));
+        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("systemProp.prop", "settings value")));
+        systemProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "system value"));
         startParameter.setSystemPropertiesArgs(WrapUtil.toMap("prop", "commandline value"));
 
         loadProperties();

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.util;
 
+import org.gradle.internal.Cast;
 import org.junit.Test;
 
 import java.util.List;
@@ -174,7 +175,7 @@ public class NameMatcherTest {
 
     @Test
     public void doesNotSelectMapEntryWhenMultiplePartialMatches() {
-        Map<String, Integer> items = GUtil.map("someName", 9, "soName", 10);
+        Map<String, Integer> items = Cast.uncheckedNonnullCast(GUtil.map("someName", 9, "soName", 10));
         Integer match = matcher.find("soNa", items);
         assertThat(match, nullValue());
     }

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -123,6 +123,10 @@ dependencies {
     crossVersionTestRuntimeOnly(project(":maven"))
 }
 
+strictCompile {
+    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/DiagnosticsServices.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/DiagnosticsServices.java
@@ -26,7 +26,7 @@ public class DiagnosticsServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.addProvider(new Object() {
-            TypeAwareBinaryRenderer createBinaryRenderer(List<AbstractBinaryRenderer> renderers, ModelSchemaStore schemaStore) {
+            TypeAwareBinaryRenderer createBinaryRenderer(List<AbstractBinaryRenderer<?>> renderers, ModelSchemaStore schemaStore) {
                 TypeAwareBinaryRenderer renderer = new TypeAwareBinaryRenderer();
                 renderer.register(new BinaryRenderer(schemaStore));
                 for (AbstractBinaryRenderer<?> binaryRenderer : renderers) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/DiagnosticsServices.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/DiagnosticsServices.java
@@ -24,9 +24,10 @@ import java.util.List;
 
 public class DiagnosticsServices extends AbstractPluginServiceRegistry {
     @Override
+    @SuppressWarnings("rawtypes")
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.addProvider(new Object() {
-            TypeAwareBinaryRenderer createBinaryRenderer(List<AbstractBinaryRenderer<?>> renderers, ModelSchemaStore schemaStore) {
+            TypeAwareBinaryRenderer createBinaryRenderer(List<AbstractBinaryRenderer> renderers, ModelSchemaStore schemaStore) {
                 TypeAwareBinaryRenderer renderer = new TypeAwareBinaryRenderer();
                 renderer.register(new BinaryRenderer(schemaStore));
                 for (AbstractBinaryRenderer<?> binaryRenderer : renderers) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -79,6 +79,7 @@ public class HtmlDependencyReportTask extends ConventionTask implements Reportin
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public DependencyReportContainer reports(Closure closure) {
         return reports(new ClosureBackedAction<>(closure));
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetailPrinter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetailPrinter.java
@@ -64,12 +64,12 @@ public class TaskDetailPrinter {
         final List<Task> tasks = sort(selection.getTasks());
 
         output.text("Detailed task information for ").withStyle(UserInput).println(taskPath);
-        final ListMultimap<Class, Task> classListMap = groupTasksByType(tasks);
+        final ListMultimap<Class<?>, Task> classListMap = groupTasksByType(tasks);
 
-        final Set<Class> classes = classListMap.keySet();
+        final Set<Class<?>> classes = classListMap.keySet();
         boolean multipleClasses = classes.size() > 1;
-        final List<Class> sortedClasses = sort(classes, Comparator.comparing(Class::getSimpleName));
-        for (Class clazz : sortedClasses) {
+        final List<Class<?>> sortedClasses = sort(classes, Comparator.comparing(Class::getSimpleName));
+        for (Class<?> clazz : sortedClasses) {
             output.println();
             final List<Task> tasksByType = classListMap.get(clazz);
             final LinePrefixingStyledTextOutput pathOutput = createIndentedOutput(output, INDENT);
@@ -99,19 +99,19 @@ public class TaskDetailPrinter {
         }
     }
 
-    private ListMultimap<Class, Task> groupTasksByType(List<Task> tasks) {
-        final Set<Class> taskTypes = new TreeSet<>(Comparator.comparing(Class::getSimpleName));
+    private ListMultimap<Class<?>, Task> groupTasksByType(List<Task> tasks) {
+        final Set<Class<?>> taskTypes = new TreeSet<>(Comparator.comparing(Class::getSimpleName));
         taskTypes.addAll(collect(tasks, this::getDeclaredTaskType));
 
-        ListMultimap<Class, Task> tasksGroupedByType = ArrayListMultimap.create();
-        for (final Class taskType : taskTypes) {
+        ListMultimap<Class<?>, Task> tasksGroupedByType = ArrayListMultimap.create();
+        for (final Class<?> taskType : taskTypes) {
             tasksGroupedByType.putAll(taskType, filter(tasks, element -> getDeclaredTaskType(element).equals(taskType)));
         }
         return tasksGroupedByType;
     }
 
-    private Class getDeclaredTaskType(Task original) {
-        Class clazz = new DslObject(original).getDeclaredType();
+    private Class<?> getDeclaredTaskType(Task original) {
+        Class<?> clazz = new DslObject(original).getDeclaredType();
         if (clazz.equals(DefaultTask.class)) {
             return org.gradle.api.Task.class;
         } else {

--- a/subprojects/ear/ear.gradle.kts
+++ b/subprojects/ear/ear.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/plugins/ear/internal/*"))
 }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -370,19 +370,20 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
 
     private DomNode toXmlNode() {
         DomNode root = new DomNode(nodeNameFor("application"));
-        root.attributes().put("version", version);
+        Map<String, String> rootAttributes = Cast.uncheckedCast(root.attributes());
+        rootAttributes.put("version", version);
         if (!"1.3".equals(version)) {
-            root.attributes().put("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+            rootAttributes.put("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
         }
         if ("1.3".equals(version)) {
             root.setPublicId("-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN");
             root.setSystemId("http://java.sun.com/dtd/application_1_3.dtd");
         } else if ("1.4".equals(version)) {
-            root.attributes().put("xsi:schemaLocation", "http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/application_1_4.xsd");
+            rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/application_1_4.xsd");
         } else if ("5".equals(version) || "6".equals(version)) {
-            root.attributes().put("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_" + version + ".xsd");
+            rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_" + version + ".xsd");
         } else if ("7".equals(version)) {
-            root.attributes().put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_" + version + ".xsd");
+            rootAttributes.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_" + version + ".xsd");
         }
         if (applicationName != null) {
             new Node(root, nodeNameFor("application-name"), applicationName);

--- a/subprojects/execution/execution.gradle.kts
+++ b/subprojects/execution/execution.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.`strict-compile`
 }
 
 description = "Execution engine that takes a unit of work and makes it happen"

--- a/subprojects/file-collections/file-collections.gradle.kts
+++ b/subprojects/file-collections/file-collections.gradle.kts
@@ -56,6 +56,10 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     // Some cycles have been inherited from the time these classes were in :core
     excludePatterns.set(listOf("org/gradle/api/internal/file/collections/"))

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -56,6 +56,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         this.patternSetFactory = patternSetFactory;
     }
 
+    @SuppressWarnings("deprecation")
     public AbstractFileCollection() {
         this.patternSetFactory = PatternSets.getNonCachingPatternSetFactory();
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 import org.gradle.internal.state.ManagedFactory;
 
 import java.io.File;
@@ -66,7 +67,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(filePropertyFactory.newFileProperty().value((Provider<RegularFile>) state));
+            return type.cast(filePropertyFactory.newFileProperty().value(Cast.<Provider<RegularFile>>uncheckedNonnullCast(state)));
         }
 
         @Override
@@ -114,7 +115,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(filePropertyFactory.newDirectoryProperty().value((Provider<Directory>) state));
+            return type.cast(filePropertyFactory.newDirectoryProperty().value(Cast.<Provider<Directory>>uncheckedNonnullCast(state)));
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -269,7 +269,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public ValueCollector plus(PathToFileResolver resolver, Object[] paths) {
+        public ValueCollector plus(PathToFileResolver resolver, Object... paths) {
             return setFrom(resolver, paths);
         }
     }
@@ -335,7 +335,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public ValueCollector plus(PathToFileResolver resolver, Object[] paths) {
+        public ValueCollector plus(PathToFileResolver resolver, Object... paths) {
             Collections.addAll(items, paths);
             return this;
         }
@@ -369,7 +369,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public ValueCollector plus(PathToFileResolver resolver, Object[] paths) {
+        public ValueCollector plus(PathToFileResolver resolver, Object... paths) {
             throw new UnsupportedOperationException("Should not be called");
         }
 

--- a/subprojects/files/files.gradle.kts
+++ b/subprojects/files/files.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 description = "Base tools to work with files"

--- a/subprojects/hashing/hashing.gradle.kts
+++ b/subprojects/hashing/hashing.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 description = "Common shared classes without external dependencies"

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateWorkspaceSettingsFileTask.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateWorkspaceSettingsFileTask.java
@@ -18,6 +18,7 @@ package org.gradle.ide.xcode.tasks;
 
 import org.gradle.api.Incubating;
 import org.gradle.ide.xcode.tasks.internal.XcodeWorkspaceSettingsFile;
+import org.gradle.internal.Cast;
 import org.gradle.plugins.ide.api.PropertyListGeneratorTask;
 
 /**
@@ -36,6 +37,6 @@ public class GenerateWorkspaceSettingsFileTask extends PropertyListGeneratorTask
 
     @Override
     protected XcodeWorkspaceSettingsFile create() {
-        return new XcodeWorkspaceSettingsFile(getPropertyListTransformer());
+        return new XcodeWorkspaceSettingsFile(Cast.uncheckedNonnullCast(getPropertyListTransformer()));
     }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateXcodeProjectFileTask.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateXcodeProjectFileTask.java
@@ -43,6 +43,7 @@ import org.gradle.ide.xcode.internal.xcodeproj.PBXSourcesBuildPhase;
 import org.gradle.ide.xcode.internal.xcodeproj.PBXTarget;
 import org.gradle.ide.xcode.internal.xcodeproj.XcodeprojSerializer;
 import org.gradle.ide.xcode.tasks.internal.XcodeProjectFile;
+import org.gradle.internal.Cast;
 import org.gradle.language.swift.SwiftVersion;
 import org.gradle.nativeplatform.MachineArchitecture;
 import org.gradle.plugins.ide.api.PropertyListGeneratorTask;
@@ -141,7 +142,7 @@ public class GenerateXcodeProjectFileTask extends PropertyListGeneratorTask<Xcod
 
     @Override
     protected XcodeProjectFile create() {
-        return new XcodeProjectFile(getPropertyListTransformer());
+        return new XcodeProjectFile(Cast.uncheckedNonnullCast(getPropertyListTransformer()));
     }
 
     private PBXFileReference toFileReference(File file) {

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/internal/XcodeSchemeFile.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/internal/XcodeSchemeFile.java
@@ -19,6 +19,7 @@ package org.gradle.ide.xcode.tasks.internal;
 import groovy.util.Node;
 import groovy.util.NodeList;
 import org.gradle.api.Action;
+import org.gradle.internal.Cast;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.internal.generator.XmlPersistableConfigurationObject;
 
@@ -96,23 +97,28 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildForRunning(boolean buildForRunning) {
-            xml.attributes().put("buildForRunning", toYesNo(buildForRunning));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildForRunning", toYesNo(buildForRunning));
         }
 
         public void setBuildForTesting(boolean buildForTesting) {
-            xml.attributes().put("buildForTesting", toYesNo(buildForTesting));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildForTesting", toYesNo(buildForTesting));
         }
 
         public void setBuildForProfiling(boolean buildForProfiling) {
-            xml.attributes().put("buildForProfiling", toYesNo(buildForProfiling));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildForProfiling", toYesNo(buildForProfiling));
         }
 
         public void setBuildForArchiving(boolean buildForArchiving) {
-            xml.attributes().put("buildForArchiving", toYesNo(buildForArchiving));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildForArchiving", toYesNo(buildForArchiving));
         }
 
         public void setBuildForAnalysing(boolean buildForAnalysing) {
-            xml.attributes().put("buildForAnalyzing", toYesNo(buildForAnalysing));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildForAnalyzing", toYesNo(buildForAnalysing));
         }
 
         public void setBuildableReference(BuildableReference buildableReference) {
@@ -128,7 +134,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildConfiguration(String buildConfiguration) {
-            xml.attributes().put("buildConfiguration", buildConfiguration);
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildConfiguration", buildConfiguration);
         }
 
         public void entry(Action<TestableEntry> action) {
@@ -144,7 +151,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setSkipped(boolean skipped) {
-            xml.attributes().put("skipped", toYesNo(skipped));
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("skipped", toYesNo(skipped));
         }
 
         public void setBuildableReference(BuildableReference buildableReference) {
@@ -160,7 +168,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildConfiguration(String buildConfiguration) {
-            xml.attributes().put("buildConfiguration", buildConfiguration);
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildConfiguration", buildConfiguration);
         }
 
         public void setBuildableProductRunnable(BuildableReference buildableReference) {
@@ -180,7 +189,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildConfiguration(String buildConfiguration) {
-            xml.attributes().put("buildConfiguration", buildConfiguration);
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildConfiguration", buildConfiguration);
         }
     }
 
@@ -192,7 +202,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildConfiguration(String buildConfiguration) {
-            xml.attributes().put("buildConfiguration", buildConfiguration);
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildConfiguration", buildConfiguration);
         }
     }
 
@@ -204,7 +215,8 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public void setBuildConfiguration(String buildConfiguration) {
-            xml.attributes().put("buildConfiguration", buildConfiguration);
+            Map<String, String> attributes = Cast.uncheckedNonnullCast(xml.attributes());
+            attributes.put("buildConfiguration", buildConfiguration);
         }
     }
 
@@ -256,7 +268,7 @@ public class XcodeSchemeFile extends XmlPersistableConfigurationObject {
         }
 
         public Node toXml() {
-            Map<String, String> attributes = new HashMap<String, String>();
+            Map<String, String> attributes = new HashMap<>();
             attributes.put("BuildableIdentifier", getBuildableIdentifier());
             attributes.put("BlueprintIdentifier", getBlueprintIdentifier());
             attributes.put("BuildableName", getBuildableName());

--- a/subprojects/ide-native/src/main/java/org/gradle/plugins/ide/api/PropertyListGeneratorTask.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/plugins/ide/api/PropertyListGeneratorTask.java
@@ -31,6 +31,7 @@ import org.gradle.plugins.ide.internal.generator.generator.PersistableConfigurat
 // TODO - DSL documentation?
 @Incubating
 public abstract class PropertyListGeneratorTask<T extends PersistableConfigurationObject> extends GeneratorTask<T> {
+    @SuppressWarnings("rawtypes")
     private final PropertyListTransformer propertyListTransformer = new PropertyListTransformer();
 
     public PropertyListGeneratorTask() {
@@ -48,6 +49,7 @@ public abstract class PropertyListGeneratorTask<T extends PersistableConfigurati
     }
 
     @Internal
+    @SuppressWarnings("rawtypes")
     public PropertyListTransformer getPropertyListTransformer() {
         return propertyListTransformer;
     }

--- a/subprojects/ide-native/src/main/java/org/gradle/plugins/ide/internal/generator/PropertyListPersistableConfigurationObject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/plugins/ide/internal/generator/PropertyListPersistableConfigurationObject.java
@@ -58,7 +58,7 @@ public abstract class PropertyListPersistableConfigurationObject<T extends NSObj
 
     protected abstract void load(T rootObject);
 
-    public void transformAction(Closure action) {
+    public void transformAction(Closure<?> action) {
         transformAction(configureUsing(action));
     }
 

--- a/subprojects/ide-play/ide-play.gradle.kts
+++ b/subprojects/ide-play/ide-play.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     integTestRuntimeResources(testFixtures(project(":platformPlay")))
 }
 
+strictCompile {
+    ignoreDeprecations() // Play support in Gradle core has been deprecated
+}
+
 tasks.withType<IntegrationTest>().configureEach {
     dependsOn(":platformPlay:integTestPrepare")
     // this is a workaround for which we need a better fix:

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -66,6 +66,10 @@ dependencies {
     integTestRuntimeOnly(project(":testKit"))
 }
 
+strictCompile {
+    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
+}
+
 classycle {
     excludePatterns.set(listOf(
         "org/gradle/plugins/ide/internal/*",

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -855,11 +855,11 @@ public class TestFile extends File {
         return new TestFileHelper(this).executeSuccess(Arrays.asList(args), null);
     }
 
-    public ExecOutput execWithFailure(List args, List env) {
+    public ExecOutput execWithFailure(List<?> args, List<?> env) {
         return new TestFileHelper(this).executeFailure(args, env);
     }
 
-    public ExecOutput execute(List args, List env) {
+    public ExecOutput execute(List<?> args, List<?> env) {
         return new TestFileHelper(this).executeSuccess(args, env);
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -19,6 +19,7 @@ package org.gradle.api.publish.ivy.internal.publication;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
@@ -73,6 +74,7 @@ import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.reflect.Instantiator;
@@ -152,7 +154,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
         this.metadataArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
         this.derivedArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.publishableArtifacts = new CompositePublicationArtifactSet<>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
+        this.publishableArtifacts = new CompositePublicationArtifactSet<>(IvyArtifact.class, Cast.uncheckedCast(new PublicationArtifactSet<?>[]{mainArtifacts, metadataArtifacts, derivedArtifacts}));
         this.ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
         this.descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
     }
@@ -531,7 +533,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             }
             return true;
         });
-        Set<IvyArtifact> artifactsToBePublished = CompositeDomainObjectSet.create(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts).matching(new Spec<IvyArtifact>() {
+        Set<IvyArtifact> artifactsToBePublished = CompositeDomainObjectSet.create(IvyArtifact.class, Cast.uncheckedCast(new DomainObjectCollection<?>[]{mainArtifacts, metadataArtifacts, derivedArtifacts})).matching(new Spec<IvyArtifact>() {
             @Override
             public boolean isSatisfiedBy(IvyArtifact element) {
                 if (!PUBLISHED_ARTIFACTS.isSatisfiedBy(element)) {

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -52,6 +52,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+strictCompile {
+    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
+}
+
 classycle {
     excludePatterns.set(listOf(
         "org/gradle/internal/jacoco/*",

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
 }
 
 strictCompile {
-    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
+    ignoreRawTypes()
 }
 
 classycle {

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
@@ -108,7 +108,7 @@ public class AntJacocoCheck extends AbstractAntJacocoReport<JacocoViolationRules
 
     private String getViolations(GroovyObjectSupport antBuilder) {
         Object project = antBuilder.getProperty("project");
-        Hashtable<String, Object> properties = JavaMethod.of(project, Hashtable.class, "getProperties").invoke(project, new Object[0]);
+        Hashtable<?, ?> properties = JavaMethod.of(project, Hashtable.class, "getProperties").invoke(project, new Object[0]);
         return (String) properties.get(VIOLATIONS_ANT_PROPERTY);
     }
 }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -185,12 +185,8 @@ public class JacocoPluginExtension {
      *
      * @param tasks the tasks to apply Jacoco to
      */
+    @SuppressWarnings("unchecked")
     public <T extends Task & JavaForkOptions> void applyTo(TaskCollection<T> tasks) {
-        ((TaskCollection) tasks).withType(JavaForkOptions.class, new Action<T>() {
-            @Override
-            public void execute(T task) {
-                applyTo(task);
-            }
-        });
+        ((TaskCollection) tasks).withType(JavaForkOptions.class, (Action<T>) this::applyTo);
     }
 }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
@@ -123,12 +123,8 @@ public class JacocoMerge extends JacocoBase {
      *
      * @param tasks one or more tasks to merge
      */
+    @SuppressWarnings("unchecked")
     public void executionData(TaskCollection tasks) {
-        tasks.all(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                executionData(task);
-            }
-        });
+        tasks.all((Action<Task>) task -> executionData(task));
     }
 }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -169,13 +169,9 @@ public abstract class JacocoReportBase extends JacocoBase {
      *
      * @param tasks one or more tasks to add
      */
+    @SuppressWarnings("unchecked")
     public void executionData(TaskCollection tasks) {
-        tasks.all(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                executionData(task);
-            }
-        });
+        tasks.all((Action<Task>) this::executionData);
     }
 
     /**

--- a/subprojects/java-compiler-plugin/java-compiler-plugin.gradle.kts
+++ b/subprojects/java-compiler-plugin/java-compiler-plugin.gradle.kts
@@ -17,7 +17,6 @@
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.classycle
-    gradlebuild.`strict-compile`
 }
 
 description = "A Java compiler plugin used by Gradle's incremental compiler"

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/http/simple/internal/SimpleFileServerContainer.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/http/simple/internal/SimpleFileServerContainer.java
@@ -68,7 +68,7 @@ public class SimpleFileServerContainer implements Container {
             if (contentType.startsWith("text/")) {
                 resp.set("Content-Encoding", Charset.defaultCharset().name());
                 Reader input = new FileReader(requestIndex.getFile());
-                IOUtils.copy(input, output);
+                IOUtils.copy(input, output, Charset.defaultCharset());
                 IoActions.closeQuietly(input);
             } else {
                 InputStream input = new FileInputStream(requestIndex.getFile());

--- a/subprojects/kotlin-dsl-tooling-models/kotlin-dsl-tooling-models.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-models/kotlin-dsl-tooling-models.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-kotlin`
-    gradlebuild.`strict-compile`
 }
 
 description = "Kotlin DSL Tooling Models for IDEs"

--- a/subprojects/kotlin-dsl/src/test/java/org/gradle/kotlin/dsl/fixtures/codegen/ClassToKClass.java
+++ b/subprojects/kotlin-dsl/src/test/java/org/gradle/kotlin/dsl/fixtures/codegen/ClassToKClass.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 
 public interface ClassToKClass {
 
+    @SuppressWarnings("rawtypes")
     void rawClass(Class type);
 
     void unknownClass(Class<?> type);

--- a/subprojects/kotlin-dsl/src/test/java/org/gradle/kotlin/dsl/fixtures/codegen/GroovyNamedArguments.java
+++ b/subprojects/kotlin-dsl/src/test/java/org/gradle/kotlin/dsl/fixtures/codegen/GroovyNamedArguments.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 
 public interface GroovyNamedArguments {
 
+    @SuppressWarnings("rawtypes")
     void rawMap(Map args);
 
     void stringUnknownMap(Map<String, ?> args);

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
@@ -119,7 +119,7 @@ public class AntGroovydoc {
             }
         });
         try {
-            return Files.toString(temp, Charset.defaultCharset()).trim();
+            return Files.asCharSource(temp, Charset.defaultCharset()).read().trim();
         } catch (IOException e) {
             throw new GradleException("Unable to find Groovy version needed for Groovydoc", e);
         }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -58,7 +58,6 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.Deleter;
-import org.gradle.jvm.toolchain.JavaToolChain;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.IncubationLogger;
@@ -330,7 +329,8 @@ public class GroovyCompile extends AbstractCompile {
      * @since 4.0
      */
     @Nested
-    protected JavaToolChain getJavaToolChain() {
+    @SuppressWarnings("deprecation")
+    protected org.gradle.jvm.toolchain.JavaToolChain getJavaToolChain() {
         return getJavaToolChainFactory().forCompileOptions(getOptions());
     }
 

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
     integTestRuntimeOnly(project(":plugins"))
 }
 
+strictCompile {
+    ignoreDeprecations() // this project currently uses many deprecated part from 'platform-jvm'
+}
+
 classycle {
     // These public packages have classes that are tangled with the corresponding internal package.
     excludePatterns.set(listOf(

--- a/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/internal/DefaultJvmResourceLanguageSourceSet.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/internal/DefaultJvmResourceLanguageSourceSet.java
@@ -16,9 +16,9 @@
 package org.gradle.language.jvm.internal;
 
 import org.gradle.language.base.sources.BaseLanguageSourceSet;
-import org.gradle.language.jvm.JvmResourceSet;
 
-public class DefaultJvmResourceLanguageSourceSet extends BaseLanguageSourceSet implements JvmResourceSet {
+@SuppressWarnings("deprecation")
+public class DefaultJvmResourceLanguageSourceSet extends BaseLanguageSourceSet implements org.gradle.language.jvm.JvmResourceSet {
     @Override
     protected String getLanguageName() {
         return "JVM resources";

--- a/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/plugins/JvmResourcesPlugin.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/plugins/JvmResourcesPlugin.java
@@ -29,7 +29,6 @@ import org.gradle.language.base.internal.SourceTransformTaskConfig;
 import org.gradle.language.base.internal.registry.LanguageTransform;
 import org.gradle.language.base.internal.registry.LanguageTransformContainer;
 import org.gradle.language.base.plugins.ComponentModelBasePlugin;
-import org.gradle.language.jvm.JvmResourceSet;
 import org.gradle.language.jvm.internal.DefaultJvmResourceLanguageSourceSet;
 import org.gradle.language.jvm.tasks.ProcessResources;
 import org.gradle.model.Mutate;
@@ -62,7 +61,8 @@ public class JvmResourcesPlugin implements Plugin<Project> {
     @SuppressWarnings("UnusedDeclaration")
     static class Rules extends RuleSource {
         @ComponentType
-        void registerLanguage(TypeBuilder<JvmResourceSet> builder) {
+        @SuppressWarnings("deprecation")
+        void registerLanguage(TypeBuilder<org.gradle.language.jvm.JvmResourceSet> builder) {
             builder.defaultImplementation(DefaultJvmResourceLanguageSourceSet.class);
         }
 
@@ -72,15 +72,16 @@ public class JvmResourcesPlugin implements Plugin<Project> {
         }
     }
 
-    private static class JvmResources implements LanguageTransform<JvmResourceSet, org.gradle.jvm.JvmResources> {
+    @SuppressWarnings("deprecation")
+    private static class JvmResources implements LanguageTransform<org.gradle.language.jvm.JvmResourceSet, org.gradle.jvm.JvmResources> {
         @Override
         public String getLanguageName() {
             return "resources";
         }
 
         @Override
-        public Class<JvmResourceSet> getSourceSetType() {
-            return JvmResourceSet.class;
+        public Class<org.gradle.language.jvm.JvmResourceSet> getSourceSetType() {
+            return org.gradle.language.jvm.JvmResourceSet.class;
         }
 
         @Override
@@ -109,7 +110,7 @@ public class JvmResourcesPlugin implements Plugin<Project> {
                 @Override
                 public void configureTask(Task task, BinarySpec binary, LanguageSourceSet sourceSet, ServiceRegistry serviceRegistry) {
                     ProcessResources resourcesTask = (ProcessResources) task;
-                    JvmResourceSet resourceSet = (JvmResourceSet) sourceSet;
+                    org.gradle.language.jvm.JvmResourceSet resourceSet = (org.gradle.language.jvm.JvmResourceSet) sourceSet;
                     resourcesTask.from(resourceSet.getSource());
 
                     // The first directory is the one created by JvmComponentPlugin.configureJvmBinaries()

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/language-scala/language-scala.gradle.kts
+++ b/subprojects/language-scala/language-scala.gradle.kts
@@ -46,6 +46,10 @@ dependencies {
     compileOnly("org.scala-sbt:zinc_2.12:1.3.5")
 }
 
+strictCompile {
+    ignoreDeprecations() // uses deprecated software model types
+}
+
 classycle {
     excludePatterns.set(listOf(
         "org/gradle/api/internal/tasks/scala/**",

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -68,6 +68,10 @@ dependencies {
     }
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 // Needed for testing debug command line option (JDWPUtil) - 'CommandLineIntegrationSpec.can debug with org.gradle.debug=true'
 val toolsJar = buildJvms.testJvm.map { jvm -> jvm.toolsClasspath }
 dependencies {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.ParallelismBuildOptions;
 import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
+import org.gradle.internal.Cast;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
@@ -58,11 +59,11 @@ public class LayoutToPropertiesConverter {
         configureFromHomeDir(layout.getGradleInstallationHomeDir(), properties);
         configureFromBuildDir(layout.getSearchDir(), layout.getSearchUpwards(), properties);
         configureFromHomeDir(layout.getGradleUserHomeDir(), properties);
-        configureFromSystemproperties(properties);
+        configureFromSystemproperties(Cast.uncheckedNonnullCast(properties));
         return properties;
     }
 
-    private void configureFromSystemproperties(Map properties) {
+    private void configureFromSystemproperties(Map<Object, Object> properties) {
         for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
             Object key = entry.getKey();
             Object value = entry.getValue();

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -160,6 +160,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
             DaemonOutputConsumer outputConsumer = new DaemonOutputConsumer();
 
             // This factory should be injected but leaves non-daemon threads running when used from the tooling API client
+            @SuppressWarnings("deprecation")
             DefaultExecActionFactory execActionFactory = DefaultExecActionFactory.root();
             try {
                 ExecHandle handle = new DaemonExecHandleBuilder().build(args, workingDir, outputConsumer, stdInput, execActionFactory.newExec());

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.api.JavaVersion;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildLayoutParameters;
+import org.gradle.internal.Cast;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -26,28 +27,20 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.tooling.UnsupportedVersionException;
 import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
-import org.gradle.tooling.internal.protocol.BuildActionRunner;
-import org.gradle.tooling.internal.protocol.BuildExceptionVersion1;
-import org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1;
 import org.gradle.tooling.internal.protocol.BuildParameters;
-import org.gradle.tooling.internal.protocol.BuildParametersVersion1;
 import org.gradle.tooling.internal.protocol.BuildResult;
 import org.gradle.tooling.internal.protocol.ConfigurableConnection;
 import org.gradle.tooling.internal.protocol.ConnectionMetaDataVersion1;
 import org.gradle.tooling.internal.protocol.ConnectionParameters;
 import org.gradle.tooling.internal.protocol.ConnectionVersion4;
-import org.gradle.tooling.internal.protocol.InternalBuildAction;
-import org.gradle.tooling.internal.protocol.InternalBuildActionExecutor;
 import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
 import org.gradle.tooling.internal.protocol.InternalCancellableConnection;
 import org.gradle.tooling.internal.protocol.InternalCancellationToken;
-import org.gradle.tooling.internal.protocol.InternalConnection;
 import org.gradle.tooling.internal.protocol.InternalInvalidatableVirtualFileSystemConnection;
 import org.gradle.tooling.internal.protocol.InternalParameterAcceptingConnection;
 import org.gradle.tooling.internal.protocol.InternalPhasedAction;
 import org.gradle.tooling.internal.protocol.InternalPhasedActionConnection;
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException;
-import org.gradle.tooling.internal.protocol.ModelBuilder;
 import org.gradle.tooling.internal.protocol.ModelIdentifier;
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener;
 import org.gradle.tooling.internal.protocol.ProjectVersion3;
@@ -71,8 +64,9 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
-public class DefaultConnection implements ConnectionVersion4, InternalConnection, BuildActionRunner,
-    ConfigurableConnection, ModelBuilder, InternalBuildActionExecutor, InternalCancellableConnection, InternalParameterAcceptingConnection,
+@SuppressWarnings("deprecation")
+public class DefaultConnection implements ConnectionVersion4, org.gradle.tooling.internal.protocol.InternalConnection, org.gradle.tooling.internal.protocol.BuildActionRunner,
+    ConfigurableConnection, org.gradle.tooling.internal.protocol.ModelBuilder,  org.gradle.tooling.internal.protocol.InternalBuildActionExecutor, InternalCancellableConnection, InternalParameterAcceptingConnection,
     StoppableConnection, InternalTestExecutionConnection, InternalPhasedActionConnection, InternalInvalidatableVirtualFileSystemConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultConnection.class);
     private static final String UNSUPPORTED_MESSAGE = "Support for clients using a tooling API version older than 3.0 was removed in Gradle 5.0. %sYou should upgrade your tooling API client to version 3.0 or later.";
@@ -157,7 +151,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      */
     @Override
     @Deprecated
-    public void executeBuild(BuildParametersVersion1 buildParameters, BuildOperationParametersVersion1 operationParameters) {
+    public void executeBuild(org.gradle.tooling.internal.protocol.BuildParametersVersion1 buildParameters, org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1 operationParameters) {
         throw unsupportedConnectionException();
     }
 
@@ -166,7 +160,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      */
     @Override
     @Deprecated
-    public ProjectVersion3 getModel(Class<? extends ProjectVersion3> type, BuildOperationParametersVersion1 parameters) {
+    public ProjectVersion3 getModel(Class<? extends ProjectVersion3> type, org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1 parameters) {
         throw unsupportedConnectionException();
     }
 
@@ -175,7 +169,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      */
     @Override
     @Deprecated
-    public <T> T getTheModel(Class<T> type, BuildOperationParametersVersion1 parameters) {
+    public <T> T getTheModel(Class<T> type, org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1 parameters) {
         throw unsupportedConnectionException();
     }
 
@@ -200,7 +194,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      * This is used by consumers 2.1-rc-1 and later
      */
     @Override
-    public BuildResult<?> getModel(ModelIdentifier modelIdentifier, InternalCancellationToken cancellationToken, BuildParameters operationParameters) throws BuildExceptionVersion1, InternalUnsupportedModelException, InternalUnsupportedBuildArgumentException, IllegalStateException {
+    public BuildResult<?> getModel(ModelIdentifier modelIdentifier, InternalCancellationToken cancellationToken, BuildParameters operationParameters) throws org.gradle.tooling.internal.protocol.BuildExceptionVersion1, InternalUnsupportedModelException, InternalUnsupportedBuildArgumentException, IllegalStateException {
         ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
         BuildCancellationToken buildCancellationToken = new InternalCancellationTokenAdapter(cancellationToken);
         Object result = connection.run(modelIdentifier.getName(), buildCancellationToken, providerParameters);
@@ -211,7 +205,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      * This is used by consumers 1.8-rc-1 to 2.0
      */
     @Override
-    public <T> BuildResult<T> run(InternalBuildAction<T> action, BuildParameters operationParameters) throws BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
+    public <T> BuildResult<T> run(org.gradle.tooling.internal.protocol.InternalBuildAction<T> action, BuildParameters operationParameters) throws org.gradle.tooling.internal.protocol.BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
         throw unsupportedConnectionException();
     }
 
@@ -219,12 +213,12 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      * This is used by consumers 2.1-rc-1 to 4.3
      */
     @Override
-    public <T> BuildResult<T> run(InternalBuildAction<T> action, InternalCancellationToken cancellationToken, BuildParameters operationParameters)
-        throws BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
+    public <T> BuildResult<T> run(org.gradle.tooling.internal.protocol.InternalBuildAction<T> action, InternalCancellationToken cancellationToken, BuildParameters operationParameters)
+        throws org.gradle.tooling.internal.protocol.BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
         ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
         BuildCancellationToken buildCancellationToken = new InternalCancellationTokenAdapter(cancellationToken);
         Object results = connection.run(action, buildCancellationToken, providerParameters);
-        return new ProviderBuildResult<T>((T) results);
+        return new ProviderBuildResult<>(Cast.uncheckedNonnullCast(results));
     }
 
     /**
@@ -232,11 +226,11 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      */
     @Override
     public <T> BuildResult<T> run(InternalBuildActionVersion2<T> action, InternalCancellationToken cancellationToken, BuildParameters operationParameters)
-        throws BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
+        throws org.gradle.tooling.internal.protocol.BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
         ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
         BuildCancellationToken buildCancellationToken = new InternalCancellationTokenAdapter(cancellationToken);
         Object results = connection.run(action, buildCancellationToken, providerParameters);
-        return new ProviderBuildResult<T>((T) results);
+        return new ProviderBuildResult<>(Cast.uncheckedNonnullCast(results));
     }
 
     /**
@@ -255,7 +249,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      */
     @Override
     public BuildResult<?> runTests(InternalTestExecutionRequest testExecutionRequest, InternalCancellationToken cancellationToken, BuildParameters operationParameters)
-        throws BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
+        throws org.gradle.tooling.internal.protocol.BuildExceptionVersion1, InternalUnsupportedBuildArgumentException, IllegalStateException {
         ProviderOperationParameters providerParameters = validateAndConvert(operationParameters);
         ProviderInternalTestExecutionRequest testExecutionRequestVersion2 = adapter.adapt(ProviderInternalTestExecutionRequest.class, testExecutionRequest);
         BuildCancellationToken buildCancellationToken = new InternalCancellationTokenAdapter(cancellationToken);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -52,7 +52,6 @@ import org.gradle.tooling.internal.build.DefaultBuildEnvironment;
 import org.gradle.tooling.internal.consumer.parameters.FailsafeBuildProgressListenerAdapter;
 import org.gradle.tooling.internal.gradle.DefaultBuildIdentifier;
 import org.gradle.tooling.internal.protocol.BuildExceptionVersion1;
-import org.gradle.tooling.internal.protocol.InternalBuildAction;
 import org.gradle.tooling.internal.protocol.InternalBuildActionFailureException;
 import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
 import org.gradle.tooling.internal.protocol.InternalBuildCancelledException;
@@ -138,10 +137,12 @@ public class ProviderConnection {
         return run(action, cancellationToken, listenerConfig, listenerConfig.buildEventConsumer, providerParameters, params);
     }
 
-    public Object run(InternalBuildAction<?> clientAction, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
+    @SuppressWarnings({"deprecation", "overloads"})
+    public Object run(org.gradle.tooling.internal.protocol.InternalBuildAction<?> clientAction, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
         return runClientAction(clientAction, cancellationToken, providerParameters);
     }
 
+    @SuppressWarnings("overloads")
     public Object run(InternalBuildActionVersion2<?> clientAction, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
         return runClientAction(clientAction, cancellationToken, providerParameters);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/PayloadSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/PayloadSerializer.java
@@ -17,6 +17,8 @@
 package org.gradle.tooling.internal.provider.serialization;
 
 import javax.annotation.concurrent.ThreadSafe;
+
+import org.gradle.internal.Cast;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.io.StreamByteBuffer;
@@ -68,7 +70,7 @@ public class PayloadSerializer {
 
         final DeserializeMap map = classLoaderRegistry.newDeserializeSession();
         try {
-            final Map<Short, ClassLoaderDetails> classLoaderDetails = (Map<Short, ClassLoaderDetails>) payload.getHeader();
+            final Map<Short, ClassLoaderDetails> classLoaderDetails = Cast.uncheckedNonnullCast(payload.getHeader());
             StreamByteBuffer buffer = StreamByteBuffer.of(payload.getSerializedModel());
             final ObjectInputStream objectStream = new PayloadSerializerObjectInputStream(buffer.getInputStream(), getClass().getClassLoader(), classLoaderDetails, map);
             return objectStream.readObject();

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/PayloadSerializerObjectInputStream.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/PayloadSerializerObjectInputStream.java
@@ -73,7 +73,9 @@ class PayloadSerializerObjectInputStream extends ExceptionReplacingObjectInputSt
         for (int i = 0; i < count; i++) {
             actualInterfaces[i] = readClass();
         }
-        return Proxy.getProxyClass(actualInterfaces[0].getClassLoader(), actualInterfaces);
+        @SuppressWarnings("deprecation")
+        Class<?> proxyClass = Proxy.getProxyClass(actualInterfaces[0].getClassLoader(), actualInterfaces);
+        return proxyClass;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/Logging.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/Logging.java
@@ -34,6 +34,7 @@ public class Logging {
      * @param c the class.
      * @return the logger. Never returns null.
      */
+    @SuppressWarnings("rawtypes")
     public static Logger getLogger(Class c) {
         return (Logger) LoggerFactory.getLogger(c);
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -79,6 +79,7 @@ public class DeprecationLogger {
      * Output: ${feature} has been deprecated.
      */
     @CheckReturnValue
+    @SuppressWarnings("rawtypes")
     public static DeprecationMessageBuilder<?> deprecate(final String feature) {
         return new DeprecationMessageBuilder() {
             @Override
@@ -124,6 +125,7 @@ public class DeprecationLogger {
      * Output: ${behaviour} ${advice}
      */
     @CheckReturnValue
+    @SuppressWarnings("rawtypes")
     public static DeprecationMessageBuilder.WithDeprecationTimeline warnOfChangedBehaviour(final String behaviour, final String advice) {
         return new DeprecationMessageBuilder.WithDeprecationTimeline(new DeprecationMessageBuilder() {
             @Override
@@ -137,6 +139,7 @@ public class DeprecationLogger {
      * Output: ${action} has been deprecated.
      */
     @CheckReturnValue
+    @SuppressWarnings("rawtypes")
     public static DeprecationMessageBuilder<?> deprecateAction(final String action) {
         return new DeprecationMessageBuilder() {
             @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultColorMap.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultColorMap.java
@@ -176,7 +176,7 @@ public class DefaultColorMap implements ColorMap {
 
         if (colorSpec.contains("-")) {
             String[] colors = colorSpec.split("-");
-            ArrayList<Color> colorList = new ArrayList(colors.length);
+            ArrayList<Color> colorList = new ArrayList<Color>(colors.length);
             for (String color : colors) {
                 colorList.add(createColorFromSpec(color));
             }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
@@ -44,12 +44,12 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
     }
 
     @Override
-    public ProgressLogger newOperation(Class loggerCategory) {
+    public ProgressLogger newOperation(Class<?> loggerCategory) {
         return newOperation(loggerCategory.getName());
     }
 
     @Override
-    public ProgressLogger newOperation(Class loggerCategory, BuildOperationDescriptor buildOperationDescriptor) {
+    public ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor) {
         String category = ProgressStartEvent.BUILD_OP_CATEGORY;
         if (buildOperationDescriptor.getOperationType() == BuildOperationCategory.TASK) {
             // This is a legacy quirk.
@@ -85,7 +85,7 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
     }
 
     @Override
-    public ProgressLogger newOperation(Class loggerClass, ProgressLogger parent) {
+    public ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent) {
         return init(loggerClass.toString(), parent);
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
@@ -17,12 +17,13 @@
 package org.gradle.internal.logging.sink;
 
 import org.fusesource.jansi.AnsiOutputStream;
-import org.fusesource.jansi.WindowsAnsiOutputStream;
+import org.fusesource.jansi.WindowsAnsiPrintStream;
 import org.gradle.internal.os.OperatingSystem;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 
 import static org.fusesource.jansi.internal.CLibrary.STDOUT_FILENO;
 import static org.fusesource.jansi.internal.CLibrary.isatty;
@@ -100,7 +101,7 @@ final class AnsiConsoleUtil {
 
             // On windows we know the console does not interpret ANSI codes..
             try {
-                return new WindowsAnsiOutputStream(stream);
+                return new WindowsAnsiPrintStream(new PrintStream(stream));
             } catch (Throwable ignore) {
                 // this happens when JNA is not in the path.. or
                 // this happens when the stdout is being redirected to a file.

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractStyledTextOutputFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractStyledTextOutputFactory.java
@@ -20,7 +20,7 @@ import org.gradle.api.logging.LogLevel;
 
 public abstract class AbstractStyledTextOutputFactory implements StyledTextOutputFactory {
     @Override
-    public StyledTextOutput create(Class logCategory) {
+    public StyledTextOutput create(Class<?> logCategory) {
         return create(logCategory.getName());
     }
 
@@ -30,7 +30,7 @@ public abstract class AbstractStyledTextOutputFactory implements StyledTextOutpu
     }
 
     @Override
-    public StyledTextOutput create(Class logCategory, LogLevel logLevel) {
+    public StyledTextOutput create(Class<?> logCategory, LogLevel logLevel) {
         return create(logCategory.getName(), logLevel);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/Style.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/Style.java
@@ -79,6 +79,6 @@ public class Style {
     }
 
     public static Style of(Color color) {
-        return new Style(Collections.EMPTY_SET, color);
+        return new Style(Collections.<Emphasis>emptySet(), color);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutputFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutputFactory.java
@@ -36,7 +36,7 @@ public interface StyledTextOutputFactory {
      * @return the output
      */
 
-    StyledTextOutput create(Class logCategory);
+    StyledTextOutput create(Class<?> logCategory);
 
     /**
      * Creates a {@code StyledTextOutput} with the given category and log level.
@@ -45,7 +45,7 @@ public interface StyledTextOutputFactory {
      * @param logLevel The log level. Can be null to use the standard output log level.
      * @return the output
      */
-    StyledTextOutput create(Class logCategory, LogLevel logLevel);
+    StyledTextOutput create(Class<?> logCategory, LogLevel logLevel);
 
     /**
      * Creates a {@code StyledTextOutput} with the given category and log level.

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -75,6 +75,11 @@ dependencies {
     testFixturesImplementation(project(":dependencyManagement"))
 }
 
+strictCompile {
+    ignoreDeprecations() // old 'maven' publishing mechanism: types are deprecated
+    ignoreRawTypes() // old 'maven' publishing mechanism: raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf(
         "org/gradle/api/publication/maven/internal/**",

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/BasePomFilterContainer.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/BasePomFilterContainer.java
@@ -71,7 +71,7 @@ public class BasePomFilterContainer implements PomFilterContainer {
     }
 
     private PublishFilter toFilter(final Closure filter) {
-        return (PublishFilter) DefaultGroovyMethods.asType(filter, PublishFilter.class);
+        return DefaultGroovyMethods.asType(filter, PublishFilter.class);
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagon.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagon.java
@@ -121,7 +121,7 @@ public class RepositoryTransportDeployWagon implements Wagon {
     }
 
     @Override
-    public final List getFileList(String resourceName) throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
+    public final List<String> getFileList(String resourceName) throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
         throwNotImplemented("getFileList(String resourceName)");
         return null;
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.event;
 
 import org.gradle.api.Action;
+import org.gradle.internal.Cast;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ReflectionDispatch;
@@ -56,7 +57,7 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
     public BroadcastDispatch<T> add(String methodName, Action<?> action) {
         assertIsMethod(methodName);
-        return add(action, new ActionInvocationHandler(methodName, action));
+        return add(action, new ActionInvocationHandler(methodName, Cast.<Action<Object>>uncheckedNonnullCast(action)));
     }
 
     abstract BroadcastDispatch<T> add(Object handler, Dispatch<MethodInvocation> dispatch);
@@ -81,9 +82,9 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
     private static class ActionInvocationHandler implements Dispatch<MethodInvocation> {
         private final String methodName;
-        private final Action action;
+        private final Action<Object> action;
 
-        ActionInvocationHandler(String methodName, Action action) {
+        ActionInvocationHandler(String methodName, Action<Object> action) {
             this.methodName = methodName;
             this.action = action;
         }
@@ -170,7 +171,7 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
         @Override
         public boolean equals(Object obj) {
-            SingletonDispatch<T> other = (SingletonDispatch<T>) obj;
+            SingletonDispatch<T> other = Cast.uncheckedNonnullCast(obj);
             return handler == other.handler || handler.equals(other.handler);
         }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.event;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
@@ -33,11 +34,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
-@SuppressWarnings({"unchecked"})
 public class DefaultListenerManager implements ListenerManager {
     private final Map<Object, ListenerDetails> allListeners = new LinkedHashMap<Object, ListenerDetails>();
     private final Map<Object, ListenerDetails> allLoggers = new LinkedHashMap<Object, ListenerDetails>();
-    private final Map<Class<?>, EventBroadcast> broadcasters = new ConcurrentHashMap<Class<?>, EventBroadcast>();
+    private final Map<Class<?>, EventBroadcast<?>> broadcasters = new ConcurrentHashMap<Class<?>, EventBroadcast<?>>();
     private final Object lock = new Object();
     private final DefaultListenerManager parent;
 
@@ -111,7 +111,7 @@ public class DefaultListenerManager implements ListenerManager {
 
     private <T> EventBroadcast<T> getBroadcasterInternal(Class<T> listenerClass) {
         synchronized (lock) {
-            EventBroadcast<T> broadcaster = broadcasters.get(listenerClass);
+            EventBroadcast<T> broadcaster = Cast.uncheckedCast(broadcasters.get(listenerClass));
             if (broadcaster == null) {
                 broadcaster = new EventBroadcast<T>(listenerClass);
                 broadcasters.put(listenerClass, broadcaster);

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/DefaultMethodArgsSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/DefaultMethodArgsSerializer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.remote.internal.hub;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
@@ -49,10 +50,10 @@ class DefaultMethodArgsSerializer implements MethodArgsSerializer {
             return defaultArgsSerializer.forTypes(types);
         }
 
-        final Serializer<Object>[] serializers = new Serializer[types.length];
+        final Serializer<Object>[] serializers = Cast.uncheckedNonnullCast(new Serializer<?>[types.length]);
         for (int i = 0; i < types.length; i++) {
             Class<?> type = types[i];
-            serializers[i] = (Serializer<Object>) selected.build(type);
+            serializers[i] = Cast.uncheckedNonnullCast(selected.build(type));
         }
         return new ArraySerializer(serializers);
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHub.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHub.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.remote.internal.hub;
 
 import org.gradle.api.Action;
+import org.gradle.internal.Cast;
 import org.gradle.internal.concurrent.AsyncStoppable;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
@@ -111,13 +112,13 @@ public class MessageHub implements AsyncStoppable {
             }
             Dispatch<Object> dispatch;
             if (handler instanceof Dispatch) {
-                dispatch = (Dispatch) handler;
+                dispatch = Cast.uncheckedNonnullCast(handler);
             } else {
                 dispatch = DISCARD;
             }
             BoundedDispatch<Object> boundedDispatch;
             if (dispatch instanceof BoundedDispatch) {
-                boundedDispatch = (BoundedDispatch) dispatch;
+                boundedDispatch = Cast.uncheckedNonnullCast(dispatch);
             } else {
                 boundedDispatch = DISCARD;
             }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractCollectionSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/AbstractCollectionSerializer.java
@@ -39,7 +39,7 @@ public abstract class AbstractCollectionSerializer<T, C extends Collection<T>> i
             return false;
         }
 
-        AbstractCollectionSerializer rhs = (AbstractCollectionSerializer) obj;
+        AbstractCollectionSerializer<?, ?> rhs = (AbstractCollectionSerializer<?, ?>) obj;
         return Objects.equal(entrySerializer, rhs.entrySerializer);
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.serialize;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.internal.Cast;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
@@ -49,36 +50,36 @@ public class BaseSerializerFactory {
 
     public <T> Serializer<T> getSerializerFor(Class<T> type) {
         if (type.equals(String.class)) {
-            return (Serializer<T>) STRING_SERIALIZER;
+            return Cast.uncheckedNonnullCast(STRING_SERIALIZER);
         }
         if (type.equals(Long.class)) {
-            return (Serializer) LONG_SERIALIZER;
+            return Cast.uncheckedNonnullCast(LONG_SERIALIZER);
         }
         if (type.equals(File.class)) {
-            return (Serializer) FILE_SERIALIZER;
+            return Cast.uncheckedNonnullCast(FILE_SERIALIZER);
         }
         if (type.equals(byte[].class)) {
-            return (Serializer) BYTE_ARRAY_SERIALIZER;
+            return Cast.uncheckedNonnullCast(BYTE_ARRAY_SERIALIZER);
         }
         if (type.isEnum()) {
-            return new EnumSerializer(type);
+            return Cast.uncheckedNonnullCast(new EnumSerializer<Enum<?>>(Cast.<Class<Enum<?>>>uncheckedNonnullCast(type)));
         }
         if (type.equals(Boolean.class)) {
-            return (Serializer<T>) BOOLEAN_SERIALIZER;
+            return Cast.uncheckedNonnullCast(BOOLEAN_SERIALIZER);
         }
         if (Throwable.class.isAssignableFrom(type)) {
-            return (Serializer<T>) THROWABLE_SERIALIZER;
+            return Cast.uncheckedNonnullCast(THROWABLE_SERIALIZER);
         }
         if (HashCode.class.isAssignableFrom(type)) {
-            return (Serializer<T>) HASHCODE_SERIALIZER;
+            return Cast.uncheckedNonnullCast(HASHCODE_SERIALIZER);
         }
         if (Path.class.isAssignableFrom(type)) {
-            return (Serializer) PATH_SERIALIZER;
+            return Cast.uncheckedNonnullCast(PATH_SERIALIZER);
         }
         return new DefaultSerializer<T>(type.getClassLoader());
     }
 
-    private static class EnumSerializer<T extends Enum> extends AbstractSerializer<T> {
+    private static class EnumSerializer<T extends Enum<?>> extends AbstractSerializer<T> {
         private final Class<T> type;
 
         private EnumSerializer(Class<T> type) {
@@ -101,7 +102,7 @@ public class BaseSerializerFactory {
                 return false;
             }
 
-            EnumSerializer rhs = (EnumSerializer) obj;
+            EnumSerializer<?> rhs = (EnumSerializer<?>) obj;
             return Objects.equal(type, rhs.type);
         }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/DefaultSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/DefaultSerializer.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.serialize;
 
 import com.google.common.base.Objects;
+import org.gradle.internal.Cast;
 import org.gradle.internal.io.ClassLoaderObjectInputStream;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public class DefaultSerializer<T> extends AbstractSerializer<T> {
     @Override
     public T read(Decoder decoder) throws Exception {
         try {
-            return (T) new ClassLoaderObjectInputStream(decoder.getInputStream(), classLoader).readObject();
+            return Cast.uncheckedNonnullCast(new ClassLoaderObjectInputStream(decoder.getInputStream(), classLoader).readObject());
         } catch (StreamCorruptedException e) {
             return null;
         }
@@ -63,7 +64,7 @@ public class DefaultSerializer<T> extends AbstractSerializer<T> {
             return false;
         }
 
-        DefaultSerializer rhs = (DefaultSerializer) obj;
+        DefaultSerializer<?> rhs = (DefaultSerializer<?>) obj;
         return Objects.equal(classLoader, rhs.classLoader);
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/MapSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/MapSerializer.java
@@ -56,7 +56,7 @@ public class MapSerializer<U, V> extends AbstractSerializer<Map<U, V>> {
             return false;
         }
 
-        MapSerializer rhs = (MapSerializer) obj;
+        MapSerializer<?, ?> rhs = (MapSerializer<?, ?>) obj;
         return Objects.equal(keySerializer, rhs.keySerializer)
             && Objects.equal(valueSerializer, rhs.valueSerializer);
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/SetSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/SetSerializer.java
@@ -49,7 +49,7 @@ public class SetSerializer<T> extends AbstractCollectionSerializer<T, Set<T>> im
             return false;
         }
 
-        SetSerializer rhs = (SetSerializer) obj;
+        SetSerializer<?> rhs = (SetSerializer<?>) obj;
         return linkedHashSet == rhs.linkedHashSet;
     }
 

--- a/subprojects/model-core/model-core.gradle.kts
+++ b/subprojects/model-core/model-core.gradle.kts
@@ -57,6 +57,10 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf(
         "org/gradle/model/internal/core/**",

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -76,7 +76,9 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    public void addAll(T... elements) {
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public final void addAll(T... elements) {
         addCollector(new ElementsFromArray<>(elements));
     }
 
@@ -98,7 +100,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     @Nullable
     @Override
     public Class<C> getType() {
-        return (Class<C>) collectionType;
+        return Cast.uncheckedCast(collectionType);
     }
 
     @Override
@@ -122,12 +124,12 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     @Override
     public void setFromAnyValue(Object object) {
         if (object instanceof Provider) {
-            set((Provider<C>) object);
+            set(Cast.<Provider<C>>uncheckedCast(object));
         } else {
             if (object != null && !(object instanceof Iterable)) {
                 throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using an instance of type %s.", collectionType.getName(), object.getClass().getName()));
             }
-            set((Iterable<? extends T>) object);
+            set(Cast.<Iterable<? extends T>>uncheckedCast(object));
         }
     }
 
@@ -151,7 +153,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using a provider of type %s.", collectionType.getName(), p.getType().getName()));
         }
         if (p instanceof CollectionPropertyInternal) {
-            CollectionPropertyInternal<T, C> collectionProp = (CollectionPropertyInternal<T, C>) p;
+            CollectionPropertyInternal<T, C> collectionProp = Cast.uncheckedCast(p);
             if (!elementType.isAssignableFrom(collectionProp.getElementType())) {
                 throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s with element type %s using a provider with element type %s.", collectionType.getName(), elementType.getName(), collectionProp.getElementType().getName()));
             }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 
@@ -55,9 +56,9 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     @Override
     public void setFromAnyValue(Object object) {
         if (object instanceof Provider) {
-            set((Provider<T>) object);
+            set(Cast.<Provider<T>>uncheckedNonnullCast(object));
         } else {
-            set((T) object);
+            set(Cast.<T>uncheckedNonnullCast(object));
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
 import org.gradle.api.provider.ValueSourceSpec;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Try;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -124,10 +125,10 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
     }
 
     private <P extends ValueSourceParameters> void configureParameters(@Nullable P parameters, Action<? super ValueSourceSpec<P>> configureAction) {
-        DefaultValueSourceSpec<P> valueSourceSpec = specInstantiator.newInstance(
+        DefaultValueSourceSpec<P> valueSourceSpec = Cast.uncheckedNonnullCast(specInstantiator.newInstance(
             DefaultValueSourceSpec.class,
             parameters
-        );
+        ));
         configureAction.execute(valueSourceSpec);
     }
 
@@ -249,12 +250,12 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
 
         private P isolateParameters() {
             // TODO - consider if should hold the project lock to do the isolation
-            return (P) isolatableFactory.isolate(parameters).isolate();
+            return isolatableFactory.isolate(parameters).isolate();
         }
 
         private void onValueObtained() {
             broadcaster.getSource().valueObtained(
-                new DefaultObtainedValue(
+                new DefaultObtainedValue<>(
                     value,
                     valueSourceType,
                     parametersType,

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -66,7 +66,7 @@ public class ManagedFactories {
                 return null;
             }
             // TODO - should preserve the property type (which may be different to the provider type)
-            ProviderInternal<S> provider = Cast.uncheckedCast(state);
+            ProviderInternal<S> provider = Cast.uncheckedNonnullCast(state);
             return type.cast(propertyOf(provider.getType(), provider));
         }
 
@@ -97,8 +97,8 @@ public class ManagedFactories {
                 return null;
             }
             // TODO - should preserve the element type
-            DefaultListProperty<?> property = propertyFactory.listProperty(Object.class);
-            property.set((Iterable) state);
+            DefaultListProperty<Object> property = propertyFactory.listProperty(Object.class);
+            property.set((Cast.<Iterable<Object>>uncheckedNonnullCast(state)));
             return type.cast(property);
         }
 
@@ -126,8 +126,8 @@ public class ManagedFactories {
                 return null;
             }
             // TODO - should preserve the element type
-            DefaultSetProperty<?> property = propertyFactory.setProperty(Object.class);
-            property.set((Iterable) state);
+            DefaultSetProperty<Object> property = propertyFactory.setProperty(Object.class);
+            property.set(Cast.<Iterable<Object>>uncheckedNonnullCast(state));
             return type.cast(property);
         }
 
@@ -155,8 +155,8 @@ public class ManagedFactories {
                 return null;
             }
             // TODO - should preserve the key and value types
-            DefaultMapProperty<?, ?> property = propertyFactory.mapProperty(Object.class, Object.class);
-            property.set((Map) state);
+            DefaultMapProperty<Object, Object> property = propertyFactory.mapProperty(Object.class, Object.class);
+            property.set(Cast.<Map<Object, Object>>uncheckedNonnullCast(state));
             return type.cast(property);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -98,7 +98,7 @@ public class ManagedFactories {
             }
             // TODO - should preserve the element type
             DefaultListProperty<Object> property = propertyFactory.listProperty(Object.class);
-            property.set((Cast.<Iterable<Object>>uncheckedNonnullCast(state)));
+            property.set(Cast.<Iterable<Object>>uncheckedNonnullCast(state));
             return type.cast(property);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -25,6 +25,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.ValueSupplier;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.internal.Cast;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
 import javax.annotation.Nullable;
@@ -120,17 +121,17 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 }
             } else if (dependency instanceof Iterable && !(dependency instanceof Path)) {
                 // Path is Iterable, but we don't want to unpack it
-                Iterable<?> iterable = (Iterable) dependency;
+                Iterable<?> iterable = Cast.uncheckedNonnullCast(dependency);
                 addAllFirst(queue, toArray(iterable, Object.class));
             } else if (dependency instanceof Map) {
-                Map<?, ?> map = (Map) dependency;
+                Map<?, ?> map = Cast.uncheckedNonnullCast(dependency);
                 addAllFirst(queue, map.values().toArray());
             } else if (dependency instanceof Object[]) {
                 Object[] array = (Object[]) dependency;
                 addAllFirst(queue, array);
             } else if (dependency instanceof Callable) {
-                Callable callable = (Callable) dependency;
-                Object callableResult = uncheckedCall(callable);
+                Callable<?> callable = Cast.uncheckedNonnullCast(dependency);
+                Object callableResult = uncheckedCall(Cast.uncheckedNonnullCast(callable));
                 if (callableResult != null) {
                     queue.addFirst(callableResult);
                 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.HasConvention;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.Convention;
+import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
 import java.util.Collection;
@@ -85,7 +86,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
 
     public void propertyMissing(String name, Object value) {
         if (value instanceof Closure) {
-            map(name, (Closure) value);
+            map(name, Cast.<Closure<?>>uncheckedNonnullCast(value));
         } else {
             throw new MissingPropertyException(name, getClass());
         }
@@ -106,7 +107,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
                 useMapping = false;
             }
             if (useMapping) {
-                returnValue = (T) _mappings.get(propertyName).getValue(_convention, _source);
+                returnValue = Cast.uncheckedNonnullCast((_mappings.get(propertyName).getValue(_convention, _source)));
             }
         }
         return returnValue;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -107,7 +107,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
                 useMapping = false;
             }
             if (useMapping) {
-                returnValue = Cast.uncheckedNonnullCast((_mappings.get(propertyName).getValue(_convention, _source)));
+                returnValue = Cast.uncheckedNonnullCast(_mappings.get(propertyName).getValue(_convention, _source));
             }
         }
         return returnValue;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.coerce.MethodArgumentsTransformer;
 import org.gradle.api.internal.coerce.PropertySetTransformer;
 import org.gradle.api.internal.coerce.StringToEnumTransformer;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 import org.gradle.internal.state.ModelObject;
@@ -598,7 +599,7 @@ public class BeanDynamicObject extends AbstractDynamicObject {
     }
 
     private class MapAdapter extends MetaClassAdapter {
-        Map<String, Object> map = (Map<String, Object>) bean;
+        Map<String, Object> map = Cast.uncheckedNonnullCast(bean);
 
         @Override
         public boolean hasProperty(String name) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
@@ -18,6 +18,7 @@ package org.gradle.internal.snapshot.impl;
 
 import org.gradle.api.Named;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 
@@ -36,7 +37,7 @@ public class CoercingStringValueSnapshot extends StringValueSnapshot {
             return type.cast(this);
         }
         if (type.isEnum()) {
-            return type.cast(Enum.valueOf(type.asSubclass(Enum.class), getValue()));
+            return type.cast(Enum.valueOf(Cast.uncheckedNonnullCast(type.asSubclass(Enum.class)), getValue()));
         }
         if (Named.class.isAssignableFrom(type)) {
             return type.cast(instantiator.named(type.asSubclass(Named.class), getValue()));

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot.impl;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -53,7 +54,7 @@ public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isol
             return type.cast(value);
         }
         if (type.isEnum() && type.getName().equals(value.getClass().getName())) {
-            return type.cast(Enum.valueOf(type.asSubclass(Enum.class), value.name()));
+            return type.cast(Enum.valueOf(Cast.uncheckedNonnullCast(type.asSubclass(Enum.class)), value.name()));
         }
         return null;
     }

--- a/subprojects/model-groovy/model-groovy.gradle.kts
+++ b/subprojects/model-groovy/model-groovy.gradle.kts
@@ -19,7 +19,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
@@ -16,17 +16,18 @@
 
 package org.gradle.internal.nativeintegration.console;
 
-import org.fusesource.jansi.WindowsAnsiOutputStream;
+import org.fusesource.jansi.WindowsAnsiPrintStream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 
 public class WindowsConsoleDetector implements ConsoleDetector {
     @Override
     public ConsoleMetaData getConsole() {
         // Use Jansi's detection mechanism
         try {
-            new WindowsAnsiOutputStream(new ByteArrayOutputStream());
+            new WindowsAnsiPrintStream(new PrintStream(new ByteArrayOutputStream()));
             return FallbackConsoleMetaData.ATTACHED;
         } catch (IOException ignore) {
             // Not attached to a console

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
@@ -122,7 +122,7 @@ class GenericFileSystem implements FileSystem {
 
     private File createFile(String content) throws IOException {
         File file = File.createTempFile("gradle_fs_probing", null, null);
-        Files.write(content, file, Charsets.UTF_8);
+        Files.asCharSink(file, Charsets.UTF_8).write(content);
         return file;
     }
 
@@ -140,7 +140,7 @@ class GenericFileSystem implements FileSystem {
     }
 
     private boolean hasContent(File file, String content) throws IOException {
-        return file.exists() && Files.readFirstLine(file, Charsets.UTF_8).equals(content);
+        return file.exists() && Files.asCharSource(file, Charsets.UTF_8).readFirstLine().equals(content);
     }
 
     private void checkJavaIoTmpDirExists() throws IOException {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -28,6 +28,7 @@ import net.rubygrapefruit.platform.internal.DefaultProcessLauncher;
 import net.rubygrapefruit.platform.memory.Memory;
 import net.rubygrapefruit.platform.terminal.Terminals;
 import org.gradle.api.JavaVersion;
+import org.gradle.internal.Cast;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -291,7 +292,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     }
 
     private <T> T notAvailable(Class<T> type) {
-        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, new BrokenService(type.getSimpleName()));
+        return Cast.uncheckedNonnullCast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, new BrokenService(type.getSimpleName())));
     }
 
     private static String format(Throwable throwable) {

--- a/subprojects/normalization-java/normalization-java.gradle.kts
+++ b/subprojects/normalization-java/normalization-java.gradle.kts
@@ -18,7 +18,6 @@ description = "API extraction for Java"
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/persistent-cache/persistent-cache.gradle.kts
+++ b/subprojects/persistent-cache/persistent-cache.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/platform-base/platform-base.gradle.kts
+++ b/subprojects/platform-base/platform-base.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -36,3 +36,7 @@ dependencies {
 
     integTestImplementation(library("slf4j_api"))
 }
+
+strictCompile {
+    ignoreDeprecations() // most of this project has been deprecated
+}

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -86,6 +86,11 @@ dependencies {
     integTestRuntimeResources(testFixtures(project(":platformPlay")))
 }
 
+strictCompile {
+    ignoreRawTypes() // deprecated raw types
+    ignoreDeprecations() // uses deprecated software model types
+}
+
 tasks.named<Test>("integTest") {
     exclude("org/gradle/play/prepare/**")
 }

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -18,7 +18,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -86,6 +86,11 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+    ignoreDeprecations() // uses deprecated software model types
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/CompositePublicationArtifactSet.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/CompositePublicationArtifactSet.java
@@ -26,6 +26,8 @@ public class CompositePublicationArtifactSet<T extends PublicationArtifact> exte
 
     private final FileCollection files;
 
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public CompositePublicationArtifactSet(Class<T> type, PublicationArtifactSet<T>... artifactSets) {
         super(CompositeDomainObjectSet.create(type, artifactSets));
         FileCollection[] fileCollections = new FileCollection[artifactSets.length];

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -96,14 +96,14 @@ public class GradleModuleMetadataWriter {
         this.checksumService = checksumService;
     }
 
-    public void generateTo(PublicationInternal publication, Collection<? extends PublicationInternal> publications, Writer writer) throws IOException {
+    public void generateTo(PublicationInternal<?> publication, Collection<? extends PublicationInternal<?>> publications, Writer writer) throws IOException {
         InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName());
         // Collect a map from component to coordinates. This might be better to move to the component or some publications model
-        Map<SoftwareComponent, ComponentData> coordinates = new HashMap<SoftwareComponent, ComponentData>();
+        Map<SoftwareComponent, ComponentData> coordinates = new HashMap<>();
         collectCoordinates(publications, coordinates);
 
         // Collect a map from component to its owning component. This might be better to move to the component or some publications model
-        Map<SoftwareComponent, SoftwareComponent> owners = new HashMap<SoftwareComponent, SoftwareComponent>();
+        Map<SoftwareComponent, SoftwareComponent> owners = new HashMap<>();
         collectOwners(publications, owners);
 
         // Write the output
@@ -116,8 +116,8 @@ public class GradleModuleMetadataWriter {
         checker.validate();
     }
 
-    private void collectOwners(Collection<? extends PublicationInternal> publications, Map<SoftwareComponent, SoftwareComponent> owners) {
-        for (PublicationInternal publication : publications) {
+    private void collectOwners(Collection<? extends PublicationInternal<?>> publications, Map<SoftwareComponent, SoftwareComponent> owners) {
+        for (PublicationInternal<?> publication : publications) {
             if (publication.getComponent() instanceof ComponentWithVariants) {
                 ComponentWithVariants componentWithVariants = (ComponentWithVariants) publication.getComponent();
                 for (SoftwareComponent child : componentWithVariants.getVariants()) {
@@ -127,8 +127,8 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void collectCoordinates(Collection<? extends PublicationInternal> publications, Map<SoftwareComponent, ComponentData> coordinates) {
-        for (PublicationInternal publication : publications) {
+    private void collectCoordinates(Collection<? extends PublicationInternal<?>> publications, Map<SoftwareComponent, ComponentData> coordinates) {
+        for (PublicationInternal<?> publication : publications) {
             if (publication.getComponent() != null) {
                 ModuleVersionIdentifier moduleVersionIdentifier = publication.getCoordinates();
                 ImmutableAttributes attributes = publication.getAttributes();
@@ -137,7 +137,7 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeComponentWithVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, Map<SoftwareComponent, SoftwareComponent> owners, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
+    private void writeComponentWithVariants(PublicationInternal<?> publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, Map<SoftwareComponent, SoftwareComponent> owners, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(publication.getCoordinates(), publication.getAttributes(), component, componentCoordinates, owners, jsonWriter);
@@ -219,7 +219,7 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
+    private void writeVariants(PublicationInternal<?> publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         boolean started = false;
         for (UsageContext usageContext : ((SoftwareComponentInternal) component).getUsages()) {
             checker.registerVariant(usageContext.getName(), usageContext.getAttributes(),  usageContext.getCapabilities());
@@ -318,7 +318,7 @@ public class GradleModuleMetadataWriter {
         return path.toString();
     }
 
-    private void writeVariantHostedInThisModule(PublicationInternal publication, UsageContext variant, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
+    private void writeVariantHostedInThisModule(PublicationInternal<?> publication, UsageContext variant, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         jsonWriter.name("name");
         jsonWriter.value(variant.getName());
@@ -338,7 +338,7 @@ public class GradleModuleMetadataWriter {
         }
         jsonWriter.name("attributes");
         jsonWriter.beginObject();
-        Map<String, Attribute<?>> sortedAttributes = new TreeMap<String, Attribute<?>>();
+        Map<String, Attribute<?>> sortedAttributes = new TreeMap<>();
         for (Attribute<?> attribute : attributes.keySet()) {
             sortedAttributes.put(attribute.getName(), attribute);
         }
@@ -367,7 +367,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.endObject();
     }
 
-    private void writeArtifacts(PublicationInternal publication, UsageContext variant, JsonWriter jsonWriter) throws IOException {
+    private void writeArtifacts(PublicationInternal<?> publication, UsageContext variant, JsonWriter jsonWriter) throws IOException {
         if (variant.getArtifacts().isEmpty()) {
             return;
         }
@@ -379,7 +379,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.endArray();
     }
 
-    private void writeArtifact(PublicationInternal publication, PublishArtifact artifact, JsonWriter jsonWriter) throws IOException {
+    private void writeArtifact(PublicationInternal<?> publication, PublishArtifact artifact, JsonWriter jsonWriter) throws IOException {
         if (artifact instanceof PublishArtifactInternal) {
             if (!((PublishArtifactInternal) artifact).shouldBePublished()) {
                 return;
@@ -571,7 +571,7 @@ public class GradleModuleMetadataWriter {
     private void writeExcludes(ModuleDependency moduleDependency, Set<ExcludeRule> additionalExcludes, JsonWriter jsonWriter) throws IOException {
         Set<ExcludeRule> excludeRules;
         if (!moduleDependency.isTransitive()) {
-            excludeRules = Collections.<ExcludeRule>singleton(new DefaultExcludeRule(null, null));
+            excludeRules = Collections.singleton(new DefaultExcludeRule(null, null));
         } else {
             excludeRules = Sets.union(additionalExcludes, moduleDependency.getExcludeRules());
         }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationFieldValidator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationFieldValidator.java
@@ -18,7 +18,7 @@ package org.gradle.api.publish.internal;
 
 import org.gradle.api.InvalidUserDataException;
 
-public abstract class PublicationFieldValidator<T extends PublicationFieldValidator> {
+public abstract class PublicationFieldValidator<T extends PublicationFieldValidator<T>> {
     private final Class<T> type;
     protected final String publicationName;
     protected final String name;

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/DuplicatePublicationTracker.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/DuplicatePublicationTracker.java
@@ -28,9 +28,9 @@ import java.net.URI;
 
 public class DuplicatePublicationTracker {
     private final static Logger LOG = Logging.getLogger(DuplicatePublicationTracker.class);
-    private final Multimap<String, PublicationInternal> published = LinkedHashMultimap.create();
+    private final Multimap<String, PublicationInternal<?>> published = LinkedHashMultimap.create();
 
-    public synchronized void checkCanPublish(PublicationInternal publication, @Nullable URI repositoryLocation, String repositoryName) {
+    public synchronized void checkCanPublish(PublicationInternal<?> publication, @Nullable URI repositoryLocation, String repositoryName) {
         // Don't track publications to repositories configured without a base URL
         if (repositoryLocation == null) {
             return;
@@ -44,7 +44,7 @@ public class DuplicatePublicationTracker {
         }
 
         ModuleVersionIdentifier projectIdentity = publication.getCoordinates();
-        for (PublicationInternal previousPublication : published.get(repositoryKey)) {
+        for (PublicationInternal<?> previousPublication : published.get(repositoryKey)) {
             if (previousPublication.getCoordinates().equals(projectIdentity)) {
                 LOG.warn("Multiple publications with coordinates '" + publication.getCoordinates() + "' are published to repository '" + repositoryName + "'. The publications will overwrite each other!");
             }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.DefaultPublicationContainer;
 import org.gradle.api.publish.internal.DefaultPublishingExtension;
 import org.gradle.api.publish.internal.PublicationInternal;
+import org.gradle.internal.Cast;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -81,7 +82,7 @@ public class PublishingPlugin implements Plugin<Project> {
             task.setGroup(PUBLISH_TASK_GROUP);
         });
         extension.getPublications().all(publication -> {
-            PublicationInternal internalPublication = (PublicationInternal) publication;
+            PublicationInternal<?> internalPublication = Cast.uncheckedNonnullCast(publication);
             ProjectInternal projectInternal = (ProjectInternal) project;
             projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
         });

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -85,7 +85,7 @@ public class GenerateModuleMetadata extends DefaultTask {
 
     private void mustHaveAttachedComponent() {
         setOnlyIf(element -> {
-            PublicationInternal publication = (PublicationInternal) GenerateModuleMetadata.this.publication.get();
+            PublicationInternal<?> publication = Cast.uncheckedNonnullCast(GenerateModuleMetadata.this.publication.get());
             if (publication.getComponent() == null) {
                 getLogger().warn(publication.getDisplayName() + " isn't attached to a component. Gradle metadata only supports publications with software components (e.g. from component.java)");
                 return false;
@@ -161,8 +161,8 @@ public class GenerateModuleMetadata extends DefaultTask {
     @TaskAction
     void run() {
         File file = outputFile.get().getAsFile();
-        PublicationInternal publication = (PublicationInternal) this.publication.get();
-        List<PublicationInternal> publications = Cast.uncheckedCast(this.publications.get());
+        PublicationInternal<?> publication = Cast.uncheckedNonnullCast(this.publication.get());
+        List<PublicationInternal<?>> publications = Cast.uncheckedCast(this.publications.get());
         try {
             Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "utf8"));
             try {
@@ -178,7 +178,7 @@ public class GenerateModuleMetadata extends DefaultTask {
     private class VariantFiles implements MinimalFileSet, Buildable {
         @Override
         public TaskDependency getBuildDependencies() {
-            PublicationInternal publication = (PublicationInternal) GenerateModuleMetadata.this.publication.get();
+            PublicationInternal<?> publication = Cast.uncheckedNonnullCast(GenerateModuleMetadata.this.publication.get());
             SoftwareComponentInternal component = publication.getComponent();
             DefaultTaskDependency dependency = new DefaultTaskDependency();
             if (component == null) {
@@ -194,7 +194,7 @@ public class GenerateModuleMetadata extends DefaultTask {
 
         @Override
         public Set<File> getFiles() {
-            PublicationInternal publication = (PublicationInternal) GenerateModuleMetadata.this.publication.get();
+            PublicationInternal<?> publication = Cast.uncheckedNonnullCast(GenerateModuleMetadata.this.publication.get());
             SoftwareComponentInternal component = publication.getComponent();
             if (component == null) {
                 return ImmutableSet.of();

--- a/subprojects/reporting/reporting.gradle.kts
+++ b/subprojects/reporting/reporting.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
     add("reports", "jquery:jquery.min:3.4.1@js")
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: GenerateBuildDashboard.aggregate()
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/api/reporting/internal/**"))
 }

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -30,6 +30,7 @@ import org.gradle.api.reporting.internal.DefaultBuildDashboardReports;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.ClosureBackedAction;
 import org.gradle.util.CollectionUtils;
@@ -103,7 +104,7 @@ public class GenerateBuildDashboard extends DefaultTask implements Reporting<Bui
                         if (!(task instanceof Reporting)) {
                             return;
                         }
-                        reports.add((Reporting) task);
+                        reports.add(Cast.uncheckedNonnullCast(task));
                     }
                 });
             }

--- a/subprojects/resources-gcs/resources-gcs.gradle.kts
+++ b/subprojects/resources-gcs/resources-gcs.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/resources-http/resources-http.gradle.kts
+++ b/subprojects/resources-http/resources-http.gradle.kts
@@ -15,10 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    // Cannot use strict compile because JDK 7 doesn't recognize
-    // @SuppressWarnings("deprecation"), used in org.gradle.internal.resource.transport.http.HttpClientHelper.AutoClosedHttpResponse
-    // in the context of a delegation pattern
-    // gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpHeaderAuthScheme.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpHeaderAuthScheme.java
@@ -60,6 +60,7 @@ public class HttpHeaderAuthScheme implements ContextAwareAuthScheme {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Header authenticate(final Credentials credentials, final HttpRequest request) throws AuthenticationException {
         return this.authenticate(credentials, request, new BasicHttpContext());
     }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpHeaderSchemeFactory.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpHeaderSchemeFactory.java
@@ -19,15 +19,13 @@ package org.gradle.internal.resource.transport.http;
 import org.apache.http.annotation.Contract;
 import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.auth.AuthScheme;
-import org.apache.http.auth.AuthSchemeFactory;
-import org.apache.http.auth.AuthSchemeProvider;
-import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 
 import java.nio.charset.Charset;
 
 @Contract(threading = ThreadingBehavior.IMMUTABLE)
-public class HttpHeaderSchemeFactory implements AuthSchemeFactory, AuthSchemeProvider {
+@SuppressWarnings("deprecation")
+public class HttpHeaderSchemeFactory implements org.apache.http.auth.AuthSchemeFactory, org.apache.http.auth.AuthSchemeProvider {
 
     public HttpHeaderSchemeFactory(final Charset charset) {
         super();
@@ -38,7 +36,7 @@ public class HttpHeaderSchemeFactory implements AuthSchemeFactory, AuthSchemePro
     }
 
     @Override
-    public AuthScheme newInstance(final HttpParams params) {
+    public AuthScheme newInstance(final org.apache.http.params.HttpParams params) {
         return new HttpHeaderAuthScheme();
     }
 

--- a/subprojects/resources-s3/resources-s3.gradle.kts
+++ b/subprojects/resources-s3/resources-s3.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/resources-sftp/resources-sftp.gradle.kts
+++ b/subprojects/resources-sftp/resources-sftp.gradle.kts
@@ -18,7 +18,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/resources/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationSchemeRegistry.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationSchemeRegistry.java
@@ -18,6 +18,7 @@ package org.gradle.internal.authentication;
 
 import com.google.common.collect.Maps;
 import org.gradle.authentication.Authentication;
+import org.gradle.internal.Cast;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,7 +32,7 @@ public class DefaultAuthenticationSchemeRegistry implements AuthenticationScheme
     }
 
     @Override
-    public Map<Class<? extends Authentication>, Class<? extends Authentication>> getRegisteredSchemes() {
-        return Collections.unmodifiableMap(registeredSchemes);
+    public <T extends Authentication> Map<Class<T>, Class<? extends T>> getRegisteredSchemes() {
+        return Collections.unmodifiableMap(Cast.uncheckedNonnullCast(registeredSchemes));
     }
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/ExternalResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/ExternalResource.java
@@ -68,6 +68,7 @@ public interface ExternalResource extends Resource {
      * @throws ResourceException on failure to read the content.
      * @throws org.gradle.api.resources.MissingResourceException when the resource does not exist
      */
+    @SuppressWarnings("overloads")
     ExternalResourceReadResult<Void> withContent(Action<? super InputStream> readAction) throws ResourceException;
 
     /**
@@ -76,6 +77,7 @@ public interface ExternalResource extends Resource {
      * @throws ResourceException on failure to read the content.
      * @throws org.gradle.api.resources.MissingResourceException when the resource does not exist
      */
+    @SuppressWarnings("overloads")
     <T> ExternalResourceReadResult<T> withContent(Transformer<? extends T, ? super InputStream> readAction) throws ResourceException;
 
     /**

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
@@ -44,6 +44,7 @@ public class DefaultScalaSourceSet implements ScalaSourceSet, HasPublicType {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public ScalaSourceSet scala(Closure configureClosure) {
         configure(configureClosure, getScala());
         return this;

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
@@ -40,6 +40,7 @@ public interface ScalaSourceSet {
      * @param configureClosure The closure to use to configure the Scala source.
      * @return this
      */
+    @SuppressWarnings("rawtypes")
     ScalaSourceSet scala(Closure configureClosure);
 
     /**

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/GenerateScaladoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/GenerateScaladoc.java
@@ -80,9 +80,9 @@ public abstract class GenerateScaladoc implements WorkAction<ScaladocParameters>
     }
 
     private void invokeScalaDoc(List<String> args) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        Class scaladocClass = Thread.currentThread().getContextClassLoader().loadClass("scala.tools.nsc.ScalaDoc");
+        Class<?> scaladocClass = Thread.currentThread().getContextClassLoader().loadClass("scala.tools.nsc.ScalaDoc");
         Method process = scaladocClass.getMethod("process", String[].class);
-        Object scaladoc = scaladocClass.newInstance();
+        Object scaladoc = scaladocClass.getDeclaredConstructor().newInstance();
         process.invoke(scaladoc, new Object[]{args.toArray(new String[0])});
     }
 }

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -43,6 +43,10 @@ dependencies {
     testRuntimeOnly(testFixtures(project(":security")))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/plugins/signing/**"))
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -25,7 +25,6 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.artifacts.maven.MavenDeployment;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.model.ObjectFactory;
@@ -33,6 +32,7 @@ import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.Cast;
 import org.gradle.plugins.signing.internal.SignOperationInternal;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.signatory.SignatoryProvider;
@@ -424,7 +424,7 @@ public class SigningExtension {
         signTask.getSignatures().all(new Action<Signature>() {
             @Override
             public void execute(final Signature signature) {
-                T artifact = publicationToSign.addDerivedArtifact((T) signature.getSource(), new DefaultDerivedArtifactFile(signature, signTask));
+                T artifact = publicationToSign.addDerivedArtifact(Cast.uncheckedNonnullCast(signature.getSource()), new DefaultDerivedArtifactFile(signature, signTask));
                 artifact.builtBy(signTask);
                 artifacts.put(signature, artifact);
             }
@@ -564,7 +564,8 @@ public class SigningExtension {
      * @deprecated Use {@link #sign(Publication...)} instead
      */
     @Deprecated
-    public Signature signPom(final MavenDeployment mavenDeployment, final Closure closure) {
+    @SuppressWarnings("deprecation")
+    public Signature signPom(final org.gradle.api.artifacts.maven.MavenDeployment mavenDeployment, final Closure closure) {
         SignOperation signOperation = doSignOperation(new Action<SignOperation>() {
             @Override
             public void execute(SignOperation so) {
@@ -619,7 +620,8 @@ public class SigningExtension {
      * @deprecated Use {@link #sign(Publication...)} instead
      */
     @Deprecated
-    public Signature signPom(MavenDeployment mavenDeployment) {
+    @SuppressWarnings("deprecation")
+    public Signature signPom(org.gradle.api.artifacts.maven.MavenDeployment mavenDeployment) {
         return signPom(mavenDeployment, null);
     }
 

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -19,7 +19,6 @@ import accessors.java
 plugins {
     gradlebuild.distribution.`core-api-java`
     gradlebuild.`publish-public-libraries`
-    gradlebuild.`strict-compile`
 }
 
 description = "Tools to take immutable, comparable snapshots of files and other things"

--- a/subprojects/test-kit/test-kit.gradle.kts
+++ b/subprojects/test-kit/test-kit.gradle.kts
@@ -17,7 +17,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 
 plugins {
     gradlebuild.distribution.`core-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternal.java
@@ -25,11 +25,11 @@ import org.gradle.api.tasks.testing.TestResult;
  * {@code TestListenerInternal} that causes the {@link TestExecuter} to stop at the first failed test
  */
 public class FailFastTestListenerInternal implements TestListenerInternal {
-    private final TestExecuter testExecuter;
+    private final TestExecuter<?> testExecuter;
     private final TestListenerInternal delegate;
     private boolean failed;
 
-    public FailFastTestListenerInternal(TestExecuter testExecuter, TestListenerInternal delegate) {
+    public FailFastTestListenerInternal(TestExecuter<?> testExecuter, TestListenerInternal delegate) {
         this.testExecuter = testExecuter;
         this.delegate = delegate;
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
@@ -90,7 +91,7 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
 
     private void startReceivingTests(WorkerProcessContext workerProcessContext, ServiceRegistry testServices) {
         TestClassProcessor targetProcessor = factory.create(testServices);
-        IdGenerator<Object> idGenerator = testServices.get(IdGenerator.class);
+        IdGenerator<Object> idGenerator = Cast.uncheckedNonnullCast(testServices.get(IdGenerator.class));
 
         targetProcessor = new WorkerTestClassProcessor(targetProcessor, idGenerator.generateId(),
                 workerProcessContext.getDisplayName(), testServices.get(Clock.class));

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -65,6 +65,7 @@ import org.gradle.api.tasks.VerificationTask;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.testing.logging.TestLogging;
 import org.gradle.api.tasks.testing.logging.TestLoggingContainer;
+import org.gradle.internal.Cast;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -471,7 +472,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         TestWorkerProgressListener testWorkerProgressListener = new TestWorkerProgressListener(getProgressLoggerFactory(), parentProgressLogger);
         getTestListenerInternalBroadcaster().add(testWorkerProgressListener);
 
-        TestExecuter testExecuter = createTestExecuter();
+        TestExecuter<TestExecutionSpec> testExecuter = Cast.uncheckedNonnullCast(createTestExecuter());
         TestListenerInternal resultProcessorDelegate = getTestListenerInternalBroadcaster().getSource();
         if (failFast) {
             resultProcessorDelegate = new FailFastTestListenerInternal(testExecuter, resultProcessorDelegate);

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -61,6 +61,10 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API (org.gradle.api.tasks.testing.AbstractTestTask)
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AllExceptIgnoredTestRunnerBuilder.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AllExceptIgnoredTestRunnerBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import org.gradle.internal.Cast;
 import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
 import org.junit.internal.builders.IgnoredBuilder;
 import org.junit.internal.builders.JUnit4Builder;
@@ -49,7 +50,7 @@ public class AllExceptIgnoredTestRunnerBuilder extends AllDefaultPossibilitiesBu
             } catch (Throwable t) {
                 //failed to instantiate BlockJUnitRunner. try deprecated JUnitRunner (for JUnit < 4.5)
                 try {
-                    Class<Runner> runnerClass = (Class<Runner>) Thread.currentThread().getContextClassLoader().loadClass("org.junit.internal.runners.JUnit4ClassRunner");
+                    Class<Runner> runnerClass = Cast.uncheckedNonnullCast(Thread.currentThread().getContextClassLoader().loadClass("org.junit.internal.runners.JUnit4ClassRunner"));
                     final Constructor<Runner> constructor = runnerClass.getConstructor(Class.class);
                     return constructor.newInstance(testClass);
                 } catch (Throwable e) {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -92,11 +92,11 @@ public class JUnitPlatformTestFramework implements TestFramework {
         @Override
         public TestClassProcessor create(ServiceRegistry serviceRegistry) {
             try {
-                IdGenerator idGenerator = serviceRegistry.get(IdGenerator.class);
+                IdGenerator<?> idGenerator = serviceRegistry.get(IdGenerator.class);
                 Clock clock = serviceRegistry.get(Clock.class);
                 ActorFactory actorFactory = serviceRegistry.get(ActorFactory.class);
                 Class<?> clazz = getClass().getClassLoader().loadClass("org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor");
-                Constructor constructor = clazz.getConstructor(JUnitPlatformSpec.class, IdGenerator.class, ActorFactory.class, Clock.class);
+                Constructor<?> constructor = clazz.getConstructor(JUnitPlatformSpec.class, IdGenerator.class, ActorFactory.class, Clock.class);
                 return (TestClassProcessor) constructor.newInstance(spec, idGenerator, actorFactory, clock);
             } catch (Exception e) {
                 throw UncheckedException.throwAsUncheckedException(e);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -135,7 +135,7 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         if (!suiteFiles.isEmpty()) {
             testNg.setTestSuites(GFileUtils.toPaths(suiteFiles));
         } else {
-            testNg.setTestClasses(testClasses.toArray(new Class[0]));
+            testNg.setTestClasses(testClasses.toArray(new Class<?>[0]));
         }
         testNg.addListener((Object) adaptListener(new TestNGTestResultProcessorAdapter(resultProcessor, idGenerator, clock)));
         testNg.run();

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    // id "gradlebuild.strict-compile"
 }
 
 gradlebuildJava.usedInWorkers()
@@ -64,6 +63,11 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
 
     integTestRuntimeOnly(project(":testingJunitPlatform"))
+}
+
+strictCompile {
+    ignoreRawTypes() // raw types used in public API (org.gradle.api.tasks.testing.Test)
+    ignoreDeprecations() // uses deprecated software model types
 }
 
 classycle {

--- a/subprojects/testing-native/testing-native.gradle.kts
+++ b/subprojects/testing-native/testing-native.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
+++ b/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     gradlebuild.distribution.`plugins-implementation-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {
@@ -31,5 +30,5 @@ dependencies {
 }
 
 strictCompile {
-    ignoreDeprecations = true
+    ignoreDeprecations()
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
@@ -30,7 +30,7 @@ import java.util.Set;
  * @param <T> the ConfigurableLauncher implementation to return as part of the fluent API.
  * @since 2.6
  * */
-public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends LongRunningOperation {
+public interface ConfigurableLauncher<T extends ConfigurableLauncher<T>> extends LongRunningOperation {
     /**
      * {@inheritDoc}
      * @since 1.0

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
@@ -235,6 +235,7 @@ public interface LongRunningOperation {
      * @return this
      * @since 1.0-milestone-7
      */
+    @SuppressWarnings("overloads")
     LongRunningOperation addProgressListener(ProgressListener listener);
 
     /**
@@ -250,6 +251,7 @@ public interface LongRunningOperation {
      * @return this
      * @since 2.5
      */
+    @SuppressWarnings("overloads")
     LongRunningOperation addProgressListener(org.gradle.tooling.events.ProgressListener listener);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/adapter/ProtocolToModelAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/adapter/ProtocolToModelAdapter.java
@@ -16,6 +16,7 @@
 package org.gradle.tooling.internal.adapter;
 
 import com.google.common.base.Optional;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.time.CountdownTimer;
@@ -198,10 +199,11 @@ public class ProtocolToModelAdapter implements ObjectGraphAdapter {
             }
         }
         if (targetType instanceof Class) {
-            if (((Class) targetType).isPrimitive()) {
+            Class<Object> targetClassType = Cast.uncheckedNonnullCast(targetType);
+            if (targetClassType.isPrimitive()) {
                 return sourceObject;
             }
-            return createView((Class) targetType, sourceObject, decoration, graphDetails);
+            return createView(targetClassType, sourceObject, decoration, graphDetails);
         }
         throw new UnsupportedOperationException(String.format("Cannot convert object of %s to %s.", sourceObject.getClass(), targetType));
     }
@@ -218,7 +220,7 @@ public class ProtocolToModelAdapter implements ObjectGraphAdapter {
         Collection<Object> convertedElements = COLLECTION_MAPPER.createEmptyCollection(collectionClass);
         convertCollectionInternal(convertedElements, targetElementType, sourceObject, decoration, graphDetails);
         if (collectionClass.equals(DomainObjectSet.class)) {
-            return new ImmutableDomainObjectSet(convertedElements);
+            return new ImmutableDomainObjectSet<>(convertedElements);
         } else {
             return convertedElements;
         }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.consumer;
 
 import org.gradle.api.Transformer;
+import org.gradle.internal.Cast;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.GradleConnectionException;
@@ -61,9 +62,9 @@ class DefaultBuildActionExecuter<T> extends AbstractLongRunningOperation<Default
 
     @Override
     public T run() throws GradleConnectionException {
-        BlockingResultHandler<Object> handler = new BlockingResultHandler<Object>(Object.class);
+        BlockingResultHandler<Object> handler = new BlockingResultHandler<>(Object.class);
         run(handler);
-        return (T) handler.getResult();
+        return Cast.uncheckedNonnullCast(handler.getResult());
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultPhasedActionResultListener.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultPhasedActionResultListener.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.consumer;
 
+import org.gradle.internal.Cast;
 import org.gradle.tooling.IntermediateResultHandler;
 import org.gradle.tooling.internal.protocol.PhasedActionResult;
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener;
@@ -48,7 +49,7 @@ public class DefaultPhasedActionResultListener implements PhasedActionResultList
 
     private <T> void onComplete(Object result, @Nullable IntermediateResultHandler<T> handler) {
         if (handler != null) {
-            handler.onComplete((T) result);
+            handler.onComplete(Cast.uncheckedNonnullCast(result));
         }
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapter.java
@@ -73,7 +73,7 @@ class BuildControllerAdapter extends AbstractBuildController implements BuildCon
         validateParameters(parameterType, parameterInitializer);
         if (parameterType != null) {
             // TODO: move this to ObjectFactory
-            P parameter = parameterType.cast(Proxy.newProxyInstance(parameterType.getClassLoader(), new Class[]{parameterType}, new ToolingParameterProxy()));
+            P parameter = parameterType.cast(Proxy.newProxyInstance(parameterType.getClassLoader(), new Class<?>[]{parameterType}, new ToolingParameterProxy()));
             parameterInitializer.execute(parameter);
             return parameter;
         } else {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/InternalBuildActionAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/InternalBuildActionAdapter.java
@@ -23,9 +23,7 @@ import org.gradle.tooling.internal.consumer.converters.ConsumerTargetTypeProvide
 import org.gradle.tooling.internal.consumer.versioning.ModelMapping;
 import org.gradle.tooling.internal.consumer.versioning.VersionDetails;
 import org.gradle.tooling.internal.protocol.BuildResult;
-import org.gradle.tooling.internal.protocol.InternalBuildAction;
 import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
-import org.gradle.tooling.internal.protocol.InternalBuildController;
 import org.gradle.tooling.internal.protocol.InternalBuildControllerVersion2;
 import org.gradle.tooling.internal.protocol.ModelIdentifier;
 
@@ -37,7 +35,7 @@ import java.io.File;
  * Used by consumer connections 1.8+.
  */
 @SuppressWarnings("deprecation")
-public class InternalBuildActionAdapter<T> implements InternalBuildAction<T>, InternalBuildActionVersion2<T> {
+public class InternalBuildActionAdapter<T> implements org.gradle.tooling.internal.protocol.InternalBuildAction<T>, InternalBuildActionVersion2<T> {
     private final BuildAction<T> action;
     private final File rootDir;
     private final VersionDetails versionDetails;
@@ -52,7 +50,7 @@ public class InternalBuildActionAdapter<T> implements InternalBuildAction<T>, In
      * This is used by providers 1.8-rc-1 to 4.3
      */
     @Override
-    public T execute(final InternalBuildController buildController) {
+    public T execute(final org.gradle.tooling.internal.protocol.InternalBuildController buildController) {
         ProtocolToModelAdapter protocolToModelAdapter = new ProtocolToModelAdapter(new ConsumerTargetTypeProvider());
         BuildController buildControllerAdapter = new BuildControllerAdapter(protocolToModelAdapter, new InternalBuildControllerAdapter() {
             @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.tooling.internal.consumer.parameters;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.tooling.Failure;
 import org.gradle.tooling.events.FinishEvent;
@@ -455,7 +456,7 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
         if (!type.isAssignableFrom(descriptorClass)) {
             throw new IllegalStateException(String.format("Unexpected operation type. Required %s but found %s", type.getName(), descriptorClass.getName()));
         }
-        return (T) descriptor;
+        return Cast.uncheckedNonnullCast(descriptor);
     }
 
     private TestOperationDescriptor toTestDescriptor(InternalTestDescriptor descriptor) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
@@ -26,9 +26,7 @@ import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
 import org.gradle.tooling.internal.consumer.CancellationTokenInternal;
 import org.gradle.tooling.internal.consumer.ConnectionParameters;
 import org.gradle.tooling.internal.gradle.TaskListingLaunchable;
-import org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1;
 import org.gradle.tooling.internal.protocol.BuildParameters;
-import org.gradle.tooling.internal.protocol.BuildParametersVersion1;
 import org.gradle.tooling.internal.protocol.InternalLaunchable;
 import org.gradle.tooling.internal.protocol.ProgressListenerVersion1;
 import org.gradle.tooling.model.Launchable;
@@ -47,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 @SuppressWarnings("deprecation")
-public class ConsumerOperationParameters implements BuildOperationParametersVersion1, BuildParametersVersion1, BuildParameters {
+public class ConsumerOperationParameters implements org.gradle.tooling.internal.protocol.BuildOperationParametersVersion1, org.gradle.tooling.internal.protocol.BuildParametersVersion1, BuildParameters {
 
     public static Builder builder() {
         return new Builder();

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -90,6 +90,10 @@ dependencies {
     integTestRuntimeOnly(project(":apiMetadata"))
 }
 
+strictCompile {
+    ignoreRawTypes() // raw types used in public API
+}
+
 classycle {
     excludePatterns.set(listOf("org/gradle/tooling/**"))
 }

--- a/subprojects/tooling-native/tooling-native.gradle.kts
+++ b/subprojects/tooling-native/tooling-native.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/version-control/version-control.gradle.kts
+++ b/subprojects/version-control/version-control.gradle.kts
@@ -15,7 +15,6 @@
  */
 plugins {
     gradlebuild.distribution.`plugins-api-java`
-    gradlebuild.`strict-compile`
 }
 
 dependencies {

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal.worker;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.stream.EncodedStream;
 
@@ -63,7 +64,7 @@ public class GradleWorkerMain {
             implementationClassLoader = getClass().getClassLoader();
         }
 
-        Class<? extends Callable> workerClass = implementationClassLoader.loadClass("org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker").asSubclass(Callable.class);
+        Class<? extends Callable<Void>> workerClass = Cast.uncheckedNonnullCast(implementationClassLoader.loadClass("org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker"));
         Callable<Void> main = workerClass.getConstructor(DataInputStream.class).newInstance(instr);
         main.call();
     }

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
@@ -16,7 +16,6 @@
 
 package org.gradle.process.internal.worker;
 
-import org.gradle.internal.Cast;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.stream.EncodedStream;
 
@@ -64,7 +63,8 @@ public class GradleWorkerMain {
             implementationClassLoader = getClass().getClassLoader();
         }
 
-        Class<? extends Callable<Void>> workerClass = Cast.uncheckedNonnullCast(implementationClassLoader.loadClass("org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker"));
+        @SuppressWarnings("unchecked")
+        Class<? extends Callable<Void>> workerClass = (Class<? extends Callable<Void>>) implementationClassLoader.loadClass("org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker").asSubclass(Callable.class);
         Callable<Void> main = workerClass.getConstructor(DataInputStream.class).newInstance(instr);
         main.call();
     }

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal.worker.child;
 import org.gradle.api.Action;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.initialization.GradleUserHomeDirProvider;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
@@ -148,7 +149,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         Action<WorkerProcessContext> action;
         try {
             ObjectInputStream instr = new ClassLoaderObjectInputStream(new ByteArrayInputStream(serializedWorker), getClass().getClassLoader());
-            action = (Action<WorkerProcessContext>) instr.readObject();
+            action = Cast.uncheckedNonnullCast(instr.readObject());
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -19,7 +19,6 @@ package org.gradle.process.internal.worker.child;
 import org.gradle.api.Action;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.initialization.GradleUserHomeDirProvider;
-import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
@@ -149,7 +148,9 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         Action<WorkerProcessContext> action;
         try {
             ObjectInputStream instr = new ClassLoaderObjectInputStream(new ByteArrayInputStream(serializedWorker), getClass().getClassLoader());
-            action = Cast.uncheckedNonnullCast(instr.readObject());
+            @SuppressWarnings("unchecked")
+            Action<WorkerProcessContext> deserializedAction = (Action<WorkerProcessContext>) instr.readObject();
+            action = deserializedAction;
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolated.IsolationScheme;
@@ -29,16 +30,16 @@ import java.util.Collections;
 
 import static org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader;
 
-public abstract class AbstractClassLoaderWorker implements RequestHandler<TransportableActionExecutionSpec<?>, DefaultWorkResult> {
+public abstract class AbstractClassLoaderWorker implements RequestHandler<TransportableActionExecutionSpec, DefaultWorkResult> {
     private final Worker worker;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
 
     public AbstractClassLoaderWorker(ServiceRegistry workServices, ActionExecutionSpecFactory actionExecutionSpecFactory, InstantiatorFactory instantiatorFactory) {
         this.actionExecutionSpecFactory = actionExecutionSpecFactory;
-        this.worker = new DefaultWorkerServer(workServices, instantiatorFactory, new IsolationScheme<>(WorkAction.class, WorkParameters.class, WorkParameters.None.class), Collections.emptyList());
+        this.worker = new DefaultWorkerServer(workServices, instantiatorFactory, new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class), Collections.emptyList());
     }
 
-    public DefaultWorkResult executeInClassLoader(TransportableActionExecutionSpec<?> spec, ClassLoader workerClassLoader) {
+    public DefaultWorkResult executeInClassLoader(TransportableActionExecutionSpec spec, ClassLoader workerClassLoader) {
         return executeInClassloader(workerClassLoader, new Factory<DefaultWorkResult>() {
             @Nullable
             @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -20,11 +20,11 @@ import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
 public interface ActionExecutionSpecFactory {
-    <T extends WorkParameters> TransportableActionExecutionSpec<T> newTransportableSpec(IsolatedParametersActionExecutionSpec<T> spec);
+    <T extends WorkParameters> TransportableActionExecutionSpec newTransportableSpec(IsolatedParametersActionExecutionSpec<T> spec);
 
     <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, WorkerRequirement workerRequirement, boolean usesInternalServices);
 
     <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(IsolatedParametersActionExecutionSpec<T> spec);
 
-    <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(TransportableActionExecutionSpec<T> spec);
+    <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(TransportableActionExecutionSpec spec);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructureProvider.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructureProvider.java
@@ -63,7 +63,7 @@ public class ClassLoaderStructureProvider {
         classpath.addAll(DefaultClassPath.of(additionalClasspath).getAsURLs());
 
         Set<ClassLoader> uniqueClassloaders = Sets.newHashSet();
-        for (Class clazz : classes) {
+        for (Class<?> clazz : classes) {
             ClassLoader classLoader = clazz.getClassLoader();
             // System types come from the system classloader and their classloader is null.
             if (classLoader != null) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
@@ -38,8 +38,8 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkParameters> TransportableActionExecutionSpec<T> newTransportableSpec(IsolatedParametersActionExecutionSpec<T> spec) {
-        return new TransportableActionExecutionSpec<T>(spec.getImplementationClass().getName(), serialize(spec.getIsolatedParams()), spec.getClassLoaderStructure(), spec.getBaseDir(), spec.isInternalServicesRequired());
+    public <T extends WorkParameters> TransportableActionExecutionSpec newTransportableSpec(IsolatedParametersActionExecutionSpec<T> spec) {
+        return new TransportableActionExecutionSpec(spec.getImplementationClass().getName(), serialize(spec.getIsolatedParams()), spec.getClassLoaderStructure(), spec.getBaseDir(), spec.isInternalServicesRequired());
     }
 
     @Override
@@ -56,7 +56,7 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(TransportableActionExecutionSpec<T> spec) {
+    public <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(TransportableActionExecutionSpec spec) {
         T params = Cast.uncheckedCast(deserialize(spec.getSerializedParameters()).isolate());
         return new SimpleActionExecutionSpec<T>(Cast.uncheckedCast(fromClassName(spec.getImplementationClassName())), params, spec.isInternalServicesRequired());
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -91,7 +91,7 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
 
     @Override
     public void classpath(Iterable<File> files) {
-        GUtil.addToCollection(classpath, Cast.uncheckedNonnullCast(new Iterable<?>[] { files }));
+        GUtil.addToCollection(classpath, Cast.uncheckedNonnullCast(new Iterable<?>[]{files}));
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.internal.DefaultActionConfiguration;
+import org.gradle.internal.Cast;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.util.GUtil;
@@ -90,7 +91,7 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
 
     @Override
     public void classpath(Iterable<File> files) {
-        GUtil.addToCollection(classpath, files);
+        GUtil.addToCollection(classpath, Cast.uncheckedNonnullCast(new Iterable<?>[] { files }));
     }
 
     @Override
@@ -109,6 +110,7 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ForkMode getForkMode() {
         switch (getIsolationMode()) {
             case AUTO:
@@ -124,6 +126,7 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void setForkMode(ForkMode forkMode) {
         switch (forkMode) {
             case AUTO:

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -19,6 +19,7 @@ package org.gradle.workers.internal;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.internal.Actions;
+import org.gradle.internal.Cast;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.isolated.IsolationScheme;
@@ -69,7 +70,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     private final ClassLoaderStructureProvider classLoaderStructureProvider;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private final Instantiator instantiator;
-    private final IsolationScheme<WorkAction, WorkParameters> isolationScheme = new IsolationScheme<>(WorkAction.class, WorkParameters.class, WorkParameters.None.class);
+    private final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class);
     private final File baseDir;
 
     public DefaultWorkerExecutor(WorkerFactory daemonWorkerFactory, WorkerFactory isolatedClassloaderWorkerFactory, WorkerFactory noIsolationWorkerFactory,
@@ -137,6 +138,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void submit(Class<? extends Runnable> actionClass, Action<? super WorkerConfiguration> configAction) {
         DefaultWorkerConfiguration configuration = new DefaultWorkerConfiguration(forkOptionsFactory);
         configAction.execute(configuration);
@@ -305,7 +307,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
                 classes.add(param.getClass());
             }
         }
-        return classes.toArray(new Class[0]);
+        return classes.toArray(new Class<?>[0]);
     }
 
     @Contextual

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -31,10 +31,10 @@ import java.util.Collection;
 public class DefaultWorkerServer implements Worker {
     private final ServiceRegistry internalServices;
     private final InstantiatorFactory instantiatorFactory;
-    private final IsolationScheme<WorkAction, WorkParameters> isolationScheme;
+    private final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme;
     private final Collection<? extends Class<?>> additionalWhitelistedServices;
 
-    public DefaultWorkerServer(ServiceRegistry internalServices, InstantiatorFactory instantiatorFactory, IsolationScheme<WorkAction, WorkParameters> isolationScheme, Collection<? extends Class<?>> additionalWhitelistedServices) {
+    public DefaultWorkerServer(ServiceRegistry internalServices, InstantiatorFactory instantiatorFactory, IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme, Collection<? extends Class<?>> additionalWhitelistedServices) {
         this.internalServices = internalServices;
         this.instantiatorFactory = instantiatorFactory;
         this.isolationScheme = isolationScheme;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/FlatClassLoaderWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/FlatClassLoaderWorker.java
@@ -28,7 +28,7 @@ public class FlatClassLoaderWorker extends AbstractClassLoaderWorker {
     }
 
     @Override
-    public DefaultWorkResult run(TransportableActionExecutionSpec<?> spec) {
+    public DefaultWorkResult run(TransportableActionExecutionSpec spec) {
         return executeInClassLoader(spec, workerClassLoader);
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
@@ -433,8 +433,8 @@ public class IsolatableSerializerRegistry extends DefaultSerializerRegistry {
         public IsolatedEnumValueSnapshot read(Decoder decoder) throws Exception {
             String className = decoder.readString();
             String name = decoder.readString();
-            Class<? extends Enum> enumClass = Cast.uncheckedCast(fromClassName(className));
-            return new IsolatedEnumValueSnapshot(Enum.valueOf(enumClass, name));
+            Class<? extends Enum<?>> enumClass = Cast.uncheckedCast(fromClassName(className));
+            return new IsolatedEnumValueSnapshot(Enum.valueOf(Cast.uncheckedCast(enumClass), name));
         }
 
         @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
@@ -43,7 +43,7 @@ public class IsolatedClassloaderWorker extends AbstractClassLoaderWorker {
     }
 
     @Override
-    public DefaultWorkResult run(TransportableActionExecutionSpec<?> spec) {
+    public DefaultWorkResult run(TransportableActionExecutionSpec spec) {
         GroovySystemLoader workerClasspathGroovy = groovySystemLoaderFactory.forClassLoader(workerClassLoader);
         try {
             return executeInClassLoader(spec, workerClassLoader);

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -49,12 +49,12 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
             public DefaultWorkResult execute(IsolatedParametersActionExecutionSpec<?> spec, BuildOperationRef parentBuildOperation) {
                 return executeWrappedInBuildOperation(spec, parentBuildOperation, workSpec -> {
                     // Serialize the incoming class and parameters
-                    TransportableActionExecutionSpec<?> transportableSpec = actionExecutionSpecFactory.newTransportableSpec(spec);
+                    TransportableActionExecutionSpec transportableSpec = actionExecutionSpecFactory.newTransportableSpec(spec);
 
                     ClassLoader workerInfrastructureClassloader = classLoaderRegistry.getPluginsClassLoader();
                     ClassLoaderStructure classLoaderStructure = ((IsolatedClassLoaderWorkerRequirement) workerRequirement).getClassLoaderStructure();
                     ClassLoader workerClassLoader = IsolatedClassloaderWorker.createIsolatedWorkerClassloader(classLoaderStructure, workerInfrastructureClassloader, legacyTypesSupport);
-                    RequestHandler<TransportableActionExecutionSpec<?>, DefaultWorkResult> worker = new IsolatedClassloaderWorker(workerClassLoader, internalServices, actionExecutionSpecFactory, instantiatorFactory);
+                    RequestHandler<TransportableActionExecutionSpec, DefaultWorkResult> worker = new IsolatedClassloaderWorker(workerClassLoader, internalServices, actionExecutionSpecFactory, instantiatorFactory);
                     return worker.run(transportableSpec);
                 });
             }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -40,7 +41,7 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
     public NoIsolationWorkerFactory(BuildOperationExecutor buildOperationExecutor, InstantiatorFactory instantiatorFactory, ActionExecutionSpecFactory specFactory, ServiceRegistry internalServices) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.specFactory = specFactory;
-        IsolationScheme<WorkAction, WorkParameters> isolationScheme = new IsolationScheme<>(WorkAction.class, WorkParameters.class, WorkParameters.None.class);
+        IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedNonnullCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class);
         workerServer = new DefaultWorkerServer(internalServices, instantiatorFactory, isolationScheme, Collections.singleton(WorkerExecutor.class));
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
@@ -16,11 +16,9 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.WorkParameters;
-
 import java.io.File;
 
-public class TransportableActionExecutionSpec<T extends WorkParameters> {
+public class TransportableActionExecutionSpec {
     protected final String implementationClassName;
     private final byte[] serializedParameters;
     private final ClassLoaderStructure classLoaderStructure;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -25,7 +25,7 @@ import org.gradle.process.internal.worker.WorkerProcess;
 class WorkerDaemonClient implements Stoppable {
     public static final String DISABLE_EXPIRATION_PROPERTY_KEY = "org.gradle.workers.internal.disable-daemons-expiration";
     private final DaemonForkOptions forkOptions;
-    private final MultiRequestClient<TransportableActionExecutionSpec<?>, DefaultWorkResult> workerClient;
+    private final MultiRequestClient<TransportableActionExecutionSpec, DefaultWorkResult> workerClient;
     private final WorkerProcess workerProcess;
     private final LogLevel logLevel;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
@@ -33,7 +33,7 @@ class WorkerDaemonClient implements Stoppable {
     private boolean failed;
     private boolean cannotBeExpired = Boolean.getBoolean(DISABLE_EXPIRATION_PROPERTY_KEY);
 
-    public WorkerDaemonClient(DaemonForkOptions forkOptions, MultiRequestClient<TransportableActionExecutionSpec<?>, DefaultWorkResult> workerClient, WorkerProcess workerProcess, LogLevel logLevel, ActionExecutionSpecFactory actionExecutionSpecFactory) {
+    public WorkerDaemonClient(DaemonForkOptions forkOptions, MultiRequestClient<TransportableActionExecutionSpec, DefaultWorkResult> workerClient, WorkerProcess workerProcess, LogLevel logLevel, ActionExecutionSpecFactory actionExecutionSpecFactory) {
         this.forkOptions = forkOptions;
         this.workerClient = workerClient;
         this.workerProcess = workerProcess;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -52,7 +52,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
-public class WorkerDaemonServer implements RequestHandler<TransportableActionExecutionSpec<?>, DefaultWorkResult> {
+public class WorkerDaemonServer implements RequestHandler<TransportableActionExecutionSpec, DefaultWorkResult> {
     private final ServiceRegistry internalServices;
     private final LegacyTypesSupport legacyTypesSupport;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
@@ -78,10 +78,10 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
     }
 
     @Override
-    public DefaultWorkResult run(TransportableActionExecutionSpec<?> spec) {
+    public DefaultWorkResult run(TransportableActionExecutionSpec spec) {
         try {
             try (WorkerProjectServices internalServices = new WorkerProjectServices(spec.getBaseDir(), this.internalServices)) {
-                RequestHandler<TransportableActionExecutionSpec<?>, DefaultWorkResult> worker = getIsolatedClassloaderWorker(spec.getClassLoaderStructure(), internalServices);
+                RequestHandler<TransportableActionExecutionSpec, DefaultWorkResult> worker = getIsolatedClassloaderWorker(spec.getClassLoaderStructure(), internalServices);
                 return worker.run(spec);
             }
         } catch (Throwable t) {
@@ -89,7 +89,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
         }
     }
 
-    private RequestHandler<TransportableActionExecutionSpec<?>, DefaultWorkResult> getIsolatedClassloaderWorker(ClassLoaderStructure classLoaderStructure, ServiceRegistry workServices) {
+    private RequestHandler<TransportableActionExecutionSpec, DefaultWorkResult> getIsolatedClassloaderWorker(ClassLoaderStructure classLoaderStructure, ServiceRegistry workServices) {
         if (classLoaderStructure instanceof FlatClassLoaderStructure) {
             return new FlatClassLoaderWorker(this.getClass().getClassLoader(), workServices, actionExecutionSpecFactory, instantiatorFactory);
         } else {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -52,7 +52,7 @@ public class WorkerDaemonStarter {
     public WorkerDaemonClient startDaemon(DaemonForkOptions forkOptions, Action<WorkerProcess> cleanupAction) {
         LOG.debug("Starting Gradle worker daemon with fork options {}.", forkOptions);
         Timer clock = Time.startTimer();
-        MultiRequestWorkerProcessBuilder<TransportableActionExecutionSpec<?>, DefaultWorkResult> builder = workerDaemonProcessFactory.multiRequestWorker(WorkerDaemonServer.class);
+        MultiRequestWorkerProcessBuilder<TransportableActionExecutionSpec, DefaultWorkResult> builder = workerDaemonProcessFactory.multiRequestWorker(WorkerDaemonServer.class);
         builder.setBaseName("Gradle Worker Daemon");
         builder.setLogLevel(loggingManager.getLevel()); // NOTE: might make sense to respect per-compile-task log level
         builder.sharedPackages("org.gradle", "javax.inject");
@@ -68,7 +68,7 @@ public class WorkerDaemonStarter {
         JavaExecHandleBuilder javaCommand = builder.getJavaCommand();
         forkOptions.getJavaForkOptions().copyTo(javaCommand);
         builder.registerArgumentSerializer(TransportableActionExecutionSpec.class, new TransportableActionExecutionSpecSerializer());
-        MultiRequestClient<TransportableActionExecutionSpec<?>, DefaultWorkResult> workerDaemonProcess = builder.build();
+        MultiRequestClient<TransportableActionExecutionSpec, DefaultWorkResult> workerDaemonProcess = builder.build();
         WorkerProcess workerProcess = workerDaemonProcess.start();
 
         WorkerDaemonClient client = new WorkerDaemonClient(forkOptions, workerDaemonProcess, workerProcess, loggingManager.getLevel(), actionExecutionSpecFactory);

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -235,13 +235,13 @@ public class Install {
     }
 
     private void unzip(File zip, File dest) throws IOException {
-        Enumeration entries;
+        Enumeration<? extends ZipEntry> entries;
         ZipFile zipFile = new ZipFile(zip);
         try {
             entries = zipFile.entries();
 
             while (entries.hasMoreElements()) {
-                ZipEntry entry = (ZipEntry) entries.nextElement();
+                ZipEntry entry = entries.nextElement();
 
                 if (entry.isDirectory()) {
                     (new File(dest, entry.getName())).mkdirs();

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -235,13 +235,13 @@ public class Install {
     }
 
     private void unzip(File zip, File dest) throws IOException {
-        Enumeration<? extends ZipEntry> entries;
+        Enumeration entries;
         ZipFile zipFile = new ZipFile(zip);
         try {
             entries = zipFile.entries();
 
             while (entries.hasMoreElements()) {
-                ZipEntry entry = entries.nextElement();
+                ZipEntry entry = (ZipEntry) entries.nextElement();
 
                 if (entry.isDirectory()) {
                     (new File(dest, entry.getName())).mkdirs();

--- a/subprojects/wrapper/wrapper.gradle.kts
+++ b/subprojects/wrapper/wrapper.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     crossVersionTestRuntimeOnly(project(":runtimeApiInfo"))
 }
 
+strictCompile {
+    ignoreRawTypes() // Raw type used in 'org.gradle.wrapper.Install', consider fixing next time the wrapper code needs changes
+}
+
 tasks.register<Jar>("executableJar") {
     archiveFileName.set("gradle-wrapper.jar")
     manifest {


### PR DESCRIPTION
This make compilation fail on compiler warnings and fixes many of the warnings for all Java subprojects in our build.

Some projects do `ignoreRawTypes()` and/or `ignoreDeprecations()` if there are many of such warning for a good reason which we won't address now.

We have a few var args APIs that cause a ` [unchecked] Possible heap pollution from parameterized vararg type...` warning. As far as I can tell, there is no way to suppress the warning except from adding a `@SafeVarargs` annotation. Which you can't do for non-final methods. So `ignoreParameterizedVarargType()` turns off `-Werror` for the projects having this issue.

Four projects remain to be checked (for now `-Werror` is turned off for these to let the build succeed):
- `core`
- `dependency-management`
- `ide`