### PR TITLE
Update Windows start script.

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -37,6 +37,12 @@ for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 set DEFAULT_JVM_OPTS=${defaultJvmOpts}
 
 @rem Find java.exe
+if exist %APP_HOME%/jre/bin/java.exe (
+set JAVA_HOME=%APP_HOME%/jre
+)
+if exist %APP_HOME%/jdk/bin/java.exe (
+set JAVA_HOME=%APP_HOME%/jdk
+)
 if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe


### PR DESCRIPTION
If the jre or jdk directory exists in the application's home directory, it will be used as the default JAVA_HOME environment variable value.