### PR TITLE
Remove test precondition: FIX_TO_WORK_ON_JAVA9

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIncrementalAnalysisIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIncrementalAnalysisIntegrationTest.groovy
@@ -42,7 +42,7 @@ class PmdPluginIncrementalAnalysisIntegrationTest extends AbstractPmdPluginVersi
                 classpath = files()
             }"""}
 
-            ${!TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled ? "sourceCompatibility = 1.7" : ""}
+            ${TestPrecondition.JDK9_OR_LATER.fulfilled ? "sourceCompatibility = 1.7" : ""}
         """.stripIndent()
     }
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -40,7 +40,7 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
 
                 apply plugin: 'java'
 
-                ${!TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled ? "sourceCompatibility = 1.7" : ""}
+                ${TestPrecondition.JDK9_OR_LATER.fulfilled ? "sourceCompatibility = 1.7" : ""}
             }
 
             project("pmd-rule") {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -45,7 +45,7 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
                 classpath = files()
             }"""}
 
-            ${!TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled ? "sourceCompatibility = 1.7" : ""}
+            ${TestPrecondition.JDK9_OR_LATER.fulfilled ? "sourceCompatibility = 1.7" : ""}
         """.stripIndent()
     }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -109,9 +109,6 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK13_OR_EARLIER({
         JavaVersion.current() <= JavaVersion.VERSION_13
     }),
-    FIX_TO_WORK_ON_JAVA9({
-        JDK8_OR_EARLIER.fulfilled
-    }),
     JDK_ORACLE({
         System.getProperty('java.vm.vendor') == 'Oracle Corporation'
     }),

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -19,23 +19,19 @@ package org.gradle.api.publish.ivy
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ProgressLoggingFixture
-import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.AuthScheme
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
 import org.gradle.util.GradleVersion
-import org.gradle.util.Requires
 import org.hamcrest.CoreMatchers
 import org.junit.Rule
 import org.mortbay.jetty.HttpStatus
-import spock.lang.Issue
 import spock.lang.Unroll
 
 import static org.gradle.test.matchers.UserAgentMatcher.matchesNameAndVersion
 import static org.gradle.util.Matchers.matchesRegexp
-import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
 
 class IvyPublishHttpIntegTest extends AbstractIvyPublishIntegTest {
     private static final int HTTP_UNRECOVERABLE_ERROR = 415
@@ -381,13 +377,14 @@ credentials {
         !module.ivy.file.text.contains(MetaDataParser.GRADLE_6_METADATA_MARKER)
     }
 
-    @Requires(FIX_TO_WORK_ON_JAVA9)
-    @Issue('provide a different large jar')
     @ToBeFixedForInstantExecution
-    public void "can publish large artifact (tools.jar) to authenticated repository"() {
+    void "can publish large artifact to authenticated repository"() {
         given:
         server.start()
-        def toolsJar = Jvm.current().toolsJar
+        def largeJar = file("large.jar")
+        new RandomAccessFile(largeJar, "rw").withCloseable {
+            it.length = 1024 * 1024 * 10 // 10 mb
+        }
 
         settingsFile << 'rootProject.name = "publish"'
         buildFile << """
@@ -410,7 +407,7 @@ credentials {
                     ivy(IvyPublication) {
                         configurations {
                             runtime {
-                                artifact('${toolsJar.toURI()}') {
+                                artifact('${largeJar.toURI()}') {
                                     name 'publish'
                                 }
                             }
@@ -436,7 +433,7 @@ credentials {
         then:
         module.assertIvyAndJarFilePublished()
         module.ivyFile.assertIsFile()
-        module.jarFile.assertIsCopyOf(new TestFile(toolsJar))
+        module.jarFile.assertIsCopyOf(new TestFile(largeJar))
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -835,7 +835,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         failureHasCause("Cannot specify -J flags via `CompileOptions.compilerArgs`. Use the `CompileOptions.forkOptions.jvmArgs` property instead.")
     }
 
-    @Requires(adhoc = { AvailableJavaHomes.getJdk7() && AvailableJavaHomes.getJdk8() && TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled })
+    @Requires(adhoc = { AvailableJavaHomes.getJdk7() && AvailableJavaHomes.getJdk8() && TestPrecondition.JDK8_OR_EARLIER.fulfilled }) // bootclasspath has been removed in Java 9+
     def "bootclasspath can be set"() {
         def jdk7 = AvailableJavaHomes.getJdk7()
         def jdk7bootClasspath = TextUtil.escapeString(jdk7.jre.homeDir.absolutePath) + "/lib/rt.jar"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaCompilationAgainstApiJarIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaCompilationAgainstApiJarIntegrationTest.groovy
@@ -19,13 +19,12 @@ package org.gradle.language.java
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Ignore
-import spock.lang.Issue
 import spock.lang.Unroll
 
 import static org.gradle.language.java.JavaIntegrationTesting.applyJavaPlugin
 import static org.gradle.language.java.JavaIntegrationTesting.expectJavaLangPluginDeprecationWarnings
-import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
 
 class JavaCompilationAgainstApiJarIntegrationTest extends AbstractIntegrationSpec {
 
@@ -209,7 +208,6 @@ public class PersonInternal extends Person {
     }
 
     @Unroll
-    @Issue('Need to investigate the reason for the Java 9 failure')
     @ToBeFixedForInstantExecution
     def "changing comment in API class should not trigger recompilation of the consuming library when API is #apiDeclared"() {
         given:
@@ -261,7 +259,7 @@ public class Person {
     }
 
     @Unroll
-    @Requires(FIX_TO_WORK_ON_JAVA9)
+    @Requires(TestPrecondition.JDK8_OR_EARLIER) // behavior changed with Java 9; we do not investigate as this tests a deprecated feature to be removed in Gradle 7.0
     @ToBeFixedForInstantExecution
     def "changing method body of API class should not trigger recompilation of the consuming library when API is #apiDeclared"() {
         given:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
@@ -55,7 +55,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         }
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
+    @Requires(TestPrecondition.JDK8_OR_EARLIER) // tests against old Gradle version that can only work with Java versions up tp 8
     @Debug
     def "fails informatively when trying to inspect build output in debug mode with unsupported gradle version"() {
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.CAPTURE_BUILD_RESULT_OUTPUT_IN_DEBUG)
@@ -77,7 +77,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         e.message == "The version of Gradle you are using ($maxUnsupportedVersion) does not capture build output in debug mode with the GradleRunner. Support for this is available in Gradle $minSupportedVersion and all later versions."
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
+    @Requires(TestPrecondition.JDK8_OR_EARLIER) // tests against old Gradle version that can only work with Java versions up tp 8
     def "fails informatively when trying to inject plugin classpath with unsupported gradle version"() {
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.PLUGIN_CLASSPATH_INJECTION)
         def minSupportedVersion = TestKitFeature.PLUGIN_CLASSPATH_INJECTION.since.version
@@ -96,7 +96,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         e.message == "The version of Gradle you are using ($maxUnsupportedVersion) does not support plugin classpath injection. Support for this is available in Gradle $minSupportedVersion and all later versions."
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
+    @Requires(TestPrecondition.JDK8_OR_EARLIER) // tests against old Gradle version that can only work with Java versions up tp 8
     def "fails informatively if trying to use conventional plugin classpath on version that does not support injection"() {
         given:
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.PLUGIN_CLASSPATH_INJECTION)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec.groovy
@@ -71,7 +71,7 @@ class JUnitCategoriesIntegrationSpec extends AbstractSampleIntegrationTest {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/3189')
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
+    @Requires(TestPrecondition.JDK8_OR_EARLIER)
     def canWorkWithPowerMock() {
         given:
         buildFile << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Ignore
 
-@Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
+@Requires(TestPrecondition.JDK8_OR_EARLIER) // tests against old Gradle version that can only work with Java versions up tp 8
 @ToolingApiVersion("current")
 class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
     def buildPluginWith(String gradleVersion) {
@@ -39,10 +39,10 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
         def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarningMode(null), pluginDir)
         builder.sourceFile("com/example/MyTask.java") << """
             package com.example;
-            
+
             import org.gradle.api.*;
             import org.gradle.api.tasks.*;
-            
+
             public class MyTask extends DefaultTask {
                 public MyTask() {
                     getInputs().file("somefile");
@@ -61,7 +61,7 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
                     classpath files("${pluginJar.toURI()}")
                 }
             }
-            
+
             task myTask(type: com.example.MyTask)
         """
     }


### PR DESCRIPTION
Gradle clearly works with Java 9 (and later) by now. There should
be nothing left to be fixed. The remaining usages of this annotation
where wrong:

- The test is not testing a feature of Gradle, but of Java or another
  tool that only works with java versions < 9
  Replaced precondition with: JDK8_OR_EARLIER
  (or JDK9_OR_LATER depending on how it is used)
- Test is running older Gradle versions that do not support Java9+
  Replaced precondition with: JDK8_OR_EARLIER
- Test itself was using features of Java not available anymore in Java9+
  Removed precondition and fixed test to do the test setup differently.
