### PR TITLE
Fix flakiness introduced in fix for generated jars

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -80,21 +80,29 @@ public class ClasspathBuilder {
 
         @Override
         public void put(String name, byte[] content) throws IOException {
-            String dir = dir(name);
-            if (dir != null && dirs.add(dir)) {
-                ZipEntry zipEntry = newZipEntryWithFixedTime(dir);
-                outputStream.putNextEntry(zipEntry);
-                outputStream.closeEntry();
-            }
+            maybeAddParent(name);
             ZipEntry zipEntry = newZipEntryWithFixedTime(name);
             outputStream.putNextEntry(zipEntry);
             outputStream.write(content);
             outputStream.closeEntry();
         }
 
+        private void maybeAddParent(String name) throws IOException {
+            String dir = dir(name);
+            if (dir != null && dirs.add(dir)) {
+                maybeAddParent(dir);
+                ZipEntry zipEntry = newZipEntryWithFixedTime(dir);
+                outputStream.putNextEntry(zipEntry);
+                outputStream.closeEntry();
+            }
+        }
+
         @Nullable
         String dir(String name) {
             int pos = name.lastIndexOf('/');
+            if (pos == name.length() - 1) {
+                pos = name.lastIndexOf('/', pos - 1);
+            }
             if (pos >= 0) {
                 return name.substring(0, pos + 1);
             } else {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -48,7 +48,7 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
     @Override
     public void applyConfigurationTo(Hasher hasher) {
         hasher.putString(InstrumentingTransformer.class.getSimpleName());
-        hasher.putInt(3); // decoration format, increment this when making changes
+        hasher.putInt(4); // decoration format, increment this when making changes
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
@@ -45,12 +45,13 @@ class ClasspathBuilderTest extends Specification {
         builder.jar(file) {
             it.put("a.class", "bytes".bytes)
             it.put("dir/b.class", "bytes".bytes)
+            it.put("some/dir/c.class", "bytes".bytes)
         }
 
         then:
         def zip = new ZipTestFixture(file)
-        zip.hasDescendants("a.class", "dir/b.class")
-        zip.hasDirs("dir")
+        zip.hasDescendants("a.class", "dir/b.class", "some/dir/c.class")
+        zip.hasDirs("dir", "some", "some/dir")
     }
 
     def "can construct jar with multiple entries in directory"() {
@@ -61,11 +62,12 @@ class ClasspathBuilderTest extends Specification {
             it.put("a.class", "bytes".bytes)
             it.put("dir/b.class", "bytes".bytes)
             it.put("dir/c.class", "bytes".bytes)
+            it.put("dir/sub/d.class", "bytes".bytes)
         }
 
         then:
         def zip = new ZipTestFixture(file)
-        zip.hasDescendants("a.class", "dir/b.class", "dir/c.class")
-        zip.hasDirs("dir")
+        zip.hasDescendants("a.class", "dir/b.class", "dir/c.class", "dir/sub/d.class")
+        zip.hasDirs("dir", "dir/sub")
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -176,7 +176,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/d854107bf6795d72eb3eecb15532cda3/thing.jar")
+        def cachedFile = testDir.file("cached/5a39c25ac6680051f529ce5fa49f4179/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -204,7 +204,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/143d06974ecda152527df49229ffee61/thing.dir.jar")
+        def cachedFile = testDir.file("cached/2f97b3a5acd5db44c4e3ea6bedbb9688/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -233,7 +233,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/87be1fc71f7c88451d22b236c88c2240/thing.jar")
+        def cachedFile = testDir.file("cached/e2045e4f8c5fcd3178f2044a0264529f/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -130,27 +130,42 @@ org.gradle.api.internal.tasks.CompileServices
         handleAsJarFile(outputJar) { JarFile file ->
             List<JarEntry> entries = file.entries() as List
             assert entries*.name == [
+                'org/',
                 'org/gradle/',
                 'org/gradle/MyClass.class',
                 'org/gradle/MySecondClass.class',
+                'net/',
+                'net/rubygrapefruit/',
+                'net/rubygrapefruit/platform/',
                 'net/rubygrapefruit/platform/osx-i386/',
                 'net/rubygrapefruit/platform/osx-i386/libnative-platform.dylib',
                 'org/gradle/reporting/',
                 'org/gradle/reporting/report.js',
+                'org/joda/',
+                'org/joda/time/',
+                'org/joda/time/tz/',
+                'org/joda/time/tz/data/',
                 'org/joda/time/tz/data/Africa/',
                 'org/joda/time/tz/data/Africa/Abidjan',
+                'org/gradle/internal/',
+                'org/gradle/internal/impldep/',
+                'org/gradle/internal/impldep/org/',
+                'org/gradle/internal/impldep/org/joda/',
+                'org/gradle/internal/impldep/org/joda/time/',
+                'org/gradle/internal/impldep/org/joda/time/tz/',
+                'org/gradle/internal/impldep/org/joda/time/tz/data/',
                 'org/gradle/internal/impldep/org/joda/time/tz/data/Africa/',
                 'org/gradle/internal/impldep/org/joda/time/tz/data/Africa/Abidjan',
                 'org/gradle/MyAClass.class',
                 'org/gradle/MyBClass.class',
                 'org/gradle/MyFirstClass.class',
+                'META-INF/',
                 'META-INF/services/',
                 'META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry',
                 'META-INF/services/org.gradle.internal.other.Service',
-                'META-INF/',
                 'META-INF/.gradle-runtime-shaded']
         }
-        outputJar.md5Hash == "a31b58b3c4e0e2f29f80f4e6884fc3ed"
+        outputJar.md5Hash == "dee78866d881612695b2875ef948d5d5"
     }
 
     def "excludes module-info.class from jar"() {
@@ -175,6 +190,7 @@ org.gradle.api.internal.tasks.CompileServices
         handleAsJarFile(outputJar) { JarFile file ->
             List<JarEntry> entries = file.entries() as List
             assert entries*.name == [
+                'org/',
                 'org/gradle/',
                 'org/gradle/MyClass.class',
                 'org/gradle/MySecondClass.class',
@@ -370,8 +386,8 @@ org.gradle.api.internal.tasks.CompileServices"""
 
         handleAsJarFile(relocatedJar) { JarFile jar ->
             assert jar.entries().toList().size() ==
-                noRelocationResources.size() + 2 +
-                (duplicateResources.size() + 1) * 2 +
+                noRelocationResources.size() + 7 +
+                duplicateResources.size() * 2 + 13 +
                 onlyRelocatedResources.size() +
                 generatedFiles.size() + 1
             noRelocationResources.each { resourceName ->


### PR DESCRIPTION

### Context

Another attempt at more correct transformed and generated jar contents, and fix some test flakiness introduced in https://github.com/gradle/gradle/pull/13036

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
