### PR TITLE
Fix metadata realization

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectDerivationStrategyIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectDerivationStrategyIntegTest.groovy
@@ -18,9 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractPolyglotIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
-import spock.lang.Ignore
 
-@Ignore
 class MultiProjectDerivationStrategyIntegTest extends AbstractPolyglotIntegrationSpec {
 
     def "different projects can use different variant derivation strategies without leaking to each other"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -243,7 +243,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
 
     public class Builder {
         private String name = DefaultConfigurationMetadata.this.getName();
-        private DependencyFilter dependencyFilter = DefaultConfigurationMetadata.this.dependencyFilter;
+        private DependencyFilter dependencyFilter = DependencyFilter.ALL;
         private CapabilitiesMetadata capabilities;
         private ImmutableAttributes attributes;
         private ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;


### PR DESCRIPTION
The "dependency filter" in module metadata is a performance optimization,
which allows filtering out some particular kinds of dependencies _without
having to duplicate the collection_ which is particularly expensive.

However, when we call the builder to mutate metadata, we shouldn't use
the current value of the builder as the initial value, because it causes
the mutated state to be in a wrong state.

This fixes a failing test in "force realize" case.

