### PR TITLE
Fix compile warnings in "ide"

### DIFF
--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 }
 
 strictCompile {
-    ignoreParameterizedVarargType() // TODO remove this and address warnings and/or add the RIGHT ignores here
+    ignoreRawTypes()
 }
 
 classycle {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/FileContentMerger.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/FileContentMerger.java
@@ -26,6 +26,7 @@ import org.gradle.util.ConfigureUtil;
  * For examples see docs for {@link org.gradle.plugins.ide.eclipse.model.EclipseProject}
  * or {@link org.gradle.plugins.ide.idea.model.IdeaProject} and others.
  */
+@SuppressWarnings("rawtypes")
 public class FileContentMerger {
 
     private MutableActionSet whenMerged = new MutableActionSet();
@@ -59,6 +60,7 @@ public class FileContentMerger {
      *
      * @param action The action to execute.
      */
+    @SuppressWarnings("unchecked")
     public void beforeMerged(Action<?> action) {
         beforeMerged.add(action);
     }
@@ -74,6 +76,7 @@ public class FileContentMerger {
      *
      * @param action The action to execute.
      */
+    @SuppressWarnings("unchecked")
     public void whenMerged(Action<?> action) {
         whenMerged.add(action);
     }
@@ -89,6 +92,7 @@ public class FileContentMerger {
      *
      * @param closure The closure to execute.
      */
+    @SuppressWarnings("unchecked")
     public void beforeMerged(Closure closure) {
         beforeMerged.add(ConfigureUtil.configureUsing(closure));
     }
@@ -104,6 +108,7 @@ public class FileContentMerger {
      *
      * @param closure The closure to execute.
      */
+    @SuppressWarnings("unchecked")
     public void whenMerged(Closure closure) {
         whenMerged.add(ConfigureUtil.configureUsing(closure));
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/FileContentMerger.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/FileContentMerger.java
@@ -26,7 +26,6 @@ import org.gradle.util.ConfigureUtil;
  * For examples see docs for {@link org.gradle.plugins.ide.eclipse.model.EclipseProject}
  * or {@link org.gradle.plugins.ide.idea.model.IdeaProject} and others.
  */
-@SuppressWarnings("rawtypes")
 public class FileContentMerger {
 
     private MutableActionSet whenMerged = new MutableActionSet();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
@@ -84,7 +84,7 @@ public class Classpath extends XmlPersistableConfigurationObject {
         }
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"}) // TODO: Change this signature once we can break compatibility
+    @SuppressWarnings({"unchecked"}) // TODO: Change this signature once we can break compatibility
     public Object configure(List newEntries) {
         Set<ClasspathEntry> updatedEntries = Sets.newLinkedHashSet();
         for (ClasspathEntry entry : entries) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
@@ -84,7 +84,7 @@ public class Classpath extends XmlPersistableConfigurationObject {
         }
     }
 
-    // TODO: Change this signature once we can break compatibility
+    @SuppressWarnings({"rawtypes", "unchecked"}) // TODO: Change this signature once we can break compatibility
     public Object configure(List newEntries) {
         Set<ClasspathEntry> updatedEntries = Sets.newLinkedHashSet();
         for (ClasspathEntry entry : entries) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -306,7 +306,6 @@ public class EclipseClasspath {
      * <p>
      * See {@link EclipseProject} for an example.
      */
-    @SuppressWarnings("rawtypes")
     public void file(Closure closure) {
         ConfigureUtil.configure(closure, file);
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -306,6 +306,7 @@ public class EclipseClasspath {
      * <p>
      * See {@link EclipseProject} for an example.
      */
+    @SuppressWarnings("rawtypes")
     public void file(Closure closure) {
         ConfigureUtil.configure(closure, file);
     }
@@ -339,6 +340,8 @@ public class EclipseClasspath {
         return classpathFactory.createEntries();
     }
 
+
+    @SuppressWarnings("unchecked")
     public void mergeXmlClasspath(Classpath xmlClasspath) {
         file.getBeforeMerged().execute(xmlClasspath);
         List<ClasspathEntry> entries = resolveDependencies();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.java
@@ -388,6 +388,7 @@ public class EclipseWtpComponent {
         return referenceFactory;
     }
 
+    @SuppressWarnings("unchecked")
     public void mergeXmlComponent(WtpComponent xmlComponent) {
         file.getBeforeMerged().execute(xmlComponent);
         ProjectInternal projectInternal = (ProjectInternal) this.project;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
@@ -144,6 +144,7 @@ public class EclipseWtpFacet {
         ));
     }
 
+    @SuppressWarnings("unchecked")
     public void mergeXmlFacet(WtpFacet xmlFacet) {
         file.getBeforeMerged().execute(xmlFacet);
         xmlFacet.configure(getFacets());

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/WtpComponent.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/WtpComponent.java
@@ -27,6 +27,7 @@ import org.gradle.plugins.ide.internal.generator.XmlPersistableConfigurationObje
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Predicates.not;
@@ -111,7 +112,7 @@ public class WtpComponent extends XmlPersistableConfigurationObject {
     protected void store(Node xml) {
         removeConfigurableDataFromXml();
         Node wbModuleNode = getWbModuleNode(xml);
-        wbModuleNode.attributes().put("deploy-name", deployName);
+        setNodeAttribute(wbModuleNode, "deploy-name", deployName);
         if (!isNullOrEmpty(contextPath)) {
             new WbProperty("context-root", contextPath).appendNode(wbModuleNode);
         }
@@ -134,6 +135,11 @@ public class WtpComponent extends XmlPersistableConfigurationObject {
         Node wbModule = XmlPersistableConfigurationObject.findFirstChildNamed(xml, "wb-module");
         Preconditions.checkNotNull(wbModule);
         return wbModule;
+    }
+
+    private static void setNodeAttribute(Node node, String key, String value) {
+        final Map<String, String> attributes = Cast.uncheckedCast(node.attributes());
+        attributes.put(key, value);
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -27,12 +27,12 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.FileCollection;
-import org.gradle.internal.metaobject.DynamicObjectUtil;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Pair;
+import org.gradle.internal.metaobject.DynamicObjectUtil;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
@@ -307,7 +307,7 @@ public class SourceFoldersCreator {
         });
     }
 
-    private static Comparable toComparable(SourceSet sourceSet) {
+    private static Integer toComparable(SourceSet sourceSet) {
         String name = sourceSet.getName();
         if (SourceSet.MAIN_SOURCE_SET_NAME.equals(name)) {
             return 0;
@@ -318,7 +318,7 @@ public class SourceFoldersCreator {
         }
     }
 
-    private static Comparable toComparable(DirectoryTree tree) {
+    private static Integer toComparable(DirectoryTree tree) {
         String path = tree.getDir().getPath();
         if (path.endsWith("java")) {
             return 0;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -44,7 +44,6 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.xml.XmlTransformer;
-import org.gradle.language.scala.plugins.ScalaLanguagePlugin;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.idea.internal.IdeaModuleMetadata;
 import org.gradle.plugins.ide.idea.internal.IdeaScalaConfigurer;
@@ -478,6 +477,8 @@ public class IdeaPlugin extends IdePlugin {
         return !moduleLanguageLevel.equals(ideaProject.getLanguageLevel());
     }
 
+
+    @SuppressWarnings("deprecation")
     private void configureForScalaPlugin() {
         project.getPlugins().withType(ScalaBasePlugin.class, new Action<ScalaBasePlugin>() {
             @Override
@@ -485,9 +486,9 @@ public class IdeaPlugin extends IdePlugin {
                 ideaModuleDependsOnRoot();
             }
         });
-        project.getPlugins().withType(ScalaLanguagePlugin.class, new Action<ScalaLanguagePlugin>() {
+        project.getPlugins().withType(org.gradle.language.scala.plugins.ScalaLanguagePlugin.class, new Action<org.gradle.language.scala.plugins.ScalaLanguagePlugin>() {
             @Override
-            public void execute(ScalaLanguagePlugin scalaLanguagePlugin) {
+            public void execute(org.gradle.language.scala.plugins.ScalaLanguagePlugin scalaLanguagePlugin) {
                 ideaModuleDependsOnRoot();
             }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
@@ -34,9 +34,9 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.ScalaRuntime;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.language.scala.internal.DefaultScalaPlatform;
-import org.gradle.language.scala.plugins.ScalaLanguagePlugin;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
@@ -213,9 +213,8 @@ public class IdeaScalaConfigurer {
         setNodeAttribute(libraryName, "value", scalaCompilerLibrary.getName());
     }
 
-    @SuppressWarnings("unchecked")
     private static void setNodeAttribute(Node node, String key, String value) {
-        final Map<String, String> attributes = (Map<String, String>) node.attributes();
+        final Map<String, String> attributes = Cast.uncheckedCast(node.attributes());
         attributes.put(key, value);
     }
 
@@ -226,7 +225,7 @@ public class IdeaScalaConfigurer {
             public boolean apply(Project project) {
                 final boolean hasIdeaPlugin = project.getPlugins().hasPlugin(IdeaPlugin.class);
                 final boolean hasScalaPlugin = project.getPlugins().hasPlugin(ScalaBasePlugin.class);
-                final boolean hasLegacyScalaPlugin = project.getPlugins().hasPlugin(ScalaLanguagePlugin.class);
+                final boolean hasLegacyScalaPlugin = project.getPlugins().hasPlugin(org.gradle.language.scala.plugins.ScalaLanguagePlugin.class);
                 return hasIdeaPlugin && (hasScalaPlugin || hasLegacyScalaPlugin);
             }
         });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
@@ -35,7 +35,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.internal.Factory;
-import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.language.scala.internal.DefaultScalaPlatform;
 import org.gradle.language.scala.plugins.ScalaLanguagePlugin;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
@@ -142,13 +141,14 @@ public class IdeaScalaConfigurer {
         return files;
     }
 
+    @SuppressWarnings("deprecation")
     private static ProjectLibrary createScalaSdkLibrary(Project scalaProject, Iterable<File> files, boolean useScalaSdk, IdeaModule ideaModule) {
         ScalaRuntime runtime = scalaProject.getExtensions().findByType(ScalaRuntime.class);
         if (runtime != null) {
             // Old Scala Plugin does not specify a ScalaPlatform
             FileCollection scalaClasspath = runtime.inferScalaClasspath(files);
             File compilerJar = runtime.findScalaJar(scalaClasspath, "compiler");
-            ScalaPlatform scalaPlatform = compilerJar != null ? new DefaultScalaPlatform(runtime.getScalaVersion(compilerJar)) : new DefaultScalaPlatform();
+            org.gradle.language.scala.ScalaPlatform scalaPlatform = compilerJar != null ? new DefaultScalaPlatform(runtime.getScalaVersion(compilerJar)) : new DefaultScalaPlatform();
             return createScalaSdkFromPlatform(scalaPlatform, scalaClasspath, useScalaSdk);
         } else if (ideaModule.getScalaPlatform() != null) {
             // TODO: Wrong, using the full classpath of the application
@@ -160,7 +160,8 @@ public class IdeaScalaConfigurer {
         }
     }
 
-    private static ProjectLibrary createScalaSdkFromPlatform(ScalaPlatform platform, FileCollection scalaClasspath, boolean useScalaSdk) {
+    @SuppressWarnings("deprecation")
+    private static ProjectLibrary createScalaSdkFromPlatform(org.gradle.language.scala.ScalaPlatform platform, FileCollection scalaClasspath, boolean useScalaSdk) {
         String version = platform.getScalaVersion();
         if (useScalaSdk) {
             return createScalaSdkLibrary("scala-sdk-" + version, scalaClasspath);
@@ -182,12 +183,7 @@ public class IdeaScalaConfigurer {
     }
 
     private static boolean containsLibraryWithSameName(Set<ProjectLibrary> libraries, final String name) {
-        return Iterables.any(libraries, new Predicate<ProjectLibrary>() {
-            @Override
-            public boolean apply(ProjectLibrary library) {
-                return Objects.equal(library.getName(), name);
-            }
-        });
+        return libraries.stream().anyMatch(library -> Objects.equal(library.getName(), name));
     }
 
     private static void declareScalaSdk(ProjectLibrary scalaSdkLibrary, Node iml) {
@@ -196,8 +192,8 @@ public class IdeaScalaConfigurer {
             Node newModuleRootManager = findOrCreateFirstChildWithAttributeValue(iml, "component", "name", "NewModuleRootManager");
 
             Node sdkLibrary = findOrCreateFirstChildWithAttributeValue(newModuleRootManager, "orderEntry", "name", scalaSdkLibrary.getName());
-            sdkLibrary.attributes().put("type", "library");
-            sdkLibrary.attributes().put("level", "project");
+            setNodeAttribute(sdkLibrary, "type", "library");
+            setNodeAttribute(sdkLibrary, "level", "project");
         }
     }
 
@@ -205,23 +201,33 @@ public class IdeaScalaConfigurer {
         Node facetManager = findOrCreateFirstChildWithAttributeValue(iml, "component", "name", "FacetManager");
 
         Node scalaFacet = findOrCreateFirstChildWithAttributeValue(facetManager, "facet", "type", "scala");
-        scalaFacet.attributes().put("name", "Scala");
+        setNodeAttribute(scalaFacet, "name", "Scala");
 
 
         Node configuration = findOrCreateFirstChildNamed(scalaFacet, "configuration");
 
         Node libraryLevel = findOrCreateFirstChildWithAttributeValue(configuration, "option", "name", "compilerLibraryLevel");
-        libraryLevel.attributes().put("value", "Project");
+        setNodeAttribute(libraryLevel, "value", "Project");
 
         Node libraryName = findOrCreateFirstChildWithAttributeValue(configuration, "option", "name", "compilerLibraryName");
-        libraryName.attributes().put("value", scalaCompilerLibrary.getName());
+        setNodeAttribute(libraryName, "value", scalaCompilerLibrary.getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setNodeAttribute(Node node, String key, String value) {
+        final Map<String, String> attributes = (Map<String, String>) node.attributes();
+        attributes.put(key, value);
     }
 
     private Collection<Project> findProjectsApplyingIdeaAndScalaPlugins() {
         return Collections2.filter(rootProject.getAllprojects(), new Predicate<Project>() {
+            @SuppressWarnings("deprecation")
             @Override
             public boolean apply(Project project) {
-                return project.getPlugins().hasPlugin(IdeaPlugin.class) && (project.getPlugins().hasPlugin(ScalaBasePlugin.class) || project.getPlugins().hasPlugin(ScalaLanguagePlugin.class));
+                final boolean hasIdeaPlugin = project.getPlugins().hasPlugin(IdeaPlugin.class);
+                final boolean hasScalaPlugin = project.getPlugins().hasPlugin(ScalaBasePlugin.class);
+                final boolean hasLegacyScalaPlugin = project.getPlugins().hasPlugin(ScalaLanguagePlugin.class);
+                return hasIdeaPlugin && (hasScalaPlugin || hasLegacyScalaPlugin);
             }
         });
     }
@@ -232,7 +238,7 @@ public class IdeaScalaConfigurer {
         if (targetVersionString != null) {
             targetVersion = VersionNumber.parse(targetVersionString);
             if (targetVersion.equals(VersionNumber.UNKNOWN)) {
-                throw new GradleScriptException("String \'" + targetVersionString + "\' is not a valid value for IdeaModel.targetVersion.", null);
+                throw new GradleScriptException("String '" + targetVersionString + "' is not a valid value for IdeaModel.targetVersion.", null);
             }
         }
         return targetVersion;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -579,6 +579,7 @@ public class IdeaModule {
         return ideaDependenciesProvider.provide(this);
     }
 
+    @SuppressWarnings("unchecked")
     public void mergeXmlModule(Module xmlModule) {
         iml.getBeforeMerged().execute(xmlModule);
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -15,9 +15,7 @@
  */
 package org.gradle.plugins.ide.idea.model;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
@@ -27,15 +25,16 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.DefaultGradleApiSourcesResolver;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.gradle.util.ConfigureUtil.configure;
 
@@ -176,7 +175,8 @@ public class IdeaModule {
     private String jdkName;
     private IdeaLanguageLevel languageLevel;
     private JavaVersion targetBytecodeVersion;
-    private ScalaPlatform scalaPlatform;
+    @SuppressWarnings("deprecation")
+    private org.gradle.language.scala.ScalaPlatform scalaPlatform;
     private final IdeaModuleIml iml;
     private final Project project;
     private PathFactory pathFactory;
@@ -475,11 +475,13 @@ public class IdeaModule {
     /**
      * The Scala version used by this module.
      */
-    public ScalaPlatform getScalaPlatform() {
+    @Deprecated
+    public org.gradle.language.scala.ScalaPlatform getScalaPlatform() {
         return scalaPlatform;
     }
 
-    public void setScalaPlatform(ScalaPlatform scalaPlatform) {
+    @Deprecated
+    public void setScalaPlatform(org.gradle.language.scala.ScalaPlatform scalaPlatform) {
         this.scalaPlatform = scalaPlatform;
     }
 
@@ -616,12 +618,7 @@ public class IdeaModule {
     }
 
     private Set<Path> pathsOf(Set<File> files) {
-        return Sets.newLinkedHashSet(Iterables.transform(files, new Function<File, Path>() {
-            @Override
-            public Path apply(File file) {
-                return getPathFactory().path(file);
-            }
-        }));
+        return files.stream().map(file -> getPathFactory().path(file)).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
@@ -338,6 +338,7 @@ public class IdeaProject implements IdeWorkspace {
         this.pathFactory = pathFactory;
     }
 
+    @SuppressWarnings("unchecked")
     public void mergeXmlProject(Project xmlProject) {
         ipr.getBeforeMerged().execute(xmlProject);
         xmlProject.configure(getModules(), getJdkName(), getLanguageLevel(), getTargetBytecodeVersion(), getWildcards(), getProjectLibraries(), getVcs());

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaWorkspace.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaWorkspace.java
@@ -59,7 +59,6 @@ public class IdeaWorkspace {
      * <p>
      * For example see docs for {@link IdeaWorkspace}
      */
-    @SuppressWarnings("rawtypes")
     public void iws(Closure closure) {
         configure(closure, iws);
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaWorkspace.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaWorkspace.java
@@ -59,6 +59,7 @@ public class IdeaWorkspace {
      * <p>
      * For example see docs for {@link IdeaWorkspace}
      */
+    @SuppressWarnings("rawtypes")
     public void iws(Closure closure) {
         configure(closure, iws);
     }
@@ -74,6 +75,7 @@ public class IdeaWorkspace {
         action.execute(iws);
     }
 
+    @SuppressWarnings("unchecked")
     public void mergeXmlWorkspace(Workspace xmlWorkspace) {
         iws.getBeforeMerged().execute(xmlWorkspace);
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Module.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Module.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import groovy.util.Node;
+import org.gradle.internal.Cast;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.internal.generator.XmlPersistableConfigurationObject;
 
@@ -382,7 +383,7 @@ public class Module extends XmlPersistableConfigurationObject {
 
     private void setContentURL() {
         if (contentPath != null) {
-            findOrCreateContentNode().attributes().put("url", contentPath.getUrl());
+            setNodeAttribute(findOrCreateContentNode(), "url", contentPath.getUrl());
         }
     }
 
@@ -448,21 +449,21 @@ public class Module extends XmlPersistableConfigurationObject {
     }
 
     private void writeInheritOutputDirsToXml() {
-        getNewModuleRootManager().attributes().put("inherit-compiler-output", inheritOutputDirs);
+        setNodeAttribute(getNewModuleRootManager(), "inherit-compiler-output", inheritOutputDirs);
     }
 
     private void writeSourceLanguageLevel() {
         if (languageLevel != null) {
-            getNewModuleRootManager().attributes().put("LANGUAGE_LEVEL", languageLevel);
+            setNodeAttribute(getNewModuleRootManager(), "LANGUAGE_LEVEL", languageLevel);
         }
     }
 
     private void addOutputDirsToXml() {
         if (outputDir != null) {
-            findOrCreateOutputDir().attributes().put("url", outputDir.getUrl());
+            setNodeAttribute(findOrCreateOutputDir(), "url", outputDir.getUrl());
         }
         if (testOutputDir != null) {
-            findOrCreateTestOutputDir().attributes().put("url", testOutputDir.getUrl());
+            setNodeAttribute(findOrCreateTestOutputDir(), "url", testOutputDir.getUrl());
         }
     }
 
@@ -476,7 +477,7 @@ public class Module extends XmlPersistableConfigurationObject {
     }
 
     protected boolean isDependencyOrderEntry(Object orderEntry) {
-        return Arrays.asList("module-library", "module").contains(((Node) orderEntry).attribute("type"));
+        return Arrays.asList("module-library", "module").contains((String) ((Node) orderEntry).attribute("type"));
     }
 
     private void addDependenciesToXml() {
@@ -537,6 +538,11 @@ public class Module extends XmlPersistableConfigurationObject {
 
     private List<Node> findOrderEntries() {
         return getChildren(getNewModuleRootManager(), "orderEntry");
+    }
+
+    private static void setNodeAttribute(Node node, String key, Object value) {
+        final Map<String, Object> attributes = Cast.uncheckedCast(node.attributes());
+        attributes.put(key, value);
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Project.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Project.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import groovy.util.Node;
 import groovy.util.NodeList;
 import org.gradle.api.JavaVersion;
+import org.gradle.internal.Cast;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.internal.generator.XmlPersistableConfigurationObject;
 
@@ -233,15 +234,15 @@ public class Project extends XmlPersistableConfigurationObject {
 
     private void storeJdk() {
         Node projectRoot = findProjectRootManager();
-        projectRoot.attributes().put("assert-keyword", jdk.isAssertKeyword());
-        projectRoot.attributes().put("assert-jdk-15", jdk.isJdk15());
-        projectRoot.attributes().put("languageLevel", jdk.getLanguageLevel());
-        projectRoot.attributes().put("project-jdk-name", jdk.getProjectJdkName());
+        setNodeAttribute(projectRoot, "assert-keyword", jdk.isAssertKeyword());
+        setNodeAttribute(projectRoot, "assert-jdk-15", jdk.isJdk15());
+        setNodeAttribute(projectRoot, "languageLevel", jdk.getLanguageLevel());
+        setNodeAttribute(projectRoot, "project-jdk-name", jdk.getProjectJdkName());
     }
 
     private void storeBytecodeLevels() {
         Node bytecodeLevelConfiguration = findOrCreateBytecodeLevelConfiguration();
-        bytecodeLevelConfiguration.attributes().put("target", bytecodeVersion.toString());
+        setNodeAttribute(bytecodeLevelConfiguration, "target", bytecodeVersion.toString());
         for (IdeaModule module : modules) {
             List<Node> bytecodeLevelModules = getChildren(bytecodeLevelConfiguration, "module");
             Node moduleNode = findFirstWithAttributeValue(bytecodeLevelModules, "name", module.getName());
@@ -253,16 +254,16 @@ public class Project extends XmlPersistableConfigurationObject {
             } else {
                 if (moduleNode == null) {
                     moduleNode = bytecodeLevelConfiguration.appendNode("module");
-                    moduleNode.attributes().put("name", module.getName());
+                    setNodeAttribute(moduleNode, "name", module.getName());
                 }
-                moduleNode.attributes().put("target", moduleBytecodeVersionOverwrite.toString());
+                setNodeAttribute(moduleNode, "target", moduleBytecodeVersionOverwrite.toString());
             }
         }
     }
 
     private void storeVcs() {
         if (!isNullOrEmpty(vcs)) {
-            findVcsDirectoryMappings().attributes().put("vcs", vcs);
+            setNodeAttribute(findVcsDirectoryMappings(), "vcs", vcs);
         }
     }
 
@@ -319,6 +320,11 @@ public class Project extends XmlPersistableConfigurationObject {
             libraryTable = getXml().appendNode("component", attributes);
         }
         return libraryTable;
+    }
+
+    private static void setNodeAttribute(Node node, String key, Object value) {
+        final Map<String, Object> attributes = Cast.uncheckedCast(node.attributes());
+        attributes.put(key, value);
     }
 
     @Override


### PR DESCRIPTION
A lot of the `@SuppressWarnings` are required because
FileContentMerger/XmlFileContentMerger use MutableActionSet
without a type (even though it is typed). Given we expose the action
sets via getBeforeMerged/getWhenMerged, we can't make it typed without
breaking API compatibility.
