### PR TITLE
Annotate internal APIs used by test-distribution

### DIFF
--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/NotUsedByScanPlugin.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/NotUsedByScanPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,17 +22,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Documents that the type or method is referenced by the build scan plugin,
- * and therefore changes need to be carefully managed.
+ * Documents that the type or method is <em>not</em> referenced by the build scan plugin,
+ * and therefore can be changed or removed without breaking it.
  *
- * @since 4.0
+ * @since 5.1
  */
 @Retention(RetentionPolicy.SOURCE)
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
-public @interface UsedByScanPlugin {
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface NotUsedByScanPlugin {
 
     /**
-     * Any clarifying comments about how it is used.
+     * Any clarifying comments about why it isn't used by the build scan plugin or how it is used instead.
      */
     String value() default "";
 

--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,17 +22,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Documents that the type or method is <em>not</em> referenced by the build scan plugin,
- * and therefore can be changed or removed without breaking it.
+ * Documents that the type or method is referenced by the build scan plugin,
+ * and therefore changes need to be carefully managed.
  *
- * @since 5.1
+ * @since 4.0
  */
 @Retention(RetentionPolicy.SOURCE)
-@Target({ElementType.METHOD, ElementType.TYPE})
-public @interface NotUsedByScanPlugin {
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface UsedByScanPlugin {
 
     /**
-     * Any clarifying comments about why it isn't used by the build scan plugin or how it is used instead.
+     * Any clarifying comments about how it is used.
      */
     String value() default "";
 

--- a/subprojects/base-services/src/main/java/org/gradle/initialization/BuildCancellationToken.java
+++ b/subprojects/base-services/src/main/java/org/gradle/initialization/BuildCancellationToken.java
@@ -31,6 +31,7 @@ public interface BuildCancellationToken {
     /**
      * @return current state of cancellation request before callback was added.
      */
+    @UsedByScanPlugin("test-distribution")
     boolean addCallback(Runnable cancellationHandler);
 
     /**
@@ -38,6 +39,7 @@ public interface BuildCancellationToken {
      *
      * @param cancellationHandler removed callback.
      */
+    @UsedByScanPlugin("test-distribution")
     void removeCallback(Runnable cancellationHandler);
 
 }

--- a/subprojects/base-services/src/main/java/org/gradle/initialization/BuildCancellationToken.java
+++ b/subprojects/base-services/src/main/java/org/gradle/initialization/BuildCancellationToken.java
@@ -16,9 +16,12 @@
 
 package org.gradle.initialization;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 /**
  * Propagates notification that the build should be cancelled.
  */
+@UsedByScanPlugin("test-distribution")
 public interface BuildCancellationToken {
 
     boolean isCancellationRequested();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/CurrentBuildOperationRef.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/CurrentBuildOperationRef.java
@@ -15,19 +15,24 @@
  */
 package org.gradle.internal.operations;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import javax.annotation.Nullable;
 
+@UsedByScanPlugin("test-distribution")
 public class CurrentBuildOperationRef {
 
     private static final CurrentBuildOperationRef INSTANCE = new CurrentBuildOperationRef();
 
     private final ThreadLocal<BuildOperationRef> ref = new ThreadLocal<BuildOperationRef>();
 
+    @UsedByScanPlugin("test-distribution")
     public static CurrentBuildOperationRef instance() {
         return INSTANCE;
     }
 
     @Nullable
+    @UsedByScanPlugin("test-distribution")
     public BuildOperationRef get() {
         return ref.get();
     }
@@ -44,6 +49,7 @@ public class CurrentBuildOperationRef {
         return operationState == null ? null : operationState.getParentId();
     }
 
+    @UsedByScanPlugin("test-distribution")
     public void set(@Nullable BuildOperationRef state) {
         if (state == null) {
             ref.remove();
@@ -52,6 +58,7 @@ public class CurrentBuildOperationRef {
         }
     }
 
+    @UsedByScanPlugin("test-distribution")
     public void clear() {
         ref.remove();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -85,6 +85,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     DynamicObject getInheritedScope();
 
     @Override
+    @UsedByScanPlugin("test-distribution")
     GradleInternal getGradle();
 
     ProjectEvaluationListener getProjectEvaluationBroadcaster();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.internal.reflect.TypeValidationContext;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 @NonNullApi
 public class TaskPropertyUtils {
@@ -28,6 +29,7 @@ public class TaskPropertyUtils {
      * Visits both properties declared via annotations on the properties of the task type as well as
      * properties declared via the runtime API ({@link org.gradle.api.tasks.TaskInputs} etc.).
      */
+    @UsedByScanPlugin("test-distribution")
     public static void visitProperties(PropertyWalker propertyWalker, TaskInternal task, PropertyVisitor visitor) {
         visitProperties(propertyWalker, task, TypeValidationContext.NOOP, visitor);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin("test-distribution")
 public enum InputFilePropertyType {
     FILE(ValidationActions.INPUT_FILE_VALIDATOR),
     DIRECTORY(ValidationActions.INPUT_DIRECTORY_VALIDATOR),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
@@ -34,6 +34,7 @@ public enum  OutputFilePropertyType {
         this.validationAction = validationAction;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public TreeType getOutputType() {
         return outputType;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.internal.file.TreeType;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin("test-distribution")
 public enum  OutputFilePropertyType {
     FILE(TreeType.FILE, ValidationActions.OUTPUT_FILE_VALIDATOR),
     DIRECTORY(TreeType.DIRECTORY, ValidationActions.OUTPUT_DIRECTORY_VALIDATOR),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
@@ -25,6 +26,7 @@ import java.util.concurrent.Callable;
 /**
  * A supplier of a property value. The property value may not necessarily be final and may change over time.
  */
+@UsedByScanPlugin("test-distribution")
 public interface PropertyValue extends Callable<Object> {
     /**
      * The value of the underlying property, replacing an empty provider by {@literal null}.
@@ -34,6 +36,7 @@ public interface PropertyValue extends Callable<Object> {
      */
     @Nullable
     @Override
+    @UsedByScanPlugin("test-distribution")
     Object call();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
@@ -17,12 +17,14 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.tasks.FileNormalizer;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 
 /**
  * Visits properties of beans which are inputs, outputs, destroyables or local state.
  */
+@UsedByScanPlugin("test-distribution")
 public interface PropertyVisitor {
     void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType);
 
@@ -34,8 +36,10 @@ public interface PropertyVisitor {
 
     void visitLocalStateProperty(Object value);
 
+    @UsedByScanPlugin("test-distribution")
     class Adapter implements PropertyVisitor {
         @Override
+        @UsedByScanPlugin("test-distribution")
         public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
         }
 
@@ -44,6 +48,7 @@ public interface PropertyVisitor {
         }
 
         @Override
+        @UsedByScanPlugin("test-distribution")
         public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
@@ -17,10 +17,12 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.internal.reflect.TypeValidationContext;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Walks properties declared by the type.
  */
+@UsedByScanPlugin("test-distribution")
 public interface PropertyWalker {
     void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/TreeType.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/TreeType.java
@@ -16,9 +16,12 @@
 
 package org.gradle.internal.file;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 /**
  * Type of an existing file tree.
  */
+@UsedByScanPlugin("test-distribution")
 public enum TreeType {
     FILE,
     DIRECTORY

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVersionDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVersionDetector.java
@@ -18,10 +18,12 @@ package org.gradle.internal.jvm.inspection;
 
 import org.gradle.api.JavaVersion;
 import org.gradle.internal.jvm.JavaInfo;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Probes a JVM installation to determine the Java version it provides.
  */
+@UsedByScanPlugin("test-distribution")
 public interface JvmVersionDetector {
     /**
      * Probes the Java version for the given JVM installation.
@@ -31,5 +33,6 @@ public interface JvmVersionDetector {
     /**
      * Probes the Java version for the given `java` command.
      */
+    @UsedByScanPlugin("test-distribution")
     JavaVersion getJavaVersion(String javaCommand);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLogger.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.logging.progress;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import javax.annotation.Nullable;
 
 /**
@@ -37,6 +39,7 @@ import javax.annotation.Nullable;
  *
  * </p>
  */
+@UsedByScanPlugin("test-distribution")
 public interface ProgressLogger {
     /**
      * Returns the description of the operation.

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
@@ -17,10 +17,12 @@
 package org.gradle.internal.logging.progress;
 
 import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Thread-safe, however the progress logger instances created are not.
  */
+@UsedByScanPlugin("test-distribution")
 public interface ProgressLoggerFactory {
     /**
      * Creates a new long-running operation which has not been started.

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
@@ -38,6 +38,7 @@ public interface ProgressLoggerFactory {
      * @param loggerCategory The logger category.
      * @return The progress logger for the operation.
      */
+    @UsedByScanPlugin("test-distribution")
     ProgressLogger newOperation(Class<?> loggerCategory);
 
     /**
@@ -50,5 +51,6 @@ public interface ProgressLoggerFactory {
      */
     ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor);
 
+    @UsedByScanPlugin("test-distribution")
     ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent);
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderException.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderException.java
@@ -31,6 +31,7 @@ public class PlaceholderException extends RuntimeException {
     private final String toString;
     private final Throwable toStringRuntimeEx;
 
+    @UsedByScanPlugin("test-distribution")
     public PlaceholderException(String exceptionClassName, @Nullable String message, @Nullable Throwable getMessageException, @Nullable String toString,
                                 @Nullable Throwable toStringException, @Nullable Throwable cause) {
         super(message, cause);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.internal.nativeintegration;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.io.File;
 import java.util.Map;
 
@@ -99,6 +101,7 @@ public interface ProcessEnvironment {
     /**
      * Returns the OS level PID for the current process, or null if not available.
      */
+    @UsedByScanPlugin("test-distribution")
     Long maybeGetPid();
 
     /**

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
@@ -25,6 +25,7 @@ import java.util.Map;
  *
  * <p>Implementations are not thread-safe.</p>
  */
+@UsedByScanPlugin("test-distribution")
 public interface ProcessEnvironment {
     /**
      * Sets the environment of this process, if possible.

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.vfs;
 
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshottingFilter;
 
@@ -43,6 +44,7 @@ public interface VirtualFileSystem {
     /**
      * Visits the hierarchy of files at the given location.
      */
+    @UsedByScanPlugin("test-distribution")
     <T> T read(String location, Function<CompleteFileSystemLocationSnapshot, T> visitor);
 
     /**

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
  *
  * The virtual file system needs to be informed when some state on disk changes, so it does not become out of sync with the actual file system.
  */
+@UsedByScanPlugin("test-distribution")
 public interface VirtualFileSystem {
 
     /**

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -16,8 +16,11 @@
 
 package org.gradle.api.internal.tasks.testing;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import javax.annotation.Nullable;
 
+@UsedByScanPlugin("test-distribution")
 public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     private final Object id;
     private final String name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.testing;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin("test-distribution")
 public class DefaultTestClassDescriptor extends DefaultTestSuiteDescriptor {
     private final String classDisplayName;
 
@@ -23,6 +26,7 @@ public class DefaultTestClassDescriptor extends DefaultTestSuiteDescriptor {
         this(id, className, className);
     }
 
+    @UsedByScanPlugin("test-distribution")
     public DefaultTestClassDescriptor(Object id, String className, String classDisplayName) {
         super(id, className);
         this.classDisplayName = classDisplayName;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestOutputEvent.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestOutputEvent.java
@@ -17,12 +17,15 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.tasks.testing.TestOutputEvent;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin("test-distribution")
 public class DefaultTestOutputEvent implements TestOutputEvent {
 
     private final Destination destination;
     private final String message;
 
+    @UsedByScanPlugin("test-distribution")
     public DefaultTestOutputEvent(Destination destination, String message) {
         this.destination = destination;
         this.message = message;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestSuiteDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestSuiteDescriptor.java
@@ -16,7 +16,12 @@
 
 package org.gradle.api.internal.tasks.testing;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin("test-distribution")
 public class DefaultTestSuiteDescriptor extends AbstractTestDescriptor {
+
+    @UsedByScanPlugin("test-distribution")
     public DefaultTestSuiteDescriptor(Object id, String name) {
         super(id, name);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
@@ -26,10 +26,12 @@ public class TestCompleteEvent {
     private final long endTime;
     private final TestResult.ResultType resultType;
 
+    @UsedByScanPlugin("test-distribution")
     public TestCompleteEvent(long endTime) {
         this(endTime, null);
     }
 
+    @UsedByScanPlugin("test-distribution")
     public TestCompleteEvent(long endTime, TestResult.ResultType resultType) {
         this.endTime = endTime;
         this.resultType = resultType;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestExecuter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestExecuter.java
@@ -20,10 +20,13 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 
 @UsedByScanPlugin("test-distribution")
 public interface TestExecuter<T extends TestExecutionSpec> {
+
+    @UsedByScanPlugin("test-distribution")
     void execute(T testExecutionSpec, TestResultProcessor testResultProcessor);
 
     /**
      * Stops any {@link TestClassProcessor} utilized by this {@code TestExecuter}.
      */
+    @UsedByScanPlugin("test-distribution")
     void stopNow();
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestExecuter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestExecuter.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.testing;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin("test-distribution")
 public interface TestExecuter<T extends TestExecutionSpec> {
     void execute(T testExecutionSpec, TestResultProcessor testResultProcessor);
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
@@ -17,10 +17,12 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.tasks.testing.TestOutputEvent;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A processor for test results. Implementations are not required to be thread-safe.
  */
+@UsedByScanPlugin("test-distribution")
 public interface TestResultProcessor {
     /**
      * Notifies this processor that a test has started execution.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
@@ -27,20 +27,24 @@ public interface TestResultProcessor {
     /**
      * Notifies this processor that a test has started execution.
      */
+    @UsedByScanPlugin("test-distribution")
     void started(TestDescriptorInternal test, TestStartEvent event);
 
     /**
      * Notifies this processor that a test has completed execution.
      */
+    @UsedByScanPlugin("test-distribution")
     void completed(Object testId, TestCompleteEvent event);
 
     /**
      * Notifies this processor that a test has produced some output.
      */
+    @UsedByScanPlugin("test-distribution")
     void output(Object testId, TestOutputEvent event);
 
     /**
      * Notifies this processor that a failure has occurred in the given test.
      */
+    @UsedByScanPlugin("test-distribution")
     void failure(Object testId, Throwable result);
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestStartEvent.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestStartEvent.java
@@ -25,10 +25,12 @@ public class TestStartEvent {
     private final long startTime;
     private final Object parentId;
 
+    @UsedByScanPlugin("test-distribution")
     public TestStartEvent(long startTime) {
         this(startTime, null);
     }
 
+    @UsedByScanPlugin("test-distribution")
     public TestStartEvent(long startTime, Object parentId) {
         this.startTime = startTime;
         this.parentId = parentId;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -15,15 +15,17 @@
  */
 package org.gradle.api.internal.tasks.testing.filter;
 
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.testing.TestFilter;
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.testing.TestFilter;
-
+@UsedByScanPlugin("test-distribution")
 public class DefaultTestFilter implements TestFilter {
 
     private final Set<String> includeTestNames = new HashSet<String>();
@@ -112,6 +114,7 @@ public class DefaultTestFilter implements TestFilter {
     }
 
     @Input
+    @UsedByScanPlugin("test-distribution")
     public Set<String> getCommandLineIncludePatterns() {
         return commandLineIncludeTestNames;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.Path;
 
@@ -25,6 +26,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
+@UsedByScanPlugin("test-distribution")
 public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final TestFramework testFramework;
     private final Iterable<? extends File> classpath;
@@ -65,14 +67,17 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         return testFramework;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public Iterable<? extends File> getClasspath() {
         return classpath;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public Iterable<? extends File> getModulePath() {
         return modulePath;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public FileTree getCandidateClassFiles() {
         return candidateClassFiles;
     }
@@ -85,18 +90,22 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         return testClassesDirs;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public String getPath() {
         return path;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public Path getIdentityPath() {
         return identityPath;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public long getForkEvery() {
         return forkEvery;
     }
 
+    @UsedByScanPlugin("test-distribution")
     public JavaForkOptions getJavaForkOptions() {
         return javaForkOptions;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -67,6 +67,7 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -1108,6 +1109,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      *
      * @since 4.2
      */
+    @UsedByScanPlugin("test-distribution")
     void setTestExecuter(TestExecuter<JvmTestExecutionSpec> testExecuter) {
         this.testExecuter = testExecuter;
     }


### PR DESCRIPTION
In order to avoid accidentally changing an internal API without
adjusting the test-distribution plugin, they are now annotated with
`@UsedByScanPlugin("test-distribution")`.