### PR TITLE
Do not watch symlinks

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -32,7 +31,6 @@ import static org.gradle.work.ChangeType.MODIFIED
 
 @Unroll
 @Requires(TestPrecondition.SYMLINKS)
-@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
 class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     def "#desc can handle symlinks"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -468,7 +468,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     void maybeDeprecated(String expression) {
         if (expression.contains("configurableFiles")) {
-            executer.expectDeprecationWarning()
+            executer.expectDocumentedDeprecationWarning("The ProjectLayout.configurableFiles() method has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the ObjectFactory.fileCollection() method instead. See https://docs.gradle.org/current/userguide/lazy_configuration.html#property_files_api_reference for more details.")
         }
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -26,7 +25,6 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 @Requires(TestPrecondition.SYMLINKS)
-@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
 class IncrementalBuildSymlinkHandlingIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
@@ -57,7 +57,8 @@ public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapsho
                     new DefaultFileMetadata(
                         FileType.RegularFile,
                         fileDetails.getLastModified(),
-                        fileDetails.getSize()
+                        fileDetails.getSize(),
+                        false
                     )
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
@@ -53,7 +53,7 @@ public class FileSystemSnapshotBuilder {
     public void addFile(File file, String[] segments, String fileName, FileMetadataSnapshot metadataSnapshot) {
         checkNoRootFileSnapshot("another root file", file);
         HashCode contentHash = fileHasher.hash(file, metadataSnapshot.getLength(), metadataSnapshot.getLastModified());
-        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot));
+        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot), metadataSnapshot.isSymlink());
         if (segments.length == 0) {
             rootFileSnapshot = fileSnapshot;
         } else {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
@@ -136,6 +136,6 @@ class FileSystemSnapshotBuilderTest extends Specification {
     }
 
     private static DefaultFileMetadata fileMetadata() {
-        new DefaultFileMetadata(FileType.RegularFile, 0, 5)
+        new DefaultFileMetadata(FileType.RegularFile, 0, 5, false)
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -138,16 +138,16 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
         public OnlyVisitSubDirectories(Consumer<String> subDirectoryConsumer) {
             this.subDirectoryConsumer = subDirectoryConsumer;
-            root = true;
+            this.root = true;
         }
 
         @Override
         public boolean preVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
-            if (!root) {
+            if (!root && !directorySnapshot.isSymlink()) {
                 subDirectoryConsumer.accept(directorySnapshot.getAbsolutePath());
             }
             root = false;
-            return true;
+            return !directorySnapshot.isSymlink();
         }
 
         @Override

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -31,4 +31,11 @@ public interface FileMetadataSnapshot {
      * Note: always 0 for directories and missing files.
      */
     long getLength();
+
+    /**
+     * Whether this file is a symlink.
+     *
+     * Note: the other methods return information about the target of the symlink.
+     */
+    boolean isSymlink();
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultFileMetadata.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultFileMetadata.java
@@ -20,20 +20,28 @@ import org.gradle.internal.file.FileMetadataSnapshot;
 import org.gradle.internal.file.FileType;
 
 public class DefaultFileMetadata implements FileMetadataSnapshot {
-    private static final FileMetadataSnapshot DIR = new DefaultFileMetadata(FileType.Directory, 0, 0);
-    private static final FileMetadataSnapshot MISSING = new DefaultFileMetadata(FileType.Missing, 0, 0);
+    private static final FileMetadataSnapshot DIR = new DefaultFileMetadata(FileType.Directory, 0, 0, false);
+    private static final FileMetadataSnapshot SYMLINKED_DIR = new DefaultFileMetadata(FileType.Directory, 0, 0, true);
+    private static final FileMetadataSnapshot MISSING = new DefaultFileMetadata(FileType.Missing, 0, 0, false);
+    private static final FileMetadataSnapshot BROKEN_SYMLINK = new DefaultFileMetadata(FileType.Missing, 0, 0, true);
     private final FileType type;
     private final long lastModified;
     private final long length;
+    private final boolean isSymlink;
 
-    public DefaultFileMetadata(FileType type, long lastModified, long length) {
+    public DefaultFileMetadata(FileType type, long lastModified, long length, boolean isSymlink) {
         this.type = type;
         this.lastModified = lastModified;
         this.length = length;
+        this.isSymlink = isSymlink;
     }
 
     public static FileMetadataSnapshot file(long lastModified, long length) {
-        return new DefaultFileMetadata(FileType.RegularFile, lastModified, length);
+        return new DefaultFileMetadata(FileType.RegularFile, lastModified, length, false);
+    }
+
+    public static FileMetadataSnapshot symlinkedFile(long lastModified, long length) {
+        return new DefaultFileMetadata(FileType.RegularFile, lastModified, length, true);
     }
 
     public static FileMetadataSnapshot directory() {
@@ -42,6 +50,14 @@ public class DefaultFileMetadata implements FileMetadataSnapshot {
 
     public static FileMetadataSnapshot missing() {
         return MISSING;
+    }
+
+    public static FileMetadataSnapshot brokenSymlink() {
+        return BROKEN_SYMLINK;
+    }
+
+    public static FileMetadataSnapshot symlinkedDirectory() {
+        return SYMLINKED_DIR;
     }
 
     @Override
@@ -57,5 +73,10 @@ public class DefaultFileMetadata implements FileMetadataSnapshot {
     @Override
     public long getLength() {
         return length;
+    }
+
+    @Override
+    public boolean isSymlink() {
+        return isSymlink;
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -185,7 +184,6 @@ class JavaSourceIncrementalCompilationIntegrationTest extends BaseJavaSourceIncr
         outputs.recompiledClasses('MyClass', 'MyAnnotation', 'TopLevel$Inner', 'TopLevel')
     }
 
-    @ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
     @Requires(TestPrecondition.SYMLINKS)
     @Issue("https://github.com/gradle/gradle/issues/9202")
     def "source mapping file works with symlinks"() {

--- a/subprojects/native/native.gradle.kts
+++ b/subprojects/native/native.gradle.kts
@@ -57,7 +57,9 @@ val convertCSV by tasks.registering {
 
                 val (benchmark, mode, threads, samples, score) = tokens.subList(0, 5)
                 val (error, unit, accessor) = tokens.subList(5, tokens.size)
-                benchmarks.getValue(benchToScenarioName.getValue(benchmark)).add(Pair(accessor.replace("FileMetadataAccessor", ""), score.toDouble().toInt()))
+                val benchmarksValue = benchmarks.getValue(benchToScenarioName.getValue(benchmark))
+                benchmarksValue.add(Pair(accessor.replace("FileMetadataAccessor", ""), score.toDouble().toInt()))
+                benchmarks.put(benchToScenarioName.getValue(benchmark), benchmarksValue)
             }
         }
         outputFile.parentFile.mkdirs()

--- a/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
+++ b/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
@@ -44,8 +44,8 @@ import java.util.Map;
 import java.util.UUID;
 
 @Threads(2)
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 2)
 @State(Scope.Benchmark)
 public class FileMetadataAccessorBenchmark {
     private static final Map<String, FileMetadataAccessor> ACCESSORS = ImmutableMap.<String, FileMetadataAccessor>builder()

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -270,13 +270,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     }
 
     protected FileMetadataAccessor createFileMetadataAccessor(OperatingSystem operatingSystem) {
-        // Based on the benchmark found in org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessorBenchmark
-        // and the results in the PR https://github.com/gradle/gradle/pull/1183
-        // we're using "native platform" for Mac OS and a  mix of File and NIO API for Linux and Windows
-        // Once JDK 9 is out, we need to revisit the choice, because testing for file.exists() should become much
-        // cheaper using the pure NIO implementation.
-
-        if ((operatingSystem.isMacOsX()) && useNativeIntegrations) {
+        if (useNativeIntegrations) {
             try {
                 return new NativePlatformBackedFileMetadataAccessor(net.rubygrapefruit.platform.Native.get(Files.class));
             } catch (NativeIntegrationUnavailableException e) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
@@ -21,10 +21,12 @@ import java.util.Optional;
 public abstract class AbstractCompleteFileSystemLocationSnapshot implements CompleteFileSystemLocationSnapshot {
     private final String absolutePath;
     private final String name;
+    private final boolean isSymlink;
 
-    public AbstractCompleteFileSystemLocationSnapshot(String absolutePath, String name) {
+    public AbstractCompleteFileSystemLocationSnapshot(String absolutePath, String name, boolean isSymlink) {
         this.absolutePath = absolutePath;
         this.name = name;
+        this.isSymlink = isSymlink;
     }
 
     protected static MissingFileSnapshot missingSnapshotForAbsolutePath(String filePath) {
@@ -39,6 +41,11 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean isSymlink() {
+        return isSymlink;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteDirectorySnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteDirectorySnapshot.java
@@ -34,10 +34,14 @@ public class CompleteDirectorySnapshot extends AbstractCompleteFileSystemLocatio
     private final List<CompleteFileSystemLocationSnapshot> children;
     private final HashCode contentHash;
 
-    public CompleteDirectorySnapshot(String absolutePath, String name, List<CompleteFileSystemLocationSnapshot> children, HashCode contentHash) {
-        super(absolutePath, name);
+    public CompleteDirectorySnapshot(String absolutePath, String name, List<CompleteFileSystemLocationSnapshot> children, HashCode contentHash, boolean isSymlink) {
+        super(absolutePath, name, isSymlink);
         this.children = children;
         this.contentHash = contentHash;
+    }
+
+    public CompleteDirectorySnapshot(String absolutePath, String name, List<CompleteFileSystemLocationSnapshot> children, HashCode contentHash) {
+        this(absolutePath, name, children, contentHash, false);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
@@ -48,6 +48,11 @@ public interface CompleteFileSystemLocationSnapshot extends FileSystemSnapshot, 
     String getAbsolutePath();
 
     /**
+     * Whether this snapshot is a symbolic link.
+     */
+    boolean isSymlink();
+
+    /**
      * The hash of the snapshot.
      *
      * This makes it possible to uniquely identify the snapshot.

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -78,6 +78,10 @@ public class MerkleDirectorySnapshotBuilder implements FileSystemSnapshotVisitor
     }
 
     public boolean postVisitDirectory(boolean includeEmpty) {
+        return postVisitDirectory(includeEmpty, false);
+    }
+
+    public boolean postVisitDirectory(boolean includeEmpty, boolean isSymlink) {
         String name = relativePathSegmentsTracker.leave();
         List<CompleteFileSystemLocationSnapshot> children = levelHolder.removeLast();
         String absolutePath = directoryAbsolutePaths.removeLast();
@@ -93,7 +97,7 @@ public class MerkleDirectorySnapshotBuilder implements FileSystemSnapshotVisitor
             hasher.putString(child.getName());
             hasher.putHash(child.getHash());
         }
-        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash());
+        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash(), isSymlink);
         List<CompleteFileSystemLocationSnapshot> siblings = levelHolder.peekLast();
         if (siblings != null) {
             siblings.add(directorySnapshot);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
@@ -32,8 +32,16 @@ public class MissingFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
         super(absolutePath, name, false);
     }
 
+    public MissingFileSnapshot(String absolutePath, String name, boolean isSymlink) {
+        super(absolutePath, name, isSymlink);
+    }
+
     public MissingFileSnapshot(String absolutePath) {
         this(absolutePath, PathUtil.getFileName(absolutePath));
+    }
+
+    public MissingFileSnapshot(String absolutePath, boolean isSymlink) {
+        this(absolutePath, PathUtil.getFileName(absolutePath), isSymlink);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
@@ -29,11 +29,11 @@ public class MissingFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
     private static final HashCode SIGNATURE = Hashing.signature(MissingFileSnapshot.class);
 
     public MissingFileSnapshot(String absolutePath, String name) {
-        super(absolutePath, name);
+        super(absolutePath, name, false);
     }
 
     public MissingFileSnapshot(String absolutePath) {
-        super(absolutePath, PathUtil.getFileName(absolutePath));
+        this(absolutePath, PathUtil.getFileName(absolutePath));
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -31,7 +31,11 @@ public class RegularFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
     private final FileMetadata metadata;
 
     public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata) {
-        super(absolutePath, name);
+        this(absolutePath, name, contentHash, metadata, false);
+    }
+
+    public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata, boolean isSymlink) {
+        super(absolutePath, name, isSymlink);
         this.contentHash = contentHash;
         this.metadata = metadata;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -171,7 +171,7 @@ public class DirectorySnapshotter {
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
             String fileName = getFilename(dir);
             String internedName = intern(fileName);
-            if (builder.isRoot() || shouldVisit(dir, internedName, true, attrs, builder.getRelativePath())) {
+            if (builder.isRoot() || shouldVisit(dir, internedName, true, builder.getRelativePath())) {
                 builder.preVisitDirectory(intern(dir.toString()), internedName);
                 return FileVisitResult.CONTINUE;
             } else {
@@ -188,7 +188,7 @@ public class DirectorySnapshotter {
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
             String internedName = intern(file.getFileName().toString());
-            if (shouldVisit(file, internedName, false, attrs, builder.getRelativePath())) {
+            if (shouldVisit(file, internedName, false, builder.getRelativePath())) {
                 builder.visitFile(snapshotFile(file, internedName, attrs));
             }
             return FileVisitResult.CONTINUE;
@@ -217,7 +217,7 @@ public class DirectorySnapshotter {
             if (isNotFileSystemLoopException(exc)) {
                 String internedName = intern(file.getFileName().toString());
                 boolean isDirectory = Files.isDirectory(file);
-                if (shouldVisit(file, internedName, isDirectory, null, builder.getRelativePath())) {
+                if (shouldVisit(file, internedName, isDirectory, builder.getRelativePath())) {
                     LOGGER.info("Could not read file path '{}'.", file);
                     String internedAbsolutePath = intern(file.toString());
                     builder.visitFile(new MissingFileSnapshot(internedAbsolutePath, internedName));
@@ -251,7 +251,7 @@ public class DirectorySnapshotter {
          * based on the directory/file excludes or the provided filtering predicate.
          * Excludes won't mark this walk as `filtered`, only if the `predicate` rejects any entry.
          **/
-        private boolean shouldVisit(Path path, String internedName, boolean isDirectory, @Nullable BasicFileAttributes attrs, Iterable<String> relativePath) {
+        private boolean shouldVisit(Path path, String internedName, boolean isDirectory, Iterable<String> relativePath) {
             if (isDirectory) {
                 if (defaultExcludes.excludeDir(internedName)) {
                     return false;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -268,7 +268,7 @@ public class DirectorySnapshotter {
                     LOGGER.info("Could not read file path '{}'.", absoluteFilePath, e);
                 }
             }
-            return new MissingFileSnapshot(internedAbsoluteFilePath, internedName);
+            return new MissingFileSnapshot(internedAbsoluteFilePath, internedName, isSymbolicLink);
         }
 
         /** unlistable directories (and maybe some locked files) will stop here */

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/SnapshotCollectingDiffListener.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/SnapshotCollectingDiffListener.java
@@ -42,7 +42,7 @@ public class SnapshotCollectingDiffListener implements SnapshotHierarchy.NodeDif
 
     private void extractRootSnapshots(FileSystemNode rootNode, Consumer<CompleteFileSystemLocationSnapshot> consumer) {
         rootNode.accept(snapshot -> {
-            if (watchFilter.test(snapshot.getAbsolutePath())) {
+            if (!snapshot.isSymlink() && watchFilter.test(snapshot.getAbsolutePath())) {
                 consumer.accept(snapshot);
             }
         });


### PR DESCRIPTION
This is a first step towards supporting symlink watching (#11851). It captures whether a snapshot is a symlink and then does not watch the locations of the VFS which are symlinks.

After the build finishes, all the elements in the VFS which are symlinks are dropped and not retained till the next build.