### PR TITLE
Antlr plugin include files + fix for multiple source-directories

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -77,7 +77,7 @@ public class AntlrTask extends SourceTask {
 
     private File outputDirectory;
     private String maxHeapSize;
-    private FileCollection sourceSetDirectories;
+    private SourceDirectorySet sourceDirectorySet;
     private final FileCollection stableSources = getProject().files((Callable<Object>) this::getSource);
 
     /**
@@ -277,7 +277,7 @@ public class AntlrTask extends SourceTask {
                 .collect(Collectors.toSet());
 
         AntlrWorkerManager manager = new AntlrWorkerManager();
-        AntlrSpec spec = new AntlrSpecFactory().create(this, processGrammarFiles, sourceSetDirectories);
+        AntlrSpec spec = new AntlrSpecFactory().create(this, processGrammarFiles, sourceDirectorySet);
         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
         AntlrResult result = manager.runWorker(projectDir, getWorkerProcessBuilderFactory(), getAntlrClasspath(), spec);
         evaluate(result);
@@ -285,7 +285,7 @@ public class AntlrTask extends SourceTask {
 
     private void evaluate(AntlrResult result) {
         int errorCount = result.getErrorCount();
-        if (errorCount < 0) {
+        if(errorCount < 0) {
             throw new AntlrSourceGenerationException("There were errors during grammar generation", result.getException());
         } else if (errorCount == 1) {
             throw new AntlrSourceGenerationException("There was 1 error during grammar generation", result.getException());
@@ -326,7 +326,7 @@ public class AntlrTask extends SourceTask {
     public void setSource(Object source) {
         super.setSource(source);
         if (source instanceof SourceDirectorySet) {
-            this.sourceSetDirectories = ((SourceDirectorySet) source).getSourceDirectories();
+            this.sourceDirectorySet = (SourceDirectorySet) source;
         }
     }
 

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
@@ -36,6 +36,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class AntlrExecuter implements RequestHandler<AntlrSpec, AntlrResult> {
 
@@ -133,11 +135,14 @@ public class AntlrExecuter implements RequestHandler<AntlrSpec, AntlrResult> {
                 numErrors += invoke(spec.asArgumentsWithFiles(), null);
             } else {
                 boolean onWindows = OperatingSystem.current().isWindows();
-                for (File inputDirectory : spec.getInputDirectories()) {
+                for (Map.Entry<File, Set<File>> fileSetEntry : spec.getFilesPerInputDirectory().entrySet()) {
+                    File inputDirectory = fileSetEntry.getKey();
+                    Set<File> grammarFiles = fileSetEntry.getValue();
+
                     final List<String> arguments = spec.getArguments();
                     arguments.add("-o");
                     arguments.add(spec.getOutputDirectory().getAbsolutePath());
-                    for (File grammarFile : spec.getGrammarFiles()) {
+                    for (File grammarFile : grammarFiles) {
                         String relativeGrammarFilePath = RelativePathUtil.relativePath(inputDirectory, grammarFile);
                         if (onWindows) {
                             relativeGrammarFilePath = relativeGrammarFilePath.replace('/', File.separatorChar);

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpec.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpec.java
@@ -20,7 +20,10 @@ import com.google.common.collect.Lists;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class AntlrSpec implements Serializable {
@@ -68,5 +71,18 @@ public class AntlrSpec implements Serializable {
 
     public Set<File> getInputDirectories() {
         return inputDirectories;
+    }
+
+    public Map<File, Set<File>> getFilesPerInputDirectory() {
+        Map<File, Set<File>> filesPerDir = new LinkedHashMap<>();
+        for (File grammarFile : grammarFiles) {
+            for (File inputDirectory : inputDirectories) {
+                if (grammarFile.toPath().startsWith(inputDirectory.toPath())) {
+                    filesPerDir.computeIfAbsent(inputDirectory, k -> new LinkedHashSet<>()).add(grammarFile);
+                    break;
+                }
+            }
+        }
+        return filesPerDir;
     }
 }

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpecFactory.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpecFactory.java
@@ -17,7 +17,7 @@
 package org.gradle.api.plugins.antlr.internal;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.antlr.AntlrTask;
 
 import java.io.File;
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class AntlrSpecFactory {
 
-    public AntlrSpec create(AntlrTask antlrTask, Set<File> grammarFiles, FileCollection sourceSetDirectories) {
+    public AntlrSpec create(AntlrTask antlrTask, Set<File> grammarFiles, SourceDirectorySet sourceDirectorySet) {
         List<String> arguments = Lists.newLinkedList(antlrTask.getArguments());
 
         if (antlrTask.isTrace() && !arguments.contains("-trace")) {
@@ -42,6 +42,6 @@ public class AntlrSpecFactory {
             arguments.add("-traceTreeWalker");
         }
 
-        return new AntlrSpec(arguments, grammarFiles, sourceSetDirectories.getFiles(), antlrTask.getOutputDirectory(), antlrTask.getMaxHeapSize());
+        return new AntlrSpec(arguments, grammarFiles, sourceDirectorySet.getSrcDirs(), antlrTask.getOutputDirectory(), antlrTask.getMaxHeapSize());
     }
 }

--- a/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/AntlrSpecFactoryTest.groovy
+++ b/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/AntlrSpecFactoryTest.groovy
@@ -16,17 +16,17 @@
 
 package org.gradle.api.plugins.antlr.internal
 
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.antlr.AntlrTask
 import spock.lang.Specification
 
 class AntlrSpecFactoryTest extends Specification {
 
     private AntlrSpecFactory factory = new AntlrSpecFactory()
-    private FileCollection sourceSetDirectories = Mock()
+    private SourceDirectorySet sourceDirectorySet = Mock()
 
     def setup(){
-        1 * sourceSetDirectories.getFiles() >> []
+        1 * sourceDirectorySet.getSrcDirs() >> []
     }
     def tracePropertiesAddedToArgumentList() {
         when:
@@ -39,7 +39,7 @@ class AntlrSpecFactoryTest extends Specification {
         _ * task.isTraceParser() >> true
         _ * task.isTraceTreeWalker() >> true
 
-        def spec = factory.create(task, [] as Set, sourceSetDirectories)
+        def spec = factory.create(task, [] as Set, sourceDirectorySet)
 
         then:
         spec.arguments.contains("-trace")
@@ -54,7 +54,7 @@ class AntlrSpecFactoryTest extends Specification {
         _ * task.outputDirectory >> destFile()
         _ * task.getArguments() >> ["-trace", "-traceLexer", "-traceParser", "-traceTreeWalker"]
 
-        def spec = factory.create(task, [] as Set, sourceSetDirectories)
+        def spec = factory.create(task, [] as Set, sourceDirectorySet)
 
         then:
         spec.arguments.contains("-trace")
@@ -73,7 +73,7 @@ class AntlrSpecFactoryTest extends Specification {
         _ * task.isTraceParser() >> true
         _ * task.isTraceTreeWalker() >> true
 
-        def spec = factory.create(task, [] as Set, sourceSetDirectories)
+        def spec = factory.create(task, [] as Set, sourceDirectorySet)
 
         then:
         spec.arguments.count { it == "-trace" } == 1

--- a/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
@@ -106,6 +106,12 @@ The source directories containing the ANTLR grammar files of this source set.
 Can set using anything <<working_with_files.adoc#sec:specifying_multiple_files, that implicitly converts to a file collection>>.
 Default value is `[__projectDir__/src/__name__/antlr]`.
 
+[[sec:antlr_include_files]]
+== ANTLR grammar include files
+
+Antlr grammar source files can include other files (e.g. via `import Parser,Lexer;`). To specify the include files, that must not be passed as grammar files to be processed by the antlr tool, specify patterns matching the include files using the `includeFilesPatterns` property, which is a set of regular expressions.
+Note: when the `includeFilesPatterns` is not empty, the antlr task will always process all source files.
+
 [[sec:controlling_the_antlr_generator_process]]
 == Controlling the ANTLR generator process
 


### PR DESCRIPTION
Fixes #13005
Fixes #13016 

Sorry for mixing up multiple issues in a single PR. I've separated the changes in multiple commits:
* fix for 13005
* minor-ish: little bit more configuration-avoidance in `AntlrPlugin`
* fix for 13016

### Context
#13005 is a shortcoming in the antlr-plugin (antlr include files don't work w/ the antlr-plugin)
#13016 is a legit bug

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
