### PR TITLE
Introduce instant execution build option

### DIFF
--- a/subprojects/build-events/build-events.gradle.kts
+++ b/subprojects/build-events/build-events.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     integTestImplementation(project(":logging")) {
         because("This isn't declared as part of integtesting's API, but should be as logging's classes are in fact visible on the API")
     }
+    integTestImplementation(project(":buildOption"))
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":toolingApiBuilders")) {

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.build.event
 
 import org.gradle.api.services.BuildServiceParameters
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InstantExecutionRunner
 import org.gradle.integtests.fixtures.RequiredFeature
@@ -130,7 +131,7 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("EVENT: finish :b:thing")
     }
 
-    @RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "false")
+    @RequiredFeature(feature = InstantExecutionOption.PROPERTY_NAME, value = "false")
     @UnsupportedWithInstantExecution
     def "listener receives task completion events from included builds"() {
         settingsFile << """

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -91,6 +91,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean refreshDependencies;
     private boolean buildCacheEnabled;
     private boolean buildCacheDebugLogging;
+    private boolean instantExecution;
     private boolean configureOnDemand;
     private boolean continuous;
     private List<File> includedBuilds = new ArrayList<>();
@@ -250,6 +251,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.refreshDependencies = refreshDependencies;
         p.setParallelProjectExecutionEnabled(isParallelProjectExecutionEnabled());
         p.buildCacheEnabled = buildCacheEnabled;
+        p.instantExecution = instantExecution;
         p.configureOnDemand = configureOnDemand;
         p.setMaxWorkerCount(getMaxWorkerCount());
         p.systemPropertiesArgs = new HashMap<>(systemPropertiesArgs);
@@ -715,6 +717,26 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public void setBuildCacheDebugLogging(boolean buildCacheDebugLogging) {
         this.buildCacheDebugLogging = buildCacheDebugLogging;
+    }
+
+    /**
+     * Returns true if instant execution is enabled.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    public boolean isInstantExecutionEnabled() {
+        return this.instantExecution;
+    }
+
+    /**
+     * Enables/disables instant execution.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    public void setInstantExecutionEnabled(boolean instantExecution) {
+        this.instantExecution = instantExecution;
     }
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InstantExecutionRunner
 import org.gradle.integtests.fixtures.RequiredFeature
@@ -189,7 +190,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 12")
     }
 
-    @RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "false")
+    @RequiredFeature(feature = InstantExecutionOption.PROPERTY_NAME, value = "false")
     @UnsupportedWithInstantExecution
     def "service can be used at configuration and execution time"() {
         serviceImplementation()
@@ -237,7 +238,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 11")
     }
 
-    @RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "true")
+    @RequiredFeature(feature = InstantExecutionOption.PROPERTY_NAME, value = "true")
     def "service used at configuration and execution time can be used with instant execution"() {
         serviceImplementation()
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -201,7 +201,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         succeeds("all")
 
         then:
-        10.times {  projectCount ->
+        10.times { projectCount ->
             def allExecutionOp = operations.only("Execute doLast {} action for :project-${projectCount}:all")
             def allExecutionOpTaskProgresses = allExecutionOp.progress
 
@@ -427,8 +427,11 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
 
         then:
         def progressOutputEvents = operations.all(Pattern.compile('.*')).collect { it.progress }.flatten()
-        assert progressOutputEvents
-            .size() == 14 // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed" +
+        def expectedEventCount = 14 // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed" +
+        if (GradleContextualExecuter.isInstant()) {
+            expectedEventCount++ // + incubating feature message
+        }
+        assert progressOutputEvents.size() == expectedEventCount
     }
 
     private void assertNestedTaskOutputTracked(String projectPath = ':nested') {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -44,7 +44,7 @@ public class StartParameterBuildOptions {
     private static List<BuildOption<StartParameterInternal>> options;
 
     static {
-        List<BuildOption<StartParameterInternal>> options = new ArrayList<BuildOption<StartParameterInternal>>();
+        List<BuildOption<StartParameterInternal>> options = new ArrayList<>();
         options.add(new ProjectCacheDirOption());
         options.add(new RerunTasksOption());
         options.add(new ProfileOption());
@@ -69,6 +69,7 @@ public class StartParameterBuildOptions {
         options.add(new DependencyLockingUpdateOption());
         options.add(new RefreshKeysOption());
         options.add(new ExportKeysOption());
+        options.add(new InstantExecutionOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
 
@@ -406,6 +407,25 @@ public class StartParameterBuildOptions {
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setExportKeys(true);
+        }
+    }
+
+    public static class InstantExecutionOption extends BooleanBuildOption<StartParameterInternal> {
+
+        public static final String PROPERTY_NAME = "org.gradle.unsafe.instant-execution";
+        public static final String LONG_OPTION = "instant-execution";
+
+        public InstantExecutionOption() {
+            super(PROPERTY_NAME, BooleanCommandLineOptionConfiguration.create(
+                LONG_OPTION,
+                "Enables instant execution. Gradle will try to reuse the build configuration from previous builds.",
+                "Disables instant execution."
+            ));
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
+            settings.setInstantExecutionEnabled(value);
         }
     }
 }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     integTestImplementation(project(":platformJvm"))
     integTestImplementation(project(":testKit"))
     integTestImplementation(project(":launcher"))
+    integTestImplementation(project(":buildOption"))
 
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
@@ -28,18 +29,20 @@ import org.intellij.lang.annotations.Language
 
 class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
 
+    protected static final String INSTANT_EXECUTION_OPTION = "--${InstantExecutionOption.LONG_OPTION}"
+
     protected InstantExecutionProblemsFixture problems
 
     def setup() {
         // Verify that the previous test cleaned up state correctly
-        assert System.getProperty(SystemProperties.isEnabled) == null
+        assert System.getProperty(InstantExecutionOption.PROPERTY_NAME) == null
         problems = new InstantExecutionProblemsFixture(executer, testDirectory)
     }
 
     @Override
     def cleanup() {
         // Verify that the test (or fixtures) has cleaned up state correctly
-        assert System.getProperty(SystemProperties.isEnabled) == null
+        assert System.getProperty(InstantExecutionOption.PROPERTY_NAME) == null
     }
 
     void buildKotlinFile(@Language("kotlin") String script) {
@@ -47,14 +50,12 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     void instantRun(String... tasks) {
-        run(INSTANT_EXECUTION_PROPERTY, *tasks)
+        run(INSTANT_EXECUTION_OPTION, *tasks)
     }
 
     void instantFails(String... tasks) {
-        fails(INSTANT_EXECUTION_PROPERTY, *tasks)
+        fails(INSTANT_EXECUTION_OPTION, *tasks)
     }
-
-    public static final String INSTANT_EXECUTION_PROPERTY = "-D${SystemProperties.isEnabled}=true"
 
     protected InstantExecutionBuildOperationsFixture newInstantExecutionFixture() {
         return new InstantExecutionBuildOperationsFixture(new BuildOperationsFixture(executer, temporaryFolder))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionClassLoaderCachingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionClassLoaderCachingIntegrationTest.groovy
@@ -93,6 +93,6 @@ class InstantExecutionClassLoaderCachingIntegrationTest extends PersistentBuildP
     }
 
     private void instantRun(String... args) {
-        run(AbstractInstantExecutionIntegrationTest.INSTANT_EXECUTION_PROPERTY, *args)
+        run(AbstractInstantExecutionIntegrationTest.INSTANT_EXECUTION_OPTION, *args)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
@@ -32,12 +32,14 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         run 'help', argument
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateStored()
 
         when:
         run 'help', argument
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateLoaded()
 
         where:
@@ -58,12 +60,14 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         run 'help'
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateStored()
 
         when:
         run 'help'
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateLoaded()
     }
 
@@ -80,12 +84,18 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         run 'help'
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateStored()
 
         when:
         run 'help'
 
         then:
+        outputContainsIncubatingFeatureUsage()
         fixture.assertStateLoaded()
+    }
+
+    private void outputContainsIncubatingFeatureUsage() {
+        outputContains("Instant execution is an incubating feature.")
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
@@ -95,6 +95,27 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         fixture.assertStateLoaded()
     }
 
+    @Unroll
+    def "can disable with a command line #origin when enabled in gradle.properties"() {
+
+        given:
+        def fixture = newInstantExecutionFixture()
+        file('gradle.properties') << """
+            ${InstantExecutionOption.PROPERTY_NAME}=true
+        """
+
+        when:
+        run 'help', argument
+
+        then:
+        fixture.assertNoInstantExecution()
+
+        where:
+        origin            | argument
+        "long option"     | "--no-${InstantExecutionOption.LONG_OPTION}"
+        "system property" | "-D${InstantExecutionOption.PROPERTY_NAME}=false"
+    }
+
     private void outputContainsIncubatingFeatureUsage() {
         outputContains("Instant execution is an incubating feature.")
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -71,7 +71,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         when:
         instantRun "help"
         def secondRunOutput = removeVfsLogOutput(result.normalizedOutput)
-            .replaceAll(/Reusing instant execution cache. This is not guaranteed to work in any way.\n/, '')
+            .replaceAll(/Reusing instant execution cache.\n/, '')
 
         then:
         firstRunOutput == secondRunOutput
@@ -208,7 +208,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateLoaded()
-        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
+        outputContains("Reusing instant execution cache.")
         outputDoesNotContain("running build script")
         outputDoesNotContain("create task")
         outputDoesNotContain("configure task")
@@ -230,7 +230,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateLoaded()
-        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
+        outputContains("Reusing instant execution cache.")
         outputDoesNotContain("running build script")
         outputDoesNotContain("create task")
         outputDoesNotContain("configure task")

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -57,7 +57,7 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
         try {
             connection.newBuild()
                 .forTasks(tasks)
-                .withArguments(INSTANT_EXECUTION_PROPERTY)
+                .withArguments(INSTANT_EXECUTION_OPTION)
                 .setStandardOutput(output)
                 .setStandardError(error)
                 .run()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -63,9 +63,6 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
                 .run()
         } finally {
             connection.close()
-            if (GradleContextualExecuter.embedded) {
-                System.clearProperty(SystemProperties.isEnabled)
-            }
         }
         result = OutputScrapingExecutionResult.from(output.toString(), error.toString())
         return result

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -35,7 +35,7 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
         runWithInstantExecutionViaToolingApi("assemble")
 
         then:
-        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
+        outputContains("Reusing instant execution cache.")
     }
 
     ExecutionResult runWithInstantExecutionViaToolingApi(String... tasks) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
@@ -20,8 +20,6 @@ package org.gradle.instantexecution
 internal
 object SystemProperties {
 
-    const val isEnabled = "org.gradle.unsafe.instant-execution"
-
     const val isQuiet = "org.gradle.unsafe.instant-execution.quiet"
 
     const val maxProblems = "org.gradle.unsafe.instant-execution.max-problems"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -31,7 +31,7 @@ class InstantExecutionStartParameter(
 ) {
 
     val isEnabled: Boolean by unsafeLazy {
-        systemPropertyFlag(SystemProperties.isEnabled)
+        startParameter.isInstantExecutionEnabled
     }
 
     val isQuiet: Boolean

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(project(":launcher"))
     implementation(project(":internalTesting"))
     implementation(project(":buildEvents"))
+    implementation(project(":buildOption"))
 
     implementation(library("groovy"))
     implementation(library("junit"))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/InstantExecutionRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/InstantExecutionRunner.java
@@ -17,13 +17,13 @@
 package org.gradle.integtests.fixtures;
 
 import com.google.common.collect.ImmutableMap;
-import org.gradle.instantexecution.SystemProperties;
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption;
 
 /**
  * Intended to be a temporary runner until there is full cross-cutting coverage for all int tests with instant execution enabled.
  */
 public class InstantExecutionRunner extends BehindFlagFeatureRunner {
     public InstantExecutionRunner(Class<?> target) {
-        super(target, ImmutableMap.of(SystemProperties.isEnabled, booleanFeature("instant execution")));
+        super(target, ImmutableMap.of(InstantExecutionOption.PROPERTY_NAME, booleanFeature("instant execution")));
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.executer
 
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.instantexecution.SystemProperties
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.GradleVersion
@@ -24,7 +25,7 @@ import org.gradle.util.GradleVersion
 class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
 
     static final List<String> INSTANT_EXECUTION_ARGS = [
-        "-D${SystemProperties.isEnabled}=true",
+        "--${InstantExecutionOption.LONG_OPTION}",
         "-D${SystemProperties.isQuiet}=true",
         "-D${SystemProperties.maxProblems}=0"
     ].collect { it.toString() }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -114,6 +114,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isRefreshDependencies());
             encoder.writeBoolean(startParameter.isBuildCacheEnabled());
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
+            encoder.writeBoolean(startParameter.isInstantExecutionEnabled());
             encoder.writeBoolean(startParameter.isConfigureOnDemand());
             encoder.writeBoolean(startParameter.isContinuous());
             encoder.writeBoolean(startParameter.isBuildScan());
@@ -188,6 +189,7 @@ public class BuildActionSerializer {
             startParameter.setRefreshDependencies(decoder.readBoolean());
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
+            startParameter.setInstantExecutionEnabled(decoder.readBoolean());
             startParameter.setConfigureOnDemand(decoder.readBoolean());
             startParameter.setContinuous(decoder.readBoolean());
             startParameter.setBuildScan(decoder.readBoolean());

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.regression.android
 
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
 import org.gradle.internal.scan.config.fixtures.GradleEnterprisePluginSettingsFixture
 import org.gradle.internal.service.scopes.VirtualFileSystemServices
@@ -23,7 +24,6 @@ import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
-import org.gradle.performance.regression.java.JavaInstantExecutionPerformanceTest
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.ScenarioContext
@@ -135,7 +135,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     enum Optimization {
-        INSTANT_EXECUTION(JavaInstantExecutionPerformanceTest.INSTANT_EXECUTION_ENABLED_PROPERTY),
+        INSTANT_EXECUTION(InstantExecutionOption.PROPERTY_NAME),
         VFS_RETENTION(VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY)
 
         Optimization(String systemProperty) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.performance.regression.java
 
-import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
 import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
@@ -36,6 +35,8 @@ import static org.junit.Assert.assertTrue
 @Category(PerformanceRegressionTest)
 class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
+    public static final String INSTANT_EXECUTION_ENABLED_PROPERTY = "org.gradle.unsafe.instant-execution"
+
     private TestFile instantExecutionStateDir
 
     def setup() {
@@ -50,7 +51,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
-        runner.args = ["--${InstantExecutionOption.LONG_OPTION}"]
+        runner.args = ["-D${INSTANT_EXECUTION_ENABLED_PROPERTY}=true"]
 
         and:
         runner.useDaemon = daemon == hot

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.regression.java
 
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
 import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
@@ -35,8 +36,6 @@ import static org.junit.Assert.assertTrue
 @Category(PerformanceRegressionTest)
 class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
-    public static final String INSTANT_EXECUTION_ENABLED_PROPERTY = "org.gradle.unsafe.instant-execution"
-
     private TestFile instantExecutionStateDir
 
     def setup() {
@@ -51,7 +50,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
-        runner.args = ["-D${INSTANT_EXECUTION_ENABLED_PROPERTY}=true"]
+        runner.args = ["-D${InstantExecutionOption.PROPERTY_NAME}=true"]
 
         and:
         runner.useDaemon = daemon == hot

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.regression.java
 
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
 import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
@@ -35,8 +36,6 @@ import static org.junit.Assert.assertTrue
 @Category(PerformanceRegressionTest)
 class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
-    public static final String INSTANT_EXECUTION_ENABLED_PROPERTY = "org.gradle.unsafe.instant-execution"
-
     private TestFile instantExecutionStateDir
 
     def setup() {
@@ -51,7 +50,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
-        runner.args = ["-D${INSTANT_EXECUTION_ENABLED_PROPERTY}=true"]
+        runner.args = ["--${InstantExecutionOption.LONG_OPTION}"]
 
         and:
         runner.useDaemon = daemon == hot

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     smokeTestImplementation(project(":launcher"))
     smokeTestImplementation(project(":persistentCache"))
     smokeTestImplementation(project(":jvmServices"))
+    smokeTestImplementation(project(":buildOption"))
     smokeTestImplementation(library("commons_io"))
     smokeTestImplementation(library("jgit"))
     smokeTestImplementation(library("gradleProfiler")) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.specs.Spec
+import org.gradle.initialization.StartParameterBuildOptions.InstantExecutionOption
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -99,7 +100,7 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
 
     private void instantRun(String... tasks) {
         result = run(
-            "-Dorg.gradle.unsafe.instant-execution=true",
+            "--${InstantExecutionOption.LONG_OPTION}",
             "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false", // TODO remove
             *tasks
         )


### PR DESCRIPTION
This PR is a **DRAFT** based on https://github.com/gradle/gradle/pull/13075 - **DO NOT MERGE**

This PR introduces a build option for enabling instant execution, supporting common build option patterns:
- `--instant-execution` / `--no-instant-execution` on the command line
- `org.gradle.unsafe.instant-execution=[true|false]` property in `gradle.properties`
- `org.gradle.unsafe.instant-execution=[true|false]` system property on the command line

Enabling instant execution also now emit a message for using an incubating feature.
