### PR TITLE
Add Travis cache to mitigate Travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk: openjdk11
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f $HOME/.gradle/caches/modules-2/gc.properties
 cache:
   directories:
     - $HOME/.gradle/caches/modules-2/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 jdk: openjdk11
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/modules-2/
 env:
     global:
         - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2


### PR DESCRIPTION
### Context
Travis checks for contributor PRs very often fail because of dependency downloads. Copying the Gradle module cache will help with this by doing less requests to public maven repositories.

Actually most of the failures I've seen are from repo.gradle.org, but usually it means an issue with unauthenticated requests and the server protecting itself from an attack (or simply not enough resources).

Network activity from a previous PR:
https://scans.gradle.com/s/nvco4el7jyd4k/performance/networkActivity

Network activity from this PR:
https://scans.gradle.com/s/duqcov42rgslo/performance/networkActivity

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
