### PR TITLE
Fix LifecyclePlugin

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
@@ -32,29 +32,40 @@ class LifecyclePlugin : Plugin<Project> {
 
     private
     val compileAllBuild = "compileAllBuild"
+
     private
     val sanityCheck = "sanityCheck"
 
     private
     val quickTest = "quickTest"
+
     private
     val platformTest = "platformTest"
+
     private
     val quickFeedbackCrossVersionTest = "quickFeedbackCrossVersionTest"
+
     private
     val allVersionsCrossVersionTest = "allVersionsCrossVersionTest"
+
     private
     val allVersionsIntegMultiVersionTest = "allVersionsIntegMultiVersionTest"
+
     private
     val parallelTest = "parallelTest"
+
     private
     val noDaemonTest = "noDaemonTest"
+
     private
     val instantTest = "instantTest"
+
     private
     val vfsRetentionTest = "vfsRetentionTest"
+
     private
     val soakTest = "soakTest"
+
     private
     val forceRealizeDependencyManagementTest = "forceRealizeDependencyManagementTest"
 
@@ -163,6 +174,7 @@ class LifecyclePlugin : Plugin<Project> {
                 ":distributions:integTest", ":docs:check", ":docs:checkSamples")
         }
     }
+
     /**
      * Task that are called by the (currently separate) promotion build running on CI.
      */
@@ -312,4 +324,5 @@ class LifecyclePlugin : Plugin<Project> {
 
     private
     fun Project.isRequestedTask(taskName: String) = gradle.startParameter.taskNames.contains(taskName)
+        || gradle.startParameter.taskNames.any { it.contains(":$taskName") }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -49,6 +49,7 @@ class JUnitPlatformTestRewriter {
     static rewriteWithJupiter(File projectDir, String dependencyVersion) {
         rewriteBuildFileWithJupiter(projectDir, dependencyVersion)
         rewriteJavaFilesWithJupiterAnno(projectDir)
+        rewriteJavaModuleFileWithJupiterRequires(projectDir)
     }
 
     static replaceCategoriesWithTags(File projectDir) {
@@ -81,6 +82,13 @@ class JUnitPlatformTestRewriter {
                 text = text.replace(key, value)
             }
             it.text = text
+        }
+    }
+
+    static rewriteJavaModuleFileWithJupiterRequires(File rootProject) {
+        def moduleInfo = new File(rootProject, 'src/test/java/module-info.java')
+        if (moduleInfo.exists()) {
+            moduleInfo.text = moduleInfo.text.replace('requires junit', 'requires org.junit.jupiter.api')
         }
     }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -20,8 +20,11 @@ import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
+
+import static org.junit.Assume.assumeFalse
 
 class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
@@ -45,6 +48,7 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
     def installApp = appDebug.install
 
     def setup() {
+        assumeFalse(toolChain.family == AvailableToolChains.ToolFamily.CYGWIN_GCC) // [test setup issue] fails with - greet.cpp:2:22: fatal error: app.hpp: No such file or directory
         buildFile << """
             project(':library') {
                 apply plugin: 'cpp-library'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.junit.Rule
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
+import static org.gradle.testing.fixture.JUnitCoverage.LATEST_LAUNCHER_VERSION
 
 @TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE_JUPITER })
 class TestEnvironmentIntegrationTest extends JUnitMultiVersionIntegrationSpec {
@@ -59,6 +60,18 @@ class TestEnvironmentIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
     def canRunTestsReferencingSlf4jWithModularJava() {
+        given:
+        if(isJupiter() && TestPrecondition.JDK14_OR_LATER.fulfilled) {
+            // Otherwise it throws exception:
+            // java.lang.IllegalAccessError: class org.junit.platform.launcher.core.LauncherFactory (in unnamed module @0x2f2a5b2d)
+            // cannot access class org.junit.platform.commons.util.Preconditions (in module org.junit.platform.commons) because module org.junit.platform.commons does not export org.junit.platform.commons.util to unnamed module @0x2f2a5b2d
+            //
+            // See https://github.com/openjdk/skara/pull/66 for details of this workaround
+            buildFile.text = buildFile.text.replace('dependencies {', """dependencies {
+                testRuntimeOnly 'org.junit.platform:junit-platform-launcher:${LATEST_LAUNCHER_VERSION}'
+                """)
+        }
+
         when:
         run 'test'
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -39,7 +39,8 @@ import static org.junit.Assume.assumeTrue
 
 @TargetCoverage({ JUNIT_4_LATEST + [JUPITER, VINTAGE] })
 class TestReportIntegrationTest extends JUnitMultiVersionIntegrationSpec {
-    @Rule Sample sample = new Sample(temporaryFolder)
+    @Rule
+    Sample sample = new Sample(temporaryFolder)
 
     @ToBeFixedForInstantExecution
     def "report includes results of most recent invocation"() {
@@ -185,13 +186,13 @@ public class SubClassTests extends SuperClassTests {
         def htmlReport = new HtmlTestExecutionResult(testDirectory, 'build/reports/allTests')
         htmlReport.testClass("org.gradle.testing.UnitTest").assertTestCount(1, 0, 0).assertTestPassed("foo").assertStdout(equalTo('org.gradle.testing.UnitTest#foo\n'))
         htmlReport.testClass("org.gradle.testing.SuperTest").assertTestCount(2, 1, 0).assertTestPassed("passing")
-                .assertTestFailed("failing", equalTo('java.lang.AssertionError: failing test'))
-                .assertStdout(allOf(containsString('org.gradle.testing.SuperTest#failing\n'), containsString('org.gradle.testing.SuperTest#passing\n')))
+            .assertTestFailed("failing", equalTo('java.lang.AssertionError: failing test'))
+            .assertStdout(allOf(containsString('org.gradle.testing.SuperTest#failing\n'), containsString('org.gradle.testing.SuperTest#passing\n')))
         htmlReport.testClass("org.gradle.testing.SubTest").assertTestCount(4, 1, 0).assertTestPassed("passing") // onlySub is passing once and failing once
-                .assertStdout(allOf(containsString('org.gradle.testing.SubTest#passing sub\n'),
-                        containsString('org.gradle.testing.SubTest#passing super\n'),
-                        containsString('org.gradle.testing.SubTest#onlySub sub\n'),
-                        containsString('org.gradle.testing.SubTest#onlySub super\n')))
+            .assertStdout(allOf(containsString('org.gradle.testing.SubTest#passing sub\n'),
+                containsString('org.gradle.testing.SubTest#passing super\n'),
+                containsString('org.gradle.testing.SubTest#onlySub sub\n'),
+                containsString('org.gradle.testing.SubTest#onlySub super\n')))
     }
 
     @Issue("https://issues.gradle.org//browse/GRADLE-2821")
@@ -421,12 +422,22 @@ public class SubClassTests extends SuperClassTests {
         then:
         def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
         def clazz = xmlReport.testClass("OutputLifecycleTest")
-        clazz.assertTestCaseStderr("m1", is("constructor err\nbeforeTest err\nm1 err\nafterTest err\n"))
-        clazz.assertTestCaseStderr("m2", is("constructor err\nbeforeTest err\nm2 err\nafterTest err\n"))
-        clazz.assertTestCaseStdout("m1", is("constructor out\nbeforeTest out\nm1 out\nafterTest out\n"))
-        clazz.assertTestCaseStdout("m2", is("constructor out\nbeforeTest out\nm2 out\nafterTest out\n"))
-        clazz.assertStderr(is("beforeClass err\nafterClass err\n"))
-        clazz.assertStdout(is("beforeClass out\nafterClass out\n"))
+        if (isJupiter()) {
+            clazz.assertTestCaseStderr("m1", is("beforeTest err\nm1 err\nafterTest err\n"))
+            clazz.assertTestCaseStderr("m2", is("beforeTest err\nm2 err\nafterTest err\n"))
+            clazz.assertTestCaseStdout("m1", is("beforeTest out\nm1 out\nafterTest out\n"))
+            clazz.assertTestCaseStdout("m2", is("beforeTest out\nm2 out\nafterTest out\n"))
+            clazz.assertStderr(is("beforeClass err\nconstructor err\nconstructor err\nafterClass err\n"))
+            clazz.assertStdout(is("beforeClass out\nconstructor out\nconstructor out\nafterClass out\n"))
+        } else {
+            // Output behavior change in JUnit 4.13
+            clazz.assertTestCaseStderr("m1", is("constructor err\nbeforeTest err\nm1 err\nafterTest err\n"))
+            clazz.assertTestCaseStderr("m2", is("constructor err\nbeforeTest err\nm2 err\nafterTest err\n"))
+            clazz.assertTestCaseStdout("m1", is("constructor out\nbeforeTest out\nm1 out\nafterTest out\n"))
+            clazz.assertTestCaseStdout("m2", is("constructor out\nbeforeTest out\nm2 out\nafterTest out\n"))
+            clazz.assertStderr(is("beforeClass err\nafterClass err\n"))
+            clazz.assertStdout(is("beforeClass out\nafterClass out\n"))
+        }
     }
 
     def "collects output for failing non-root suite descriptors"() {
@@ -484,6 +495,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 """
     }
+
     void failingTestClass(String name) {
         testClass(name, true)
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -24,6 +24,7 @@ class JUnitCoverage {
     final static String NEWEST = '4.13'
     final static String LATEST_JUPITER_VERSION = '5.6.2'
     final static String LATEST_VINTAGE_VERSION = '5.6.2'
+    final static String LATEST_LAUNCHER_VERSION = '1.6.2'
     final static String JUPITER = 'Jupiter:' + LATEST_JUPITER_VERSION
     final static String VINTAGE = 'Vintage:' + LATEST_VINTAGE_VERSION
     final static List<String> LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST]

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
@@ -85,7 +85,7 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
 
         then:
         def expectedTestClasses = ['org.gradle.NestedTestsWithCategories$TagOnMethodNoParam', 'org.gradle.NestedTestsWithCategories$TagOnMethod']
-        if (isVintage() || !(version in ['4.10', '4.11', '4.12', '4.13'])) {
+        if (isVintage() || !(version in ['4.10', '4.11', '4.12'])) {
             expectedTestClasses << 'org.gradle.NestedTestsWithCategories$TagOnClass'
         }
         DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -96,7 +96,52 @@ public class OkTest {
         succeeds "test"
 
         then:
-        outputContains """Test class OkTest -> class loaded
+        if (isJupiter()) {
+            outputContains """Test class OkTest -> class loaded
+Test class OkTest -> before class out
+Test class OkTest -> before class err
+Test class OkTest -> test constructed
+Test anotherOk(OkTest) -> before out
+Test anotherOk(OkTest) -> before err
+Test anotherOk(OkTest) -> ok out
+Test anotherOk(OkTest) -> ok err
+Test anotherOk(OkTest) -> after out
+Test anotherOk(OkTest) -> after err
+Test class OkTest -> test constructed
+Test ok(OkTest) -> before out
+Test ok(OkTest) -> before err
+Test ok(OkTest) -> test out: \u03b1</html>
+Test ok(OkTest) -> test err
+Test ok(OkTest) -> after out
+Test ok(OkTest) -> after err
+Test class OkTest -> after class out
+Test class OkTest -> after class err
+"""
+
+            // This test covers current behaviour, not necessarily desired behaviour
+
+            def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
+            def classResult = xmlReport.testClass("OkTest")
+            classResult.assertTestCaseStdout("ok", is("""before out
+test out: \u03b1</html>
+after out
+"""))
+            classResult.assertTestCaseStderr("ok", is("""before err
+test err
+after err
+"""))
+            classResult.assertStdout(is("""class loaded
+before class out
+test constructed
+test constructed
+after class out
+"""))
+            classResult.assertStderr(is("""before class err
+after class err
+"""))
+        } else {
+            // Behavior change of JUnit 4.13
+            outputContains """Test class OkTest -> class loaded
 Test class OkTest -> before class out
 Test class OkTest -> before class err
 Test anotherOk(OkTest) -> test constructed
@@ -117,26 +162,27 @@ Test class OkTest -> after class out
 Test class OkTest -> after class err
 """
 
-        // This test covers current behaviour, not necessarily desired behaviour
+            // This test covers current behaviour, not necessarily desired behaviour
 
-        def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
-        def classResult = xmlReport.testClass("OkTest")
-        classResult.assertTestCaseStdout("ok", is("""test constructed
+            def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
+            def classResult = xmlReport.testClass("OkTest")
+            classResult.assertTestCaseStdout("ok", is("""test constructed
 before out
 test out: \u03b1</html>
 after out
 """))
-        classResult.assertTestCaseStderr("ok", is("""before err
+            classResult.assertTestCaseStderr("ok", is("""before err
 test err
 after err
 """))
-        classResult.assertStdout(is("""class loaded
+            classResult.assertStdout(is("""class loaded
 before class out
 after class out
 """))
-        classResult.assertStderr(is("""before class err
+            classResult.assertStderr(is("""before class err
 after class err
 """))
+        }
 
         def htmlReport = new HtmlTestExecutionResult(testDirectory)
         def classReport = htmlReport.testClass("OkTest")
@@ -182,7 +228,8 @@ dependencies { testImplementation "org.slf4j:slf4j-simple:1.7.10", "org.slf4j:sl
             }
         """
 
-        when: succeeds("test")
+        when:
+        succeeds("test")
 
         then:
         outputContains("Test foo(FooTest) -> [Test worker] INFO FooTest - slf4j info")
@@ -286,7 +333,8 @@ public class OkTest {
 }
 """
 
-        when: run "test"
+        when:
+        run "test"
 
         then:
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
@@ -16,8 +16,10 @@ dependencies {
 
 compileTestJava {
     def args = ["--module-path", compileTestJava.classpath.asPath,
+                "--add-modules", "slf4j.api",
                 "--add-modules", "junit",
-                "--add-reads", "org.gradle.example=junit"]
+                "--add-reads", "org.gradle.example=junit",
+                "--add-reads", "org.gradle.example=slf4j.api"]
     options.compilerArgs = args
     classpath = files()
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
@@ -7,32 +7,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-api:1.7.25'
-    implementation 'org.slf4j:slf4j-simple:1.7.25'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
 
     testImplementation 'junit:junit:4.13'
 }
 
-
-compileTestJava {
-    def args = ["--module-path", compileTestJava.classpath.asPath,
-                "--add-modules", "slf4j.api",
-                "--add-modules", "junit",
-                "--add-reads", "org.gradle.example=junit",
-                "--add-reads", "org.gradle.example=slf4j.api"]
-    options.compilerArgs = args
-    classpath = files()
-}
-
-test {
-    def args = ["--module-path", test.classpath.asPath,
-                "--add-modules", "ALL-MODULE-PATH",
-                "--add-reads", "org.gradle.example=junit",
-                "--add-reads", "org.gradle.example=slf4j.api"]
-    jvmArgs = args
-    classpath = files()
-
-    // Required because modular tests are not properly supported
-    scanForTestClasses = false
-    include "**/TestUsingSlf4j.class"
-}
+java.modularity.inferModulePath = true

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/module-info.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/module-info.java
@@ -1,3 +1,5 @@
 module org.gradle.example {
-    exports org.gradle.example; 
+    exports org.gradle.example;
+    requires junit;
+    requires org.slf4j;
 }


### PR DESCRIPTION
### Context 

```
    private
    fun Project.isRequestedTask(taskName: String) = gradle.startParameter.taskNames.contains(taskName)
```

The old code doesn't handle `codeQuality:allVersionsIntegMultiVersionTest` correctly.