### PR TITLE
Instant execution allows undeclared system property reads when the property value is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 # ------
 .gradle
+.instant-execution-state
 /build
 /buildSrc/build
 /buildSrc/subprojects/*/build

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -20,10 +20,11 @@ import org.codehaus.groovy.runtime.callsite.AbstractCallSite;
 import org.codehaus.groovy.runtime.callsite.CallSite;
 import org.codehaus.groovy.runtime.callsite.CallSiteArray;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class Instrumented {
-    private static final Listener NO_OP = (key, consumer) -> {
+    private static final Listener NO_OP = (key, value, consumer) -> {
     };
     private static final AtomicReference<Listener> LISTENER = new AtomicReference<>(NO_OP);
 
@@ -46,12 +47,16 @@ public class Instrumented {
 
     // Called by generated code.
     public static String systemProperty(String key, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, consumer);
-        return System.getProperty(key);
+        String value = System.getProperty(key);
+        LISTENER.get().systemPropertyQueried(key, value, consumer);
+        return value;
     }
 
     public interface Listener {
-        void systemPropertyQueried(String key, String consumer);
+        /**
+         * @param consumer The name of the class that is reading the property value
+         */
+        void systemPropertyQueried(String key, @Nullable String value, String consumer);
     }
 
     private static class SystemPropertyCallSite extends AbstractCallSite {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
@@ -183,9 +183,10 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
         result.assertTasksSkipped(":producer", ":transformer")
 
         where:
-        description         | propertyConfig
-        "default behaviour" | ""
-        "finalize on read"  | "it.finalizeValueOnRead()"
+        description            | propertyConfig
+        "default behaviour"    | ""
+        "finalize on read"     | "it.finalizeValueOnRead()"
+        "disallow unsafe read" | "it.disallowUnsafeRead()"
     }
 
     def "task input collection property can consume the mapped output of another task"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyInjection.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyInjection.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.inputs.undeclared
+
+import org.gradle.instantexecution.AbstractInstantExecutionIntegrationTest
+
+abstract class SystemPropertyInjection {
+    abstract String getDescription()
+
+    List<String> getGradleArgs() {
+        return []
+    }
+
+    void setup(AbstractInstantExecutionIntegrationTest test) {
+    }
+
+    static List<SystemPropertyInjection> all(String prop, String value) {
+        return [
+            commandLine(prop, value),
+            gradleProperties(prop, value),
+            clientJvmArgs(prop, value)
+        ]
+    }
+
+    static SystemPropertyInjection commandLine(String prop, String value) {
+        return new SystemPropertyInjection() {
+            @Override
+            String getDescription() {
+                return "using command-line"
+            }
+
+            @Override
+            List<String> getGradleArgs() {
+                return ["-D${prop}=${value}"]
+            }
+        }
+    }
+
+    static SystemPropertyInjection gradleProperties(String prop, String value) {
+        return new SystemPropertyInjection() {
+            @Override
+            String getDescription() {
+                return "using gradle.properties"
+            }
+
+            @Override
+            void setup(AbstractInstantExecutionIntegrationTest test) {
+                test.file("gradle.properties").text = "systemProp.${prop}=${value}"
+            }
+        }
+    }
+
+    static SystemPropertyInjection clientJvmArgs(String prop, String value) {
+        return new SystemPropertyInjection() {
+            @Override
+            String getDescription() {
+                return "using client JVM args"
+            }
+
+            @Override
+            void setup(AbstractInstantExecutionIntegrationTest test) {
+                test.executer.requireGradleDistribution()
+                test.executer.withCommandLineGradleOpts("-D${prop}=${value}")
+            }
+        }
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
+        buildFile << """
+            buildscript {
+                println("apply CI = " + System.getProperty("CI"))
+            }
             tasks.register("thing") {
                 doLast {
                     println("task CI = " + System.getProperty("CI"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
@@ -20,22 +20,12 @@ class UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest extends Abstr
     @Override
     void buildLogicApplication() {
         buildFile << """
-            buildscript {
-                println("apply BUILDSCRIPT = " + System.getProperty("BUILDSCRIPT"))
+            println("apply CI = " + System.getProperty("CI"))
+            tasks.register("thing") {
+                doLast {
+                    println("task CI = " + System.getProperty("CI"))
+                }
             }
         """
-
-        dynamicGroovyPlugin(buildFile)
-
-        buildFile << """
-            apply plugin: SneakyPlugin
-            println("apply SCRIPT = " + System.getProperty("SCRIPT"))
-        """
-    }
-
-    @Override
-    void additionalProblems() {
-        outputContains("- unknown location: read system property 'BUILDSCRIPT' from '")
-        outputContains("- unknown location: read system property 'SCRIPT' from '")
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
@@ -16,16 +16,12 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
+        dynamicGroovyPlugin(buildFile)
+        buildFile << """
+            apply plugin: SneakyPlugin
         """
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest.groovy
@@ -20,20 +20,17 @@ class UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest extends Abst
     @Override
     void buildLogicApplication() {
         def script = file("plugin.gradle")
-        dynamicGroovyPlugin(script)
-
         script << """
-            apply plugin: SneakyPlugin
-            println("apply SCRIPT = " + System.getProperty("SCRIPT"))
+            println("apply CI = " + System.getProperty("CI"))
+            tasks.register("thing") {
+                doLast {
+                    println("task CI = " + System.getProperty("CI"))
+                }
+            }
         """
 
         buildFile << """
             apply from: "plugin.gradle"
         """
-    }
-
-    @Override
-    void additionalProblems() {
-        outputContains("- unknown location: read system property 'SCRIPT' from '")
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
@@ -16,14 +16,16 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildKotlinFile << """
+        settingsFile << """
             println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
+            gradle.rootProject {
+                tasks.register("thing") {
+                    doLast {
+                        println("task CI = " + System.getProperty("CI"))
+                    }
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.instantexecution.inputs.undeclared
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.instantexecution.AbstractInstantExecutionIntegrationTest
+import spock.lang.Unroll
 
 class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionIntegrationTest {
     def "reports build logic reading a system property via the Java API"() {
@@ -39,7 +40,8 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         failure.assertThatCause(containsNormalizedString("Read system property 'CI' from 'build_"))
     }
 
-    def "plugin can use standard properties without declaring access"() {
+    @Unroll
+    def "plugin can use standard property #prop without declaring access"() {
         file("buildSrc/src/main/java/SneakyPlugin.java") << """
             import ${Project.name};
             import ${Plugin.name};
@@ -72,6 +74,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         prop << [
             "os.name",
             "os.version",
+            "os.arch",
             "java.version",
             "java.vm.version",
             "java.specification.version",

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
@@ -16,16 +16,12 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
     void buildLogicApplication() {
+        kotlinPlugin(buildKotlinFile)
         buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
+            plugins.apply(SneakyPlugin::class.java)
         """
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
     void buildLogicApplication() {
         buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
+            plugins {
+                println("apply CI = " + System.getProperty("CI"))
+            }
             tasks.register("thing") {
                 doLast {
                     println("task CI = " + System.getProperty("CI"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
@@ -20,19 +20,16 @@ class UndeclaredBuildInputsKotlinScriptPluginIntegrationTest extends AbstractUnd
     @Override
     void buildLogicApplication() {
         def script = file("plugin.gradle.kts")
-        kotlinPlugin(script)
         script << """
-            println("apply SCRIPT = " + System.getProperty("SCRIPT"))
-
-            plugins.apply(SneakyPlugin::class.java)
+            println("apply CI = " + System.getProperty("CI"))
+            tasks.register("thing") {
+                doLast {
+                    println("task CI = " + System.getProperty("CI"))
+                }
+            }
         """
         buildFile << """
             apply from: "plugin.gradle.kts"
         """
-    }
-
-    @Override
-    void additionalProblems() {
-        outputContains("- unknown location: read system property 'SCRIPT' from '")
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
@@ -16,14 +16,16 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
+class UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildKotlinFile << """
+        settingsKotlinFile << """
             println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
+            gradle.rootProject {
+                tasks.register("thing") {
+                    doLast {
+                        println("task CI = " + System.getProperty("CI"))
+                    }
                 }
             }
         """

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -69,12 +69,12 @@ class DefaultInstantExecution internal constructor(
     private val host: Host,
     private val startParameter: InstantExecutionStartParameter,
     private val problems: InstantExecutionProblems,
+    private val systemPropertyListener: SystemPropertyAccessListener,
     private val scopeRegistryListener: InstantExecutionClassLoaderScopeRegistryListener,
     private val cacheFingerprintController: InstantExecutionCacheFingerprintController,
     private val beanConstructors: BeanConstructors,
     private val gradlePropertiesController: GradlePropertiesController
 ) : InstantExecution {
-
     interface Host {
 
         val currentBuild: VintageGradleBuild
@@ -133,7 +133,7 @@ class DefaultInstantExecution internal constructor(
         if (!isInstantExecutionEnabled) return
 
         startCollectingCacheFingerprint()
-        Instrumented.setListener(SystemPropertyAccessListener(problems))
+        Instrumented.setListener(systemPropertyListener)
     }
 
     override fun saveScheduledWork() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -50,6 +50,7 @@ class InstantExecutionServices : AbstractPluginServiceRegistry() {
         registration.run {
             add(InstantExecutionClassLoaderScopeRegistryListener::class.java)
             add(InstantExecutionBuildScopeListenerManagerAction::class.java)
+            add(SystemPropertyAccessListener::class.java)
             addProvider(BuildServicesProvider())
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
@@ -32,6 +32,7 @@ class SystemPropertyAccessListener(
     val whitelistedProperties = setOf(
         "os.name",
         "os.version",
+        "os.arch",
         "java.version",
         "java.vm.version",
         "java.runtime.version",

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/UndeclaredBuildInputListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/UndeclaredBuildInputListener.kt
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.instantexecution.inputs.undeclared
+package org.gradle.instantexecution
 
-class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
-    @Override
-    void buildLogicApplication() {
-        buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
-        """
-    }
+
+interface UndeclaredBuildInputListener {
+    fun systemPropertyRead(key: String)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprint.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprint.kt
@@ -44,6 +44,10 @@ sealed class InstantExecutionCacheFingerprint {
     data class ValueSource(
         val obtainedValue: ObtainedValue
     ) : InstantExecutionCacheFingerprint()
+
+    data class UndeclaredSystemProperty(
+        val key: String
+    ) : InstantExecutionCacheFingerprint()
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintChecker.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintChecker.kt
@@ -69,6 +69,11 @@ class InstantExecutionCacheFingerprintChecker(private val host: Host) {
                         return reason
                     }
                 }
+                is InstantExecutionCacheFingerprint.UndeclaredSystemProperty -> input.run {
+                    if (isDefined(key)) {
+                        return "system property '$key' has changed"
+                    }
+                }
                 else -> throw IllegalStateException("Unexpected instant execution cache fingerprint: $input")
             }
         }
@@ -119,6 +124,11 @@ class InstantExecutionCacheFingerprintChecker(private val host: Host) {
             return buildLogicInputHasChanged(valueSource)
         }
         return null
+    }
+
+    private
+    fun isDefined(key: String): Boolean {
+        return System.getProperty(key) != null
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
@@ -27,6 +27,7 @@ import org.gradle.instantexecution.extensions.serviceOf
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.vfs.VirtualFileSystem
@@ -46,7 +47,8 @@ class InstantExecutionCacheFingerprintController internal constructor(
     private val valueSourceProviderFactory: ValueSourceProviderFactory,
     private val virtualFileSystem: VirtualFileSystem,
     private val fileCollectionFingerprinter: AbsolutePathFileCollectionFingerprinter,
-    private val listenerManager: BuildTreeListenerManager
+    private val listenerManager: ListenerManager,
+    private val buildTreeListenerManager: BuildTreeListenerManager
 ) {
 
     private
@@ -126,14 +128,15 @@ class InstantExecutionCacheFingerprintController internal constructor(
 
     private
     fun addListener(listener: InstantExecutionCacheFingerprintWriter) {
-        listenerManager.service.addListener(listener)
+        listenerManager.addListener(listener)
+        buildTreeListenerManager.service.addListener(listener)
         taskInputsListeners.addListener(listener)
     }
 
     private
     fun removeListener(listener: InstantExecutionCacheFingerprintWriter) {
         taskInputsListeners.removeListener(listener)
-        listenerManager.service.removeListener(listener)
+        buildTreeListenerManager.service.removeListener(listener)
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
@@ -25,6 +25,7 @@ import org.gradle.api.internal.provider.sources.FileContentValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.initialization.DefaultSettingsLoader.BUILD_SRC_PROJECT_PATH
+import org.gradle.instantexecution.UndeclaredBuildInputListener
 import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprint.InputFile
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprint.ValueSource
@@ -39,7 +40,7 @@ internal
 class InstantExecutionCacheFingerprintWriter(
     private val host: Host,
     private val writeContext: DefaultWriteContext
-) : ValueSourceProviderFactory.Listener, TaskInputsListener, ScriptExecutionListener {
+) : ValueSourceProviderFactory.Listener, TaskInputsListener, ScriptExecutionListener, UndeclaredBuildInputListener {
 
     interface Host {
 
@@ -74,6 +75,10 @@ class InstantExecutionCacheFingerprintWriter(
     fun close() {
         write(null)
         writeContext.close()
+    }
+
+    override fun systemPropertyRead(key: String) {
+        write(InstantExecutionCacheFingerprint.UndeclaredSystemProperty(key))
     }
 
     override fun <T : Any, P : ValueSourceParameters> valueObtained(

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDependencySubstitutionIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesDependencySubstitutionIntegrationTest extends AbstractIntegrationSp
 
     @Unroll
     @UsesSample("dependencyManagement/customizingResolution/conditionalSubstitutionRule")
-    @ToBeFixedForInstantExecution(because = "sample uses system property")
+    @ToBeFixedForInstantExecution(because = "sample uses system property", iterationMatchers = ".*kotlin dsl.*")
     def "can run sample with all external dependencies with #dsl dsl" () {
         executer.inDirectory(sample.dir.file(dsl))
 


### PR DESCRIPTION

### Context

Tweak the strategy for handling undeclared system property reads when instant execution is enabled, so that a plugin or library can read a system property that has no value, but that system property also becomes a build input.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
