### PR TITLE
Serialize `Task.doNotCacheIf` specs to the instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/Lambdas.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/Lambdas.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.lambdas;
+
+import org.gradle.api.Action;
+import org.gradle.api.specs.Spec;
+
+import java.io.Serializable;
+
+/**
+ * Provides a mechanism for creating Java lambdas that can be stored to the instant execution cache.
+ *
+ * The methods on this class are meant to be statically imported.
+ */
+public class Lambdas {
+
+    public static <T> Spec<T> spec(SerializableSpec<T> spec) {
+        return spec;
+    }
+
+    public static <T> Action<T> action(SerializableAction<T> action) {
+        return action;
+    }
+
+    public interface SerializableSpec<T> extends Spec<T>, Serializable {
+    }
+
+    public interface SerializableAction<T> extends Action<T>, Serializable {
+    }
+
+    private Lambdas() {
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  *
  * The methods on this class are meant to be statically imported.
  */
-public class Lambdas {
+public class SerializableLambdas {
 
     public static <T> Spec<T> spec(SerializableSpec<T> spec) {
         return spec;
@@ -36,12 +36,18 @@ public class Lambdas {
         return action;
     }
 
+    /**
+     * A {@link Serializable} version of {@link Spec}.
+     */
     public interface SerializableSpec<T> extends Spec<T>, Serializable {
     }
 
+    /**
+     * A {@link Serializable} version of {@link Action}.
+     */
     public interface SerializableAction<T> extends Action<T>, Serializable {
     }
 
-    private Lambdas() {
+    private SerializableLambdas() {
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -50,7 +50,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
-import static org.gradle.api.internal.lambdas.Lambdas.spec;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
 /**
  * {@code AbstractCopyTask} is the base class for all copy tasks.

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -50,6 +50,8 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
+import static org.gradle.api.internal.lambdas.Lambdas.spec;
+
 /**
  * {@code AbstractCopyTask} is the base class for all copy tasks.
  */
@@ -86,7 +88,10 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
                 .optional(true);
             getInputs().property(specPropertyName + ".filteringCharset", (Callable<String>) spec::getFilteringCharset);
         });
-        this.getOutputs().doNotCacheIf("Has custom actions", task -> rootSpec.hasCustomActions());
+        this.getOutputs().doNotCacheIf(
+            "Has custom actions",
+            spec(task -> rootSpec.hasCustomActions())
+        );
         this.mainSpec = rootSpec.addChild();
     }
 
@@ -138,6 +143,7 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
 
     /**
      * Returns the source files for this task.
+     *
      * @return The source files. Never returns null.
      */
     @Internal

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -91,6 +91,7 @@ class TaskNodeCodec(
         withTaskOf(taskType, task, userTypesCodec) {
             writeUpToDateSpec(task)
             writeCollection(task.outputs.cacheIfSpecs)
+            writeCollection(task.outputs.doNotCacheIfSpecs)
             beanStateWriterFor(task.javaClass).run {
                 writeStateOf(task)
                 writeRegisteredPropertiesOf(task, this as BeanPropertyWriter)
@@ -112,6 +113,7 @@ class TaskNodeCodec(
         withTaskOf(taskType, task, userTypesCodec) {
             readUpToDateSpec(task)
             readCollectionInto { task.outputs.cacheIfSpecs.uncheckedCast() }
+            readCollectionInto { task.outputs.doNotCacheIfSpecs.uncheckedCast() }
             beanStateReaderFor(task.javaClass).run {
                 readStateOf(task)
                 readRegisteredPropertiesOf(task)

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilerForkUtils.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilerForkUtils.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.compile.CompileOptions;
 
-import static org.gradle.api.internal.lambdas.Lambdas.spec;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
 public class CompilerForkUtils {
     public static void doNotCacheIfForkingViaExecutable(final CompileOptions compileOptions, TaskOutputs outputs) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilerForkUtils.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilerForkUtils.java
@@ -16,18 +16,16 @@
 
 package org.gradle.api.internal.tasks.compile;
 
-import org.gradle.api.Task;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.compile.CompileOptions;
 
+import static org.gradle.api.internal.lambdas.Lambdas.spec;
+
 public class CompilerForkUtils {
     public static void doNotCacheIfForkingViaExecutable(final CompileOptions compileOptions, TaskOutputs outputs) {
-        outputs.doNotCacheIf("Forking compiler via ForkOptions.executable", new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task element) {
-                return compileOptions.isFork() && compileOptions.getForkOptions().getExecutable() != null;
-            }
-        });
+        outputs.doNotCacheIf(
+            "Forking compiler via ForkOptions.executable",
+            spec(element -> compileOptions.isFork() && compileOptions.getForkOptions().getExecutable() != null)
+        );
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -19,18 +19,17 @@ import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.jvm.ClassDirectoryBinaryNamingScheme;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 
+import static org.gradle.api.internal.lambdas.Lambdas.spec;
 import static org.gradle.util.ConfigureUtil.configure;
 
 public abstract class DefaultSourceSet implements SourceSet {
@@ -64,7 +63,12 @@ public abstract class DefaultSourceSet implements SourceSet {
 
         String resourcesDisplayName = displayName + " resources";
         resources = objectFactory.sourceDirectorySet("resources", resourcesDisplayName);
-        resources.getFilter().exclude(new IsJavaSourceSpec(javaSource));
+
+        // Explicitly capture only a FileCollection in the lambda below for compatibility with instant-execution.
+        FileCollection javaSourceFiles = javaSource;
+        resources.getFilter().exclude(
+            spec(element -> javaSourceFiles.contains(element.getFile()))
+        );
 
         String allSourceDisplayName = displayName + " source";
         allSource = objectFactory.sourceDirectorySet("allsource", allSourceDisplayName);
@@ -292,18 +296,5 @@ public abstract class DefaultSourceSet implements SourceSet {
     @Override
     public SourceDirectorySet getAllSource() {
         return allSource;
-    }
-
-    private static class IsJavaSourceSpec implements Spec<FileTreeElement> {
-        private final FileCollection javaSource;
-
-        public IsJavaSourceSpec(FileCollection javaSource) {
-            this.javaSource = javaSource;
-        }
-
-        @Override
-        public boolean isSatisfiedBy(FileTreeElement element) {
-            return javaSource.contains(element.getFile());
-        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -29,7 +29,7 @@ import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 
-import static org.gradle.api.internal.lambdas.Lambdas.spec;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 import static org.gradle.util.ConfigureUtil.configure;
 
 public abstract class DefaultSourceSet implements SourceSet {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -24,7 +24,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.plugins.DslObject;
@@ -33,7 +32,6 @@ import org.gradle.api.internal.tasks.DefaultSourceSet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.JvmPluginsHelper;
 import org.gradle.api.reporting.ReportingExtension;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
@@ -44,6 +42,8 @@ import org.gradle.api.tasks.javadoc.Groovydoc;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.concurrent.Callable;
+
+import static org.gradle.api.internal.lambdas.Lambdas.spec;
 
 /**
  * Extends {@link org.gradle.api.plugins.JavaBasePlugin} to provide support for compiling and documenting Groovy
@@ -103,7 +103,12 @@ public class GroovyBasePlugin implements Plugin<Project> {
 
                 final SourceDirectorySet groovySource = groovySourceSet.getGroovy();
                 groovySource.srcDir("src/" + sourceSet.getName() + "/groovy");
-                sourceSet.getResources().getFilter().exclude(new IsGroovySourceSpec(groovySource));
+
+                // Explicitly capture only a FileCollection in the lambda below for compatibility with instant-execution.
+                final FileCollection groovySourceFiles = groovySource;
+                sourceSet.getResources().getFilter().exclude(
+                    spec(element -> groovySourceFiles.contains(element.getFile()))
+                );
                 sourceSet.getAllJava().source(groovySource);
                 sourceSet.getAllSource().source(groovySource);
 
@@ -176,18 +181,5 @@ public class GroovyBasePlugin implements Plugin<Project> {
 
     private JavaPluginConvention java(Convention convention) {
         return convention.getPlugin(JavaPluginConvention.class);
-    }
-
-    private static class IsGroovySourceSpec implements Spec<FileTreeElement> {
-        private final FileCollection groovySource;
-
-        public IsGroovySourceSpec(FileCollection groovySource) {
-            this.groovySource = groovySource;
-        }
-
-        @Override
-        public boolean isSatisfiedBy(FileTreeElement element) {
-            return groovySource.contains(element.getFile());
-        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -43,7 +43,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.lambdas.Lambdas.spec;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
 /**
  * Extends {@link org.gradle.api.plugins.JavaBasePlugin} to provide support for compiling and documenting Groovy

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -35,7 +35,6 @@ import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.tasks.DefaultScalaSourceSet;
@@ -63,6 +62,7 @@ import java.io.File;
 import java.util.concurrent.Callable;
 
 import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
+import static org.gradle.api.internal.lambdas.Lambdas.spec;
 
 /**
  * <p>A {@link Plugin} which compiles and tests Scala sources.</p>
@@ -173,8 +173,12 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 scalaDirectorySet.srcDir(project.file("src/" + sourceSet.getName() + "/scala"));
                 sourceSet.getAllJava().source(scalaDirectorySet);
                 sourceSet.getAllSource().source(scalaDirectorySet);
+
+                // Explicitly capture only a FileCollection in the lambda below for compatibility with instant-execution.
                 FileCollection scalaSource = scalaDirectorySet;
-                sourceSet.getResources().getFilter().exclude(new IsScalaSourceSpec(scalaSource));
+                sourceSet.getResources().getFilter().exclude(
+                    spec(element -> scalaSource.contains(element.getFile()))
+                );
 
                 Configuration classpath = project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName());
                 Configuration incrementalAnalysis = project.getConfigurations().create("incrementalScalaAnalysisFor" + sourceSet.getName());
@@ -313,19 +317,6 @@ public class ScalaBasePlugin implements Plugin<Project> {
                     details.closestMatch(javaRuntime);
                 }
             }
-        }
-    }
-
-    private static class IsScalaSourceSpec implements Spec<FileTreeElement> {
-        private final FileCollection scalaSource;
-
-        public IsScalaSourceSpec(FileCollection scalaSource) {
-            this.scalaSource = scalaSource;
-        }
-
-        @Override
-        public boolean isSatisfiedBy(FileTreeElement element) {
-            return scalaSource.contains(element.getFile());
         }
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -62,7 +62,7 @@ import java.io.File;
 import java.util.concurrent.Callable;
 
 import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
-import static org.gradle.api.internal.lambdas.Lambdas.spec;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
 /**
  * <p>A {@link Plugin} which compiles and tests Scala sources.</p>


### PR DESCRIPTION
This also requires making all the `Spec<T>` instances passed to `TaskOutputs.doNotCacheIf` serializable to the instant execution cache which is accomplished via the `SerializableLambdas` helper.