### PR TITLE
Use Providers in InitBuild task

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/BuildInitTestFramework.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/BuildInitTestFramework.java
@@ -30,7 +30,7 @@ public enum BuildInitTestFramework implements WithIdentifier {
     JUNIT_JUPITER("JUnit Jupiter");
 
     public static List<String> listSupported() {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         for (BuildInitTestFramework testFramework : values()) {
             if (testFramework != NONE) {
                 result.add(testFramework.getId());
@@ -43,6 +43,15 @@ public enum BuildInitTestFramework implements WithIdentifier {
 
     BuildInitTestFramework(String displayName) {
         this.displayName = displayName;
+    }
+
+    public static BuildInitTestFramework fromName(String name) {
+        for (BuildInitTestFramework framework : values()) {
+            if (framework.getId().equals(name)) {
+                return framework;
+            }
+        }
+        return NONE;
     }
 
     @Override

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
@@ -62,6 +62,7 @@ class InitBuildSpec extends Specification {
         projectLayoutRegistry.default >> projectSetupDescriptor
         projectLayoutRegistry.getLanguagesFor(ComponentType.BASIC) >> [Language.NONE]
         projectLayoutRegistry.get(ComponentType.BASIC, Language.NONE) >> projectSetupDescriptor
+        projectLayoutRegistry.componentTypes >> [ComponentType.BASIC]
         projectSetupDescriptor.componentType >> ComponentType.BASIC
         projectSetupDescriptor.dsls >> [GROOVY]
         projectSetupDescriptor.defaultDsl >> GROOVY


### PR DESCRIPTION
InitBuild task provides an interactive wizard used to configure the build when the options are not supplied via command-line arguments.
I wanted to experiment and see if the current wizard can be recreated by chaining providers where the last fallback option would be to fire up the current interactive prompt to query the user for an answer.
Turns out the logic is a bit more complicated for such a simplistic approach.

Regardless, I split up the task action into several smaller methods - perhaps this will make the logic a bit easier to read. I'll let the reviewers decide whether to merge or abandon this.