### PR TITLE
Let instant execution capture Task.destroyables and Task.localState

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -26,6 +26,7 @@ import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.internal.tasks.TaskDestroyablesInternal
+import org.gradle.api.internal.tasks.TaskLocalStateInternal
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType
 import org.gradle.api.internal.tasks.properties.InputParameterUtils
 import org.gradle.api.internal.tasks.properties.OutputFilePropertyType
@@ -91,6 +92,7 @@ class TaskNodeCodec(
                 writeStateOf(task)
                 writeRegisteredPropertiesOf(task, this as BeanPropertyWriter)
                 writeDestroyablesOf(task)
+                writeLocalStateOf(task)
             }
             writeRegisteredServicesOf(task)
         }
@@ -110,6 +112,7 @@ class TaskNodeCodec(
                 readStateOf(task)
                 readRegisteredPropertiesOf(task)
                 readDestroyablesOf(task)
+                readLocalStateOf(task)
             }
             readRegisteredServicesOf(task)
         }
@@ -156,6 +159,18 @@ class TaskNodeCodec(
     suspend fun ReadContext.readDestroyablesOf(task: TaskInternal) {
         readCollection {
             task.destroyables.register(readNonNull())
+        }
+    }
+
+    private
+    suspend fun WriteContext.writeLocalStateOf(task: TaskInternal) {
+        writeCollection((task.localState as TaskLocalStateInternal).registeredPaths)
+    }
+
+    private
+    suspend fun ReadContext.readLocalStateOf(task: TaskInternal) {
+        readCollection {
+            task.localState.register(readNonNull())
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -25,6 +25,7 @@ import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.Providers
+import org.gradle.api.internal.tasks.TaskDestroyablesInternal
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType
 import org.gradle.api.internal.tasks.properties.InputParameterUtils
 import org.gradle.api.internal.tasks.properties.OutputFilePropertyType
@@ -89,6 +90,7 @@ class TaskNodeCodec(
             beanStateWriterFor(task.javaClass).run {
                 writeStateOf(task)
                 writeRegisteredPropertiesOf(task, this as BeanPropertyWriter)
+                writeDestroyablesOf(task)
             }
             writeRegisteredServicesOf(task)
         }
@@ -107,6 +109,7 @@ class TaskNodeCodec(
             beanStateReaderFor(task.javaClass).run {
                 readStateOf(task)
                 readRegisteredPropertiesOf(task)
+                readDestroyablesOf(task)
             }
             readRegisteredServicesOf(task)
         }
@@ -141,6 +144,18 @@ class TaskNodeCodec(
     suspend fun ReadContext.readRegisteredServicesOf(task: TaskInternal) {
         readCollection {
             task.usesService(readNonNull())
+        }
+    }
+
+    private
+    suspend fun WriteContext.writeDestroyablesOf(task: TaskInternal) {
+        writeCollection((task.destroyables as TaskDestroyablesInternal).registeredPaths)
+    }
+
+    private
+    suspend fun ReadContext.readDestroyablesOf(task: TaskInternal) {
+        readCollection {
+            task.destroyables.register(readNonNull())
         }
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -650,7 +650,6 @@ task someTask(dependsOn: [someDep, someOtherDep])
         thrown(CircularReferenceException)
     }
 
-    @ToBeFixedForInstantExecution(because = "Task.destroyables")
     def "produces a sensible error when a task declares both outputs and destroys"() {
         buildFile << """
             task a {
@@ -668,7 +667,6 @@ task someTask(dependsOn: [someDep, someOtherDep])
         }
     }
 
-    @ToBeFixedForInstantExecution(because = "Task.destroyables")
     def "produces a sensible error when a task declares both inputs and destroys"() {
         buildFile << """
             task a {
@@ -686,7 +684,6 @@ task someTask(dependsOn: [someDep, someOtherDep])
         }
     }
 
-    @ToBeFixedForInstantExecution(because = "Task.destroyables and Task.localState")
     def "produces a sensible error when a task declares both local state and destroys"() {
         buildFile << """
             task a {


### PR DESCRIPTION
and remove `@ToBeFixedForInstantExecution` where appropriate
