### PR TITLE
Don't write in RO dependency cache when parent POM is missing

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ParentPomsReadOnlyCacheDependencyResolutionTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ParentPomsReadOnlyCacheDependencyResolutionTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.rocache
+
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import spock.lang.Issue
+
+class ParentPomsReadOnlyCacheDependencyResolutionTest extends AbstractReadOnlyCacheDependencyResolutionTest {
+
+    @Issue("https://github.com/gradle/gradle/issues/12996")
+    def "doesn't attempt to write in read-only cache if parent POM is missing from it"() {
+        given:
+        def parent = mavenHttpRepo.module('org.readonly', 'parent', '1.0')
+        def other = mavenHttpRepo.module("org.other", "other", "1.0")
+            .parent("org.readonly", "parent", "1.0").publish()
+        buildFile << """
+            dependencies {
+                implementation 'org.other:other:1.0'
+            }
+        """
+
+        when:
+        fileInReadReadOnlyCache("modules-${CacheLayout.ROOT.version}/files-${CacheLayout.FILE_STORE.version}/org.readonly/parent/1.0").eachFileRecurse { it.delete() }
+        withReadOnlyCache()
+        other.allowAll()
+        parent.allowAll()
+        succeeds ':checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+
+    @Override
+    List<MavenHttpModule> getModulesInReadOnlyCache(MavenHttpRepository repo) {
+        def parent = repo.module("org.readonly", "parent", "1.0").hasPackaging("pom")
+        [
+            repo.module("org.readonly", "core", "1.0"),
+            repo.module("org.readonly", "util", "1.0"),
+            parent,
+            repo.module("org.readonly", "child", "1.0").parent("org.readonly", "parent", "1.0")
+        ]
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ReadOnlyArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ReadOnlyArtifactCacheLockingManager.java
@@ -134,12 +134,10 @@ public class ReadOnlyArtifactCacheLockingManager implements ArtifactCacheLocking
 
         @Override
         public void put(K key, V value) {
-            failSafe(() -> delegate.put(key, value));
         }
 
         @Override
         public void remove(K key) {
-            failSafe(() -> delegate.remove(key));
         }
 
         private <T> T failSafe(Factory<T> operation) {
@@ -155,17 +153,6 @@ public class ReadOnlyArtifactCacheLockingManager implements ArtifactCacheLocking
             return null;
         }
 
-        private void failSafe(Runnable operation) {
-            if (failed) {
-                return;
-            }
-            try {
-                operation.run();
-            } catch (Exception ex) {
-                failed = true;
-                LOGGER.debug("Error accessing read-only cache", ex);
-            }
-        }
     }
 
     private class TransparentCacheLockingPersistentCache<K, V> implements PersistentIndexedCache<K, V> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ReadOnlyModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ReadOnlyModuleArtifactCache.java
@@ -46,7 +46,8 @@ public class ReadOnlyModuleArtifactCache extends DefaultModuleArtifactCache {
 
     @Override
     public void clear(ArtifactAtRepositoryKey key) {
-        operationShouldNotHaveBeenCalled();
+        // clear is actually called from org.gradle.internal.resource.cached.AbstractCachedIndex.lookup which
+        // is a read operation, in case of missing entry, so we can't fail here, but should be a no-op only
     }
 
     private static void operationShouldNotHaveBeenCalled() {


### PR DESCRIPTION
This commit works around a bug whenever the read-only dependency cache
used to contain a parent POM, but it has been cleaned up in between
(for example via the seeding build).

In this case, if a "consumer" build uses the read-only cache and
resolves a dependency which has the same parent POM, it will attempt
to write in the read-only dependency cache even if it shouldn't.

The ideal fix would be to avoid tweaking the failsafe cache, but it
appears that some read operations _may_ trigger a write operation
in between (as a cleanup side effect). This commit therefore makes
sure that we don't even attempt to call a write operation in this
case.

Fixes #12996
