### PR TITLE
Run docsTest as part of the functional test coverage

### DIFF
--- a/.teamcity/Gradle_Check/model/GradleSubprojectProvider.kt
+++ b/.teamcity/Gradle_Check/model/GradleSubprojectProvider.kt
@@ -27,7 +27,6 @@ val slowSubprojects = listOf("platformPlay")
 val ignoredSubprojects = listOf(
     "soak", // soak test
     "distributions", // build distributions
-    "docs", // sanity check
     "architectureTest" // sanity check
 )
 

--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -178,7 +178,7 @@
     "dirName": "docs",
     "name": "docs",
     "unitTests": true,
-    "functionalTests": false,
+    "functionalTests": true,
     "crossVersionTests": false
   },
   {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -269,7 +269,7 @@ class CIConfigIntegrationTests {
         }.forEach {
             val dir = getSubProjectFolder(it)
             assertEquals(it.unitTests, File(dir, "src/test").isDirectory, "${it.name}'s unitTests is wrong!")
-            assertEquals(it.functionalTests, File(dir, "src/integTest").isDirectory, "${it.name}'s functionalTests is wrong!")
+            assertEquals(it.functionalTests, if (it.name == "docs") true else File(dir, "src/integTest").isDirectory, "${it.name}'s functionalTests is wrong!")
             assertEquals(it.crossVersionTests, File(dir, "src/crossVersionTest").isDirectory, "${it.name}'s crossVersionTests is wrong!")
         }
     }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/GenerateSubprojectsInfoPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/GenerateSubprojectsInfoPlugin.kt
@@ -46,7 +46,7 @@ open class GenerateSubprojectsInfoTask : DefaultTask() {
         return GradleSubproject(subprojectDir.name,
             subprojectDir.name.kebabToCamel(),
             subprojectDir.hasDescendantDir("src/test"),
-            subprojectDir.hasDescendantDir("src/integTest"),
+            if (subprojectDir.name == "docs") true else subprojectDir.hasDescendantDir("src/integTest"),
             subprojectDir.hasDescendantDir("src/crossVersionTest"))
     }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
@@ -171,7 +171,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros and smoke test them"
             group = "build"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", ":docs:checkSamples")
+                ":distributions:integTest", "docs:releaseNotes", ":docs:checkSamples")
         }
     }
 
@@ -184,7 +184,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros, smoke test them and publish"
             group = "publishing"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", "publish")
+                ":distributions:integTest", "docs:releaseNotes", "publish")
         }
     }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
@@ -171,7 +171,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros and smoke test them"
             group = "build"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", "docs:releaseNotes", ":docs:checkSamples")
+                ":distributions:integTest", ":docs:releaseNotes", ":docs:checkSamples")
         }
     }
 
@@ -184,7 +184,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros, smoke test them and publish"
             group = "publishing"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", "docs:releaseNotes", "publish")
+                ":distributions:integTest", ":docs:releaseNotes", "publish")
         }
     }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
@@ -171,7 +171,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros and smoke test them"
             group = "build"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", ":docs:check", ":docs:checkSamples")
+                ":distributions:integTest", ":docs:checkSamples")
         }
     }
 
@@ -184,7 +184,7 @@ class LifecyclePlugin : Plugin<Project> {
             description = "Build production distros, smoke test them and publish"
             group = "publishing"
             dependsOn(":distributions:verifyIsProductionBuildEnvironment", ":distributions:buildDists",
-                ":distributions:integTest", ":docs:check", "publish")
+                ":distributions:integTest", "publish")
         }
     }
 

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -520,6 +520,7 @@ configurations {
     }
 }
 
+// TODO (donat) if we introduce integration tests in this subproject (e.g. samples tests are moved here) then remove the special handling in GenerateSubprojectsInfoPlugin
 tasks.register('integTest') {
     dependsOn(tasks.named('docsTest'))
 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -519,3 +519,7 @@ configurations {
         outgoing.artifact(file("src/docs/README"))
     }
 }
+
+tasks.register('integTest') {
+    dependsOn(tasks.named('docsTest'))
+}


### PR DESCRIPTION
We have insufficient coverage for our samples. We should run them through the pipeline just like any other functional tests. This way we can verify that they work on all supported platforms and JVM versions.

Prerequisite for https://github.com/gradle/gradle/pull/13048