### PR TITLE
Fix `ResolvedDependencyResult#getResolvedVariant` returning `null`

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -347,6 +347,15 @@ class EdgeState implements DependencyGraphEdge {
         if (resolvedVariant != null) {
             return resolvedVariant;
         }
+        List<NodeState> targetNodes = this.targetNodes;
+        if (targetNodes.isEmpty()) {
+            // happens for substituted dependencies
+            ComponentState targetComponent = getTargetComponent();
+            if (targetComponent != null) {
+                targetNodes = targetComponent.getNodes();
+            }
+        }
+        assert !targetNodes.isEmpty();
         for (NodeState targetNode : targetNodes) {
             if (targetNode.isSelected()) {
                 resolvedVariant = targetNode.getResolvedVariant();


### PR DESCRIPTION
A resolved dependency should always have a resolved variant. It was
possible to get `null` in case the actual component being resolved
was from a different component, for example in the case of dependency
substitution.

Thanks for the reproducer, @jjohannes!

Fixes #12643

