### PR TITLE
Do not use System.console in signing documentation snippet

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
@@ -50,66 +50,10 @@ signing.password=secret
 signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
 ----
 
-If specifying this information (especially `signing.password`) in the user `gradle.properties` file is not feasible for your environment, you can source the information however you need to and set the project properties manually.
-
-[.multi-language-sample]
-====
-.build.gradle
-[source,groovy]
+If specifying this information (especially `signing.password`) in the user `gradle.properties` file is not feasible for your environment, you can supply the information via the command line:
 ----
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.allTasks.any { it instanceof Sign }) {
-        // Use Java's console to read from the console (no good for
-        // a CI environment)
-        def console = System.console()
-        console.printf "\n\nWe have to sign some things in this build." +
-                       "\n\nPlease enter your signing details.\n\n"
-
-        def id = console.readLine("PGP Key Id: ")
-        def file = console.readLine("PGP Secret Key Ring File (absolute path): ")
-        def password = console.readPassword("PGP Private Key Password: ")
-
-        allprojects {
-            ext."signing.keyId" = id
-            ext."signing.secretKeyRingFile" = file
-            ext."signing.password" = password
-        }
-
-        console.printf "\nThanks.\n\n"
-    }
-}
+> gradle sign -Psigning.secretKeyRingFile=/Users/me/.gnupg/secring.gpg -Psigning.password=secret -Psigning.keyId=24875D73
 ----
-====
-[.multi-language-sample]
-====
-.build.gradle.kts
-[source,kotlin]
-----
-gradle.taskGraph.whenReady {
-    if (allTasks.any { it is Sign }) {
-        // Use Java's console to read from the console (no good for
-        // a CI environment)
-        val console = System.console()
-        console.printf("\n\nWe have to sign some things in this build." +
-                       "\n\nPlease enter your signing details.\n\n")
-
-        val id = console.readLine("PGP Key Id: ")
-        val file = console.readLine("PGP Secret Key Ring File (absolute path): ")
-        val password = console.readPassword("PGP Private Key Password: ")
-
-        allprojects {
-            extra["signing.keyId"] = id
-            extra["signing.secretKeyRingFile"] = file
-            extra["signing.password"] = password
-        }
-
-        console.printf("\nThanks.\n\n")
-    }
-}
-----
-====
-
-Note that the presence of a null value for any these three properties will cause an exception.
 
 [[sec:in-memory-keys]]
 === Using in-memory ascii-armored keys


### PR DESCRIPTION
System.console() does not work unless the daemon is disabled. Remove the snippet suggesting to use System.console() for signing credentials and instead show how to supply the data via the command line using `-P` project properties.

I also wanted to show the same using environment variables, but couldn't get them to work in this case - it seems that project properties with a dot in their name like `signing.something` are not mapped to an environment variable `ORG_GRADLE_PROJECT_signing_something`.
