### PR TITLE
Disable test when no includes found

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/BuildBucketProvider.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/BuildBucketProvider.kt
@@ -97,7 +97,13 @@ class CrossVersionBucketProvider(private val onlyTestGradleVersion: String) : Bu
 class IncludeTestClassProvider(private val includeTestClasses: Map<String, List<String>>) : BuildBucketProvider {
     override fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType) {
         testTask.filter.isFailOnNoMatchingTests = false
-        includeTestClasses[sourceSet.name]?.apply { testTask.filter.includePatterns.addAll(this) }
+        val classesForSourceSet = includeTestClasses[sourceSet.name]
+        if (classesForSourceSet == null) {
+            // No classes included, disable
+            testTask.enabled = false
+        } else {
+            testTask.filter.includePatterns.addAll(classesForSourceSet)
+        }
     }
 }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
@@ -36,6 +36,10 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
     def "can use tooling API to build Eclipse model"() {
         tweakProject()
 
+        if (true) {
+            throw new RuntimeException()
+        }
+
         when:
         run()
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
@@ -36,10 +36,6 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
     def "can use tooling API to build Eclipse model"() {
         tweakProject()
 
-        if (true) {
-            throw new RuntimeException()
-        }
-
         when:
         run()
 


### PR DESCRIPTION
### Context

We generate "include patterns" before a test:

```
org.gradle.ClassA=integTest
...
org.gradle.ClassB=crossVersionTest
```

So corresponding test classes can configure `includeClass`. However, when a source set is missing in the "patterns":

```
org.gradle.ClassA=integTest
...
(No crossVersionTest at all)
```

We expect no crossVersionTest executed, but current implementation executes ALL crossVersionTest, which wastes CI resources. This PR fixes this issue with correct behavior.