### PR TITLE
Do not watch symlinks

### DIFF
--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -31,6 +31,7 @@ import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.caching.internal.origin.OriginReader;
 import org.gradle.caching.internal.origin.OriginWriter;
 import org.gradle.caching.internal.packaging.BuildCacheEntryPacker;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.TreeType;
 import org.gradle.internal.hash.HashCode;
@@ -260,7 +261,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
             chmodUnpackedFile(entry, file);
             String internedAbsolutePath = stringInterner.intern(file.getAbsolutePath());
             String internedFileName = stringInterner.intern(fileName);
-            return new RegularFileSnapshot(internedAbsolutePath, internedFileName, hash, new FileMetadata(output.getCount(), file.lastModified()));
+            return new RegularFileSnapshot(internedAbsolutePath, internedFileName, hash, new FileMetadata(output.getCount(), file.lastModified()), AccessType.DIRECT);
         }
     }
 

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -281,7 +281,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
             boolean isDir = entry.isDirectory();
             int directoriesLeft = parser.nextPath(entry.getName(), isDir);
             for (int i = 0; i < directoriesLeft; i++) {
-                builder.postVisitDirectory();
+                builder.postVisitDirectory(AccessType.DIRECT);
             }
             if (parser.getDepth() == 0) {
                 break;
@@ -302,7 +302,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
         }
 
         for (int i = 0; i < parser.getDepth(); i++) {
-            builder.postVisitDirectory();
+            builder.postVisitDirectory(AccessType.DIRECT);
         }
 
         snapshots.put(treeName, builder.getResult());

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -32,7 +31,6 @@ import static org.gradle.work.ChangeType.MODIFIED
 
 @Unroll
 @Requires(TestPrecondition.SYMLINKS)
-@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
 class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     def "#desc can handle symlinks"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -26,7 +25,6 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 @Requires(TestPrecondition.SYMLINKS)
-@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
 class IncrementalBuildSymlinkHandlingIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactory.java
@@ -27,6 +27,7 @@ import org.gradle.caching.internal.controller.BuildCacheStoreCommand;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.caching.internal.origin.OriginMetadataFactory;
 import org.gradle.caching.internal.packaging.BuildCacheEntryPacker;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
@@ -124,7 +125,7 @@ public class DefaultBuildCacheCommandFactory implements BuildCacheCommandFactory
                 List<FileSystemSnapshot> roots = new ArrayList<>();
 
                 if (treeSnapshot == null) {
-                    MissingFileSnapshot missingFileSnapshot = new MissingFileSnapshot(internedAbsolutePath);
+                    MissingFileSnapshot missingFileSnapshot = new MissingFileSnapshot(internedAbsolutePath, AccessType.DIRECT);
                     virtualFileSystem.updateWithKnownSnapshot(missingFileSnapshot);
                     builder.put(treeName, fingerprintingStrategy.getEmptyFingerprint());
                     return;

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
@@ -60,7 +60,7 @@ public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapsho
                     DefaultFileMetadataSnapshot.file(
                         fileDetails.getLastModified(),
                         fileDetails.getSize(),
-                        Files.isSymbolicLink(Paths.get(fileDetails.getPath())) ? AccessType.VIA_SYMLINK : AccessType.DIRECT
+                        AccessType.viaSymlink(Files.isSymbolicLink(Paths.get(fileDetails.getPath())))
                     )
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Interner;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.hash.FileHasher;
@@ -55,7 +56,8 @@ public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapsho
                     fileDetails.getName(),
                     DefaultFileMetadataSnapshot.file(
                         fileDetails.getLastModified(),
-                        fileDetails.getSize()
+                        fileDetails.getSize(),
+                        AccessType.DIRECT
                     )
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
@@ -26,6 +26,9 @@ import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapshotter {
 
     private final FileHasher hasher;
@@ -57,7 +60,7 @@ public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapsho
                     DefaultFileMetadataSnapshot.file(
                         fileDetails.getLastModified(),
                         fileDetails.getSize(),
-                        AccessType.DIRECT
+                        Files.isSymbolicLink(Paths.get(fileDetails.getPath())) ? AccessType.VIA_SYMLINK : AccessType.DIRECT
                     )
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
@@ -54,7 +54,7 @@ public class FileSystemSnapshotBuilder {
     public void addFile(File file, String[] segments, String fileName, FileMetadataSnapshot metadataSnapshot) {
         checkNoRootFileSnapshot("another root file", file);
         HashCode contentHash = fileHasher.hash(file, metadataSnapshot.getLength(), metadataSnapshot.getLastModified());
-        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot), AccessType.DIRECT);
+        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot), metadataSnapshot.getAccessType());
         if (segments.length == 0) {
             rootFileSnapshot = fileSnapshot;
         } else {
@@ -92,7 +92,7 @@ public class FileSystemSnapshotBuilder {
         MerkleDirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.sortingRequired();
         builder.preVisitDirectory(rootPath, rootName);
         rootDirectoryBuilder.accept(rootPath, builder);
-        builder.postVisitDirectory();
+        builder.postVisitDirectory(AccessType.DIRECT);
         return Preconditions.checkNotNull(builder.getResult());
     }
 
@@ -145,7 +145,7 @@ public class FileSystemSnapshotBuilder {
                 String dirPath = stringInterner.intern(directoryPath + File.separatorChar + dirName);
                 builder.preVisitDirectory(dirPath, dirName);
                 entry.getValue().accept(dirPath, builder);
-                builder.postVisitDirectory();
+                builder.postVisitDirectory(AccessType.DIRECT);
             }
             for (RegularFileSnapshot fileSnapshot : files.values()) {
                 builder.visitFile(fileSnapshot);

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
@@ -19,6 +19,7 @@ package org.gradle.internal.fingerprint.impl;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Interner;
 import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileMetadata;
@@ -53,7 +54,7 @@ public class FileSystemSnapshotBuilder {
     public void addFile(File file, String[] segments, String fileName, FileMetadataSnapshot metadataSnapshot) {
         checkNoRootFileSnapshot("another root file", file);
         HashCode contentHash = fileHasher.hash(file, metadataSnapshot.getLength(), metadataSnapshot.getLastModified());
-        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot));
+        RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(stringInterner.intern(file.getAbsolutePath()), fileName, contentHash, FileMetadata.from(metadataSnapshot), AccessType.DIRECT);
         if (segments.length == 0) {
             rootFileSnapshot = fileSnapshot;
         } else {

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
@@ -157,6 +157,6 @@ public class FileSystemSnapshotBuilder {
     }
 
     private static AccessType determineAccessTypeForLocation(String absolutePath) {
-        return Files.isSymbolicLink(Paths.get(absolutePath)) ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+        return AccessType.viaSymlink(Files.isSymbolicLink(Paths.get(absolutePath)));
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.changedetection.state.CachingFileHasher.FileInfo
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.PersistentIndexedCache
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.HashCode
@@ -147,7 +148,7 @@ class CachingFileHasherTest extends Specification {
     def hashesGivenFileLengthAndLastModified() {
         long lastModified = 123l
         long length = 321l
-        def fileDetails = DefaultFileMetadataSnapshot.file(lastModified, length)
+        def fileDetails = DefaultFileMetadataSnapshot.file(lastModified, length, AccessType.DIRECT)
 
         when:
         def result = hasher.hash(file, fileDetails.length, fileDetails.lastModified)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.changedetection.state
 
 import org.gradle.api.internal.file.archive.ZipEntry
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.FileMetadata
@@ -28,7 +29,7 @@ class CachingResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def path = "some"
     def relativePath = ["relative", "path"]
-    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", HashCode.fromInt(456), new FileMetadata(3456, 456))
+    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", HashCode.fromInt(456), new FileMetadata(3456, 456), AccessType.DIRECT)
     def cachingHasher = new CachingResourceHasher(delegate, new DefaultResourceSnapshotterCacheService(new InMemoryIndexedCache(new HashCodeSerializer())))
 
     def "returns result from delegate"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.FileMetadata
 import org.gradle.internal.snapshot.RegularFileSnapshot
@@ -74,6 +75,6 @@ class ZipHasherTest extends Specification {
     }
 
     private static RegularFileSnapshot snapshot(TestFile file) {
-        new RegularFileSnapshot(file.path, file.name, HashCode.fromInt(0), new FileMetadata(0, 0))
+        new RegularFileSnapshot(file.path, file.name, HashCode.fromInt(0), new FileMetadata(0, 0), AccessType.DIRECT)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactoryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.caching.internal.origin.OriginMetadataFactory
 import org.gradle.caching.internal.origin.OriginReader
 import org.gradle.caching.internal.origin.OriginWriter
 import org.gradle.caching.internal.packaging.BuildCacheEntryPacker
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot
@@ -69,9 +70,9 @@ class DefaultBuildCacheCommandFactoryTest extends Specification {
         )
         def load = commandFactory.createLoad(key, entity)
 
-        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, HashCode.fromInt(234), new FileMetadata(15, 234))
+        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, HashCode.fromInt(234), new FileMetadata(15, 234), AccessType.DIRECT)
         def fileSnapshots = ImmutableMap.of(
-            "outputDir", new CompleteDirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, ImmutableList.of(new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, HashCode.fromInt(123), new FileMetadata(46, 123))), HashCode.fromInt(456)),
+            "outputDir", new CompleteDirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, ImmutableList.of(new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, HashCode.fromInt(123), new FileMetadata(46, 123), AccessType.DIRECT)), HashCode.fromInt(456), AccessType.DIRECT),
             "outputFile", outputFileSnapshot)
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.fingerprint.impl
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.internal.file.FileMetadataSnapshot
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.HashCode
@@ -136,6 +137,6 @@ class FileSystemSnapshotBuilderTest extends Specification {
     }
 
     private static FileMetadataSnapshot fileMetadata() {
-        DefaultFileMetadataSnapshot.file(0, 5)
+        DefaultFileMetadataSnapshot.file(0, 5, AccessType.DIRECT)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
@@ -28,10 +28,21 @@ import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshotVisitor
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.RelativePathSegmentsTracker
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
+import org.gradle.util.UsesNativeServices
+import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
+@CleanupTestDirectory(fieldName = "tmpDir")
 class FileSystemSnapshotBuilderTest extends Specification {
+
+    @Rule
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def stringInterner = Stub(StringInterner) {
             intern(_) >> { String string -> string }
@@ -42,7 +53,7 @@ class FileSystemSnapshotBuilderTest extends Specification {
         }
     }
 
-    String basePath = new File("some/path").absolutePath
+    String basePath = tmpDir.file("some/path").absolutePath
 
     def "can rebuild tree from relative paths"() {
         def builder = new FileSystemSnapshotBuilder(stringInterner, hasher)
@@ -136,7 +147,44 @@ class FileSystemSnapshotBuilderTest extends Specification {
         builder.build() == FileSystemSnapshot.EMPTY
     }
 
-    private static FileMetadataSnapshot fileMetadata() {
-        DefaultFileMetadataSnapshot.file(0, 5, AccessType.DIRECT)
+    @Requires(TestPrecondition.SYMLINKS)
+    def "can add symlinked files"() {
+        def builder = new FileSystemSnapshotBuilder(stringInterner, hasher)
+        def symlink = fileMetadata(AccessType.VIA_SYMLINK)
+
+        when:
+        builder.addFile(new File(basePath), [] as String[], "path", symlink)
+        def result = builder.build()
+
+        then:
+        result instanceof RegularFileSnapshot
+        result.accessType == AccessType.VIA_SYMLINK
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "detects symlinked directories"() {
+        def builder = new FileSystemSnapshotBuilder(stringInterner, hasher)
+        def actualRootDir = tmpDir.file("actualDir").createDir()
+        def actualSubDir = tmpDir.file("actualSubDir").createDir()
+        def rootDir = tmpDir.file("rootDir")
+        def subDir = rootDir.file("subDir")
+        rootDir.createLink(actualRootDir)
+        subDir.createLink(actualSubDir)
+
+        when:
+        builder.addDir(subDir, ["subDir"] as String[])
+        def result = builder.build()
+        then:
+        result instanceof CompleteDirectorySnapshot
+        result.accessType == AccessType.VIA_SYMLINK
+        result.absolutePath == rootDir.absolutePath
+        result.children.size() == 1
+        CompleteDirectorySnapshot subDirSnapshot = result.children[0] as CompleteDirectorySnapshot
+        subDirSnapshot.accessType == AccessType.VIA_SYMLINK
+        subDirSnapshot.absolutePath == subDir.absolutePath
+    }
+
+    private static FileMetadataSnapshot fileMetadata(AccessType accessType = AccessType.DIRECT) {
+        DefaultFileMetadataSnapshot.file(0, 5, accessType)
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -168,7 +168,7 @@ public class OutputFilterUtil {
         public void postVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
             treeDepth--;
             boolean isOutputDir = predicate.test(directorySnapshot, isRoot());
-            boolean includedDir = merkleBuilder.postVisitDirectory(isOutputDir);
+            boolean includedDir = merkleBuilder.postVisitDirectory(isOutputDir, directorySnapshot.getAccessType());
             if (!includedDir) {
                 currentRootFiltered = true;
                 hasBeenFiltered = true;

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableBiMap
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
@@ -31,7 +32,7 @@ import spock.lang.Specification
 class NonIncrementalInputChangesTest extends Specification {
 
     def "can iterate changes more than once"() {
-        def fingerprint = DefaultCurrentFileCollectionFingerprint.from([new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), new FileMetadata(4, 5))], AbsolutePathFingerprintingStrategy.INCLUDE_MISSING)
+        def fingerprint = DefaultCurrentFileCollectionFingerprint.from([new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), new FileMetadata(4, 5), AccessType.DIRECT)], AbsolutePathFingerprintingStrategy.INCLUDE_MISSING)
 
         Provider<FileSystemLocation> value = Mock()
         def changes = new NonIncrementalInputChanges(ImmutableSortedMap.<String, CurrentFileCollectionFingerprint>of("input", fingerprint), new DefaultIncrementalInputProperties(ImmutableBiMap.of("input", value)))

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -21,17 +21,17 @@ import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.VfsRetentionFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
-
+import spock.lang.Unroll
 
 // The whole test makes no sense if there isn't a daemon to retain the state.
 @IgnoreIf({ GradleContextualExecuter.noDaemon || GradleContextualExecuter.vfsRetention })
+@Unroll
 class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, VfsRetentionFixture {
 
     @Rule
@@ -614,7 +614,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
 
     @Issue("https://github.com/gradle/gradle/issues/11851")
     @Requires(TestPrecondition.SYMLINKS)
-    def "gracefully handle when watching the same path via symlinks"() {
+    def "gracefully handle when declaring the same path as an input via symlinks"() {
         def actualDir = file("actualDir").createDir()
         file("symlink1").createLink(actualDir)
         file("symlink2").createLink(actualDir)
@@ -641,9 +641,48 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         withRetention().run "myTask"
         then:
         skipped(":myTask")
-        if (OperatingSystem.current().linux) {
-            outputContains("Watching not supported, not tracking changes between builds: Unable to watch same file twice via different paths")
-        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/11851")
+    @Requires(TestPrecondition.SYMLINKS)
+    def "changes to #description are detected"() {
+        file(fileToChange).createFile()
+        file(linkSource).createLink(file(linkTarget))
+
+        buildFile << """
+            task myTask {
+                def outputFile = file("build/output.txt")
+                inputs.${inputDeclaration}
+                outputs.file(outputFile)
+
+                doLast {
+                    outputFile.text = "Hello world"
+                }
+            }
+        """
+
+        when:
+        withRetention().run "myTask"
+        then:
+        executedAndNotSkipped ":myTask"
+
+        when:
+        withRetention().run "myTask"
+        then:
+        skipped(":myTask")
+
+        when:
+        file(fileToChange).text = "changed"
+        waitForChangesToBePickedUp()
+        withRetention().run "myTask"
+        then:
+        executedAndNotSkipped ":myTask"
+
+        where:
+        description                     | linkSource                     | linkTarget       | inputDeclaration        | fileToChange
+        "symlinked file"                | "symlinkedFile"                | "actualFile"     | 'file("symlinkedFile")' | "actualFile"
+        "symlinked directory"           | "symlinkedDir"                 | "actualDir"      | 'dir("symlinkedDir")'   | "actualDir/file.txt"
+        "symlink in a directory"        | "dirWithSymlink/symlinkInside" | "fileInside.txt" | 'dir("dirWithSymlink")' | "fileInside.txt"
     }
 
     // This makes sure the next Gradle run starts with a clean BuildOutputCleanupRegistry

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.file.FileWatcher;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotVisitor;
@@ -138,16 +139,17 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
         public OnlyVisitSubDirectories(Consumer<String> subDirectoryConsumer) {
             this.subDirectoryConsumer = subDirectoryConsumer;
-            root = true;
+            this.root = true;
         }
 
         @Override
         public boolean preVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
-            if (!root) {
+            boolean directoryAccessedDirectly = directorySnapshot.getAccessType() == AccessType.DIRECT;
+            if (!root && directoryAccessedDirectly) {
                 subDirectoryConsumer.accept(directorySnapshot.getAbsolutePath());
             }
             root = false;
-            return true;
+            return directoryAccessedDirectly;
         }
 
         @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -20,6 +20,7 @@ import com.google.common.collect.EnumMultiset;
 import com.google.common.collect.Multiset;
 import org.gradle.internal.file.DefaultFileHierarchySet;
 import org.gradle.internal.file.FileHierarchySet;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
@@ -118,13 +119,28 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
             getRoot().update(currentRoot -> {
                 buildRunning = false;
                 producedByCurrentBuild.set(DefaultFileHierarchySet.of());
-                SnapshotHierarchy newRoot = handleWatcherRegistryEvents(currentRoot, "for current build");
+                SnapshotHierarchy newRoot = removeSymbolicLinks(currentRoot);
+                newRoot = handleWatcherRegistryEvents(newRoot, "for current build");
                 printStatistics(newRoot, "retains", "till next build");
                 return newRoot;
             });
         } else {
             invalidateAll();
         }
+    }
+
+    /**
+     * Removes all files which are reached via symbolic links from the VFS.
+     *
+     * Currently, we don't model symbolic links in the VFS.
+     * We can only watch the sources of symbolic links.
+     * When the target of symbolic link changes, we do not get informed about those changes.
+     * Therefore, we maintain the state of symbolic links between builds and we need to remove them from the VFS.
+     */
+    private SnapshotHierarchy removeSymbolicLinks(SnapshotHierarchy currentRoot) {
+        SymlinkRemovingFileSystemSnapshotVisitor symlinkRemovingFileSystemSnapshotVisitor = new SymlinkRemovingFileSystemSnapshotVisitor(currentRoot);
+        currentRoot.visitSnapshotRoots(snapshotRoot -> snapshotRoot.accept(symlinkRemovingFileSystemSnapshotVisitor));
+        return symlinkRemovingFileSystemSnapshotVisitor.getRootWithSymlinksRemoved();
     }
 
     /**
@@ -306,6 +322,44 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
             } finally {
                 watchRegistry = null;
             }
+        }
+    }
+
+    private class SymlinkRemovingFileSystemSnapshotVisitor implements FileSystemSnapshotVisitor {
+        private SnapshotHierarchy root;
+
+        public SymlinkRemovingFileSystemSnapshotVisitor(SnapshotHierarchy root) {
+            this.root = root;
+        }
+
+        @Override
+        public boolean preVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
+            boolean accessedViaSymlink = directorySnapshot.getAccessType() == AccessType.VIA_SYMLINK;
+            if (accessedViaSymlink) {
+                invalidateSymlink(directorySnapshot);
+            }
+            return !accessedViaSymlink;
+        }
+
+        @Override
+        public void visitFile(CompleteFileSystemLocationSnapshot fileSnapshot) {
+            if (fileSnapshot.getAccessType() == AccessType.VIA_SYMLINK) {
+                invalidateSymlink(fileSnapshot);
+            }
+        }
+
+        @Override
+        public void postVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
+        }
+
+        private void invalidateSymlink(CompleteFileSystemLocationSnapshot snapshot) {
+            root = delegatingUpdateFunctionDecorator
+                .decorate((root, diffListener) -> root.invalidate(snapshot.getAbsolutePath(), diffListener))
+                .updateRoot(root);
+        }
+
+        public SnapshotHierarchy getRootWithSymlinksRemoved() {
+            return root;
         }
     }
 }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.watch.registry.impl
 import net.rubygrapefruit.platform.file.FileWatcher
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot
@@ -128,7 +129,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     }
 
     static RegularFileSnapshot snapshotRegularFile(File regularFile) {
-        new RegularFileSnapshot(regularFile.absolutePath, regularFile.name, TestFiles.fileHasher().hash(regularFile), FileMetadata.from(Files.readAttributes(regularFile.toPath(), BasicFileAttributes)))
+        new RegularFileSnapshot(regularFile.absolutePath, regularFile.name, TestFiles.fileHasher().hash(regularFile), FileMetadata.from(Files.readAttributes(regularFile.toPath(), BasicFileAttributes)), AccessType.DIRECT)
     }
 
     static boolean equalIgnoringOrder(Object actual, Collection<?> expected) {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchRootUtilTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchRootUtilTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.watch.vfs.impl
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot
 import org.gradle.internal.snapshot.FileMetadata
@@ -80,11 +81,11 @@ class WatchRootUtilTest extends Specification {
     }
 
     private static RegularFileSnapshot fileSnapshot(String absolutePath) {
-        new RegularFileSnapshot(absolutePath, absolutePath.substring(absolutePath.lastIndexOf('/') + 1), Hashing.md5().hashString(absolutePath), new FileMetadata(1, 1))
+        new RegularFileSnapshot(absolutePath, absolutePath.substring(absolutePath.lastIndexOf('/') + 1), Hashing.md5().hashString(absolutePath), new FileMetadata(1, 1), AccessType.DIRECT)
     }
 
     private static CompleteDirectorySnapshot directorySnapshot(String absolutePath) {
-        new CompleteDirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), [], Hashing.md5().hashString(absolutePath))
+        new CompleteDirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), [], Hashing.md5().hashString(absolutePath), AccessType.DIRECT)
     }
 
     private static List<String> resolveRecursiveRoots(List<String> directories) {

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -31,4 +31,23 @@ public interface FileMetadataSnapshot {
      * Note: always 0 for directories and missing files.
      */
     long getLength();
+
+    /**
+     * How the file with the metadata was accessed.
+     */
+    AccessType getAccessType();
+
+    /**
+     * How the file with the metadata was accessed.
+     */
+    enum AccessType {
+        /**
+         * The path pointed to the file directly.
+         */
+        DIRECT,
+        /**
+         * The path pointed to a symlink pointing to the file with the metadata.
+         */
+        VIA_SYMLINK
+    }
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -39,6 +39,15 @@ public interface FileMetadataSnapshot {
 
     /**
      * How the file with the metadata was accessed.
+     *
+     * If we have a symlink situation like `symlink1` -> `symlink2` -> `target`,
+     * then the metadata snapshot for `symlink1` will have an access type {@link AccessType#VIA_SYMLINK}
+     * and the metadata of `target`, i.e. the accessor will resolve transitive symlinks.
+     *
+     * If the directory `symlinkedDir` -> `targetDir` is a symlink, then the
+     * metadata snapshot of `symlinkedDir/fileInDir` will be {@link AccessType#DIRECT},
+     * given the file `targetDir/fileInDir` exists. That means that {@link AccessType}
+     * only gives information about the queried path, not about parents of the queried path.
      */
     enum AccessType {
         /**

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -45,6 +45,7 @@ public interface FileMetadataSnapshot {
          * The path pointed to the file directly.
          */
         DIRECT,
+
         /**
          * The path pointed to a symlink pointing to the file with the metadata.
          */

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -58,6 +58,15 @@ public interface FileMetadataSnapshot {
         /**
          * The path pointed to a symlink pointing to the file with the metadata.
          */
-        VIA_SYMLINK
+        VIA_SYMLINK;
+
+        /**
+         * Factory method for returning the access type based on a boolean.
+         */
+        public static AccessType viaSymlink(boolean viaSymlink) {
+            return viaSymlink
+                ? VIA_SYMLINK
+                : DIRECT;
+        }
     }
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileMetadataSnapshot.java
@@ -40,14 +40,15 @@ public interface FileMetadataSnapshot {
     /**
      * How the file with the metadata was accessed.
      *
+     * {@link AccessType} only gives information about the queried path, not about parents of the queried path.
+     *
      * If we have a symlink situation like `symlink1` -> `symlink2` -> `target`,
      * then the metadata snapshot for `symlink1` will have an access type {@link AccessType#VIA_SYMLINK}
      * and the metadata of `target`, i.e. the accessor will resolve transitive symlinks.
      *
      * If the directory `symlinkedDir` -> `targetDir` is a symlink, then the
      * metadata snapshot of `symlinkedDir/fileInDir` will be {@link AccessType#DIRECT},
-     * given the file `targetDir/fileInDir` exists. That means that {@link AccessType}
-     * only gives information about the queried path, not about parents of the queried path.
+     * given the file `targetDir/fileInDir` exists.
      */
     enum AccessType {
         /**

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -185,7 +184,6 @@ class JavaSourceIncrementalCompilationIntegrationTest extends BaseJavaSourceIncr
         outputs.recompiledClasses('MyClass', 'MyAnnotation', 'TopLevel$Inner', 'TopLevel')
     }
 
-    @ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/11851")
     @Requires(TestPrecondition.SYMLINKS)
     @Issue("https://github.com/gradle/gradle/issues/9202")
     def "source mapping file works with symlinks"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.language.nativeplatform.internal.incremental
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.PersistentStateCache
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.snapshot.MissingFileSnapshot
@@ -517,6 +518,6 @@ class IncrementalCompileProcessorTest extends Specification {
     private HashCode getContentHash(File file) {
         virtualFileSystem.update([file.absolutePath], {})
         return virtualFileSystem.readRegularFileContentHash(file.getAbsolutePath(), { it })
-            .orElse(new MissingFileSnapshot(file.getAbsolutePath(), file.getName()).hash)
+            .orElse(new MissingFileSnapshot(file.getAbsolutePath(), file.getName(), AccessType.DIRECT).hash)
     }
 }

--- a/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
+++ b/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import net.rubygrapefruit.platform.file.Files;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot;
 import org.gradle.internal.nativeintegration.filesystem.jdk7.NioFileMetadataAccessor;
 import org.gradle.internal.nativeintegration.filesystem.services.FallbackFileMetadataAccessor;
@@ -120,14 +121,14 @@ public class FileMetadataAccessorBenchmark {
                 // This is really not cool, but we cannot rely on `readAttributes` because it will
                 // THROW AN EXCEPTION if the file is missing, which is really incredibly slow just
                 // to determine if a file exists or not.
-                return DefaultFileMetadataSnapshot.missing();
+                return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
             }
             try {
                 BasicFileAttributes bfa = java.nio.file.Files.readAttributes(f.toPath(), BasicFileAttributes.class);
                 if (bfa.isDirectory()) {
-                    return DefaultFileMetadataSnapshot.directory();
+                    return DefaultFileMetadataSnapshot.directory(AccessType.DIRECT);
                 }
-                return DefaultFileMetadataSnapshot.file(bfa.lastModifiedTime().toMillis(), bfa.size());
+                return DefaultFileMetadataSnapshot.file(bfa.lastModifiedTime().toMillis(), bfa.size(), AccessType.DIRECT);
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -16,12 +16,15 @@
 package org.gradle.internal.nativeintegration.filesystem.jdk7;
 
 import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot;
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
 @SuppressWarnings("Since15")
@@ -29,16 +32,25 @@ public class NioFileMetadataAccessor implements FileMetadataAccessor {
     @Override
     public FileMetadataSnapshot stat(File f) {
         try {
-            BasicFileAttributes bfa = Files.readAttributes(f.toPath(), BasicFileAttributes.class);
+            Path path = f.toPath();
+            BasicFileAttributes bfa = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            AccessType accessType = bfa.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+            if (accessType == AccessType.VIA_SYMLINK) {
+                try {
+                    bfa = Files.readAttributes(path, BasicFileAttributes.class);
+                } catch (IOException e) {
+                    return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
+                }
+            }
             if (bfa.isDirectory()) {
-                return DefaultFileMetadataSnapshot.directory();
+                return DefaultFileMetadataSnapshot.directory(accessType);
             }
             if (bfa.isOther()) {
-                return DefaultFileMetadataSnapshot.missing();
+                return DefaultFileMetadataSnapshot.missing(accessType);
             }
-            return DefaultFileMetadataSnapshot.file(bfa.lastModifiedTime().toMillis(), bfa.size());
+            return DefaultFileMetadataSnapshot.file(bfa.lastModifiedTime().toMillis(), bfa.size(), accessType);
         } catch (IOException e) {
-            return DefaultFileMetadataSnapshot.missing();
+            return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -30,25 +30,25 @@ import java.nio.file.attribute.BasicFileAttributes;
 @SuppressWarnings("Since15")
 public class NioFileMetadataAccessor implements FileMetadataAccessor {
     @Override
-    public FileMetadataSnapshot stat(File f) {
+    public FileMetadataSnapshot stat(File file) {
         try {
-            Path path = f.toPath();
-            BasicFileAttributes bfa = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            AccessType accessType = bfa.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+            Path path = file.toPath();
+            BasicFileAttributes attributes = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            AccessType accessType = attributes.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
             if (accessType == AccessType.VIA_SYMLINK) {
                 try {
-                    bfa = Files.readAttributes(path, BasicFileAttributes.class);
+                    attributes = Files.readAttributes(path, BasicFileAttributes.class);
                 } catch (IOException e) {
                     return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
                 }
             }
-            if (bfa.isDirectory()) {
+            if (attributes.isDirectory()) {
                 return DefaultFileMetadataSnapshot.directory(accessType);
             }
-            if (bfa.isOther()) {
+            if (attributes.isOther()) {
                 return DefaultFileMetadataSnapshot.missing(accessType);
             }
-            return DefaultFileMetadataSnapshot.file(bfa.lastModifiedTime().toMillis(), bfa.size(), accessType);
+            return DefaultFileMetadataSnapshot.file(attributes.lastModifiedTime().toMillis(), attributes.size(), accessType);
         } catch (IOException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -34,7 +34,7 @@ public class NioFileMetadataAccessor implements FileMetadataAccessor {
         Path path = file.toPath();
         BasicFileAttributes attributes;
         try {
-            attributes = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            attributes = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
         } catch (IOException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -31,26 +31,27 @@ import java.nio.file.attribute.BasicFileAttributes;
 public class NioFileMetadataAccessor implements FileMetadataAccessor {
     @Override
     public FileMetadataSnapshot stat(File file) {
+        Path path = file.toPath();
+        BasicFileAttributes attributes;
         try {
-            Path path = file.toPath();
-            BasicFileAttributes attributes = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            AccessType accessType = attributes.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
-            if (accessType == AccessType.VIA_SYMLINK) {
-                try {
-                    attributes = Files.readAttributes(path, BasicFileAttributes.class);
-                } catch (IOException e) {
-                    return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
-                }
-            }
-            if (attributes.isDirectory()) {
-                return DefaultFileMetadataSnapshot.directory(accessType);
-            }
-            if (attributes.isOther()) {
-                return DefaultFileMetadataSnapshot.missing(accessType);
-            }
-            return DefaultFileMetadataSnapshot.file(attributes.lastModifiedTime().toMillis(), attributes.size(), accessType);
+            attributes = java.nio.file.Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
         } catch (IOException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }
+        AccessType accessType = attributes.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+        if (accessType == AccessType.VIA_SYMLINK) {
+            try {
+                attributes = Files.readAttributes(path, BasicFileAttributes.class);
+            } catch (IOException e) {
+                return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
+            }
+        }
+        if (attributes.isDirectory()) {
+            return DefaultFileMetadataSnapshot.directory(accessType);
+        }
+        if (attributes.isOther()) {
+            return DefaultFileMetadataSnapshot.missing(accessType);
+        }
+        return DefaultFileMetadataSnapshot.file(attributes.lastModifiedTime().toMillis(), attributes.size(), accessType);
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -38,7 +38,7 @@ public class NioFileMetadataAccessor implements FileMetadataAccessor {
         } catch (IOException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }
-        AccessType accessType = attributes.isSymbolicLink() ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+        AccessType accessType = AccessType.viaSymlink(attributes.isSymbolicLink());
         if (accessType == AccessType.VIA_SYMLINK) {
             try {
                 attributes = Files.readAttributes(path, BasicFileAttributes.class);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.nativeintegration.filesystem.services;
 
 import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadataSnapshot;
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor;
 
@@ -26,14 +27,14 @@ public class FallbackFileMetadataAccessor implements FileMetadataAccessor {
     @Override
     public FileMetadataSnapshot stat(File f) {
         if (!f.exists()) {
-            return DefaultFileMetadataSnapshot.missing();
+            return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }
         if (f.isDirectory()) {
-            return DefaultFileMetadataSnapshot.directory();
+            return DefaultFileMetadataSnapshot.directory(AccessType.DIRECT);
         }
         if (f.isFile()) {
-            return DefaultFileMetadataSnapshot.file(f.lastModified(), f.length());
+            return DefaultFileMetadataSnapshot.file(f.lastModified(), f.length(), AccessType.DIRECT);
         }
-        return DefaultFileMetadataSnapshot.missing();
+        return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
@@ -35,29 +35,30 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
 
     @Override
     public FileMetadataSnapshot stat(File f) {
+        FileInfo stat;
         try {
-            FileInfo stat = files.stat(f, false);
-            AccessType accessType = stat.getType() == FileInfo.Type.Symlink ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
-            if (accessType == AccessType.VIA_SYMLINK) {
-                try {
-                    stat = files.stat(f, true);
-                } catch (NativeException e) {
-                    return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
-                }
-            }
-            switch (stat.getType()) {
-                case File:
-                    return DefaultFileMetadataSnapshot.file(stat.getLastModifiedTime(), stat.getSize(), accessType);
-                case Directory:
-                    return DefaultFileMetadataSnapshot.directory(accessType);
-                case Missing:
-                case Other:
-                    return DefaultFileMetadataSnapshot.missing(accessType);
-                default:
-                    throw new IllegalArgumentException("Unrecognised file type: " + stat.getType());
-            }
+            stat = files.stat(f, false);
         } catch (NativeException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
+        }
+        AccessType accessType = stat.getType() == FileInfo.Type.Symlink ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+        if (accessType == AccessType.VIA_SYMLINK) {
+            try {
+                stat = files.stat(f, true);
+            } catch (NativeException e) {
+                return DefaultFileMetadataSnapshot.missing(AccessType.VIA_SYMLINK);
+            }
+        }
+        switch (stat.getType()) {
+            case File:
+                return DefaultFileMetadataSnapshot.file(stat.getLastModifiedTime(), stat.getSize(), accessType);
+            case Directory:
+                return DefaultFileMetadataSnapshot.directory(accessType);
+            case Missing:
+            case Other:
+                return DefaultFileMetadataSnapshot.missing(accessType);
+            default:
+                throw new IllegalArgumentException("Unrecognised file type: " + stat.getType());
         }
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
@@ -41,7 +41,7 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
         } catch (NativeException e) {
             return DefaultFileMetadataSnapshot.missing(AccessType.DIRECT);
         }
-        AccessType accessType = stat.getType() == FileInfo.Type.Symlink ? AccessType.VIA_SYMLINK : AccessType.DIRECT;
+        AccessType accessType = AccessType.viaSymlink(stat.getType() == FileInfo.Type.Symlink);
         if (accessType == AccessType.VIA_SYMLINK) {
             try {
                 stat = files.stat(f, true);

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
@@ -36,10 +36,10 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     abstract FileMetadataAccessor getAccessor()
 
-    abstract boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file)
+    abstract void assertSameLastModified(FileMetadataSnapshot metadataSnapshot, File file)
 
-    boolean sameAccessType(FileMetadataSnapshot metadataSnapshot, AccessType accessType) {
-        metadataSnapshot.accessType == accessType
+    void assertSameAccessType(FileMetadataSnapshot metadataSnapshot, AccessType accessType) {
+        assert metadataSnapshot.accessType == accessType
     }
 
     def "stats missing file"() {
@@ -50,7 +50,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, DIRECT)
+        assertSameAccessType(stat, DIRECT)
     }
 
     def "stats regular file"() {
@@ -60,9 +60,9 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         expect:
         def stat = accessor.stat(file)
         stat.type == FileType.RegularFile
-        sameLastModified(stat, file)
+        assertSameLastModified(stat, file)
         stat.length == 3
-        sameAccessType(stat, DIRECT)
+        assertSameAccessType(stat, DIRECT)
     }
 
     def "stats directory"() {
@@ -73,7 +73,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Directory
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, DIRECT)
+        assertSameAccessType(stat, DIRECT)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -86,9 +86,9 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         expect:
         def stat = accessor.stat(link)
         stat.type == FileType.RegularFile
-        sameLastModified(stat, file)
+        assertSameLastModified(stat, file)
         stat.length == 3
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -102,7 +102,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Directory
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -116,7 +116,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -131,9 +131,9 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         expect:
         def stat = accessor.stat(linkToLink)
         stat.type == FileType.RegularFile
-        sameLastModified(stat, file)
+        assertSameLastModified(stat, file)
         stat.length == 3
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -149,7 +149,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -166,7 +166,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, VIA_SYMLINK)
+        assertSameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
@@ -179,6 +179,6 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
-        sameAccessType(stat, DIRECT)
+        assertSameAccessType(stat, DIRECT)
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.nativeintegration.filesystem.services
 
 import org.gradle.internal.file.FileMetadataSnapshot
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.FileType
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -26,6 +27,9 @@ import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+import static org.gradle.internal.file.FileMetadataSnapshot.AccessType.DIRECT
+import static org.gradle.internal.file.FileMetadataSnapshot.AccessType.VIA_SYMLINK
+
 @UsesNativeServices
 abstract class AbstractFileMetadataAccessorTest extends Specification {
     @Rule
@@ -33,6 +37,10 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
     abstract FileMetadataAccessor getAccessor()
 
     abstract boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file)
+
+    boolean sameAccessType(FileMetadataSnapshot metadataSnapshot, AccessType accessType) {
+        metadataSnapshot.accessType == accessType
+    }
 
     def "stats missing file"() {
         def file = tmpDir.file("missing")
@@ -42,6 +50,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, DIRECT)
     }
 
     def "stats regular file"() {
@@ -53,6 +62,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.RegularFile
         sameLastModified(stat, file)
         stat.length == 3
+        sameAccessType(stat, DIRECT)
     }
 
     def "stats directory"() {
@@ -63,6 +73,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Directory
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, DIRECT)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -77,6 +88,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.RegularFile
         sameLastModified(stat, file)
         stat.length == 3
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -90,6 +102,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Directory
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -103,6 +116,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -119,6 +133,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.RegularFile
         sameLastModified(stat, file)
         stat.length == 3
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -134,6 +149,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.SYMLINKS)
@@ -150,6 +166,7 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, VIA_SYMLINK)
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
@@ -162,5 +179,6 @@ abstract class AbstractFileMetadataAccessorTest extends Specification {
         stat.type == FileType.Missing
         stat.lastModified == 0
         stat.length == 0
+        sameAccessType(stat, DIRECT)
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessorTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.internal.file.FileMetadataSnapshot
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor
 import org.gradle.util.UsesNativeServices
 
+import static org.gradle.internal.file.FileMetadataSnapshot.AccessType.DIRECT
+
 @UsesNativeServices
 class FallbackFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
     FileMetadataAccessor getAccessor() {
@@ -29,5 +31,11 @@ class FallbackFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest 
     @Override
     boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
         return metadataSnapshot.lastModified == file.lastModified()
+    }
+
+    @Override
+    boolean sameAccessType(FileMetadataSnapshot metadataSnapshot, FileMetadataSnapshot.AccessType accessType) {
+        // Via the old Java API, it is impossible to decide whether a location is a symbolic link or not.
+        metadataSnapshot.accessType == DIRECT
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessorTest.groovy
@@ -29,13 +29,13 @@ class FallbackFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest 
     }
 
     @Override
-    boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
-        return metadataSnapshot.lastModified == file.lastModified()
+    void assertSameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
+        assert metadataSnapshot.lastModified == file.lastModified()
     }
 
     @Override
-    boolean sameAccessType(FileMetadataSnapshot metadataSnapshot, FileMetadataSnapshot.AccessType accessType) {
+    void assertSameAccessType(FileMetadataSnapshot metadataSnapshot, FileMetadataSnapshot.AccessType accessType) {
         // Via the old Java API, it is impossible to decide whether a location is a symbolic link or not.
-        metadataSnapshot.accessType == DIRECT
+        assert metadataSnapshot.accessType == DIRECT
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -36,8 +36,8 @@ class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataA
     }
 
     @Override
-    boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
-        return maybeRoundLastModified(metadataSnapshot.lastModified) == maybeRoundLastModified(lastModifiedViaJavaNio(file))
+    void assertSameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
+        assert maybeRoundLastModified(metadataSnapshot.lastModified) == maybeRoundLastModified(lastModifiedViaJavaNio(file))
     }
 
     private static maybeRoundLastModified(long lastModified) {

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NioFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NioFileMetadataAccessorTest.groovy
@@ -32,8 +32,8 @@ class NioFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
     }
 
     @Override
-    boolean sameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
-        return metadataSnapshot.lastModified == lastModified(file)
+    void assertSameLastModified(FileMetadataSnapshot metadataSnapshot, File file) {
+        assert metadataSnapshot.lastModified == lastModified(file)
     }
 
     private static long lastModified(File file) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
@@ -16,19 +16,23 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
+
 import java.util.Optional;
 
 public abstract class AbstractCompleteFileSystemLocationSnapshot implements CompleteFileSystemLocationSnapshot {
     private final String absolutePath;
     private final String name;
+    private final AccessType accessType;
 
-    public AbstractCompleteFileSystemLocationSnapshot(String absolutePath, String name) {
+    public AbstractCompleteFileSystemLocationSnapshot(String absolutePath, String name, AccessType accessType) {
         this.absolutePath = absolutePath;
         this.name = name;
+        this.accessType = accessType;
     }
 
     protected static MissingFileSnapshot missingSnapshotForAbsolutePath(String filePath) {
-        return new MissingFileSnapshot(filePath);
+        return new MissingFileSnapshot(filePath, AccessType.DIRECT);
     }
 
     @Override
@@ -39,6 +43,11 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public AccessType getAccessType() {
+        return accessType;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteDirectorySnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteDirectorySnapshot.java
@@ -18,6 +18,7 @@ package org.gradle.internal.snapshot;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.hash.HashCode;
 
@@ -34,8 +35,8 @@ public class CompleteDirectorySnapshot extends AbstractCompleteFileSystemLocatio
     private final List<CompleteFileSystemLocationSnapshot> children;
     private final HashCode contentHash;
 
-    public CompleteDirectorySnapshot(String absolutePath, String name, List<CompleteFileSystemLocationSnapshot> children, HashCode contentHash) {
-        super(absolutePath, name);
+    public CompleteDirectorySnapshot(String absolutePath, String name, List<CompleteFileSystemLocationSnapshot> children, HashCode contentHash, AccessType accessType) {
+        super(absolutePath, name, accessType);
         this.children = children;
         this.contentHash = contentHash;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
@@ -69,7 +69,7 @@ public interface CompleteFileSystemLocationSnapshot extends FileSystemSnapshot, 
     boolean isContentAndMetadataUpToDate(CompleteFileSystemLocationSnapshot other);
 
     /**
-     * How this snapshot was accessed.
+     * Whether the file system location represented by this snapshot is a symlink or not.
      */
     FileMetadataSnapshot.AccessType getAccessType();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
@@ -68,5 +68,8 @@ public interface CompleteFileSystemLocationSnapshot extends FileSystemSnapshot, 
      */
     boolean isContentAndMetadataUpToDate(CompleteFileSystemLocationSnapshot other);
 
+    /**
+     * How this snapshot was accessed.
+     */
     FileMetadataSnapshot.AccessType getAccessType();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.file.FileMetadataSnapshot;
 import org.gradle.internal.hash.HashCode;
 
 import java.util.Comparator;
@@ -66,4 +67,6 @@ public interface CompleteFileSystemLocationSnapshot extends FileSystemSnapshot, 
      * Whether the content and the metadata (modification date) of the current snapshot is the same as for the given one.
      */
     boolean isContentAndMetadataUpToDate(CompleteFileSystemLocationSnapshot other);
+
+    FileMetadataSnapshot.AccessType getAccessType();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
@@ -93,7 +94,7 @@ public class MerkleDirectorySnapshotBuilder implements FileSystemSnapshotVisitor
             hasher.putString(child.getName());
             hasher.putHash(child.getHash());
         }
-        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash());
+        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash(), AccessType.DIRECT);
         List<CompleteFileSystemLocationSnapshot> siblings = levelHolder.peekLast();
         if (siblings != null) {
             siblings.add(directorySnapshot);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -71,14 +71,14 @@ public class MerkleDirectorySnapshotBuilder implements FileSystemSnapshotVisitor
 
     @Override
     public void postVisitDirectory(CompleteDirectorySnapshot directorySnapshot) {
-        postVisitDirectory(true);
+        postVisitDirectory(true, directorySnapshot.getAccessType());
     }
 
-    public void postVisitDirectory() {
-        postVisitDirectory(true);
+    public void postVisitDirectory(AccessType accessType) {
+        postVisitDirectory(true, accessType);
     }
 
-    public boolean postVisitDirectory(boolean includeEmpty) {
+    public boolean postVisitDirectory(boolean includeEmpty, AccessType accessType) {
         String name = relativePathSegmentsTracker.leave();
         List<CompleteFileSystemLocationSnapshot> children = levelHolder.removeLast();
         String absolutePath = directoryAbsolutePaths.removeLast();
@@ -94,7 +94,7 @@ public class MerkleDirectorySnapshotBuilder implements FileSystemSnapshotVisitor
             hasher.putString(child.getName());
             hasher.putHash(child.getHash());
         }
-        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash(), AccessType.DIRECT);
+        CompleteDirectorySnapshot directorySnapshot = new CompleteDirectorySnapshot(absolutePath, name, children, hasher.hash(), accessType);
         List<CompleteFileSystemLocationSnapshot> siblings = levelHolder.peekLast();
         if (siblings != null) {
             siblings.add(directorySnapshot);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MissingFileSnapshot.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hashing;
@@ -28,12 +29,12 @@ import java.util.Optional;
 public class MissingFileSnapshot extends AbstractCompleteFileSystemLocationSnapshot {
     private static final HashCode SIGNATURE = Hashing.signature(MissingFileSnapshot.class);
 
-    public MissingFileSnapshot(String absolutePath, String name) {
-        super(absolutePath, name);
+    public MissingFileSnapshot(String absolutePath, String name, AccessType accessType) {
+        super(absolutePath, name, accessType);
     }
 
-    public MissingFileSnapshot(String absolutePath) {
-        super(absolutePath, PathUtil.getFileName(absolutePath));
+    public MissingFileSnapshot(String absolutePath, AccessType accessType) {
+        this(absolutePath, PathUtil.getFileName(absolutePath), accessType);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.hash.HashCode;
 
@@ -30,8 +31,8 @@ public class RegularFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
     private final HashCode contentHash;
     private final FileMetadata metadata;
 
-    public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata) {
-        super(absolutePath, name);
+    public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata, AccessType accessType) {
+        super(absolutePath, name, accessType);
         this.contentHash = contentHash;
         this.metadata = metadata;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -235,7 +235,7 @@ public class DirectorySnapshotter {
             if (isNotFileSystemLoopException(exc)) {
                 throw new UncheckedIOException(String.format("Could not read directory path '%s'.", dir), exc);
             }
-            builder.postVisitDirectory();
+            builder.postVisitDirectory(AccessType.DIRECT);
             return FileVisitResult.CONTINUE;
         }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -308,9 +308,9 @@ public class DirectorySnapshotter {
             if (isNotFileSystemLoopException(exc)) {
                 throw new UncheckedIOException(String.format("Could not read directory path '%s'.", dir), exc);
             }
-            AccessType accessType = (!symbolicLinkMappings.isEmpty() && symbolicLinkMappings.getFirst().target.equals(dir.toString()))
-                ? AccessType.VIA_SYMLINK
-                : AccessType.DIRECT;
+            AccessType accessType = AccessType.viaSymlink(
+                !symbolicLinkMappings.isEmpty() && symbolicLinkMappings.getFirst().target.equals(dir.toString())
+            );
             builder.postVisitDirectory(accessType);
             parentDirectories.removeFirst();
             return FileVisitResult.CONTINUE;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -264,6 +264,8 @@ public class DirectorySnapshotter {
             try {
                 return Files.readAttributes(symlink, BasicFileAttributes.class);
             } catch (IOException ioe) {
+                // We emulate the behavior of `Files.walkFileTree(Path, EnumSet.of(FileVisitOption.FOLLOW_LINKS), PathVisitor)`,
+                // and return the attributes of the symlink if we can't read the attributes of the target of the symlink.
                 return symlinkAttributes;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Lists;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
@@ -200,12 +201,12 @@ public class DirectorySnapshotter {
                 try {
                     HashCode hash = hasher.hash(absoluteFilePath.toFile(), attrs.size(), attrs.lastModifiedTime().toMillis());
                     FileMetadata metadata = FileMetadata.from(attrs);
-                    return new RegularFileSnapshot(internedAbsoluteFilePath, internedName, hash, metadata);
+                    return new RegularFileSnapshot(internedAbsoluteFilePath, internedName, hash, metadata, AccessType.DIRECT);
                 } catch (UncheckedIOException e) {
                     LOGGER.info("Could not read file path '{}'.", absoluteFilePath, e);
                 }
             }
-            return new MissingFileSnapshot(internedAbsoluteFilePath, internedName);
+            return new MissingFileSnapshot(internedAbsoluteFilePath, internedName, AccessType.DIRECT);
         }
 
         /** unlistable directories (and maybe some locked files) will stop here */
@@ -220,7 +221,7 @@ public class DirectorySnapshotter {
                 if (shouldVisit(file, internedName, isDirectory, builder.getRelativePath())) {
                     LOGGER.info("Could not read file path '{}'.", file);
                     String internedAbsolutePath = intern(file.toString());
-                    builder.visitFile(new MissingFileSnapshot(internedAbsolutePath, internedName));
+                    builder.visitFile(new MissingFileSnapshot(internedAbsolutePath, internedName, AccessType.DIRECT));
                 }
             }
             return FileVisitResult.CONTINUE;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -53,6 +53,7 @@ import java.util.function.Predicate;
 
 public class DirectorySnapshotter {
     private static final Logger LOGGER = LoggerFactory.getLogger(DirectorySnapshotter.class);
+    private static final EnumSet<FileVisitOption> DONT_FOLLOW_SYMLINKS = EnumSet.noneOf(FileVisitOption.class);
 
     private final FileHasher hasher;
     private final Interner<String> stringInterner;
@@ -68,7 +69,7 @@ public class DirectorySnapshotter {
         try {
             Path rootPath = Paths.get(absolutePath);
             PathVisitor visitor = new PathVisitor(predicate, hasBeenFiltered, hasher, stringInterner, defaultExcludes);
-            Files.walkFileTree(rootPath, EnumSet.noneOf(FileVisitOption.class), Integer.MAX_VALUE, visitor);
+            Files.walkFileTree(rootPath, DONT_FOLLOW_SYMLINKS, Integer.MAX_VALUE, visitor);
             return visitor.getResult();
         } catch (IOException e) {
             throw new UncheckedIOException(String.format("Could not list contents of directory '%s'.", absolutePath), e);
@@ -239,12 +240,7 @@ public class DirectorySnapshotter {
         }
 
         private boolean introducesCycle(String targetDirString) {
-            for (String parentDirectory : parentDirectories) {
-                if (parentDirectory.equals(targetDirString)) {
-                    return true;
-                }
-            }
-            return false;
+            return parentDirectories.contains(targetDirString);
         }
 
         private String remapAbsolutePath(Path dir) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
@@ -19,6 +19,7 @@ package org.gradle.internal.vfs.impl;
 import com.google.common.collect.Interner;
 import com.google.common.util.concurrent.Striped;
 import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.hash.FileHasher;
@@ -89,7 +90,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
                     () -> root.get().getSnapshot(location)
                         .orElseGet(() -> {
                             HashCode hashCode = hasher.hash(file, stat.getLength(), stat.getLastModified());
-                            RegularFileSnapshot snapshot = new RegularFileSnapshot(location, file.getName(), hashCode, FileMetadata.from(stat));
+                            RegularFileSnapshot snapshot = new RegularFileSnapshot(location, file.getName(), hashCode, FileMetadata.from(stat), AccessType.DIRECT);
                             updateRoot((root, changeListener) -> root.store(snapshot.getAbsolutePath(), snapshot, changeListener));
                             return snapshot;
                         }).getHash());
@@ -99,7 +100,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
     }
 
     private void storeStatForMissingFile(String location) {
-        updateRoot((root, changeListener) -> root.store(location, new MissingFileSnapshot(location), changeListener));
+        updateRoot((root, changeListener) -> root.store(location, new MissingFileSnapshot(location, AccessType.DIRECT), changeListener));
     }
 
     @Override
@@ -135,11 +136,11 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
         switch (stat.getType()) {
             case RegularFile:
                 HashCode hash = hasher.hash(file, stat.getLength(), stat.getLastModified());
-                RegularFileSnapshot regularFileSnapshot = new RegularFileSnapshot(location, file.getName(), hash, FileMetadata.from(stat));
+                RegularFileSnapshot regularFileSnapshot = new RegularFileSnapshot(location, file.getName(), hash, FileMetadata.from(stat), AccessType.DIRECT);
                 updateRoot((root, changeListener) -> root.store(regularFileSnapshot.getAbsolutePath(), regularFileSnapshot, changeListener));
                 return regularFileSnapshot;
             case Missing:
-                MissingFileSnapshot missingFileSnapshot = new MissingFileSnapshot(location);
+                MissingFileSnapshot missingFileSnapshot = new MissingFileSnapshot(location, AccessType.DIRECT);
                 updateRoot((root, changeListener) -> root.store(missingFileSnapshot.getAbsolutePath(), missingFileSnapshot, changeListener));
                 return missingFileSnapshot;
             case Directory:

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/SnapshotCollectingDiffListener.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/SnapshotCollectingDiffListener.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.vfs.impl;
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemNode;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
@@ -42,7 +43,7 @@ public class SnapshotCollectingDiffListener implements SnapshotHierarchy.NodeDif
 
     private void extractRootSnapshots(FileSystemNode rootNode, Consumer<CompleteFileSystemLocationSnapshot> consumer) {
         rootNode.accept(snapshot -> {
-            if (watchFilter.test(snapshot.getAbsolutePath())) {
+            if (snapshot.getAccessType() == AccessType.DIRECT && watchFilter.test(snapshot.getAbsolutePath())) {
                 consumer.accept(snapshot);
             }
         });

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/overlap/impl/DefaultOverlappingOutputDetectorTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/overlap/impl/DefaultOverlappingOutputDetectorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.fingerprint.overlap.impl
 
 import com.google.common.collect.ImmutableSortedMap
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.hash.HashCode
@@ -40,7 +41,7 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
     }
 
     def "detects overlap when there is one"() {
-        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", HashCode.fromInt(1234), new FileMetadata(0, 0))
+        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", HashCode.fromInt(1234), new FileMetadata(0, 0), AccessType.DIRECT)
         def outputFilesAfterPreviousExecution = ImmutableSortedMap.<String, FileCollectionFingerprint>of(
             "output", AbsolutePathFingerprintingStrategy.INCLUDE_MISSING.emptyFingerprint
         )

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/CompleteDirectorySnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/CompleteDirectorySnapshotTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.FileType
 import org.gradle.internal.hash.HashCode
 import spock.lang.Unroll
@@ -26,7 +27,7 @@ import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 class CompleteDirectorySnapshotTest extends AbstractSnapshotWithChildrenTest<FileSystemNode, CompleteFileSystemLocationSnapshot> {
     @Override
     protected FileSystemNode createInitialRootNode(String pathToParent, List<CompleteFileSystemLocationSnapshot> children) {
-        return new CompleteDirectorySnapshot("/root/${pathToParent}", PathUtil.getFileName(pathToParent), children, HashCode.fromInt(1234)).asFileSystemNode(pathToParent)
+        return new CompleteDirectorySnapshot("/root/${pathToParent}", PathUtil.getFileName(pathToParent), children, HashCode.fromInt(1234), AccessType.DIRECT).asFileSystemNode(pathToParent)
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/MissingFileSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/MissingFileSnapshotTest.groovy
@@ -16,9 +16,11 @@
 
 package org.gradle.internal.snapshot
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
+
 class MissingFileSnapshotTest extends AbstractCompleteSnapshotWithoutChildrenTest {
     @Override
     protected CompleteFileSystemLocationSnapshot createInitialRootNode(String absolutePath) {
-        return new MissingFileSnapshot(absolutePath)
+        return new MissingFileSnapshot(absolutePath, AccessType.DIRECT)
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.internal.snapshot
 
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.hash.HashCode
 
 class RegularFileSnapshotTest extends AbstractCompleteSnapshotWithoutChildrenTest {
     @Override
     protected CompleteFileSystemLocationSnapshot createInitialRootNode(String absolutePath) {
-        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), HashCode.fromInt(1235), new FileMetadata(1, 2))
+        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), HashCode.fromInt(1235), new FileMetadata(1, 2), AccessType.DIRECT)
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.internal.snapshot.FileSystemSnapshotVisitor
 import org.gradle.internal.snapshot.MissingFileSnapshot
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.SnapshottingFilter
+import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -41,6 +42,7 @@ import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicBoolean
 
 @UsesNativeServices
+@CleanupTestDirectory(fieldName = "tmpDir")
 class DirectorySnapshotterTest extends Specification {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.snapshot.impl
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.MutableReference
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.fingerprint.impl.PatternSetSnapshottingFilter
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
@@ -74,12 +75,12 @@ class FileSystemSnapshotFilterTest extends Specification {
         def root = temporaryFolder.createFile("root")
 
         expect:
-        filteredPaths(new CompleteDirectorySnapshot(root.absolutePath, root.name, [], HashCode.fromInt(789)), include("different")) == [root] as Set
+        filteredPaths(new CompleteDirectorySnapshot(root.absolutePath, root.name, [], HashCode.fromInt(789), AccessType.DIRECT), include("different")) == [root] as Set
     }
 
     def "root file can be filtered"() {
         def root = temporaryFolder.createFile("root")
-        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, HashCode.fromInt(1234), new FileMetadata(5, 1234))
+        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, HashCode.fromInt(1234), new FileMetadata(5, 1234), AccessType.DIRECT)
 
         expect:
         filteredPaths(regularFileSnapshot, include("different")) == [] as Set

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.vfs.impl
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.file.FileMetadataSnapshot.AccessType
 import org.gradle.internal.file.FileType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.AbstractIncompleteSnapshotWithChildren
@@ -443,12 +444,12 @@ class DefaultSnapshotHierarchyTest extends Specification {
         Assume.assumeTrue("Root is only defined for the file separator '/'", File.separator == '/')
 
         when:
-        def set = EMPTY.store("/", new CompleteDirectorySnapshot("/", "", [new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1))], HashCode.fromInt(1111)), diffListener)
+        def set = EMPTY.store("/", new CompleteDirectorySnapshot("/", "", [new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1), AccessType.DIRECT)], HashCode.fromInt(1111), AccessType.DIRECT), diffListener)
         then:
         set.getMetadata("/root.txt").get().type == FileType.RegularFile
 
         when:
-        set = set.invalidate("/root.txt", diffListener).store("/", new CompleteDirectorySnapshot("/", "", [new RegularFileSnapshot("/base.txt", "base.txt", HashCode.fromInt(1234), new FileMetadata(1, 1))], HashCode.fromInt(2222)), diffListener)
+        set = set.invalidate("/root.txt", diffListener).store("/", new CompleteDirectorySnapshot("/", "", [new RegularFileSnapshot("/base.txt", "base.txt", HashCode.fromInt(1234), new FileMetadata(1, 1), AccessType.DIRECT)], HashCode.fromInt(2222), AccessType.DIRECT), diffListener)
         then:
         set.getMetadata("/base.txt").get().type == FileType.RegularFile
     }
@@ -608,13 +609,13 @@ class DefaultSnapshotHierarchyTest extends Specification {
 
     private static CompleteDirectorySnapshot rootDirectorySnapshot() {
         new CompleteDirectorySnapshot("/", "", [
-            new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1)),
-            new RegularFileSnapshot("/other.txt", "other.txt", HashCode.fromInt(4321), new FileMetadata(5, 28))
-        ], HashCode.fromInt(1111))
+            new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1), AccessType.DIRECT),
+            new RegularFileSnapshot("/other.txt", "other.txt", HashCode.fromInt(4321), new FileMetadata(5, 28), AccessType.DIRECT)
+        ], HashCode.fromInt(1111), AccessType.DIRECT)
     }
 
     private static CompleteDirectorySnapshot directorySnapshotForPath(String absolutePath) {
-        new CompleteDirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), [new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1))], HashCode.fromInt(1111))
+        new CompleteDirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), [new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", HashCode.fromInt(1234), new FileMetadata(1, 1), AccessType.DIRECT)], HashCode.fromInt(1111), AccessType.DIRECT)
     }
 
     private CompleteFileSystemLocationSnapshot snapshotDir(File dir) {
@@ -623,9 +624,9 @@ class DefaultSnapshotHierarchyTest extends Specification {
 
     private static CompleteFileSystemLocationSnapshot snapshotFile(File file) {
         if (!file.exists()) {
-            return new MissingFileSnapshot(file.absolutePath, file.name)
+            return new MissingFileSnapshot(file.absolutePath, file.name, AccessType.DIRECT)
         }
-        return new RegularFileSnapshot(file.absolutePath, file.name, TestFiles.fileHasher().hash(file), FileMetadata.from(TestFiles.fileSystem().stat(file)))
+        return new RegularFileSnapshot(file.absolutePath, file.name, TestFiles.fileHasher().hash(file), FileMetadata.from(TestFiles.fileSystem().stat(file)), AccessType.DIRECT)
     }
 
     static HashCode hashFile(File file) {


### PR DESCRIPTION
This is a first step towards supporting symlink watching (#11851). It captures whether a snapshot is a symlink and then does not watch the locations of the VFS which are symlinks.

After the build finishes, all the elements in the VFS which are symlinks are dropped and not retained till the next build.