### PR TITLE
Cleanup IDEA configuration of gradle/gradle build

### DIFF
--- a/buildSrc/subprojects/ide/ide.gradle.kts
+++ b/buildSrc/subprojects/ide/ide.gradle.kts
@@ -1,9 +1,6 @@
 dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
-    implementation(project(":docs")) {
-        because("we need to access the release notes location for the JUnit run configuration")
-    }
 
     implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")
 }

--- a/buildSrc/subprojects/ide/ide.gradle.kts
+++ b/buildSrc/subprojects/ide/ide.gradle.kts
@@ -1,8 +1,9 @@
 dependencies {
     implementation(project(":configuration"))
-    // TODO remove dependency once docs has publications
-    implementation(project(":docs"))
     implementation(project(":kotlinDsl"))
+    implementation(project(":docs")) {
+        because("we need to access the release notes location for the JUnit run configuration")
+    }
 
     implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")
 }

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -52,14 +52,15 @@ limitations under the License."""
 open class IdePlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        if (providers.systemProperty("idea.active").getOrElse("false").toBoolean()) {
-            configureIdeaForRootProject()
-        }
+        configureIdeaForRootProject()
     }
 
     private
     fun Project.configureIdeaForRootProject() {
         apply(plugin = "org.jetbrains.gradle.plugin.idea-ext")
+        tasks.named("idea") {
+            doFirst { throw RuntimeException("To import in IntelliJ, please follow the instructions here: https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#intellij") }
+        }
         with(the<IdeaModel>()) {
             module {
                 excludeDirs = setOf(intTestHomeDir)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -120,8 +120,6 @@ fun IntegrationTest.addDebugProperties() {
 internal
 fun Project.configureIde(testType: TestType) {
     val prefix = testType.prefix
-    val compile = configurations.getByName("${prefix}TestCompileClasspath")
-    val runtime = configurations.getByName("${prefix}TestRuntimeClasspath")
     val sourceSet = java.sourceSets.getByName("${prefix}Test")
 
     // We apply lazy as we don't want to depend on the order
@@ -131,10 +129,6 @@ fun Project.configureIde(testType: TestType) {
                 testSourceDirs = testSourceDirs + sourceSet.java.srcDirs
                 testSourceDirs = testSourceDirs + sourceSet.groovy.srcDirs
                 testResourceDirs = testResourceDirs + sourceSet.resources.srcDirs
-                scopes["TEST"]!!["plus"]!!.apply {
-                    add(compile)
-                    add(runtime)
-                }
             }
         }
     }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -319,10 +319,6 @@ class PerformanceTestPlugin : Plugin<Project> {
                 module {
                     testSourceDirs = testSourceDirs + performanceTestSourceSet.groovy.srcDirs
                     testResourceDirs = testResourceDirs + performanceTestSourceSet.resources.srcDirs
-                    scopes["TEST"]!!["plus"]!!.apply {
-                        add(performanceTestCompileClasspath)
-                        add(performanceTestRuntimeClasspath)
-                    }
                 }
             }
         }


### PR DESCRIPTION
This removes unnecessary IDEA configuration code.

Now that everything is delegated to Gradle, we do not need to configure
certain aspects in IDEA anymore.

Some code - the setup of the "run" task - was also still configured
for the old "one module per project" setup and thus broken. I removed
that one as I am not sure if there is still a requirement for it. Since it
was broken, I don't think anyone still used that. If needed, we should
add run configurations that also delegate everything to Gradle.

There was also some unnecessary configuration, because IDEA now does
some things by default by now (like knowing about buildSrc/build).

All warnings in the IdeaPlugin code have been addressed
and TODO comments have been clarified.

There was some uncommented code for setting inspections with the comment
to activate it later. This dead code has been removed as the moment
to activate it never came and the rule setup was outdated by now in
any case.