### PR TITLE
Sort subprojects when generating subprojects.json

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -1,91 +1,14 @@
 [
   {
+    "dirName": "antlr",
+    "name": "antlr",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
     "dirName": "api-metadata",
     "name": "apiMetadata",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "ide",
-    "name": "ide",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "internal-integ-testing",
-    "name": "internalIntegTesting",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "platform-native",
-    "name": "platformNative",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "reporting",
-    "name": "reporting",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "language-groovy",
-    "name": "languageGroovy",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-option",
-    "name": "buildOption",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "launcher",
-    "name": "launcher",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "platform-base",
-    "name": "platformBase",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "signing",
-    "name": "signing",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "core",
-    "name": "core",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "installation-beacon",
-    "name": "installationBeacon",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "bootstrap",
-    "name": "bootstrap",
     "unitTests": false,
     "functionalTests": false,
     "crossVersionTests": false
@@ -98,111 +21,6 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "jvm-services",
-    "name": "jvmServices",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "native",
-    "name": "native",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "tooling-api",
-    "name": "toolingApi",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "runtime-api-info",
-    "name": "runtimeApiInfo",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "platform-play",
-    "name": "platformPlay",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "ivy",
-    "name": "ivy",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "wrapper",
-    "name": "wrapper",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "process-services",
-    "name": "processServices",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "snapshots",
-    "name": "snapshots",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "security",
-    "name": "security",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "integ-test",
-    "name": "integTest",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "plugins",
-    "name": "plugins",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "antlr",
-    "name": "antlr",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "plugin-use",
-    "name": "pluginUse",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "language-jvm",
-    "name": "languageJvm",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
     "dirName": "base-annotations",
     "name": "baseAnnotations",
     "unitTests": false,
@@ -210,421 +28,8 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "maven",
-    "name": "maven",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "distributions-dependencies",
-    "name": "distributionsDependencies",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "testing-base",
-    "name": "testingBase",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "resources",
-    "name": "resources",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "version-control",
-    "name": "versionControl",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "testing-junit-platform",
-    "name": "testingJunitPlatform",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "resources-http",
-    "name": "resourcesHttp",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "internal-testing",
-    "name": "internalTesting",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "composite-builds",
-    "name": "compositeBuilds",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "model-groovy",
-    "name": "modelGroovy",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "normalization-java",
-    "name": "normalizationJava",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "smoke-test",
-    "name": "smokeTest",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "test-kit",
-    "name": "testKit",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "instant-execution",
-    "name": "instantExecution",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "docs",
-    "name": "docs",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "cli",
-    "name": "cli",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "hashing",
-    "name": "hashing",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-init",
-    "name": "buildInit",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "soak",
-    "name": "soak",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl-plugins",
-    "name": "kotlinDslPlugins",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "ear",
-    "name": "ear",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "jacoco",
-    "name": "jacoco",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl-tooling-models",
-    "name": "kotlinDslToolingModels",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl-integ-tests",
-    "name": "kotlinDslIntegTests",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "persistent-cache",
-    "name": "persistentCache",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "samples",
-    "name": "samples",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl",
-    "name": "kotlinDsl",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "file-watching",
-    "name": "fileWatching",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "publish",
-    "name": "publish",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "platform-jvm",
-    "name": "platformJvm",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "resources-sftp",
-    "name": "resourcesSftp",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl-test-fixtures",
-    "name": "kotlinDslTestFixtures",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
     "dirName": "base-services",
     "name": "baseServices",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "internal-build-reports",
-    "name": "internalBuildReports",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "model-core",
-    "name": "modelCore",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "scala",
-    "name": "scala",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "kotlin-dsl-tooling-builders",
-    "name": "kotlinDslToolingBuilders",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "execution",
-    "name": "execution",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-scan-performance",
-    "name": "buildScanPerformance",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-cache-base",
-    "name": "buildCacheBase",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "diagnostics",
-    "name": "diagnostics",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-events",
-    "name": "buildEvents",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "dependency-management",
-    "name": "dependencyManagement",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "kotlin-compiler-embeddable",
-    "name": "kotlinCompilerEmbeddable",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "files",
-    "name": "files",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "ide-play",
-    "name": "idePlay",
-    "unitTests": false,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "workers",
-    "name": "workers",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "code-quality",
-    "name": "codeQuality",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "language-java",
-    "name": "languageJava",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "build-profile",
-    "name": "buildProfile",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "build-cache",
-    "name": "buildCache",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "plugin-development",
-    "name": "pluginDevelopment",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "core-api",
-    "name": "coreApi",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "javascript",
-    "name": "javascript",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "worker-processes",
-    "name": "workerProcesses",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "resources-gcs",
-    "name": "resourcesGcs",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "testing-native",
-    "name": "testingNative",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "performance",
-    "name": "performance",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "internal-performance-testing",
-    "name": "internalPerformanceTesting",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "ide-native",
-    "name": "ideNative",
     "unitTests": true,
     "functionalTests": true,
     "crossVersionTests": false
@@ -637,57 +42,120 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "tooling-native",
-    "name": "toolingNative",
+    "dirName": "bootstrap",
+    "name": "bootstrap",
     "unitTests": false,
     "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-cache",
+    "name": "buildCache",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-cache-base",
+    "name": "buildCacheBase",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-cache-http",
+    "name": "buildCacheHttp",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-cache-packaging",
+    "name": "buildCachePackaging",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-events",
+    "name": "buildEvents",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-init",
+    "name": "buildInit",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-option",
+    "name": "buildOption",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-profile",
+    "name": "buildProfile",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "build-scan-performance",
+    "name": "buildScanPerformance",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "cli",
+    "name": "cli",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "code-quality",
+    "name": "codeQuality",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "composite-builds",
+    "name": "compositeBuilds",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "core",
+    "name": "core",
+    "unitTests": true,
+    "functionalTests": true,
     "crossVersionTests": true
   },
   {
-    "dirName": "messaging",
-    "name": "messaging",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "testing-jvm",
-    "name": "testingJvm",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "tooling-api-builders",
-    "name": "toolingApiBuilders",
+    "dirName": "core-api",
+    "name": "coreApi",
     "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },
   {
-    "dirName": "java-compiler-plugin",
-    "name": "javaCompilerPlugin",
-    "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "logging",
-    "name": "logging",
+    "dirName": "dependency-management",
+    "name": "dependencyManagement",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": true
   },
   {
-    "dirName": "language-scala",
-    "name": "languageScala",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "language-native",
-    "name": "languageNative",
+    "dirName": "diagnostics",
+    "name": "diagnostics",
     "unitTests": true,
     "functionalTests": true,
     "crossVersionTests": false
@@ -700,22 +168,92 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "resources-s3",
-    "name": "resourcesS3",
-    "unitTests": true,
-    "functionalTests": true,
+    "dirName": "distributions-dependencies",
+    "name": "distributionsDependencies",
+    "unitTests": false,
+    "functionalTests": false,
     "crossVersionTests": false
   },
   {
-    "dirName": "kotlin-dsl-provider-plugins",
-    "name": "kotlinDslProviderPlugins",
+    "dirName": "docs",
+    "name": "docs",
     "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },
   {
+    "dirName": "ear",
+    "name": "ear",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "execution",
+    "name": "execution",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
     "dirName": "file-collections",
     "name": "fileCollections",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "file-watching",
+    "name": "fileWatching",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "files",
+    "name": "files",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "hashing",
+    "name": "hashing",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "ide",
+    "name": "ide",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "ide-native",
+    "name": "ideNative",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "ide-play",
+    "name": "idePlay",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "installation-beacon",
+    "name": "installationBeacon",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "instant-execution",
+    "name": "instantExecution",
     "unitTests": true,
     "functionalTests": true,
     "crossVersionTests": false
@@ -728,11 +266,11 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "build-cache-packaging",
-    "name": "buildCachePackaging",
-    "unitTests": true,
-    "functionalTests": false,
-    "crossVersionTests": false
+    "dirName": "integ-test",
+    "name": "integTest",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": true
   },
   {
     "dirName": "internal-android-performance-testing",
@@ -742,10 +280,472 @@
     "crossVersionTests": false
   },
   {
-    "dirName": "build-cache-http",
-    "name": "buildCacheHttp",
+    "dirName": "internal-build-reports",
+    "name": "internalBuildReports",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "internal-integ-testing",
+    "name": "internalIntegTesting",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "internal-performance-testing",
+    "name": "internalPerformanceTesting",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "internal-testing",
+    "name": "internalTesting",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "ivy",
+    "name": "ivy",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "jacoco",
+    "name": "jacoco",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "java-compiler-plugin",
+    "name": "javaCompilerPlugin",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "javascript",
+    "name": "javascript",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "jvm-services",
+    "name": "jvmServices",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-compiler-embeddable",
+    "name": "kotlinCompilerEmbeddable",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl",
+    "name": "kotlinDsl",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl-integ-tests",
+    "name": "kotlinDslIntegTests",
     "unitTests": false,
     "functionalTests": true,
     "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl-plugins",
+    "name": "kotlinDslPlugins",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl-provider-plugins",
+    "name": "kotlinDslProviderPlugins",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl-test-fixtures",
+    "name": "kotlinDslTestFixtures",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "kotlin-dsl-tooling-builders",
+    "name": "kotlinDslToolingBuilders",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "kotlin-dsl-tooling-models",
+    "name": "kotlinDslToolingModels",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "language-groovy",
+    "name": "languageGroovy",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "language-java",
+    "name": "languageJava",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "language-jvm",
+    "name": "languageJvm",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "language-native",
+    "name": "languageNative",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "language-scala",
+    "name": "languageScala",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "launcher",
+    "name": "launcher",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "logging",
+    "name": "logging",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "maven",
+    "name": "maven",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "messaging",
+    "name": "messaging",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "model-core",
+    "name": "modelCore",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "model-groovy",
+    "name": "modelGroovy",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "native",
+    "name": "native",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "normalization-java",
+    "name": "normalizationJava",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "performance",
+    "name": "performance",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "persistent-cache",
+    "name": "persistentCache",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "platform-base",
+    "name": "platformBase",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "platform-jvm",
+    "name": "platformJvm",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "platform-native",
+    "name": "platformNative",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "platform-play",
+    "name": "platformPlay",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "plugin-development",
+    "name": "pluginDevelopment",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "plugin-use",
+    "name": "pluginUse",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "plugins",
+    "name": "plugins",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "process-services",
+    "name": "processServices",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "publish",
+    "name": "publish",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "reporting",
+    "name": "reporting",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "resources",
+    "name": "resources",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "resources-gcs",
+    "name": "resourcesGcs",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "resources-http",
+    "name": "resourcesHttp",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "resources-s3",
+    "name": "resourcesS3",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "resources-sftp",
+    "name": "resourcesSftp",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "runtime-api-info",
+    "name": "runtimeApiInfo",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "samples",
+    "name": "samples",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "scala",
+    "name": "scala",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "security",
+    "name": "security",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "signing",
+    "name": "signing",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "smoke-test",
+    "name": "smokeTest",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "snapshots",
+    "name": "snapshots",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "soak",
+    "name": "soak",
+    "unitTests": false,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "test-kit",
+    "name": "testKit",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "testing-base",
+    "name": "testingBase",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "testing-junit-platform",
+    "name": "testingJunitPlatform",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "testing-jvm",
+    "name": "testingJvm",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "testing-native",
+    "name": "testingNative",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "tooling-api",
+    "name": "toolingApi",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "tooling-api-builders",
+    "name": "toolingApiBuilders",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "tooling-native",
+    "name": "toolingNative",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "version-control",
+    "name": "versionControl",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "worker-processes",
+    "name": "workerProcesses",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "workers",
+    "name": "workers",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "dirName": "wrapper",
+    "name": "wrapper",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
   }
 ]

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/GenerateSubprojectsInfoPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/GenerateSubprojectsInfoPlugin.kt
@@ -34,7 +34,9 @@ class GenerateSubprojectsInfoPlugin : Plugin<Project> {
 open class GenerateSubprojectsInfoTask : DefaultTask() {
     @TaskAction
     fun generateSubprojectsInfo() {
-        val subprojects: List<GradleSubproject> = project.rootDir.resolve("subprojects").listFiles(File::isDirectory).map(this::generateSubproject)
+        val subprojects: List<GradleSubproject> = project.rootDir.resolve("subprojects").listFiles(File::isDirectory)!!
+            .sorted()
+            .map(this::generateSubproject)
         val gson = GsonBuilder().setPrettyPrinting().create()
         project.rootDir.resolve(".teamcity/subprojects.json").writeText(gson.toJson(subprojects))
     }


### PR DESCRIPTION
When adding a new subproject, the `subprojects.json` files changed quite a bit when looking at the diff manually. This seems to be due to the task `generateSubprojectsInfo` using the (random order) of sub-directories returned by the file system.

This PR sorts the list of sub-directories, so that the diff of the json file is easily parseable.