### PR TITLE
Proposal: Add opt out for "no valid plugin descriptors" noise

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -88,6 +88,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
     static final String BAD_IMPL_CLASS_WARNING_MESSAGE = "%s: A valid plugin descriptor was found for %s but the implementation class %s was not found in the jar.";
     static final String INVALID_DESCRIPTOR_WARNING_MESSAGE = "%s: A plugin descriptor was found for %s but it was invalid.";
     static final String NO_DESCRIPTOR_WARNING_MESSAGE = "%s: No valid plugin descriptors were found in META-INF/" + GRADLE_PLUGINS + "";
+    static final String DISABLE_NO_DESCRIPTOR_WARNING_MESSAGE_PROPERTY = "systemProp.org.gradle.plugin.disablenodescriptorwarning"
     static final String DECLARED_PLUGIN_MISSING_MESSAGE = "%s: Could not find plugin descriptor of %s at META-INF/" + GRADLE_PLUGINS + "/%s.properties";
     static final String DECLARATION_MISSING_ID_MESSAGE = "Missing id for %s";
     static final String DECLARATION_MISSING_IMPLEMENTATION_MESSAGE = "Missing implementationClass for %s";
@@ -291,7 +292,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
         @Override
         public void execute(Task task) {
-            if (descriptors == null || descriptors.isEmpty()) {
+            if ((descriptors == null || descriptors.isEmpty()) && ! Boolean.getBoolean(DISABLE_NO_DESCRIPTOR_WARNING_MESSAGE_PROPERTY)) {
                 LOGGER.warn(String.format(NO_DESCRIPTOR_WARNING_MESSAGE, task.getPath()));
             } else {
                 Set<String> pluginFileNames = Sets.newHashSet();


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #9758

### Context
In multiple projects, I've found myself using buildSrc for shared build logic rather than solely just gradle plugins. If this is done though, Gradle logs noise about finding no plugin descriptors. While this would make sense if this was programmer error, it's often not. When using kotlin gradle DSL, this is a frequent issue.

This PR is a proposal to add a property to disable this log. There are no tests yet, as I want to get initial feedback on the proposal before moving forward (especially given how frictional Gradle's contributor checklist is).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
