### PR TITLE
Rebaseline `JavaInstantExecutionPerformanceTest`

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -47,7 +47,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
     def "assemble on #testProject #action instant execution state with #daemon daemon"() {
 
         given:
-        runner.targetVersions = ["6.5-20200424145747+0000"]
+        runner.targetVersions = ["6.5-20200512182414+0000"]
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]


### PR DESCRIPTION
After the latest changes to store more details about the task graph.