### PR TITLE
Use different source hash for absent metadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
@@ -38,12 +38,12 @@ import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 
 public class DefaultArtifactMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalResourceResolver.class);
-    private static final HashCode MISSING = Hashing.md5().hashString("");
     private final MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory;
     private final String artifactType;
     private final String artifactExtension;
@@ -61,12 +61,18 @@ public class DefaultArtifactMetadataSource extends AbstractMetadataSource<Mutabl
         if (metaDataFromDefaultArtifact != null) {
             LOGGER.debug("Found artifact but no meta-data for module '{}' in repository '{}', using default meta-data.", moduleComponentIdentifier, repositoryName);
             metaDataFromDefaultArtifact.getSources()
-                .add(new ModuleDescriptorHashModuleSource(MISSING, false));
+                .add(new ModuleDescriptorHashModuleSource(getDescriptorHash(moduleComponentIdentifier), false));
             return metaDataFromDefaultArtifact;
         }
         return null;
     }
 
+    private HashCode getDescriptorHash(ModuleComponentIdentifier moduleComponentIdentifier) {
+        // For empty metadata, we use a hash based on the identifier
+        return Hashing.md5().hashString(moduleComponentIdentifier.toString());
+    }
+
+    @Nullable
     private MutableModuleComponentResolveMetadata createMetaDataFromDependencyArtifact(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata overrideMetadata, ExternalResourceArtifactResolver artifactResolver, ResourceAwareResolveResult result) {
         List<IvyArtifactName> artifactNames = getArtifactNames(moduleComponentIdentifier, overrideMetadata);
         for (IvyArtifactName artifact : artifactNames) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataSource.java
@@ -28,6 +28,7 @@ import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -36,6 +37,7 @@ import java.util.List;
  */
 public interface MetadataSource<S extends MutableModuleComponentResolveMetadata> {
 
+    @Nullable
     S create(String repositoryName,
              ComponentResolvers componentResolvers,
              ModuleComponentIdentifier moduleComponentIdentifier,


### PR DESCRIPTION
Previously, a constant was used, but that meant that all modules missing
metadata would have the same source hash.
With this change, the module component identifier is used, so that two
different modules with no metadata do not have the same hash.