### PR TITLE
Sort configurations in single lock file

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class LockFileReaderWriter {
 
@@ -225,10 +226,10 @@ public class LockFileReaderWriter {
             List<String> content = new ArrayList<>(50);
             content.addAll(LOCKFILE_HEADER_LIST);
             for (Map.Entry<String, List<String>> entry : dependencyToConfigurations.entrySet()) {
-                String builder = entry.getKey() + "=" + String.join(",", entry.getValue());
+                String builder = entry.getKey() + "=" + entry.getValue().stream().sorted().collect(Collectors.joining(","));
                 content.add(builder);
             }
-            content.add("empty=" + String.join(",", emptyConfigurations));
+            content.add("empty=" + emptyConfigurations.stream().sorted().collect(Collectors.joining(",")));
             Files.write(lockfilePath, content, CHARSET);
         } catch (IOException e) {
             throw new RuntimeException("Unable to write unique lockfile", e);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -209,7 +209,6 @@ public class LockFileReaderWriter {
 
     public void writeUniqueLockfile(Map<String, List<String>> lockState) {
         checkValidRoot();
-        makeLockfilesRoot();
         Path lockfilePath = getUniqueLockfilePath();
 
         // Revert mapping

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -60,6 +60,19 @@ empty=c
 """.denormalize()
     }
 
+    def 'writes dependencies and configurations sorted in the unique lock file'() {
+        when:
+        lockFileReaderWriter.writeUniqueLockfile([b: ['foo', 'bar'], d: ['bar', 'foobar'],a: ['foo'], e: [], f: [], c: []])
+
+        then:
+        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+bar=b,d
+foo=a,b
+foobar=d
+empty=c,e,f
+""".denormalize()
+    }
+
     def 'writes a unique lock file to a custom location'() {
         def lockFile = tmpDir.file('different', 'lock.file')
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -50,6 +50,7 @@ class LockFileReaderWriterTest extends Specification {
 
     def 'writes a unique lock file'() {
         when:
+        lockDir.deleteDir()
         lockFileReaderWriter.writeUniqueLockfile([a: ['foo', 'bar'], b: ['foo'], c: []])
 
         then:
@@ -58,6 +59,7 @@ bar=a
 foo=a,b
 empty=c
 """.denormalize()
+        !lockDir.exists()
     }
 
     def 'writes dependencies and configurations sorted in the unique lock file'() {
@@ -75,6 +77,7 @@ empty=c,e,f
 
     def 'writes a unique lock file to a custom location'() {
         def lockFile = tmpDir.file('different', 'lock.file')
+        lockDir.deleteDir()
         given:
         this.lockFile.set(lockFile)
 
@@ -87,6 +90,7 @@ bar=a
 foo=a,b
 empty=c
 """.denormalize()
+        !lockDir.exists()
     }
 
     def 'writes a legacy lock file on persist'() {


### PR DESCRIPTION
This will make sure resolution ordering or internal representation gives
a consistent output.