### PR TITLE
Support creating TAR archives containing files larger than 8 GB

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -74,6 +74,7 @@ public class TarCopyAction implements CopyAction {
                     throw new GradleException(String.format("Could not create TAR '%s'.", tarFile), e);
                 }
                 tarOutStr.setLongFileMode(TarOutputStream.LONGFILE_GNU);
+                tarOutStr.setBigNumberMode(TarOutputStream.BIGNUMBER_STAR);
                 stream.process(new StreamAction(tarOutStr));
                 tarOutStr.close();
             }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -3,6 +3,7 @@ The Gradle team is excited to announce Gradle @version@.
 This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
+ [Peter Runge](https://github.com/causalnet)
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)


### PR DESCRIPTION
Signed-off-by: Peter Runge <prunge@causal.net.au>

<!--- The issue this PR addresses -->
Fixes #12989 

### Context
Allows TAR files with entries larger than 8 GB to be created using GNU TAR extensions.

Configuring this extension is safe for creating 'normal' TARs with small entries - in `TarOutputStream`, the big number mode will only have effect when there are actually large entries.  So existing TAR files should be written out 100% the same as before.  I have tested this locally and done a binary diff on a sample TAR file to confirm this too.

Reference:
https://github.com/apache/ant/blob/rel/1.10.7/src/main/org/apache/tools/tar/TarOutputStream.java#L317
https://github.com/apache/ant/blob/rel/1.10.7/src/main/org/apache/tools/tar/TarEntry.java#L892

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
