### PR TITLE
Include directories in generated jars

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
@@ -35,6 +35,7 @@ class ClasspathBuilderTest extends Specification {
         then:
         def zip = new ZipTestFixture(file)
         zip.hasDescendants()
+        zip.hasDirs()
     }
 
     def "can construct jar with entries"() {
@@ -49,5 +50,22 @@ class ClasspathBuilderTest extends Specification {
         then:
         def zip = new ZipTestFixture(file)
         zip.hasDescendants("a.class", "dir/b.class")
+        zip.hasDirs("dir")
+    }
+
+    def "can construct jar with multiple entries in directory"() {
+        def file = tmpDir.file("thing.zip")
+
+        when:
+        builder.jar(file) {
+            it.put("a.class", "bytes".bytes)
+            it.put("dir/b.class", "bytes".bytes)
+            it.put("dir/c.class", "bytes".bytes)
+        }
+
+        then:
+        def zip = new ZipTestFixture(file)
+        zip.hasDescendants("a.class", "dir/b.class", "dir/c.class")
+        zip.hasDirs("dir")
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -130,20 +130,27 @@ org.gradle.api.internal.tasks.CompileServices
         handleAsJarFile(outputJar) { JarFile file ->
             List<JarEntry> entries = file.entries() as List
             assert entries*.name == [
+                'org/gradle/',
                 'org/gradle/MyClass.class',
                 'org/gradle/MySecondClass.class',
+                'net/rubygrapefruit/platform/osx-i386/',
                 'net/rubygrapefruit/platform/osx-i386/libnative-platform.dylib',
+                'org/gradle/reporting/',
                 'org/gradle/reporting/report.js',
+                'org/joda/time/tz/data/Africa/',
                 'org/joda/time/tz/data/Africa/Abidjan',
+                'org/gradle/internal/impldep/org/joda/time/tz/data/Africa/',
                 'org/gradle/internal/impldep/org/joda/time/tz/data/Africa/Abidjan',
                 'org/gradle/MyAClass.class',
                 'org/gradle/MyBClass.class',
                 'org/gradle/MyFirstClass.class',
+                'META-INF/services/',
                 'META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry',
                 'META-INF/services/org.gradle.internal.other.Service',
+                'META-INF/',
                 'META-INF/.gradle-runtime-shaded']
         }
-        outputJar.md5Hash == "84791783853fcd2c66437a674c219bbe"
+        outputJar.md5Hash == "a31b58b3c4e0e2f29f80f4e6884fc3ed"
     }
 
     def "excludes module-info.class from jar"() {
@@ -168,9 +175,11 @@ org.gradle.api.internal.tasks.CompileServices
         handleAsJarFile(outputJar) { JarFile file ->
             List<JarEntry> entries = file.entries() as List
             assert entries*.name == [
+                'org/gradle/',
                 'org/gradle/MyClass.class',
                 'org/gradle/MySecondClass.class',
                 'org/gradle/MyFirstClass.class',
+                'META-INF/',
                 'META-INF/.gradle-runtime-shaded']
         }
     }
@@ -361,10 +370,10 @@ org.gradle.api.internal.tasks.CompileServices"""
 
         handleAsJarFile(relocatedJar) { JarFile jar ->
             assert jar.entries().toList().size() ==
-                noRelocationResources.size() +
-                duplicateResources.size() * 2 +
+                noRelocationResources.size() + 2 +
+                (duplicateResources.size() + 1) * 2 +
                 onlyRelocatedResources.size() +
-                generatedFiles.size()
+                generatedFiles.size() + 1
             noRelocationResources.each { resourceName ->
                 assert jar.getEntry(resourceName)
             }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/ArchiveTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/ArchiveTestFixture.groovy
@@ -24,15 +24,20 @@ import org.hamcrest.Matcher
 
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
-import static org.junit.Assert.assertEquals
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.assertEquals
 
 class ArchiveTestFixture {
     private final ListMultimap<String, String> filesByRelativePath = LinkedListMultimap.create()
     private final ListMultimap<String, Integer> fileModesByRelativePath = ArrayListMultimap.create()
+    private final List<String> dirs = new ArrayList<>()
 
     protected void add(String relativePath, String content) {
         filesByRelativePath.put(relativePath, content)
+    }
+
+    protected void addDir(String relativePath) {
+        dirs.add(relativePath)
     }
 
     protected void addMode(String relativePath, int mode) {
@@ -72,6 +77,11 @@ class ArchiveTestFixture {
 
     Integer countFiles(String relativePath) {
         filesByRelativePath.get(relativePath).size()
+    }
+
+    def hasDirs(String... relativePaths) {
+        assert dirs.sort() == relativePaths.collect { it + "/" }.sort()
+        this
     }
 
     def hasDescendants(String... relativePaths) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
@@ -25,8 +25,6 @@ import java.util.jar.JarFile
 import java.util.jar.Manifest
 
 class JarTestFixture extends ZipTestFixture {
-    final int classFileDescriptor = 0xCAFEBABE
-
     File file
 
     /**

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/ZipTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/ZipTestFixture.groovy
@@ -38,6 +38,8 @@ class ZipTestFixture extends ArchiveTestFixture {
                 String content = getContentForEntry(entry, zipFile)
                 if (!entry.directory) {
                     add(entry.name, content)
+                } else {
+                    addDir(entry.name)
                 }
                 addMode(entry.name, entry.getUnixMode())
             }


### PR DESCRIPTION

### Context

When transforming or generating jars, include intermediate directories in the jar rather than just including files. Some plugins, for example jruby (via asciidoctorj), expect the directories to be present in jars.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
