### PR TITLE
Only use the snapshot hierarchy lock

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/internal/vfs/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/vfs/AbstractFileWatcherUpdaterTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.snapshot.CompleteDirectorySnapshot
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileMetadata
 import org.gradle.internal.snapshot.RegularFileSnapshot
+import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.snapshot.impl.DirectorySnapshotter
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.vfs.impl.DelegatingDiffCapturingUpdateFunctionDecorator
@@ -52,7 +53,10 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
 
     def setup() {
         updater = createUpdater(watcher)
-        decorator.setSnapshotDiffListener(updater)
+        decorator.setSnapshotDiffListener(updater) { SnapshotHierarchy currentRoot, Runnable runnable ->
+            runnable.run()
+            return currentRoot
+        }
     }
 
     abstract FileWatcherUpdater createUpdater(FileWatcher watcher)

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/WatchingVirtualFileSystem.java
@@ -52,9 +52,15 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     private final DelegatingDiffCapturingUpdateFunctionDecorator delegatingUpdateFunctionDecorator;
     private final AtomicReference<FileHierarchySet> producedByCurrentBuild = new AtomicReference<>(DefaultFileHierarchySet.of());
     private final Predicate<String> watchFilter;
-    private final SnapshotHierarchy.SnapshotDiffListener snapshotDiffListener = (removedSnapshots, addedSnapshots) -> updateWatchRegistry(watchRegistry -> watchRegistry.getFileWatcherUpdater().changed(removedSnapshots, addedSnapshots));
 
     private FileWatcherRegistry watchRegistry;
+
+    private final SnapshotHierarchy.SnapshotDiffListener snapshotDiffListener = (removedSnapshots, addedSnapshots) -> {
+        if (watchRegistry != null) {
+            watchRegistry.getFileWatcherUpdater().changed(removedSnapshots, addedSnapshots);
+        }
+    };
+
     private volatile boolean buildRunning;
 
     public WatchingVirtualFileSystem(
@@ -71,27 +77,32 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
 
     @Override
     public void afterBuildStarted(boolean watchingEnabled) {
-        if (watchingEnabled) {
-            startWatching();
-            handleWatcherRegistryEvents("since last build");
-            printStatistics("retained", "since last build");
-            producedByCurrentBuild.set(DefaultFileHierarchySet.of());
-            buildRunning = true;
-        } else {
-            stopWatching();
-        }
+        getRoot().update(currentRoot -> {
+            if (watchingEnabled) {
+                SnapshotHierarchy newRoot = handleWatcherRegistryEvents(currentRoot, "since last build");
+                newRoot = startWatching(newRoot);
+                printStatistics(newRoot, "retained", "since last build");
+                producedByCurrentBuild.set(DefaultFileHierarchySet.of());
+                buildRunning = true;
+                return newRoot;
+            } else {
+                return stopWatching(currentRoot);
+            }
+        });
     }
 
     private void updateWatchRegistry(Consumer<FileWatcherRegistry> updateFunction) {
         updateWatchRegistry(updateFunction, () -> {});
     }
 
-    private synchronized void updateWatchRegistry(Consumer<FileWatcherRegistry> updateFunction, Runnable noWatchRegistry) {
-        if (watchRegistry == null) {
-            noWatchRegistry.run();
-        } else {
-            handleWatcherChanges(updateFunction);
-        }
+    private void updateWatchRegistry(Consumer<FileWatcherRegistry> updateFunction, Runnable noWatchRegistry) {
+        getRoot().update(currentRoot -> {
+            if (watchRegistry == null) {
+                noWatchRegistry.run();
+                return currentRoot;
+            }
+            return handleWatcherChangeErrors(currentRoot, () -> updateFunction.accept(watchRegistry));
+        });
     }
 
     @Override
@@ -102,11 +113,13 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     @Override
     public void beforeBuildFinished(boolean watchingEnabled) {
         if (watchingEnabled) {
-            handleWatcherRegistryEvents("for current build");
-            buildRunning = false;
-            producedByCurrentBuild.set(DefaultFileHierarchySet.of());
-            printStatistics("retains", "till next build");
-            updateWatchRegistry(watchRegistry -> {}, this::invalidateAll);
+            getRoot().update(currentRoot -> {
+                buildRunning = false;
+                producedByCurrentBuild.set(DefaultFileHierarchySet.of());
+                SnapshotHierarchy newRoot = handleWatcherRegistryEvents(currentRoot, "for current build");
+                printStatistics(newRoot, "retains", "till next build");
+                return newRoot;
+            });
         } else {
             invalidateAll();
         }
@@ -115,9 +128,9 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     /**
      * Start watching the known areas of the file system for changes.
      */
-    private synchronized void startWatching() {
+    private SnapshotHierarchy startWatching(SnapshotHierarchy currentRoot) {
         if (watchRegistry != null) {
-            return;
+            return currentRoot;
         }
         try {
             long startTime = System.currentTimeMillis();
@@ -131,8 +144,10 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
                             getRoot().update(root -> {
                                 SnapshotCollectingDiffListener diffListener = new SnapshotCollectingDiffListener(watchFilter);
                                 SnapshotHierarchy newRoot = root.invalidate(absolutePath, diffListener);
-                                diffListener.publishSnapshotDiff(snapshotDiffListener);
-                                return newRoot;
+                                return handleWatcherChangeErrors(
+                                    newRoot,
+                                    () -> diffListener.publishSnapshotDiff(snapshotDiffListener)
+                                );
                             });
                         }
                     } catch (Exception e) {
@@ -147,65 +162,73 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
                     stopWatching();
                 }
             });
-            getRoot().update(SnapshotHierarchy::empty);
-            delegatingUpdateFunctionDecorator.setSnapshotDiffListener(snapshotDiffListener);
+            delegatingUpdateFunctionDecorator.setSnapshotDiffListener(snapshotDiffListener, this::handleWatcherChangeErrors);
             long endTime = System.currentTimeMillis() - startTime;
             LOGGER.warn("Spent {} ms registering watches for file system events", endTime);
+            // TODO: Move start watching early enough so that the root is always empty
+            return currentRoot.empty();
         } catch (Exception ex) {
             LOGGER.error("Couldn't create watch service, not tracking changes between builds", ex);
-            invalidateAll();
-            close();
+            closeUnderLock();
         }
+        return currentRoot.empty();
     }
 
-    private void handleWatcherChanges(Consumer<FileWatcherRegistry> consumer) {
+    private SnapshotHierarchy handleWatcherChangeErrors(SnapshotHierarchy currentRoot, Runnable runnable) {
         try {
-            consumer.accept(watchRegistry);
+            runnable.run();
+            return currentRoot;
         } catch (WatchingNotSupportedException ex) {
             // No stacktrace here, since this is a known shortcoming of our implementation
             LOGGER.warn("Watching not supported, not tracking changes between builds: {}", ex.getMessage());
-            stopWatching();
+            return stopWatching(currentRoot);
         } catch (Exception ex) {
             LOGGER.error("Couldn't update watches, not watching anymore", ex);
-            stopWatching();
+            return stopWatching(currentRoot);
         }
     }
 
     /**
      * Stop watching the known areas of the file system, and invalidate
-     * the parts that have been changed since calling {@link #startWatching()}}.
+     * the parts that have been changed since calling {@link #startWatching(SnapshotHierarchy)}}.
      */
     private void stopWatching() {
-        updateWatchRegistry(fileWatcherRegistry -> {
+        getRoot().update(this::stopWatching);
+    }
+
+    private SnapshotHierarchy stopWatching(SnapshotHierarchy currentRoot) {
+        if (watchRegistry != null) {
             try {
+                FileWatcherRegistry toBeClosed = watchRegistry;
                 watchRegistry = null;
-                delegatingUpdateFunctionDecorator.setSnapshotDiffListener(null);
-                fileWatcherRegistry.close();
+                delegatingUpdateFunctionDecorator.stopListening();
+                toBeClosed.close();
             } catch (IOException ex) {
                 LOGGER.error("Couldn't fetch file changes, dropping VFS state", ex);
-                getRoot().update(SnapshotHierarchy::empty);
             }
-        });
-        getRoot().update(SnapshotHierarchy::empty);
+        }
+        return currentRoot.empty();
     }
 
-    private void handleWatcherRegistryEvents(String eventsFor) {
-        updateWatchRegistry(watchRegistry -> {
-            FileWatcherRegistry.FileWatchingStatistics statistics = watchRegistry.getAndResetStatistics();
-            LOGGER.warn("Received {} file system events {}", statistics.getNumberOfReceivedEvents(), eventsFor);
-            if (statistics.isUnknownEventEncountered()) {
-                LOGGER.warn("Dropped VFS state due to lost state");
-                stopWatching();
-            }
-            if (statistics.getErrorWhileReceivingFileChanges().isPresent()) {
-                LOGGER.warn("Dropped VFS state due to error while receiving file changes", statistics.getErrorWhileReceivingFileChanges().get());
-                stopWatching();
-            }
-        });
+    private SnapshotHierarchy handleWatcherRegistryEvents(SnapshotHierarchy currentRoot, String eventsFor) {
+        if (watchRegistry == null) {
+            return currentRoot.empty();
+        }
+        FileWatcherRegistry.FileWatchingStatistics statistics = watchRegistry.getAndResetStatistics();
+        LOGGER.warn("Received {} file system events {}", statistics.getNumberOfReceivedEvents(), eventsFor);
+        if (statistics.isUnknownEventEncountered()) {
+            LOGGER.warn("Dropped VFS state due to lost state");
+            return stopWatching(currentRoot);
+        }
+        if (statistics.getErrorWhileReceivingFileChanges().isPresent()) {
+            LOGGER.warn("Dropped VFS state due to error while receiving file changes", statistics.getErrorWhileReceivingFileChanges().get());
+            return stopWatching(currentRoot);
+        }
+        return currentRoot;
     }
 
-    private void printStatistics(String verb, String statisticsFor) {
-        VirtualFileSystemStatistics statistics = getStatistics();
+    private static void printStatistics(SnapshotHierarchy root, String verb, String statisticsFor) {
+        VirtualFileSystemStatistics statistics = getStatistics(root);
         LOGGER.warn(
             "Virtual file system {} information about {} files, {} directories and {} missing files {}",
             verb,
@@ -216,23 +239,9 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
         );
     }
 
-    @Override
-    public void update(Iterable<String> locations, Runnable action) {
-        if (buildRunning) {
-            producedByCurrentBuild.updateAndGet(currentValue -> {
-                FileHierarchySet newValue = currentValue;
-                for (String location : locations) {
-                    newValue = newValue.plus(new File(location));
-                }
-                return newValue;
-            });
-        }
-        super.update(locations, action);
-    }
-
-    private VirtualFileSystemStatistics getStatistics() {
+    private static VirtualFileSystemStatistics getStatistics(SnapshotHierarchy root) {
         EnumMultiset<FileType> retained = EnumMultiset.create(FileType.class);
-        getRoot().get().visitSnapshotRoots(snapshot -> snapshot.accept(new FileSystemSnapshotVisitor() {
+        root.visitSnapshotRoots(snapshot -> snapshot.accept(new FileSystemSnapshotVisitor() {
             @Override
             public boolean preVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
                 retained.add(directorySnapshot.getType());
@@ -264,15 +273,37 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     }
 
     @Override
+    public void update(Iterable<String> locations, Runnable action) {
+        if (buildRunning) {
+            producedByCurrentBuild.updateAndGet(currentValue -> {
+                FileHierarchySet newValue = currentValue;
+                for (String location : locations) {
+                    newValue = newValue.plus(new File(location));
+                }
+                return newValue;
+            });
+        }
+        super.update(locations, action);
+    }
+
+    @Override
     public void close() {
+        getRoot().update(currentRoot -> {
+            closeUnderLock();
+            return currentRoot.empty();
+        });
+    }
+
+    private void closeUnderLock() {
         producedByCurrentBuild.set(DefaultFileHierarchySet.of());
-        updateWatchRegistry(fileWatcherRegistry -> {
+        if (watchRegistry != null) {
             try {
-                fileWatcherRegistry.close();
+                watchRegistry.close();
             } catch (IOException ex) {
                 LOGGER.error("Couldn't close watch service", ex);
+            } finally {
+                watchRegistry = null;
             }
-            watchRegistry = null;
-        });
+        }
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/watch/FileWatcherUpdater.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/watch/FileWatcherUpdater.java
@@ -31,7 +31,7 @@ public interface FileWatcherUpdater extends SnapshotHierarchy.SnapshotDiffListen
     void updateMustWatchDirectories(Collection<File> updatedWatchDirectories);
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc}.
      *
      * @throws WatchingNotSupportedException when the native watchers can't be updated.
      */

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -54,7 +54,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         _ * delegate.getRoot() >> new AtomicSnapshotHierarchyReference(snapshotHierarchy)
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * capturingUpdateFunctionDecorator.setSnapshotDiffListener(_)
+        1 * capturingUpdateFunctionDecorator.setSnapshotDiffListener(_, _)
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         0 * _
 
@@ -71,7 +71,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         1 * delegate.root >> rootReference
         1 * rootHierarchy.empty()
         1 * watcherRegistry.close()
-        1 * capturingUpdateFunctionDecorator.setSnapshotDiffListener(null)
+        1 * capturingUpdateFunctionDecorator.stopListening()
         0 * _
     }
 
@@ -82,7 +82,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         _ * delegate.getRoot() >> new AtomicSnapshotHierarchyReference(snapshotHierarchy)
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
-        1 * capturingUpdateFunctionDecorator.setSnapshotDiffListener(_)
+        1 * capturingUpdateFunctionDecorator.setSnapshotDiffListener(_, _)
         0 * _
 
         when:


### PR DESCRIPTION
and not a second lock for the watcher registry.
This makes deadlocks impossible and simplifies
invalidating the VFS when we fail to update
the watchers.