### PR TITLE
Report on more undeclared system property reads from build logic

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -21,7 +21,15 @@ import org.codehaus.groovy.runtime.callsite.CallSite;
 import org.codehaus.groovy.runtime.callsite.CallSiteArray;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public class Instrumented {
     private static final Listener NO_OP = (key, value, consumer) -> {
@@ -41,6 +49,8 @@ public class Instrumented {
         for (CallSite callSite : array.array) {
             if (callSite.getName().equals("getProperty")) {
                 array.array[callSite.getIndex()] = new SystemPropertyCallSite(callSite);
+            } else if (callSite.getName().equals("properties")) {
+                array.array[callSite.getIndex()] = new SystemPropertiesCallSite(callSite);
             }
         }
     }
@@ -59,11 +69,185 @@ public class Instrumented {
         return value;
     }
 
+    // Called by generated code.
+    public static Properties systemProperties(String consumer) {
+        return new DecoratingProperties(System.getProperties(), consumer);
+    }
+
     public interface Listener {
         /**
          * @param consumer The name of the class that is reading the property value
          */
         void systemPropertyQueried(String key, @Nullable String value, String consumer);
+    }
+
+    private static class DecoratingProperties extends Properties {
+        private final String consumer;
+        private final Properties delegate;
+
+        public DecoratingProperties(Properties delegate, String consumer) {
+            this.consumer = consumer;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Enumeration<?> propertyNames() {
+            return delegate.propertyNames();
+        }
+
+        @Override
+        public Set<String> stringPropertyNames() {
+            return delegate.stringPropertyNames();
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public Enumeration<Object> keys() {
+            return delegate.keys();
+        }
+
+        @Override
+        public Enumeration<Object> elements() {
+            return delegate.elements();
+        }
+
+        @Override
+        public Set<Object> keySet() {
+            return delegate.keySet();
+        }
+
+        @Override
+        public Collection<Object> values() {
+            return delegate.values();
+        }
+
+        @Override
+        public Set<Map.Entry<Object, Object>> entrySet() {
+            return delegate.entrySet();
+        }
+
+        @Override
+        public Object getOrDefault(Object key, Object defaultValue) {
+            return delegate.getOrDefault(key, defaultValue);
+        }
+
+        @Override
+        public void forEach(BiConsumer<? super Object, ? super Object> action) {
+            delegate.forEach(action);
+        }
+
+        @Override
+        public void replaceAll(BiFunction<? super Object, ? super Object, ?> function) {
+            delegate.replaceAll(function);
+        }
+
+        @Override
+        public Object putIfAbsent(Object key, Object value) {
+            return delegate.putIfAbsent(key, value);
+        }
+
+        @Override
+        public boolean remove(Object key, Object value) {
+            return delegate.remove(key, value);
+        }
+
+        @Override
+        public boolean replace(Object key, Object oldValue, Object newValue) {
+            return delegate.replace(key, oldValue, newValue);
+        }
+
+        @Override
+        public Object replace(Object key, Object value) {
+            return delegate.replace(key, value);
+        }
+
+        @Override
+        public Object computeIfAbsent(Object key, Function<? super Object, ?> mappingFunction) {
+            return delegate.computeIfAbsent(key, mappingFunction);
+        }
+
+        @Override
+        public Object computeIfPresent(Object key, BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+            return delegate.computeIfPresent(key, remappingFunction);
+        }
+
+        @Override
+        public Object compute(Object key, BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+            return delegate.compute(key, remappingFunction);
+        }
+
+        @Override
+        public Object merge(Object key, Object value, BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+            return delegate.merge(key, value, remappingFunction);
+        }
+
+        @Override
+        public boolean contains(Object value) {
+            return delegate.contains(value);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return delegate.containsValue(value);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return delegate.containsKey(key);
+        }
+
+        @Override
+        public Object put(Object key, Object value) {
+            return delegate.put(key, value);
+        }
+
+        @Override
+        public Object setProperty(String key, String value) {
+            return delegate.setProperty(key, value);
+        }
+
+        @Override
+        public Object remove(Object key) {
+            return delegate.remove(key);
+        }
+
+        @Override
+        public void putAll(Map<?, ?> t) {
+            delegate.putAll(t);
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+
+        @Override
+        public String getProperty(String key) {
+            String value = delegate.getProperty(key);
+            LISTENER.get().systemPropertyQueried(key, value, consumer);
+            return value;
+        }
+
+        @Override
+        public String getProperty(String key, String defaultValue) {
+            String value = delegate.getProperty(key, defaultValue);
+            LISTENER.get().systemPropertyQueried(key, value, consumer);
+            return value;
+        }
+
+        @Override
+        public Object get(Object key) {
+            return getProperty((String) key);
+        }
     }
 
     private static class SystemPropertyCallSite extends AbstractCallSite {
@@ -86,6 +270,21 @@ public class Instrumented {
                 return systemProperty((String) arg1, (String) arg2, array.owner.getName());
             } else {
                 return super.call(receiver, arg1, arg2);
+            }
+        }
+    }
+
+    private static class SystemPropertiesCallSite extends AbstractCallSite {
+        public SystemPropertiesCallSite(CallSite callSite) {
+            super(callSite);
+        }
+
+        @Override
+        public Object callGetProperty(Object receiver) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperties(array.owner.getName());
+            } else {
+                return super.callGetProperty(receiver);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -52,6 +52,13 @@ public class Instrumented {
         return value;
     }
 
+    // Called by generated code.
+    public static String systemProperty(String key, String defaultValue, String consumer) {
+        String value = System.getProperty(key, defaultValue);
+        LISTENER.get().systemPropertyQueried(key, value, consumer);
+        return value;
+    }
+
     public interface Listener {
         /**
          * @param consumer The name of the class that is reading the property value
@@ -65,11 +72,20 @@ public class Instrumented {
         }
 
         @Override
-        public Object call(Object receiver, Object arg1) throws Throwable {
+        public Object call(Object receiver, Object arg) throws Throwable {
             if (receiver.equals(System.class)) {
-                return systemProperty((String) arg1, array.owner.getName());
+                return systemProperty((String) arg, array.owner.getName());
             } else {
-                return super.call(receiver, arg1);
+                return super.call(receiver, arg);
+            }
+        }
+
+        @Override
+        public Object call(Object receiver, Object arg1, Object arg2) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperty((String) arg1, (String) arg2, array.owner.getName());
+            } else {
+                return super.call(receiver, arg1, arg2);
             }
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -176,7 +176,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/e439082a083201d1490a2b56e9912fee/thing.jar")
+        def cachedFile = testDir.file("cached/d854107bf6795d72eb3eecb15532cda3/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -204,7 +204,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/df5d1902040cc6341fb55d364d61d23f/thing.dir.jar")
+        def cachedFile = testDir.file("cached/143d06974ecda152527df49229ffee61/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -233,7 +233,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/938e3f5ef62c725f67a878b29f3176cf/thing.jar")
+        def cachedFile = testDir.file("cached/87be1fc71f7c88451d22b236c88c2240/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -176,7 +176,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/349f8baba38535e2ce3916f4d42f83ee/thing.jar")
+        def cachedFile = testDir.file("cached/e439082a083201d1490a2b56e9912fee/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -204,7 +204,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/33fbc773e43e04aa1837a9e4e20be853/thing.dir.jar")
+        def cachedFile = testDir.file("cached/df5d1902040cc6341fb55d364d61d23f/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -233,7 +233,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/1a0547a447cfc594a350aa4dbb30ae3d/thing.jar")
+        def cachedFile = testDir.file("cached/938e3f5ef62c725f67a878b29f3176cf/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcChangesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcChangesIntegrationTest.groovy
@@ -86,9 +86,15 @@ class InstantExecutionBuildSrcChangesIntegrationTest extends AbstractInstantExec
 
             import org.gradle.api.provider.*
 
-            abstract class IsCi : ValueSource<String, ValueSourceParameters.None> {
-                // TODO - need a solution for this case: can value source impls access the environment?
-                override fun obtain(): String? = System.getProperty("test_is_ci", null)
+            interface Params: ValueSourceParameters {
+                val value: Property<String>
+            }
+
+            abstract class IsCi : ValueSource<String, Params> {
+                override fun obtain(): String? = parameters.value.orNull
+            }
+            val ciProvider = providers.of(IsCi::class.java) {
+                parameters.value.set(providers.systemProperty("test_is_ci"))
             }
 
             val isCi = $inputExpression
@@ -139,7 +145,7 @@ class InstantExecutionBuildSrcChangesIntegrationTest extends AbstractInstantExec
 
         where:
         inputName             | inputExpression                          | inputArgument
-        'custom value source' | 'providers.of(IsCi::class) {}'           | '-Dtest_is_ci=true'
+        'custom value source' | 'ciProvider'                             | '-Dtest_is_ci=true'
         'system property'     | 'providers.systemProperty("test_is_ci")' | '-Dtest_is_ci=true'
         'Gradle property'     | 'providers.gradleProperty("test_is_ci")' | '-Ptest_is_ci=true'
         'gradle.properties'   | 'providers.gradleProperty("test_is_ci")' | ''

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/GroovyPluginImplementation.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/GroovyPluginImplementation.groovy
@@ -22,32 +22,26 @@ import org.gradle.api.Project
 import org.gradle.test.fixtures.file.TestFile
 
 trait GroovyPluginImplementation {
-    void groovyDsl(TestFile sourceFile) {
+    void groovyDsl(TestFile sourceFile, SystemPropertyRead read) {
         sourceFile << """
-            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+            println("apply = " + ${read.groovyExpression})
             tasks.register("thing") {
                 doLast {
-                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                    println("task = " + ${read.groovyExpression})
                 }
             }
         """
     }
 
-    void dynamicGroovyPlugin(TestFile sourceFile) {
+    void dynamicGroovyPlugin(TestFile sourceFile, SystemPropertyRead read) {
         sourceFile << """
             import ${Project.name}
             import ${Plugin.name}
 
             class SneakyPlugin implements Plugin<Project> {
                 public void apply(Project project) {
-                    // Static method call
-                    def value = System.getProperty("GET_PROPERTY")
-                    println("apply GET_PROPERTY = " + value)
-
-                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
+                    def value = ${read.groovyExpression}
+                    println("apply = " + value)
 
                     // Instance call
                     def sys = System
@@ -61,11 +55,8 @@ trait GroovyPluginImplementation {
 
                     project.tasks.register("thing") { t ->
                         t.doLast {
-                            value = System.getProperty("GET_PROPERTY")
-                            println("task GET_PROPERTY = " + value)
-
-                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+                            value = ${read.groovyExpression}
+                            println("task = " + value)
 
                             println("task INSTANCE = " + sys.getProperty("INSTANCE"))
 
@@ -77,7 +68,7 @@ trait GroovyPluginImplementation {
         """
     }
 
-    void staticGroovyPlugin(TestFile sourceFile) {
+    void staticGroovyPlugin(TestFile sourceFile, SystemPropertyRead read) {
         sourceFile << """
             import ${Project.name}
             import ${Plugin.name}
@@ -85,12 +76,8 @@ trait GroovyPluginImplementation {
             @${CompileStatic.name}
             class SneakyPlugin implements Plugin<Project> {
                 public void apply(Project project) {
-                    // Static method call
-                    def value = System.getProperty("GET_PROPERTY")
-                    println("apply GET_PROPERTY = " + value)
-
-                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
+                    def value = ${read.groovyExpression}
+                    println("apply = " + value)
 
                     // Instance call
                     def sys = System
@@ -104,11 +91,8 @@ trait GroovyPluginImplementation {
 
                     project.tasks.register("thing") { t ->
                         t.doLast {
-                            value = System.getProperty("GET_PROPERTY")
-                            println("task GET_PROPERTY = " + value)
-
-                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+                            value = ${read.groovyExpression}
+                            println("task = " + value)
 
                             println("task INSTANCE = " + sys.getProperty("INSTANCE"))
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/GroovyPluginImplementation.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/GroovyPluginImplementation.groovy
@@ -16,11 +16,25 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.test.fixtures.file.TestFile
 
 trait GroovyPluginImplementation {
+    void groovyDsl(TestFile sourceFile) {
+        sourceFile << """
+            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+            tasks.register("thing") {
+                doLast {
+                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                }
+            }
+        """
+    }
+
     void dynamicGroovyPlugin(TestFile sourceFile) {
         sourceFile << """
             import ${Project.name}
@@ -29,23 +43,76 @@ trait GroovyPluginImplementation {
             class SneakyPlugin implements Plugin<Project> {
                 public void apply(Project project) {
                     // Static method call
-                    def ci = System.getProperty("CI")
-                    println("apply CI = " + ci)
+                    def value = System.getProperty("GET_PROPERTY")
+                    println("apply GET_PROPERTY = " + value)
+
+                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
 
                     // Instance call
                     def sys = System
-                    println("apply CI2 = " + sys.getProperty("CI2"))
+                    println("apply INSTANCE = " + sys.getProperty("INSTANCE"))
 
                     // Call from closure
                     def cl = { p ->
-                        println("apply \$p = " + sys.getProperty(p))
+                        println("\$p CLOSURE = " + sys.getProperty("CLOSURE"))
                     }
-                    cl("CI3")
+                    cl("apply")
 
                     project.tasks.register("thing") { t ->
                         t.doLast {
-                            def ci2 = System.getProperty("CI")
-                            println("task CI = " + ci2)
+                            value = System.getProperty("GET_PROPERTY")
+                            println("task GET_PROPERTY = " + value)
+
+                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+
+                            println("task INSTANCE = " + sys.getProperty("INSTANCE"))
+
+                            cl("task")
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    void staticGroovyPlugin(TestFile sourceFile) {
+        sourceFile << """
+            import ${Project.name}
+            import ${Plugin.name}
+
+            @${CompileStatic.name}
+            class SneakyPlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    // Static method call
+                    def value = System.getProperty("GET_PROPERTY")
+                    println("apply GET_PROPERTY = " + value)
+
+                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
+
+                    // Instance call
+                    def sys = System
+                    println("apply INSTANCE = " + sys.getProperty("INSTANCE"))
+
+                    // Call from closure
+                    def cl = { p ->
+                        println("\$p CLOSURE = " + sys.getProperty("CLOSURE"))
+                    }
+                    cl("apply")
+
+                    project.tasks.register("thing") { t ->
+                        t.doLast {
+                            value = System.getProperty("GET_PROPERTY")
+                            println("task GET_PROPERTY = " + value)
+
+                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+
+                            println("task INSTANCE = " + sys.getProperty("INSTANCE"))
+
+                            cl("task")
                         }
                     }
                 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/JavaPluginImplementation.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/JavaPluginImplementation.groovy
@@ -32,24 +32,34 @@ trait JavaPluginImplementation {
 
             public class SneakyPlugin implements Plugin<Project> {
                 public void apply(Project project) {
-                    String ci = System.getProperty("CI");
-                    System.out.println("apply CI = " + ci);
-                    System.out.println("apply CI2 = " + System.getProperty("CI2"));
+                    String value = System.getProperty("GET_PROPERTY");
+                    System.out.println("apply GET_PROPERTY = " + value);
 
-                    // Lambda
-                    Runnable r = () -> {
-                        System.out.println("apply CI3 = " + System.getProperty("CI3"));
-                    };
-                    r.run();
+                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default");
+                    System.out.println("apply GET_PROPERTY_OR_DEFAULT = " + value);
+
+                    // Inside a lambda body
+                    lambda("apply").run();
 
                     project.getTasks().register("thing", t -> {
                         t.doLast(new Action<Task>() {
                             public void execute(Task t) {
-                                String ci2 = System.getProperty("CI");
-                                System.out.println("task CI = " + ci2);
+                                String value = System.getProperty("GET_PROPERTY");
+                                System.out.println("task GET_PROPERTY = " + value);
+
+                                value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default");
+                                System.out.println("task GET_PROPERTY_OR_DEFAULT = " + value);
+
+                                lambda("task").run();
                             }
                         });
                     });
+                }
+
+                static Runnable lambda(String location) {
+                    return () -> {
+                        System.out.println(location + " LAMBDA = " + System.getProperty("LAMBDA"));
+                    };
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/KotlinPluginImplementation.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/KotlinPluginImplementation.groovy
@@ -28,22 +28,43 @@ trait KotlinPluginImplementation {
 
             class SneakyPlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    val ci = System.getProperty("CI")
-                    println("apply CI = " + ci)
-                    println("apply CI2 = \${System.getProperty("CI2")}")
+                    var value = System.getProperty("GET_PROPERTY")
+                    println("apply GET_PROPERTY = " + value)
 
-                    // Function
+                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
+
+                    // Call from a function body
                     val f = { p: String ->
-                        println("apply \$p = " + System.getProperty(p))
+                        println("\$p FUNCTION = " + System.getProperty("FUNCTION"))
                     }
-                    f("CI3")
+                    f("apply")
 
                     project.tasks.register("thing") {
                         doLast {
-                            val ci2 = System.getProperty("CI")
-                            println("task CI = " + ci2)
+                            var value = System.getProperty("GET_PROPERTY")
+                            println("task GET_PROPERTY = " + value)
+
+                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
+                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+
+                            f("task")
                         }
                     }
+                }
+            }
+        """
+    }
+
+    void kotlinDsl(TestFile sourceFile) {
+        sourceFile << """
+            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+
+            tasks.register("thing") {
+                doLast {
+                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/KotlinPluginImplementation.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/KotlinPluginImplementation.groovy
@@ -21,18 +21,15 @@ import org.gradle.api.Project
 import org.gradle.test.fixtures.file.TestFile
 
 trait KotlinPluginImplementation {
-    void kotlinPlugin(TestFile sourceFile) {
+    void kotlinPlugin(TestFile sourceFile, SystemPropertyRead read) {
         sourceFile << """
             import ${Project.name}
             import ${Plugin.name}
 
             class SneakyPlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    var value = System.getProperty("GET_PROPERTY")
-                    println("apply GET_PROPERTY = " + value)
-
-                    value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                    println("apply GET_PROPERTY_OR_DEFAULT = " + value)
+                    var value = ${read.kotlinExpression}
+                    println("apply = " + value)
 
                     // Call from a function body
                     val f = { p: String ->
@@ -42,11 +39,8 @@ trait KotlinPluginImplementation {
 
                     project.tasks.register("thing") {
                         doLast {
-                            var value = System.getProperty("GET_PROPERTY")
-                            println("task GET_PROPERTY = " + value)
-
-                            value = System.getProperty("GET_PROPERTY_OR_DEFAULT", "default")
-                            println("task GET_PROPERTY_OR_DEFAULT = " + value)
+                            var value = ${read.kotlinExpression}
+                            println("task = " + value)
 
                             f("task")
                         }
@@ -56,15 +50,13 @@ trait KotlinPluginImplementation {
         """
     }
 
-    void kotlinDsl(TestFile sourceFile) {
+    void kotlinDsl(TestFile sourceFile, SystemPropertyRead read) {
         sourceFile << """
-            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+            println("apply = " + ${read.kotlinExpression})
 
             tasks.register("thing") {
                 doLast {
-                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                    println("task = " + ${read.kotlinExpression})
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyRead.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyRead.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.inputs.undeclared
+
+abstract class SystemPropertyRead {
+    String getJavaExpression() {
+        return getKotlinExpression()
+    }
+
+    String getGroovyExpression() {
+        return getKotlinExpression()
+    }
+
+    abstract String getKotlinExpression()
+
+    static SystemPropertyRead systemGetProperty(String name) {
+        return new SystemPropertyRead() {
+            @Override
+            String getKotlinExpression() {
+                return "System.getProperty(\"$name\")"
+            }
+        }
+    }
+
+    static SystemPropertyRead systemGetPropertyWithDefault(String name, String defaultValue) {
+        return new SystemPropertyRead() {
+            @Override
+            String getKotlinExpression() {
+                return "System.getProperty(\"$name\", \"$defaultValue\")"
+            }
+        }
+    }
+
+    static SystemPropertyRead systemGetProperties(String name) {
+        return new SystemPropertyRead() {
+            @Override
+            String getJavaExpression() {
+                return "(String)System.getProperties().get(\"$name\")"
+            }
+
+            @Override
+            String getGroovyExpression() {
+                return "System.properties[\"$name\"]"
+            }
+
+            @Override
+            String getKotlinExpression() {
+                return "System.getProperties()[\"$name\"]"
+            }
+        }
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
@@ -21,11 +21,13 @@ class UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest extends 
     void buildLogicApplication() {
         buildFile << """
             buildscript {
-                println("apply CI = " + System.getProperty("CI"))
+                println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
             }
             tasks.register("thing") {
                 doLast {
-                    println("task CI = " + System.getProperty("CI"))
+                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest.groovy
@@ -18,16 +18,14 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsDynamicGroovyBuildScriptBlockIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         buildFile << """
             buildscript {
-                println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                println("apply = " + ${read.groovyExpression})
             }
             tasks.register("thing") {
                 doLast {
-                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                    println("task = " + ${read.groovyExpression})
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    void buildLogicApplication() {
-        groovyDsl(buildFile)
+    void buildLogicApplication(SystemPropertyRead read) {
+        groovyDsl(buildFile, read)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest.groovy
@@ -19,13 +19,6 @@ package org.gradle.instantexecution.inputs.undeclared
 class UndeclaredBuildInputsDynamicGroovyBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildFile << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
-        """
+        groovyDsl(buildFile)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
@@ -18,6 +18,11 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
+    List<String> getAdditionalProperties() {
+        return ["INSTANCE", "CLOSURE"]
+    }
+
+    @Override
     void buildLogicApplication() {
         dynamicGroovyPlugin(buildFile)
         buildFile << """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest.groovy
@@ -16,17 +16,24 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
+import spock.lang.Ignore
+
 class UndeclaredBuildInputsDynamicGroovyBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["INSTANCE", "CLOSURE"]
-    }
-
-    @Override
-    void buildLogicApplication() {
-        dynamicGroovyPlugin(buildFile)
+    void buildLogicApplication(SystemPropertyRead read) {
+        dynamicGroovyPlugin(buildFile, read)
         buildFile << """
             apply plugin: SneakyPlugin
         """
+    }
+
+    @Ignore
+    def "can reference static methods via instance variables"() {
+        expect: false
+    }
+
+    @Ignore
+    def "can reference methods from groovy closure"() {
+        expect: false
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
@@ -18,9 +18,13 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
+    List<String> getAdditionalProperties() {
+        return ["INSTANCE", "CLOSURE"]
+    }
+
+    @Override
     void buildLogicApplication() {
         dynamicGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"))
-
         buildFile << """
             apply plugin: SneakyPlugin
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
@@ -16,17 +16,24 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
+import spock.lang.Ignore
+
 class UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["INSTANCE", "CLOSURE"]
-    }
-
-    @Override
-    void buildLogicApplication() {
-        dynamicGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"))
+    void buildLogicApplication(SystemPropertyRead read) {
+        dynamicGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"), read)
         buildFile << """
             apply plugin: SneakyPlugin
         """
+    }
+
+    @Ignore
+    def "can reference static methods via instance variables"() {
+        expect: false
+    }
+
+    @Ignore
+    def "can reference methods from groovy closure"() {
+        expect: false
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest.groovy
@@ -20,15 +20,7 @@ class UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest extends Abst
     @Override
     void buildLogicApplication() {
         def script = file("plugin.gradle")
-        script << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
-        """
-
+        groovyDsl(script)
         buildFile << """
             apply from: "plugin.gradle"
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
@@ -18,15 +18,13 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         settingsFile << """
-            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+            println("apply = " + ${read.groovyExpression})
             gradle.rootProject {
                 tasks.register("thing") {
                     doLast {
-                        println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                        println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                        println("task = " + ${read.groovyExpression})
                     }
                 }
             }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest.groovy
@@ -20,11 +20,13 @@ class UndeclaredBuildInputsDynamicGroovySettingsScriptIntegrationTest extends Ab
     @Override
     void buildLogicApplication() {
         settingsFile << """
-            println("apply CI = " + System.getProperty("CI"))
+            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
             gradle.rootProject {
                 tasks.register("thing") {
                     doLast {
-                        println("task CI = " + System.getProperty("CI"))
+                        println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                        println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
                     }
                 }
             }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaBuildSrcIntegrationTest.groovy
@@ -18,6 +18,11 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsJavaBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
     @Override
+    List<String> getAdditionalProperties() {
+        return ["LAMBDA"]
+    }
+
+    @Override
     void buildLogicApplication() {
         javaPlugin(file("buildSrc/src/main/java/SneakyPlugin.java"))
         buildFile << """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaBuildSrcIntegrationTest.groovy
@@ -18,13 +18,8 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsJavaBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["LAMBDA"]
-    }
-
-    @Override
-    void buildLogicApplication() {
-        javaPlugin(file("buildSrc/src/main/java/SneakyPlugin.java"))
+    void buildLogicApplication(SystemPropertyRead read) {
+        javaPlugin(file("buildSrc/src/main/java/SneakyPlugin.java"), read)
         buildFile << """
             apply plugin: SneakyPlugin
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaLambdaBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsJavaLambdaBuildSrcIntegrationTest.groovy
@@ -16,13 +16,12 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-class UndeclaredBuildInputsDynamicGroovyScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
+class UndeclaredBuildInputsJavaLambdaBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
     @Override
     void buildLogicApplication(SystemPropertyRead read) {
-        def script = file("plugin.gradle")
-        groovyDsl(script, read)
+        javaLambdaPlugin(file("buildSrc/src/main/java/SneakyPlugin.java"), read)
         buildFile << """
-            apply from: "plugin.gradle"
+            apply plugin: SneakyPlugin
         """
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    void buildLogicApplication() {
-        kotlinDsl(buildKotlinFile)
+    void buildLogicApplication(SystemPropertyRead read) {
+        kotlinDsl(buildKotlinFile, read)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptIntegrationTest.groovy
@@ -19,13 +19,6 @@ package org.gradle.instantexecution.inputs.undeclared
 class UndeclaredBuildInputsKotlinBuildScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
     void buildLogicApplication() {
-        buildKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
-        """
+        kotlinDsl(buildKotlinFile)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
@@ -18,6 +18,11 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
+    List<String> getAdditionalProperties() {
+        return ["FUNCTION"]
+    }
+
+    @Override
     void buildLogicApplication() {
         kotlinPlugin(buildKotlinFile)
         buildKotlinFile << """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest.groovy
@@ -16,17 +16,19 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
+import spock.lang.Ignore
+
 class UndeclaredBuildInputsKotlinBuildScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["FUNCTION"]
-    }
-
-    @Override
-    void buildLogicApplication() {
-        kotlinPlugin(buildKotlinFile)
+    void buildLogicApplication(SystemPropertyRead read) {
+        kotlinPlugin(buildKotlinFile, read)
         buildKotlinFile << """
             plugins.apply(SneakyPlugin::class.java)
         """
+    }
+
+    @Ignore
+    def "can reference methods from kotlin function"() {
+        expect: false
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
@@ -18,16 +18,14 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         buildKotlinFile << """
             plugins {
-                println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                println("apply = " + ${read.kotlinExpression})
             }
             tasks.register("thing") {
                 doLast {
-                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                    println("task = " + ${read.kotlinExpression})
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest.groovy
@@ -21,11 +21,13 @@ class UndeclaredBuildInputsKotlinBuildScriptPluginsBlockIntegrationTest extends 
     void buildLogicApplication() {
         buildKotlinFile << """
             plugins {
-                println("apply CI = " + System.getProperty("CI"))
+                println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
             }
             tasks.register("thing") {
                 doLast {
-                    println("task CI = " + System.getProperty("CI"))
+                    println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                    println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
                 }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
@@ -21,6 +21,11 @@ import org.gradle.integtests.fixtures.KotlinDslTestUtil
 
 class UndeclaredBuildInputsKotlinBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
+    List<String> getAdditionalProperties() {
+        return ["FUNCTION"]
+    }
+
+    @Override
     void buildLogicApplication() {
         file("buildSrc/build.gradle.kts").text = KotlinDslTestUtil.kotlinDslBuildSrcScript
         kotlinPlugin(file("buildSrc/src/main/kotlin/SneakyPlugin.kt"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
@@ -18,19 +18,20 @@ package org.gradle.instantexecution.inputs.undeclared
 
 
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import spock.lang.Ignore
 
 class UndeclaredBuildInputsKotlinBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["FUNCTION"]
-    }
-
-    @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         file("buildSrc/build.gradle.kts").text = KotlinDslTestUtil.kotlinDslBuildSrcScript
-        kotlinPlugin(file("buildSrc/src/main/kotlin/SneakyPlugin.kt"))
+        kotlinPlugin(file("buildSrc/src/main/kotlin/SneakyPlugin.kt"), read)
         buildFile << """
             apply plugin: SneakyPlugin
         """
+    }
+
+    @Ignore
+    def "can reference methods from kotlin function"() {
+        expect: false
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
@@ -20,14 +20,7 @@ class UndeclaredBuildInputsKotlinScriptPluginIntegrationTest extends AbstractUnd
     @Override
     void buildLogicApplication() {
         def script = file("plugin.gradle.kts")
-        script << """
-            println("apply CI = " + System.getProperty("CI"))
-            tasks.register("thing") {
-                doLast {
-                    println("task CI = " + System.getProperty("CI"))
-                }
-            }
-        """
+        kotlinDsl(script)
         buildFile << """
             apply from: "plugin.gradle.kts"
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinScriptPluginIntegrationTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsKotlinScriptPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         def script = file("plugin.gradle.kts")
-        kotlinDsl(script)
+        kotlinDsl(script, read)
         buildFile << """
             apply from: "plugin.gradle.kts"
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
@@ -18,15 +18,14 @@ package org.gradle.instantexecution.inputs.undeclared
 
 class UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         settingsKotlinFile << """
-            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+            println("apply = " + ${read.kotlinExpression})
+
             gradle.rootProject {
                 tasks.register("thing") {
                     doLast {
-                        println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
-                        println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
+                        println("task = " + ${read.kotlinExpression})
                     }
                 }
             }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest.groovy
@@ -20,11 +20,13 @@ class UndeclaredBuildInputsKotlinSettingsScriptIntegrationTest extends AbstractU
     @Override
     void buildLogicApplication() {
         settingsKotlinFile << """
-            println("apply CI = " + System.getProperty("CI"))
+            println("apply GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+            println("apply GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
             gradle.rootProject {
                 tasks.register("thing") {
                     doLast {
-                        println("task CI = " + System.getProperty("CI"))
+                        println("task GET_PROPERTY = " + System.getProperty("GET_PROPERTY"))
+                        println("task GET_PROPERTY_OR_DEFAULT = " + System.getProperty("GET_PROPERTY_OR_DEFAULT", "default"))
                     }
                 }
             }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
@@ -16,17 +16,24 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
+import spock.lang.Ignore
+
 class UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
-    List<String> getAdditionalProperties() {
-        return ["INSTANCE", "CLOSURE"]
-    }
-
-    @Override
-    void buildLogicApplication() {
-        staticGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"))
+    void buildLogicApplication(SystemPropertyRead read) {
+        staticGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"), read)
         buildFile << """
             apply plugin: SneakyPlugin
         """
+    }
+
+    @Ignore
+    def "can reference static methods via instance variables"() {
+        expect: false
+    }
+
+    @Ignore
+    def "can reference methods from groovy closure"() {
+        expect: false
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
@@ -16,45 +16,15 @@
 
 package org.gradle.instantexecution.inputs.undeclared
 
-import groovy.transform.CompileStatic
-import org.gradle.api.Plugin
-import org.gradle.api.Project
+class UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
+    @Override
+    List<String> getAdditionalProperties() {
+        return ["INSTANCE", "CLOSURE"]
+    }
 
-class UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest {
     @Override
     void buildLogicApplication() {
-        file("buildSrc/src/main/groovy/SneakyPlugin.groovy") << """
-            import ${Project.name}
-            import ${Plugin.name}
-            import ${CompileStatic.name}
-
-            @CompileStatic
-            class SneakyPlugin implements Plugin<Project> {
-                public void apply(Project project) {
-                    // Static method call
-                    def ci = System.getProperty("CI")
-                    println("apply CI = " + ci)
-
-                    // Instance call
-                    def sys = System
-                    println("apply CI2 = " + sys.getProperty("CI2"))
-
-                    // Call from closure
-                    def cl = { String p ->
-                        println("apply \$p = " + sys.getProperty(p))
-                    }
-                    cl("CI3")
-
-                    project.tasks.register("thing") { t ->
-                        t.doLast {
-                            def ci2 = System.getProperty("CI")
-                            println("task CI = " + ci2)
-                        }
-                    }
-                }
-            }
-        """
-
+        staticGroovyPlugin(file("buildSrc/src/main/groovy/SneakyPlugin.groovy"))
         buildFile << """
             apply plugin: SneakyPlugin
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
@@ -52,6 +52,11 @@ class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends Abst
     }
 
     @Override
+    List<String> getAdditionalProperties() {
+        return ["LAMBDA"]
+    }
+
+    @Override
     void buildLogicApplication() {
         def builder = artifactBuilder()
         javaPlugin(builder.sourceFile("SneakyPlugin.java"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
@@ -51,14 +51,9 @@ class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends Abst
     }
 
     @Override
-    List<String> getAdditionalProperties() {
-        return ["LAMBDA"]
-    }
-
-    @Override
-    void buildLogicApplication() {
+    void buildLogicApplication(SystemPropertyRead read) {
         def builder = artifactBuilder()
-        javaPlugin(builder.sourceFile("SneakyPlugin.java"))
+        javaPlugin(builder.sourceFile("SneakyPlugin.java"), read)
         builder.resourceFile("META-INF/gradle-plugins/sneaky.properties") << """
 implementation-class: SneakyPlugin
         """

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.integtests.fixtures.executer.InProcessGradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
@@ -340,7 +341,7 @@ class AbstractIntegrationSpec extends Specification {
     }
 
     ArtifactBuilder artifactBuilder() {
-        def executer = distribution.executer(temporaryFolder, getBuildContext())
+        def executer = new InProcessGradleExecuter(distribution, temporaryFolder)
         executer.withGradleUserHomeDir(this.executer.getGradleUserHomeDir())
         for (int i = 1; ; i++) {
             def dir = getTestDirectory().file("artifacts-$i")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder;
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter;
 import org.gradle.integtests.fixtures.executer.GradleDistribution;
 import org.gradle.integtests.fixtures.executer.GradleExecuter;
+import org.gradle.integtests.fixtures.executer.InProcessGradleExecuter;
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution;
 import org.gradle.test.fixtures.file.TestFile;
@@ -109,7 +110,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected ArtifactBuilder artifactBuilder() {
-        GradleExecuter gradleExecuter = getDistribution().executer(testDirectoryProvider, getBuildContext());
+        GradleExecuter gradleExecuter = new InProcessGradleExecuter(distribution, testDirectoryProvider);
         gradleExecuter.withGradleUserHomeDir(getExecuter().getGradleUserHomeDir());
         return new GradleBackedArtifactBuilder(gradleExecuter, getTestDirectory().file("artifacts"));
     }


### PR DESCRIPTION

### Context

Adds instrumentation to report undeclared system property reads made via:
- `System.getProperty(key, default)`
- `System.getProperties().get(key)`, `getProperty(key)` and `getProperty(key, value)`.

Also fixes and enables a test.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
