### PR TITLE
Serialize Property instances with finalize on read enabled to the instant execution cache

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-rc-4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.5-20200430220121+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -31,7 +31,15 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
     protected InstantExecutionProblemsFixture problems
 
     def setup() {
+        // Verify that the previous test cleaned up state correctly
+        assert System.getProperty(SystemProperties.isEnabled) == null
         problems = new InstantExecutionProblemsFixture(executer, testDirectory)
+    }
+
+    @Override
+    def cleanup() {
+        // Verify that the test (or fixtures) has cleaned up state correctly
+        assert System.getProperty(SystemProperties.isEnabled) == null
     }
 
     void buildKotlinFile(@Language("kotlin") String script) {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
@@ -16,13 +16,8 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
 import org.gradle.util.ToBeImplemented
-
-import javax.annotation.Nullable
-
 import spock.lang.Ignore
-
 
 class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
@@ -39,11 +34,9 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
     }
 
     def "can enable instant execution from the client jvm"() {
-
         setup:
-        AbstractGradleExecuter.propagateSystemProperty(SystemProperties.isEnabled)
-        def previousProp = System.getProperty(SystemProperties.isEnabled)
-        System.setProperty(SystemProperties.isEnabled, "true")
+        executer.withCommandLineGradleOpts(INSTANT_EXECUTION_PROPERTY)
+        executer.requireGradleDistribution()
 
         and:
         def fixture = newInstantExecutionFixture()
@@ -53,22 +46,12 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
 
         then:
         fixture.assertStateStored()
-
-        cleanup:
-        setOrClearProperty(SystemProperties.isEnabled, previousProp)
-        AbstractGradleExecuter.doNotPropagateSystemProperty(SystemProperties.isEnabled)
     }
 
     @Ignore
     @ToBeImplemented
     def "can enable instant execution from gradle.properties"() {
         setup:
-        def previousProp = System.getProperty(SystemProperties.isEnabled)
-        if (GradleContextualExecuter.isEmbedded()) {
-            System.clearProperty(SystemProperties.isEnabled)
-        }
-
-        and:
         file('gradle.properties') << """
             systemProp.${SystemProperties.isEnabled}=true
         """
@@ -81,16 +64,5 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
 
         then: 'instant execution is enabled'
         fixture.assertStateStored()
-
-        cleanup:
-        setOrClearProperty(SystemProperties.isEnabled, previousProp)
-    }
-
-    private static void setOrClearProperty(String name, @Nullable String value) {
-        if (value != null) {
-            System.setProperty(name, value)
-        } else {
-            System.clearProperty(name)
-        }
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -27,7 +27,7 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
         buildFile << """
             plugins {
                 id("java")
-            }    
+            }
         """
 
         when:
@@ -39,6 +39,7 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
     }
 
     ExecutionResult runWithInstantExecutionViaToolingApi(String... tasks) {
+        // TODO - move this to a GradleExecuter implementation
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
         def context = new IntegrationTestBuildContext()
@@ -62,6 +63,9 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
                 .run()
         } finally {
             connection.close()
+            if (GradleContextualExecuter.embedded) {
+                System.clearProperty(SystemProperties.isEnabled)
+            }
         }
         result = OutputScrapingExecutionResult.from(output.toString(), error.toString())
         return result

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -531,7 +531,6 @@ project.extensions.create("some", SomeExtension)
         'prop5' | 'fileProperty()'      | 'RegularFile' | ''
     }
 
-    @ToBeFixedForInstantExecution
     @IgnoreIf({ GradleContextualExecuter.parallel })
     @Issue("https://github.com/gradle/gradle/issues/12811")
     def "multiple tasks can have property values calculated from a shared finalize on read property instance with value derived from dependency resolution"() {
@@ -587,7 +586,6 @@ project.extensions.create("some", SomeExtension)
         file("consumer/build/consumer2.txt").text == "producer"
     }
 
-    @ToBeFixedForInstantExecution
     @Issue("https://github.com/gradle/gradle/issues/12969")
     @IgnoreIf({ GradleContextualExecuter.parallel })
     def "task can have property value derived from dependency resolution result when another task has input files derived from same result"() {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -144,7 +144,6 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        beforeRead(producer, ValueConsumer.IgnoreUnsafeRead);
         ExecutionTimeValue<? extends T> value = calculateOwnExecutionTimeValue(this.value);
         if (getProducerTask() == null) {
             return value;

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -2553,6 +2553,30 @@ The value of this provider is derived from:
         value.changingValue.get() == someOtherValue()
     }
 
+    def "can calculate execution time value without finalizing when finalize on read is enabled"() {
+        def property = propertyWithNoValue()
+        property.set(someValue())
+        property.finalizeValueOnRead()
+
+        expect:
+        property.calculateExecutionTimeValue().getFixedValue() == someValue()
+        property.set(someOtherValue())
+        property.calculateExecutionTimeValue().getFixedValue() == someOtherValue()
+        property.get() == someOtherValue()
+    }
+
+    def "can calculate execution time value without finalizing when unsafe read disallowed"() {
+        def property = propertyWithNoValue()
+        property.set(someValue())
+        property.disallowUnsafeRead()
+
+        expect:
+        property.calculateExecutionTimeValue().getFixedValue() == someValue()
+        property.set(someOtherValue())
+        property.calculateExecutionTimeValue().getFixedValue() == someOtherValue()
+        property.get() == someOtherValue()
+    }
+
     def "mapped value has changing execution time value when producer task attached to original property"() {
         def task = Mock(Task)
         def property = propertyWithDefaultValue()


### PR DESCRIPTION

### Context

Correctly serialize `Property` instances with finalize on read enabled to the instant execution cache, when the property value is derived from a task output.

Also fixes some test flakiness and upgrades to a recent Gradle nightly.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
