### PR TITLE
Introduce `Provider<T>.forUseAtConfigurationTime(): Provider<T>`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -147,6 +147,8 @@ public interface Provider<T> {
 
     /**
      * Returns a view of this {@link Provider} which can be safely read at configuration time.
+     *
+     * @since 6.5
      */
     @Incubating
     Provider<T> forUseAtConfigurationTime();

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -144,4 +144,10 @@ public interface Provider<T> {
      */
     @Incubating
     Provider<T> orElse(Provider<? extends T> provider);
+
+    /**
+     * Returns a view of this {@link Provider} which can be safely read at configuration time.
+     */
+    @Incubating
+    Provider<T> forUseAtConfigurationTime();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -125,7 +125,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public Provider<T> forUseAtConfigurationTime() {
-        throw new UnsupportedOperationException();
+        return this;
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -124,6 +124,11 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     }
 
     @Override
+    public Provider<T> forUseAtConfigurationTime() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         // When used as an input, add the producing tasks if known
         getProducer().visitProducerTasks(context);


### PR DESCRIPTION
So a new wrapper can be built with the new API and used to make the build compatible with the future implementation.