### PR TITLE
Let instant execution serialize task destroyables and local state as file collections

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -180,7 +180,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskMutator = new TaskMutator(this);
         taskInputs = new DefaultTaskInputs(this, taskMutator, propertyWalker, fileCollectionFactory);
         taskOutputs = new DefaultTaskOutputs(this, taskMutator, propertyWalker, fileCollectionFactory);
-        taskDestroyables = new DefaultTaskDestroyables(taskMutator);
+        taskDestroyables = new DefaultTaskDestroyables(taskMutator, fileCollectionFactory);
         taskLocalState = new DefaultTaskLocalState(taskMutator);
 
         this.dependencies = new DefaultTaskDependency(tasks, ImmutableSet.of(taskInputs));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -181,7 +181,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskInputs = new DefaultTaskInputs(this, taskMutator, propertyWalker, fileCollectionFactory);
         taskOutputs = new DefaultTaskOutputs(this, taskMutator, propertyWalker, fileCollectionFactory);
         taskDestroyables = new DefaultTaskDestroyables(taskMutator, fileCollectionFactory);
-        taskLocalState = new DefaultTaskLocalState(taskMutator);
+        taskLocalState = new DefaultTaskLocalState(taskMutator, fileCollectionFactory);
 
         this.dependencies = new DefaultTaskDependency(tasks, ImmutableSet.of(taskInputs));
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
@@ -20,8 +20,8 @@ import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,15 +44,14 @@ public class DefaultTaskDestroyables implements TaskDestroyablesInternal {
     }
 
     @Override
-    public Collection<Object> getRegisteredPaths() {
-        return registeredPaths;
+    public void visitRegisteredProperties(PropertyVisitor visitor) {
+        for (Object registeredPath : registeredPaths) {
+            visitor.visitDestroyableProperty(registeredPath);
+        }
     }
 
     @Override
     public FileCollection getRegisteredFiles() {
-        if (registeredPaths.isEmpty()) {
-            return null;
-        }
         return fileCollectionFactory.resolving("destroyables", registeredPaths);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskLocalState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskLocalState.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.tasks;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -26,24 +28,31 @@ import java.util.List;
 @NonNullApi
 public class DefaultTaskLocalState implements TaskLocalStateInternal {
     private final TaskMutator taskMutator;
+    private final FileCollectionFactory fileCollectionFactory;
     private final List<Object> registeredPaths = Lists.newArrayList();
 
-    public DefaultTaskLocalState(TaskMutator taskMutator) {
+    public DefaultTaskLocalState(TaskMutator taskMutator, FileCollectionFactory fileCollectionFactory) {
         this.taskMutator = taskMutator;
+        this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
     public void register(final Object... paths) {
-        taskMutator.mutate("TaskLocalState.register(Object...)", new Runnable() {
-            @Override
-            public void run() {
-                Collections.addAll(DefaultTaskLocalState.this.registeredPaths, paths);
-            }
+        taskMutator.mutate("TaskLocalState.register(Object...)", () -> {
+            Collections.addAll(DefaultTaskLocalState.this.registeredPaths, paths);
         });
     }
 
     @Override
     public Collection<Object> getRegisteredPaths() {
         return registeredPaths;
+    }
+
+    @Override
+    public FileCollection getRegisteredFiles() {
+        if (registeredPaths.isEmpty()) {
+            return null;
+        }
+        return fileCollectionFactory.resolving("localState", registeredPaths);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskLocalState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskLocalState.java
@@ -20,8 +20,8 @@ import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,15 +44,14 @@ public class DefaultTaskLocalState implements TaskLocalStateInternal {
     }
 
     @Override
-    public Collection<Object> getRegisteredPaths() {
-        return registeredPaths;
+    public void visitRegisteredProperties(PropertyVisitor visitor) {
+        for (Object registeredPath : registeredPaths) {
+            visitor.visitLocalStateProperty(registeredPath);
+        }
     }
 
     @Override
     public FileCollection getRegisteredFiles() {
-        if (registeredPaths.isEmpty()) {
-            return null;
-        }
         return fileCollectionFactory.resolving("localState", registeredPaths);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskDestroyablesInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskDestroyablesInternal.java
@@ -16,13 +16,19 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.TaskDestroyables;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
  * Note: this is currently not visible on {@link org.gradle.api.internal.TaskInternal} to avoid it leaking onto {@link org.gradle.api.internal.AbstractTask} and so on to the public API.
  */
 public interface TaskDestroyablesInternal extends TaskDestroyables {
+
     Collection<Object> getRegisteredPaths();
+
+    @Nullable
+    FileCollection getRegisteredFiles();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskDestroyablesInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskDestroyablesInternal.java
@@ -17,18 +17,16 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.tasks.TaskDestroyables;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
 
 /**
  * Note: this is currently not visible on {@link org.gradle.api.internal.TaskInternal} to avoid it leaking onto {@link org.gradle.api.internal.AbstractTask} and so on to the public API.
  */
 public interface TaskDestroyablesInternal extends TaskDestroyables {
 
-    Collection<Object> getRegisteredPaths();
+    void visitRegisteredProperties(PropertyVisitor visitor);
 
-    @Nullable
     FileCollection getRegisteredFiles();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskLocalStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskLocalStateInternal.java
@@ -16,11 +16,17 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.TaskLocalState;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 // Note: this is currently not visible on {@link org.gradle.api.internal.TaskInternal} to avoid it leaking onto AbstractTask and so on to the public API.
 public interface TaskLocalStateInternal extends TaskLocalState {
+
     Collection<Object> getRegisteredPaths();
+
+    @Nullable
+    FileCollection getRegisteredFiles();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskLocalStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskLocalStateInternal.java
@@ -17,16 +17,14 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.tasks.TaskLocalState;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
 
 // Note: this is currently not visible on {@link org.gradle.api.internal.TaskInternal} to avoid it leaking onto AbstractTask and so on to the public API.
 public interface TaskLocalStateInternal extends TaskLocalState {
 
-    Collection<Object> getRegisteredPaths();
+    void visitRegisteredProperties(PropertyVisitor visitor);
 
-    @Nullable
     FileCollection getRegisteredFiles();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -44,12 +44,8 @@ public class TaskPropertyUtils {
         propertyWalker.visitProperties(task, validationContext, visitor);
         task.getInputs().visitRegisteredProperties(visitor);
         task.getOutputs().visitRegisteredProperties(visitor);
-        for (Object path : ((TaskDestroyablesInternal) task.getDestroyables()).getRegisteredPaths()) {
-            visitor.visitDestroyableProperty(path);
-        }
-        for (Object path : ((TaskLocalStateInternal) task.getLocalState()).getRegisteredPaths()) {
-            visitor.visitLocalStateProperty(path);
-        }
+        ((TaskDestroyablesInternal) task.getDestroyables()).visitRegisteredProperties(visitor);
+        ((TaskLocalStateInternal) task.getLocalState()).visitRegisteredProperties(visitor);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -222,7 +222,7 @@ public class LocalTaskNode extends TaskNode {
                 public void visitLocalStateProperty(final Object value) {
                     withDeadlockHandling(
                         taskNode,
-                        "a local state property", "local state properties",
+                        "a local state", "local state properties",
                         () -> mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, fileCollectionFactory.resolving(value))));
                     mutations.hasLocalState = true;
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
@@ -48,9 +48,8 @@ class DefaultTaskDestroyablesTest extends Specification {
 
     def "empty destroys by default"() {
         expect:
-        taskDestroys.registeredPaths != null
-        taskDestroys.registeredPaths.isEmpty()
-        taskDestroys.registeredFiles == null
+        taskDestroys.registeredFiles != null
+        taskDestroys.registeredFiles.isEmpty()
     }
 
     def "can declare a file that a task destroys"() {
@@ -58,7 +57,6 @@ class DefaultTaskDestroyablesTest extends Specification {
         taskDestroys.register("a")
 
         then:
-        taskDestroys.registeredPaths == ["a"]
         taskDestroys.registeredFiles.singleFile == testDir.file("a")
     }
 
@@ -67,7 +65,6 @@ class DefaultTaskDestroyablesTest extends Specification {
         taskDestroys.register("a", "b")
 
         then:
-        taskDestroys.registeredPaths == ["a", "b"]
         taskDestroys.registeredFiles.files == [testDir.file("a"), testDir.file("b")] as Set
     }
 
@@ -79,7 +76,6 @@ class DefaultTaskDestroyablesTest extends Specification {
         taskDestroys.register(fileCollection)
 
         then:
-        taskDestroys.registeredPaths == [fileCollection]
         taskDestroys.registeredFiles.files == files
     }
 
@@ -89,7 +85,6 @@ class DefaultTaskDestroyablesTest extends Specification {
         taskDestroys.register(closure)
 
         then:
-        taskDestroys.registeredPaths == [closure]
         taskDestroys.registeredFiles.singleFile == testDir.file("a")
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -171,13 +171,19 @@ class TaskNodeCodec(
 
     private
     suspend fun WriteContext.writeLocalStateOf(task: TaskInternal) {
-        writeCollection((task.localState as TaskLocalStateInternal).registeredPaths)
+        val localState = (task.localState as TaskLocalStateInternal).registeredFiles
+        if (localState == null) {
+            writeBoolean(false)
+        } else {
+            writeBoolean(true)
+            write(localState)
+        }
     }
 
     private
     suspend fun ReadContext.readLocalStateOf(task: TaskInternal) {
-        readCollection {
-            task.localState.register(readNonNull())
+        if (readBoolean()) {
+            task.localState.register(readNonNull<FileCollection>())
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskInternal
@@ -152,13 +153,19 @@ class TaskNodeCodec(
 
     private
     suspend fun WriteContext.writeDestroyablesOf(task: TaskInternal) {
-        writeCollection((task.destroyables as TaskDestroyablesInternal).registeredPaths)
+        val destroyables = (task.destroyables as TaskDestroyablesInternal).registeredFiles
+        if (destroyables == null) {
+            writeBoolean(false)
+        } else {
+            writeBoolean(true)
+            write(destroyables)
+        }
     }
 
     private
     suspend fun ReadContext.readDestroyablesOf(task: TaskInternal) {
-        readCollection {
-            task.destroyables.register(readNonNull())
+        if (readBoolean()) {
+            task.destroyables.register(readNonNull<FileCollection>())
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -154,7 +154,7 @@ class TaskNodeCodec(
     private
     suspend fun WriteContext.writeDestroyablesOf(task: TaskInternal) {
         val destroyables = (task.destroyables as TaskDestroyablesInternal).registeredFiles
-        if (destroyables == null) {
+        if (destroyables.isEmpty) {
             writeBoolean(false)
         } else {
             writeBoolean(true)
@@ -172,7 +172,7 @@ class TaskNodeCodec(
     private
     suspend fun WriteContext.writeLocalStateOf(task: TaskInternal) {
         val localState = (task.localState as TaskLocalStateInternal).registeredFiles
-        if (localState == null) {
+        if (localState.isEmpty) {
             writeBoolean(false)
         } else {
             writeBoolean(true)


### PR DESCRIPTION
This is a follow up to https://github.com/gradle/gradle/pull/13027