### PR TITLE
Use lazy task APIs in best practices Groovy snippets

### DIFF
--- a/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/groovy/build.gradle
@@ -1,5 +1,5 @@
 if (project.findProperty('releaseEngineer') != null) {
-    task release {
+    tasks.register('release') {
         doLast {
             logger.quiet 'Releasing to production...'
 

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'log4j:log4j:1.2.17'
 }
 
-task printArtifactNames {
+tasks.register('printArtifactNames') {
     doLast {
         def libraryNames = configurations.compileClasspath.collect { it.name }
         logger.quiet libraryNames

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'log4j:log4j:1.2.17'
 }
 
-task printArtifactNames {
+tasks.register('printArtifactNames') {
     // always executed
     def libraryNames = configurations.compileClasspath.collect { it.name }
 

--- a/subprojects/docs/src/snippets/bestPractices/taskDefinition/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/taskDefinition/groovy/build.gradle
@@ -1,13 +1,13 @@
 import com.enterprise.DocsGenerate
 
-task generateHtmlDocs(type: DocsGenerate) {
+def generateHtmlDocs = tasks.register('generateHtmlDocs', DocsGenerate) {
     group = JavaBasePlugin.DOCUMENTATION_GROUP
     description = 'Generates the HTML documentation for this project.'
     title = 'Project docs'
     outputDir = file("$buildDir/docs")
 }
 
-task allDocs {
+tasks.register('allDocs') {
     group = JavaBasePlugin.DOCUMENTATION_GROUP
     description = 'Generates all documentation for this project.'
     dependsOn generateHtmlDocs

--- a/subprojects/docs/src/snippets/bestPractices/taskGroupDescription/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/taskGroupDescription/groovy/build.gradle
@@ -1,4 +1,4 @@
-task generateDocs {
+tasks.register('generateDocs') {
     group = 'Documentation'
     description = 'Generates the HTML documentation for this project.'
 


### PR DESCRIPTION
Kotlin snippets already use the lazy APIs.
This change makes Groovy counterparts do the same for the snippets shown on this page: https://docs.gradle.org/current/userguide/authoring_maintainable_build_scripts.html