### PR TITLE
Tell JaCoCo to ignore kotlin-dsl generated files

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Generated.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Generated.java
@@ -24,10 +24,13 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated member code was generated.
+ *
+ * @since 6.5
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
 @Documented
+@Incubating
 @SuppressWarnings("unused")
 public @interface Generated {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/Generated.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Generated.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated member code was generated.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@Documented
+@SuppressWarnings("unused")
+public @interface Generated {
+}

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
@@ -1,0 +1,63 @@
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.junit.Test
+
+
+@LeaksFileHandles("Kotlin Compiler Daemon working directory")
+class JacocoIntegrationTest : AbstractPluginIntegrationTest() {
+
+    @Test
+    @ToBeFixedForInstantExecution
+    fun `jacoco ignore codegen`() {
+
+        requireGradleDistributionOnEmbeddedExecuter()
+
+        withBuildScript("""
+            plugins {
+                `kotlin-dsl`
+                jacoco
+            }
+            ${jcenterRepository(GradleDsl.KOTLIN)}
+            dependencies {
+                testImplementation("junit:junit:4.12")
+            }
+            tasks {
+                test {
+                    useJUnit()
+                }
+                jacocoTestCoverageVerification {
+                    violationRules {
+                        rule {
+                            element = "CLASS"
+                            includes = listOf("org.gradle.*", "gradle.*")
+                            limit {
+                                minimum = 1.toBigDecimal()
+                            }
+                        }
+                        rule {
+                            element = "METHOD"
+                            includes = listOf("org.gradle.*", "gradle.*")
+                            limit {
+                                minimum = 1.toBigDecimal()
+                            }
+                        }
+                    }
+                }
+            }
+        """)
+
+        withFile("src/main/kotlin/foo.gradle.kts", "plugins { base }")
+        withFile("src/test/kotlin/fooTest.kt", """
+            import org.junit.Test
+            class FooTest {
+                @Test fun testFoo() { }
+            }""".trimIndent()
+        )
+
+        build("test", "jacocoTestCoverageVerification")
+    }
+}

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -86,8 +86,8 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             }
         """)
 
-        val fooScript = withFile("src/main/kotlin/foo.gradle.kts", "plugins { base }")
-        val fooTest = withFile("src/test/kotlin/fooTest.kt", """
+        withFile("src/main/kotlin/foo.gradle.kts", "plugins { base }")
+        withFile("src/test/kotlin/fooTest.kt", """
             import org.junit.Test
             class FooTest {
                 @Test fun testFoo() { }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -48,57 +48,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     @ToBeFixedForInstantExecution
-    fun `generated code is ignored by JaCoCo`() {
-
-        requireGradleDistributionOnEmbeddedExecuter()
-
-        withBuildScript("""
-            plugins {
-                `kotlin-dsl`
-                jacoco
-            }
-            ${jcenterRepository(GradleDsl.KOTLIN)}
-            dependencies {
-                testImplementation("junit:junit:4.12")
-            }
-            tasks {
-                test {
-                    useJUnit()
-                }
-                jacocoTestCoverageVerification {
-                    violationRules {
-                        rule {
-                            element = "CLASS"
-                            includes = listOf("org.gradle.*", "gradle.*")
-                            limit {
-                                minimum = 1.toBigDecimal()
-                            }
-                        }
-                        rule {
-                            element = "METHOD"
-                            includes = listOf("org.gradle.*", "gradle.*")
-                            limit {
-                                minimum = 1.toBigDecimal()
-                            }
-                        }
-                    }
-                }
-            }
-        """)
-
-        withFile("src/main/kotlin/foo.gradle.kts", "plugins { base }")
-        withFile("src/test/kotlin/fooTest.kt", """
-            import org.junit.Test
-            class FooTest {
-                @Test fun testFoo() { }
-            }""".trimIndent()
-        )
-
-        build("test", "jacocoTestCoverageVerification")
-    }
-
-    @Test
-    @ToBeFixedForInstantExecution
     fun `precompiled script plugins tasks are cached and relocatable`() {
 
         requireGradleDistributionOnEmbeddedExecuter()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -259,6 +259,7 @@ fun BufferedWriter.appendSourceCodeForPluginAccessors(
                     /**
                      * The `$id` plugin group.
                      */
+                    @org.gradle.api.Generated
                     class `$groupType`(internal val plugins: PluginDependenciesSpec)
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/SourceFileHeader.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/SourceFileHeader.kt
@@ -36,6 +36,7 @@ fun fileHeaderFor(packageName: String) =
     "RemoveRedundantBackticks",
     "ObjectPropertyName"
 )
+@file:org.gradle.api.Generated
 
 /* ktlint-disable */
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPathTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPathTest.kt
@@ -107,6 +107,7 @@ class PluginAccessorsClassPathTest : TestWithClassPath() {
                     /**
                      * The `my` plugin group.
                      */
+                    @org.gradle.api.Generated
                     class `MyPluginGroup`(internal val plugins: PluginDependenciesSpec)
 
 
@@ -120,6 +121,7 @@ class PluginAccessorsClassPathTest : TestWithClassPath() {
                     /**
                      * The `my.own` plugin group.
                      */
+                    @org.gradle.api.Generated
                     class `MyOwnPluginGroup`(internal val plugins: PluginDependenciesSpec)
 
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -64,7 +64,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
             ClassAndGroovyNamedArguments::class
         ) {
 
-            assertGeneratedJarHash("c42d6067815922bce1c3f67afcd96e7f")
+            assertGeneratedJarHash("b429469f8feb02fe9435b6bf7de2f7a5")
         }
     }
 
@@ -376,7 +376,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
 
     private
     fun apiJarsWith(vararg classes: KClass<*>): List<File> =
-        jarClassPathWith("gradle-api.jar", *classes).asFiles
+        jarClassPathWith("gradle-api.jar", *classes, org.gradle.api.Generated::class).asFiles
 
     private
     fun fixturesApiMetadataJar(): File =

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -7,13 +7,14 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
+import org.gradle.api.Generated
 
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_API
 import org.gradle.api.internal.classpath.Module
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 
-import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
+import org.gradle.kotlin.dsl.accessors.TestWithClassPath
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -21,12 +22,12 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
 
-class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
+class KotlinScriptClassPathProviderTest : TestWithClassPath() {
 
     @Test
     fun `should report progress based on the number of entries in gradle-api jar`() {
 
-        val gradleApiJar = file("gradle-api-3.1.jar")
+        val gradleApiJar = jarClassPathWith("gradle-api-3.1.jar", Generated::class).asFiles
 
         val generatedKotlinExtensions = file("kotlin-dsl-extensions.jar")
 
@@ -39,15 +40,15 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
         val subject = KotlinScriptClassPathProvider(
             moduleRegistry = mock { on { getExternalModule(any()) } doReturn apiMetadataModule },
-            classPathRegistry = mock { on { getClassPath(GRADLE_API.name) } doReturn ClassPath.EMPTY },
+            classPathRegistry = mock { on { getClassPath(GRADLE_API.name) } doReturn DefaultClassPath.of(gradleApiJar) },
             coreAndPluginsScope = mock(),
-            gradleApiJarsProvider = { listOf(gradleApiJar) },
+            gradleApiJarsProvider = { gradleApiJar },
             jarCache = { id, generator -> file("$id.jar").apply(generator) },
             progressMonitorProvider = progressMonitorProvider)
 
         assertThat(
             subject.gradleKotlinDsl.asFiles.toList(),
-            equalTo(listOf(gradleApiJar, generatedKotlinExtensions)))
+            equalTo(gradleApiJar + generatedKotlinExtensions))
 
         verifyProgressMonitor(kotlinExtensionsMonitor)
     }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -11,7 +11,6 @@ import org.gradle.api.Generated
 
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_API
 import org.gradle.api.internal.classpath.Module
-import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 
 import org.gradle.kotlin.dsl.accessors.TestWithClassPath


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #10956

Here's what JaCoCo verification outputs for a single empty precompiled script plugin
https://scans.gradle.com/s/2imyhaxpz3yww/console-log?task=:jacocoTestCoverageVerification

### Context
As stated in the issue #10956 the code generated by Gradle affects severely to our coverage.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
