### PR TITLE
Allow undeclared read of system properties with no value when default provided

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -64,8 +64,11 @@ public class Instrumented {
 
     // Called by generated code.
     public static String systemProperty(String key, String defaultValue, String consumer) {
-        String value = System.getProperty(key, defaultValue);
+        String value = System.getProperty(key);
         LISTENER.get().systemPropertyQueried(key, value, consumer);
+        if (value == null) {
+            return defaultValue;
+        }
         return value;
     }
 
@@ -133,11 +136,6 @@ public class Instrumented {
         @Override
         public Set<Map.Entry<Object, Object>> entrySet() {
             return delegate.entrySet();
-        }
-
-        @Override
-        public Object getOrDefault(Object key, Object defaultValue) {
-            return delegate.getOrDefault(key, defaultValue);
         }
 
         @Override
@@ -239,9 +237,17 @@ public class Instrumented {
 
         @Override
         public String getProperty(String key, String defaultValue) {
-            String value = delegate.getProperty(key, defaultValue);
+            String value = delegate.getProperty(key);
             LISTENER.get().systemPropertyQueried(key, value, consumer);
+            if (value == null) {
+                return defaultValue;
+            }
             return value;
+        }
+
+        @Override
+        public Object getOrDefault(Object key, Object defaultValue) {
+            return getProperty((String) key, (String) defaultValue);
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentedTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentedTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath
+
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
+import spock.lang.Specification
+
+class InstrumentedTest extends Specification {
+    @Rule
+    SetSystemProperties systemProperties = new SetSystemProperties()
+
+    def cleanup() {
+        Instrumented.discardListener()
+    }
+
+    def "notifies listener when default value for system property is used"() {
+        def listener = Mock(Instrumented.Listener)
+        Instrumented.setListener(listener)
+
+        when:
+        def result = Instrumented.systemProperty("not-set", "default", "consumer")
+
+        then:
+        result == "default"
+        1 * listener.systemPropertyQueried("not-set", null, "consumer")
+        0 * listener._
+    }
+
+    def "notifies listener when system property is used via properties map"() {
+        def listener = Mock(Instrumented.Listener)
+        Instrumented.setListener(listener)
+
+        System.setProperty("prop", "value")
+
+        when:
+        def properties = Instrumented.systemProperties("consumer")
+        def result = properties.get("prop")
+
+        then:
+        result == "value"
+        1 * listener.systemPropertyQueried("prop", "value", "consumer")
+        0 * listener._
+
+        when:
+        result = properties.getProperty("prop")
+
+        then:
+        result == "value"
+        1 * listener.systemPropertyQueried("prop", "value", "consumer")
+        0 * listener._
+    }
+
+    def "notifies listener when default value for system property is used via properties map"() {
+        def listener = Mock(Instrumented.Listener)
+        Instrumented.setListener(listener)
+
+        when:
+        def properties = Instrumented.systemProperties("consumer")
+        def result = properties.getProperty("not-set", "default")
+
+        then:
+        result == "default"
+        1 * listener.systemPropertyQueried("not-set", null, "consumer")
+        0 * listener._
+
+        when:
+        result = properties.getOrDefault("not-set", "default")
+
+        then:
+        result == "default"
+        1 * listener.systemPropertyQueried("not-set", null, "consumer")
+        0 * listener._
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -23,7 +23,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
     abstract void buildLogicApplication(SystemPropertyRead read)
 
     @Unroll
-    def "reports undeclared system property read using #propertyRead.kotlinExpression prior to task execution from plugin"() {
+    def "reports undeclared system property read using #propertyRead.groovyExpression prior to task execution from plugin"() {
         buildLogicApplication(propertyRead)
         def fixture = newInstantExecutionFixture()
 
@@ -64,7 +64,9 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         propertyRead << [
             SystemPropertyRead.systemGetProperty("CI"),
             SystemPropertyRead.systemGetPropertyWithDefault("CI", "default"),
-            SystemPropertyRead.systemGetProperties("CI")
+            SystemPropertyRead.systemGetPropertiesGet("CI"),
+            SystemPropertyRead.systemGetPropertiesGetProperty("CI"),
+            SystemPropertyRead.systemGetPropertiesGetPropertyWithDefault("CI", "default")
         ]
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyRead.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/SystemPropertyRead.groovy
@@ -45,7 +45,7 @@ abstract class SystemPropertyRead {
         }
     }
 
-    static SystemPropertyRead systemGetProperties(String name) {
+    static SystemPropertyRead systemGetPropertiesGet(String name) {
         return new SystemPropertyRead() {
             @Override
             String getJavaExpression() {
@@ -60,6 +60,44 @@ abstract class SystemPropertyRead {
             @Override
             String getKotlinExpression() {
                 return "System.getProperties()[\"$name\"]"
+            }
+        }
+    }
+
+    static SystemPropertyRead systemGetPropertiesGetProperty(String name) {
+        return new SystemPropertyRead() {
+            @Override
+            String getJavaExpression() {
+                return "(String)System.getProperties().getProperty(\"$name\")"
+            }
+
+            @Override
+            String getGroovyExpression() {
+                return "System.properties.getProperty(\"$name\")"
+            }
+
+            @Override
+            String getKotlinExpression() {
+                return "System.getProperties().getProperty(\"$name\")"
+            }
+        }
+    }
+
+    static SystemPropertyRead systemGetPropertiesGetPropertyWithDefault(String name, String defaultValue) {
+        return new SystemPropertyRead() {
+            @Override
+            String getJavaExpression() {
+                return "(String)System.getProperties().getProperty(\"$name\", \"$defaultValue\")"
+            }
+
+            @Override
+            String getGroovyExpression() {
+                return "System.properties.getProperty(\"$name\", \"$defaultValue\")"
+            }
+
+            @Override
+            String getKotlinExpression() {
+                return "System.getProperties().getProperty(\"$name\", \"$defaultValue\")"
             }
         }
     }


### PR DESCRIPTION

### Context

Adjust the handling of calls to `System.getProperty(key, default)` so that validation is the same as a call to `System.getProperty(key)`.

Also apply this to `System.getProperties().getOrDefault()` and `getProperty(key, default)`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
