### PR TITLE
Consider the derivation strategy when requesting component metadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectDerivationStrategyIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectDerivationStrategyIntegTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractPolyglotIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class MultiProjectDerivationStrategyIntegTest extends AbstractPolyglotIntegrationSpec {
+
+    def "different projects can use different variant derivation strategies without leaking to each other"() {
+        mavenRepo.module("org", "foo", '1.1').publish()
+
+        def resolveA = new ResolveTestFixture(testDirectory.file("resolve-a.gradle"), "conf")
+            .expectDefaultConfiguration("runtime")
+        def resolveB = new ResolveTestFixture(testDirectory.file("resolve-b.gradle"), "other")
+            .expectDefaultConfiguration("runtime")
+
+        writeSpec {
+            settings {
+                rootProjectName = 'test'
+            }
+            project("a") {
+                group = 'org'
+                version = '1.0'
+                repositories {
+                    maven(mavenRepo.uri)
+                }
+                configurations {
+                    conf
+                }
+                dependencies {
+                    conf('org:foo:1.1')
+                }
+                applyFrom("../resolve-a")
+            }
+            project("b") {
+                group = 'org'
+                version = '1.0'
+                repositories {
+                    maven(mavenRepo.uri)
+                }
+                configurations {
+                    other
+                }
+                dependencies {
+                    other('org:foo:1.1')
+                }
+                applyFrom("../resolve-b")
+            }
+        }
+        resolveA.prepare()
+        resolveB.addDefaultVariantDerivationStrategy()
+        resolveB.prepare()
+
+        when:
+        run 'checkDeps'
+
+        then:
+        resolveA.expectGraph {
+            root(":a", "org:a:1.0") {
+                module("org:foo:1.1") {
+                    variant "default", ['org.gradle.status': 'release']
+                }
+            }
+        }
+        resolveB.expectGraph {
+            root(":b", "org:b:1.0") {
+                module("org:foo:1.1") {
+                    variant "runtime", [
+                        'org.gradle.status': 'release',
+                        'org.gradle.category':'library',
+                        'org.gradle.libraryelements':'jar',
+                        'org.gradle.usage':'java-runtime'
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -578,7 +578,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor, PlatformSupport platformSupport) {
             DefaultComponentMetadataHandler componentMetadataHandler = instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor, platformSupport);
             if (domainObjectContext.isScript()) {
-                componentMetadataHandler.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
+                componentMetadataHandler.setVariantDerivationStrategy(JavaEcosystemVariantDerivationStrategy.getInstance());
             }
             return componentMetadataHandler;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
@@ -33,7 +33,7 @@ class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
     private final List<MetadataRuleWrapper> rules = Lists.newArrayListWithExpectedSize(10);
     private MetadataRuleWrapper lastAdded;
     private boolean classBasedRulesOnly = true;
-    private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
+    private VariantDerivationStrategy variantDerivationStrategy = NoOpDerivationStrategy.getInstance();
     private int rulesHash = 0;
 
     void addRule(SpecRuleAction<? super ComponentMetadataDetails> ruleAction) {
@@ -82,6 +82,6 @@ class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
     }
 
     public int getRulesHash() {
-        return rulesHash;
+        return 31 * variantDerivationStrategy.hashCode() + rulesHash;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractStatelessDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractStatelessDerivationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,23 @@
  */
 package org.gradle.internal.component.external.model;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.internal.component.model.ConfigurationMetadata;
+public abstract class AbstractStatelessDerivationStrategy implements VariantDerivationStrategy {
+    private final int hashCode;
 
-/**
- * Variant derivation strategies should be stateless. If they aren't singletons,
- * implementors must make sure that equals/hashcode returns true for all instances.
- */
-public interface VariantDerivationStrategy {
-    boolean derivesVariants();
-    ImmutableList<? extends ConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata);
+    protected AbstractStatelessDerivationStrategy() {
+        hashCode = this.getClass().getName().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -25,7 +25,16 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 
 import java.util.Collections;
 
-public class JavaEcosystemVariantDerivationStrategy implements VariantDerivationStrategy {
+public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDerivationStrategy {
+    private static final JavaEcosystemVariantDerivationStrategy INSTANCE = new JavaEcosystemVariantDerivationStrategy();
+
+    private JavaEcosystemVariantDerivationStrategy() {
+    }
+
+    public static JavaEcosystemVariantDerivationStrategy getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public boolean derivesVariants() {
         return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/NoOpDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/NoOpDerivationStrategy.java
@@ -18,7 +18,15 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
-public class NoOpDerivationStrategy implements VariantDerivationStrategy {
+public class NoOpDerivationStrategy extends AbstractStatelessDerivationStrategy {
+    private static final NoOpDerivationStrategy INSTANCE = new NoOpDerivationStrategy();
+
+    private NoOpDerivationStrategy() {
+    }
+
+    public static NoOpDerivationStrategy getInstance() {
+        return INSTANCE;
+    }
 
     @Override
     public boolean derivesVariants() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -51,7 +51,7 @@ public class VariantMetadataRules {
     private VariantAttributesRules variantAttributesRules;
     private CapabilitiesRules capabilitiesRules;
     private VariantFilesRules variantFilesRules;
-    private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
+    private VariantDerivationStrategy variantDerivationStrategy = NoOpDerivationStrategy.getInstance();
     private final ModuleVersionIdentifier moduleVersionId;
     private List<AdditionalVariant> additionalVariants = Lists.newArrayList();
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -127,7 +127,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         def componentTypeAttribute = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class)
         def metadata = mavenMetadataFactory.create(id, [])
         metadata.packaging = packaging
-        metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()
+        metadata.variantMetadataRules.variantDerivationStrategy = JavaEcosystemVariantDerivationStrategy.instance
 
         when:
         def immutableMetadata = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -49,7 +49,7 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
         ])
 
         when:
-        mavenMetadata.variantMetadataRules.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy())
+        mavenMetadata.variantMetadataRules.setVariantDerivationStrategy(JavaEcosystemVariantDerivationStrategy.instance)
         mavenMetadata.variantMetadataRules.addDependencyAction(instantiator, notationParser, constraintNotationParser, variantAction("default", {
             assert it.size() == 1
             assert it[0].name == "notOptional"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -77,7 +77,7 @@ class VariantFilesMetadataRulesTest extends Specification {
             new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), null, [])
         }
         def metadata = mavenMetadataFactory.create(componentIdentifier, dependencies)
-        metadata.getVariantMetadataRules().setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy())
+        metadata.getVariantMetadataRules().setVariantDerivationStrategy(JavaEcosystemVariantDerivationStrategy.instance)
         metadata
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.java
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegrationSpec {
@@ -77,7 +76,6 @@ project(':consumer') {
         succeeds "resolve"
     }
 
-    @ToBeFixedForInstantExecution
     def "provides runtime JAR as default variant"() {
         when:
         resolve()
@@ -109,7 +107,6 @@ project(':consumer') {
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
 
-    @ToBeFixedForInstantExecution
     def "provides API variant"() {
         buildFile << """
             project(':consumer') {
@@ -151,7 +148,6 @@ project(':consumer') {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
@@ -216,7 +212,6 @@ project(':consumer') {
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
 
-    @ToBeFixedForInstantExecution
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.java
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class JavaLibraryOutgoingVariantsIntegrationTest extends AbstractIntegrationSpec {
@@ -79,7 +78,6 @@ project(':consumer') {
         succeeds "resolve"
     }
 
-    @ToBeFixedForInstantExecution
     def "provides runtime JAR as default variant"() {
         when:
         resolve()
@@ -111,7 +109,6 @@ project(':consumer') {
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
 
-    @ToBeFixedForInstantExecution
     def "provides API variant"() {
         buildFile << """
             project(':consumer') {
@@ -152,7 +149,6 @@ project(':consumer') {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
@@ -217,7 +213,6 @@ project(':consumer') {
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
 
-    @ToBeFixedForInstantExecution
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -18,9 +18,7 @@ package org.gradle.java
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.maven.MavenFileModule
-import spock.lang.Unroll
 
 abstract class JavaProjectOutgoingVariantsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -93,11 +91,6 @@ project(':consumer') {
         succeeds "resolve"
     }
 
-    @ToBeFixedForInstantExecution(
-        bottomSpecs = [
-            "JavaProjectOutgoingVariantsPomMetadataIntegrationTest"
-        ]
-    )
     def "provides runtime JAR as default variant"() {
         when:
         resolve()
@@ -129,12 +122,6 @@ project(':consumer') {
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
 
-    @Unroll
-    @ToBeFixedForInstantExecution(
-        bottomSpecs = [
-            "JavaProjectOutgoingVariantsPomMetadataIntegrationTest"
-        ]
-    )
     def "provides API variant - #format"() {
         buildFile << """
             project(':consumer') {
@@ -180,12 +167,6 @@ project(':consumer') {
         "LibraryElements.RESOURCES" | _
     }
 
-    @Unroll
-    @ToBeFixedForInstantExecution(
-        bottomSpecs = [
-            "JavaProjectOutgoingVariantsPomMetadataIntegrationTest"
-        ]
-    )
     def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
@@ -249,12 +230,7 @@ project(':consumer') {
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
-
-    @ToBeFixedForInstantExecution(
-        bottomSpecs = [
-            "JavaProjectOutgoingVariantsPomMetadataIntegrationTest"
-        ]
-    )
+    
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -129,7 +129,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
     private void configureVariantDerivationStrategy(ProjectInternal project) {
         ComponentMetadataHandlerInternal metadataHandler = (ComponentMetadataHandlerInternal) project.getDependencies().getComponents();
-        metadataHandler.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
+        metadataHandler.setVariantDerivationStrategy(JavaEcosystemVariantDerivationStrategy.getInstance());
     }
 
     private JavaPluginConvention addExtensions(final ProjectInternal project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -113,7 +113,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
 
     private static void configureVariantDerivationStrategy(ProjectInternal project) {
         ComponentMetadataHandlerInternal metadataHandler = (ComponentMetadataHandlerInternal) project.getDependencies().getComponents();
-        metadataHandler.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
+        metadataHandler.setVariantDerivationStrategy(JavaEcosystemVariantDerivationStrategy.getInstance());
     }
 
     private void createSoftwareComponent(Project project, Configuration apiElements, Configuration runtimeElements) {


### PR DESCRIPTION
Gradle has a single, build scoped cache for dependency metadata. It's
using a build cache scope because component metadata is quite expensive
to read and process. However, component metadata _may_ be different
based on the plugins applied on a project. For example, Java projects
apply what we call a "Java derivation strategy", which is capable
of transforming regular POM files into so-called "platforms" but
more importantly, they are what map the different Maven scopes to
actual "variants" in variant-aware dependency management.

The problem is that it's not a requirement that all projects are
Java projects. It is possible to have native subprojects, or projects
which do _not_ apply the Java base plugin. While it's in general an
error to have a project which wants to perform "Java dependency
resolution" not to apply the Java derivation strategy, there are
consequences in not doing so. In particular, Gradle becomes order
dependent: if a subproject which does not apply the derivation
strategy resolves a module first, then subsequent resolutions for
projects which _do_ apply the derivation strategy would get wrong
metadata.

To avoid this, this commit makes sure that when we consume module
metadata, we actually use the derivation strategy as part of the
processed metadata cache key.

This does _not_ fix the fact that the consumers _should have_ applied
the derivation strategy and will make realizing this harder, but it
_does_ fix the inconsistency in resolution, which is probably a
much bigger issue (for caching and reproducibility).

Fixes #12951
Closes #9415
