### PR TITLE
Load Gradle properties earlier at launch

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
+import org.gradle.initialization.SettingsLocation;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -71,6 +72,22 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      * Returns the broadcaster for {@link ProjectEvaluationListener} events for this build
      */
     ProjectEvaluationListener getProjectEvaluationBroadcaster();
+
+    /**
+     * The settings location for this build.
+     *
+     * @return the settings location for this build
+     * @throws IllegalStateException when the build is not loaded yet, see {@link #setSettingsLocation(SettingsLocation)}
+     */
+    SettingsLocation getSettingsLocation() throws IllegalStateException;
+
+    /**
+     * Called by the launcher after the settings location is loaded.
+     * Until the location is loaded, {@link #getSettingsLocation()} will throw {@link IllegalStateException}.
+     *
+     * @param settingsLocation The settings location for this build.
+     */
+    void setSettingsLocation(SettingsLocation settingsLocation);
 
     /**
      * The settings for this build.

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultEnvironmentPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultEnvironmentPreparer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.StartParameter;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.initialization.layout.BuildLayoutConfiguration;
+import org.gradle.initialization.layout.BuildLayoutFactory;
+
+
+public class DefaultEnvironmentPreparer implements EnvironmentPreparer {
+
+    private final BuildLayoutFactory buildLayoutFactory;
+    private final GradlePropertiesController gradlePropertiesController;
+
+    public DefaultEnvironmentPreparer(BuildLayoutFactory buildLayoutFactory, GradlePropertiesController gradlePropertiesController) {
+        this.buildLayoutFactory = buildLayoutFactory;
+        this.gradlePropertiesController = gradlePropertiesController;
+    }
+
+    @Override
+    public void prepareEnvironment(GradleInternal gradle) {
+        SettingsLocation settingsLocation = locateSettings(gradle.getStartParameter());
+        gradle.setSettingsLocation(settingsLocation);
+        loadGradleProperties(settingsLocation);
+    }
+
+    private SettingsLocation locateSettings(StartParameter startParameter) {
+        return buildLayoutFactory.getLayoutFor(
+            new BuildLayoutConfiguration(startParameter)
+        );
+    }
+
+    private void loadGradleProperties(SettingsLocation settingsLocation) {
+        gradlePropertiesController.loadGradlePropertiesFrom(
+            settingsLocation.getSettingsDir()
+        );
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -149,6 +149,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             serviceRegistry,
             servicesToStop,
             includedBuildControllers,
+            gradle.getServices().get(EnvironmentPreparer.class),
             settingsPreparer,
             taskExecutionPreparer,
             gradle.getServices().get(InstantExecution.class),

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -46,7 +46,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
+    public SettingsInternal loadSettings(GradleInternal gradle) {
         StartParameter startParameter = gradle.getStartParameter();
 
         SettingsLocation settingsLocation = gradle.getSettingsLocation();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -32,7 +32,6 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
     private final PublicBuildPath publicBuildPath;
     private final Instantiator instantiator;
     private final BuildLayoutFactory buildLayoutFactory;
-    private final GradlePropertiesController gradlePropertiesController;
 
     public DefaultSettingsLoaderFactory(
         SettingsProcessor settingsProcessor,
@@ -40,8 +39,7 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         ProjectStateRegistry projectRegistry,
         PublicBuildPath publicBuildPath,
         Instantiator instantiator,
-        BuildLayoutFactory buildLayoutFactory,
-        GradlePropertiesController gradlePropertiesController
+        BuildLayoutFactory buildLayoutFactory
     ) {
         this.settingsProcessor = settingsProcessor;
         this.buildRegistry = buildRegistry;
@@ -49,7 +47,6 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         this.publicBuildPath = publicBuildPath;
         this.instantiator = instantiator;
         this.buildLayoutFactory = buildLayoutFactory;
-        this.gradlePropertiesController = gradlePropertiesController;
     }
 
     @Override
@@ -80,8 +77,7 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         return new SettingsAttachingSettingsLoader(
             new DefaultSettingsLoader(
                 settingsProcessor,
-                buildLayoutFactory,
-                gradlePropertiesController
+                buildLayoutFactory
             ),
             projectRegistry
         );

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -33,6 +33,6 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
         initScriptHandler.executeScripts(gradle);
         // Build `buildSrc`, load settings.gradle, and construct composite (if appropriate)
         SettingsLoader settingsLoader = gradle.getParent() != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();
-        settingsLoader.findAndLoadSettings(gradle);
+        settingsLoader.loadSettings(gradle);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/EnvironmentPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/EnvironmentPreparer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+
+
+public interface EnvironmentPreparer {
+    void prepareEnvironment(GradleInternal gradle);
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
@@ -31,8 +31,8 @@ class SettingsAttachingSettingsLoader implements SettingsLoader {
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
-        SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+    public SettingsInternal loadSettings(GradleInternal gradle) {
+        SettingsInternal settings = delegate.loadSettings(gradle);
         gradle.setSettings(settings);
         projectRegistry.registerProjects(gradle.getServices().get(BuildState.class));
         return settings;

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsLoader.java
@@ -20,5 +20,5 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 
 public interface SettingsLoader {
-    SettingsInternal findAndLoadSettings(GradleInternal gradle);
+    SettingsInternal loadSettings(GradleInternal gradle);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -48,8 +48,8 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
-        SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+    public SettingsInternal loadSettings(GradleInternal gradle) {
+        SettingsInternal settings = delegate.loadSettings(gradle);
 
         // Add included builds defined in settings
         List<IncludedBuildSpec> includedBuilds = settings.getIncludedBuilds();

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/CommandLineIncludedBuildSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/CommandLineIncludedBuildSettingsLoader.java
@@ -30,8 +30,8 @@ public class CommandLineIncludedBuildSettingsLoader implements SettingsLoader {
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
-        SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+    public SettingsInternal loadSettings(GradleInternal gradle) {
+        SettingsInternal settings = delegate.loadSettings(gradle);
 
         // Add all included builds from the command-line
         for (File rootDir : gradle.getStartParameter().getIncludedBuilds()) {

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/CompositeBuildSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/CompositeBuildSettingsLoader.java
@@ -31,8 +31,8 @@ public class CompositeBuildSettingsLoader implements SettingsLoader {
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
-        SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+    public SettingsInternal loadSettings(GradleInternal gradle) {
+        SettingsInternal settings = delegate.loadSettings(gradle);
 
         // Lock-in explicitly included builds
         buildRegistry.finalizeIncludedBuilds();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -126,6 +126,7 @@ import org.gradle.initialization.DefaultGradlePropertiesController;
 import org.gradle.initialization.DefaultGradlePropertiesLoader;
 import org.gradle.initialization.DefaultProjectDescriptorRegistry;
 import org.gradle.initialization.DefaultSettingsLoaderFactory;
+import org.gradle.initialization.DefaultEnvironmentPreparer;
 import org.gradle.initialization.DefaultSettingsPreparer;
 import org.gradle.initialization.GradlePropertiesController;
 import org.gradle.initialization.IGradlePropertiesLoader;
@@ -141,6 +142,7 @@ import org.gradle.initialization.ScriptEvaluatingSettingsProcessor;
 import org.gradle.initialization.SettingsEvaluatedCallbackFiringSettingsProcessor;
 import org.gradle.initialization.SettingsFactory;
 import org.gradle.initialization.SettingsLoaderFactory;
+import org.gradle.initialization.EnvironmentPreparer;
 import org.gradle.initialization.SettingsPreparer;
 import org.gradle.initialization.SettingsProcessor;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
@@ -392,14 +394,20 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(CompileOperationFactory.class));
     }
 
+    protected EnvironmentPreparer createEnvironmentPreparer(
+        BuildLayoutFactory buildLayoutFactory,
+        GradlePropertiesController gradlePropertiesController
+    ) {
+        return new DefaultEnvironmentPreparer(buildLayoutFactory, gradlePropertiesController);
+    }
+
     protected SettingsLoaderFactory createSettingsLoaderFactory(
         SettingsProcessor settingsProcessor,
         BuildStateRegistry buildRegistry,
         ProjectStateRegistry projectRegistry,
         PublicBuildPath publicBuildPath,
         Instantiator instantiator,
-        BuildLayoutFactory buildLayoutFactory,
-        GradlePropertiesController gradlePropertiesController
+        BuildLayoutFactory buildLayoutFactory
     ) {
         return new DefaultSettingsLoaderFactory(
             settingsProcessor,
@@ -407,8 +415,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             projectRegistry,
             publicBuildPath,
             instantiator,
-            buildLayoutFactory,
-            gradlePropertiesController
+            buildLayoutFactory
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -47,6 +47,7 @@ import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
+import org.gradle.initialization.SettingsLocation;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.build.BuildState;
@@ -78,6 +79,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     private final ListenerBroadcast<BuildListener> buildListenerBroadcast;
     private final ListenerBroadcast<ProjectEvaluationListener> projectEvaluationListenerBroadcast;
     private final CrossProjectConfigurator crossProjectConfigurator;
+    private SettingsLocation settingsLocation;
     private Collection<IncludedBuild> includedBuilds;
     private MutableActionSet<Project> rootProjectActions = new MutableActionSet<Project>();
     private boolean projectsLoaded;
@@ -191,6 +193,19 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         }
 
         this.baseProjectClassLoaderScope = classLoaderScope;
+    }
+
+    @Override
+    public SettingsLocation getSettingsLocation() throws IllegalStateException {
+        if (settingsLocation == null) {
+            throw new IllegalStateException("The settings location is not yet available for " + this + ".");
+        }
+        return settingsLocation;
+    }
+
+    @Override
+    public void setSettingsLocation(SettingsLocation settingsLocation) {
+        this.settingsLocation = settingsLocation;
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -35,6 +35,7 @@ import spock.lang.Specification
 import static org.gradle.util.Path.path
 
 class DefaultGradleLauncherSpec extends Specification {
+    def environmentPreparerMock = Mock(EnvironmentPreparer)
     def settingsPreparerMock = Mock(SettingsPreparer)
     def taskExecutionPreparerMock = Mock(TaskExecutionPreparer)
     def taskGraphMock = Mock(TaskExecutionGraphInternal)
@@ -69,12 +70,13 @@ class DefaultGradleLauncherSpec extends Specification {
     DefaultGradleLauncher launcher() {
         return new DefaultGradleLauncher(gradleMock, buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
             buildCompletionListener, buildFinishedListener, buildExecuter, buildServices, [otherService], includedBuildControllers,
-            settingsPreparerMock, taskExecutionPreparerMock, instantExecution, buildSourceBuilder)
+            environmentPreparerMock, settingsPreparerMock, taskExecutionPreparerMock, instantExecution, buildSourceBuilder)
     }
 
     void testRunTasks() {
         when:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
@@ -90,6 +92,7 @@ class DefaultGradleLauncherSpec extends Specification {
         when:
         isNestedBuild()
 
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
@@ -104,6 +107,7 @@ class DefaultGradleLauncherSpec extends Specification {
     void testGetBuildAnalysis() {
         when:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectBuildListenerCallbacks()
 
@@ -122,6 +126,7 @@ class DefaultGradleLauncherSpec extends Specification {
     void testNotifiesListenerOfBuildAnalysisStages() {
         when:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectBuildListenerCallbacks()
 
@@ -138,6 +143,7 @@ class DefaultGradleLauncherSpec extends Specification {
     void testNotifiesListenerOfBuildStages() {
         when:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
@@ -184,6 +190,7 @@ class DefaultGradleLauncherSpec extends Specification {
     void testNotifiesListenerOnBuildCompleteWithFailure() {
         given:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure)
@@ -207,6 +214,7 @@ class DefaultGradleLauncherSpec extends Specification {
 
         given:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure, failure2)
@@ -228,6 +236,7 @@ class DefaultGradleLauncherSpec extends Specification {
     void testTransformsBuildFinishedListenerFailure() {
         given:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
@@ -256,6 +265,7 @@ class DefaultGradleLauncherSpec extends Specification {
 
         given:
         isRootBuild()
+        expectEnvironmentBuilt()
         expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure, failure2)
@@ -297,6 +307,10 @@ class DefaultGradleLauncherSpec extends Specification {
     private void isRootBuild() {
         _ * gradleMock.parent >> null
         _ * gradleMock.contextualize(_) >> { it[0] }
+    }
+
+    private void expectEnvironmentBuilt() {
+        1 * environmentPreparerMock.prepareEnvironment(gradleMock)
     }
 
     private void expectSettingsBuilt() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -40,7 +40,7 @@ class DefaultSettingsLoaderTest extends Specification {
     def settingsProcessor = Mock(SettingsProcessor)
     def settingsHandler = new DefaultSettingsLoader(settingsProcessor, Mock(BuildLayoutFactory))
 
-    void findAndLoadSettingsWithExistingSettings() {
+    void loadSettingsWithExistingSettings() {
         when:
         def projectRegistry = Mock(ProjectRegistry)
         def projectDescriptor = Mock(DefaultProjectDescriptor) {
@@ -63,7 +63,7 @@ class DefaultSettingsLoaderTest extends Specification {
         1 * settingsScript.displayName >> "foo"
 
         then:
-        settingsHandler.findAndLoadSettings(gradle).is(settings)
+        settingsHandler.loadSettings(gradle).is(settings)
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -35,6 +35,7 @@ import org.gradle.configuration.internal.TestListenerBuildOperationDecorator
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.initialization.ClassLoaderScopeRegistry
+import org.gradle.initialization.SettingsLocation
 import org.gradle.internal.build.DefaultPublicBuildPath
 import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.event.DefaultListenerManager
@@ -335,6 +336,21 @@ class DefaultGradleSpec extends Specification {
 
         then:
         1 * listenerManager.useLogger(logger)
+    }
+
+    def "get settings location throws exception when settings is not available"() {
+        when:
+        gradle.settingsLocation
+
+        then:
+        thrown IllegalStateException
+
+        when:
+        def settingsLocation = Stub(SettingsLocation)
+        gradle.settingsLocation = settingsLocation
+
+        then:
+        gradle.settingsLocation == settingsLocation
     }
 
     def "get settings throws exception when settings is not available"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
@@ -33,21 +33,6 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         fixture.assertStateStored()
     }
 
-    def "can enable instant execution from the client jvm"() {
-        setup:
-        executer.withCommandLineGradleOpts(INSTANT_EXECUTION_PROPERTY)
-        executer.requireGradleDistribution()
-
-        and:
-        def fixture = newInstantExecutionFixture()
-
-        when:
-        run 'help'
-
-        then:
-        fixture.assertStateStored()
-    }
-
     @Ignore
     @ToBeImplemented
     def "can enable instant execution from gradle.properties"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -26,7 +26,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
 import org.gradle.caching.configuration.BuildCache
 import org.gradle.execution.plan.Node
-import org.gradle.initialization.GradlePropertiesController
 import org.gradle.initialization.InstantExecution
 import org.gradle.instantexecution.coroutines.runToCompletion
 import org.gradle.instantexecution.extensions.unsafeLazy
@@ -74,8 +73,7 @@ class DefaultInstantExecution internal constructor(
     private val systemPropertyListener: SystemPropertyAccessListener,
     private val scopeRegistryListener: InstantExecutionClassLoaderScopeRegistryListener,
     private val cacheFingerprintController: InstantExecutionCacheFingerprintController,
-    private val beanConstructors: BeanConstructors,
-    private val gradlePropertiesController: GradlePropertiesController
+    private val beanConstructors: BeanConstructors
 ) : InstantExecution {
     interface Host {
 
@@ -267,13 +265,7 @@ class DefaultInstantExecution internal constructor(
         }
 
     private
-    fun checkFingerprint(): InvalidationReason? {
-        loadGradleProperties()
-        return checkInstantExecutionFingerprintFile()
-    }
-
-    private
-    fun checkInstantExecutionFingerprintFile(): InvalidationReason? =
+    fun checkFingerprint(): InvalidationReason? =
         withReadContextFor(instantExecutionFingerprintFile) {
             withHostIsolate {
                 cacheFingerprintController.run {
@@ -281,13 +273,6 @@ class DefaultInstantExecution internal constructor(
                 }
             }
         }
-
-    private
-    fun loadGradleProperties() {
-        gradlePropertiesController.loadGradlePropertiesFrom(
-            startParameter.settingsDirectory
-        )
-    }
 
     private
     fun invalidateInstantExecutionState() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -38,7 +38,6 @@ import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.NotifyingBuildLoader
-import org.gradle.initialization.SettingsLocation
 import org.gradle.initialization.SettingsPreparer
 import org.gradle.initialization.SettingsProcessor
 import org.gradle.initialization.TaskExecutionPreparer
@@ -201,7 +200,7 @@ class InstantExecutionHost internal constructor(
                 service()
             ).process(
                 gradle,
-                SettingsLocation(rootDir, File(rootDir, "settings.gradle")),
+                gradle.settingsLocation,
                 gradle.classLoaderScope,
                 gradle.startParameter
             )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -102,5 +102,5 @@ class InstantExecutionStartParameter(
 
     private
     fun systemProperty(propertyName: String) =
-        startParameter.systemPropertiesArgs[propertyName] ?: System.getProperty(propertyName)
+        startParameter.systemPropertiesArgs[propertyName]
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -50,9 +50,6 @@ class InstantExecutionStartParameter(
     val recreateCache: Boolean
         get() = systemPropertyFlag(SystemProperties.recreateCache)
 
-    val settingsDirectory: File
-        get() = buildLayout.settingsDir
-
     val rootDirectory: File
         get() = buildLayout.rootDirectory
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.launcher
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ExecutionResult
@@ -227,7 +226,7 @@ task check {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/1001")
-    @NotYetImplemented
+    @ToBeFixedForInstantExecution(because = "read system property")
     def "system properties from gradle.properties are available to init scripts for buildSrc"() {
         given:
         executer.requireOwnGradleUserHomeDir()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -188,9 +188,11 @@ abstract class AbstractSmokeTest extends Specification {
             .withTestKitDir(IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
             .withProjectDir(testProjectDir.root)
             .forwardOutput()
-            .withArguments(tasks.toList() + outputParameters() + repoMirrorParameters()) as DefaultGradleRunner
+            .withArguments(
+                tasks.toList() + outputParameters() + repoMirrorParameters() + buildContextParameters()
+            ) as DefaultGradleRunner
         gradleRunner.withJvmArguments(
-            ["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + buildContextParameters()
+            ["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"]
         )
     }
 


### PR DESCRIPTION
This PR changes launcher build stages to load Gradle properties as a first stage, before loading settings.

This makes Gradle properties available earlier allowing for instant execution to properly check if it is enabled, paving the way to use regular "build options" to add a command line flag & co in a normal way (drafted in https://github.com/gradle/gradle/pull/13076). Instant execution can now also use a correct settings location when loading its cache.

This also makes system properties from `gradle.properties` available to init scripts for buildSrc. Due release notes for this behavioural change are missing and would be added after a first round of review.