### PR TITLE
Improve performance of plugin instrumentation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -19,13 +19,15 @@ package org.gradle.internal.classpath;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.PersistentCache;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.vfs.VirtualFileSystem;
 
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -34,6 +36,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.SynchronousQueue;
 import java.util.function.Consumer;
 
 public class DefaultCachedClasspathTransformer implements CachedClasspathTransformer, Closeable {
@@ -43,6 +47,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
     private final VirtualFileSystem virtualFileSystem;
+    private final ManagedExecutor executor;
 
     public DefaultCachedClasspathTransformer(
         CacheRepository cacheRepository,
@@ -50,13 +55,15 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         FileAccessTimeJournal fileAccessTimeJournal,
         ClasspathWalker classpathWalker,
         ClasspathBuilder classpathBuilder,
-        VirtualFileSystem virtualFileSystem
+        VirtualFileSystem virtualFileSystem,
+        ExecutorFactory executorFactory
     ) {
         this.classpathWalker = classpathWalker;
         this.classpathBuilder = classpathBuilder;
         this.virtualFileSystem = virtualFileSystem;
         this.cache = classpathTransformerCacheFactory.createCache(cacheRepository, fileAccessTimeJournal);
         this.fileAccessTracker = classpathTransformerCacheFactory.createFileAccessTracker(fileAccessTimeJournal);
+        this.executor = executorFactory.create("jar transforms");
     }
 
     @Override
@@ -73,23 +80,15 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     public Collection<URL> transform(Collection<URL> urls, StandardTransform transform) {
         ClasspathFileTransformer transformer = fileTransformerFor(transform);
         return cache.useCache(() -> {
-            List<URL> cachedFiles = new ArrayList<>(urls.size());
+            List<CacheOperation> operations = new ArrayList<>(urls.size());
             for (URL url : urls) {
-                if (url.getProtocol().equals("file")) {
-                    try {
-                        cached(new File(url.toURI()), transformer, f -> {
-                            try {
-                                cachedFiles.add(f.toURI().toURL());
-                            } catch (MalformedURLException e) {
-                                throw UncheckedException.throwAsUncheckedException(e);
-                            }
-                        });
-                    } catch (URISyntaxException e) {
-                        throw UncheckedException.throwAsUncheckedException(e);
-                    }
-                } else {
-                    cachedFiles.add(url);
-                }
+                CacheOperation operation = cached(url, transformer);
+                operation.schedule(executor);
+                operations.add(operation);
+            }
+            List<URL> cachedFiles = new ArrayList<>(urls.size());
+            for (CacheOperation operation : operations) {
+                operation.collectUrl(cachedFiles::add);
             }
             return cachedFiles;
         });
@@ -106,9 +105,15 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     private ClassPath transform(ClassPath classPath, ClasspathFileTransformer transformer) {
         return cache.useCache(() -> {
             List<File> originalFiles = classPath.getAsFiles();
-            List<File> cachedFiles = new ArrayList<>(originalFiles.size());
+            List<CacheOperation> operations = new ArrayList<>(originalFiles.size());
             for (File file : originalFiles) {
-                cached(file, transformer, cachedFiles::add);
+                CacheOperation operation = cached(file, transformer);
+                operation.schedule(executor);
+                operations.add(operation);
+            }
+            List<File> cachedFiles = new ArrayList<>(originalFiles.size());
+            for (CacheOperation operation : operations) {
+                operation.collect(cachedFiles::add);
             }
             return DefaultClassPath.of(cachedFiles);
         });
@@ -125,28 +130,30 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         }
     }
 
-    private void cached(File original, ClasspathFileTransformer transformer, Consumer<File> dest) {
-        if (shouldUseFromCache(original)) {
-            File result = getCachedJar(transformer, original, cache.getBaseDir());
-            if (result != null) {
-                dest.accept(result);
+    private CacheOperation cached(URL original, ClasspathFileTransformer transformer) {
+        if (original.getProtocol().equals("file")) {
+            try {
+                return cached(new File(original.toURI()), transformer);
+            } catch (URISyntaxException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
             }
-        } else if (original.exists()) {
-            dest.accept(original);
         }
+        return new RetainUrl(original);
     }
 
-    @Nullable
-    private File getCachedJar(ClasspathFileTransformer transformer, File original, File cacheDir) {
+    private CacheOperation cached(File original, ClasspathFileTransformer transformer) {
         CompleteFileSystemLocationSnapshot snapshot = virtualFileSystem.read(original.getAbsolutePath(), s -> s);
         if (snapshot.getType() == FileType.Missing) {
-            return null;
+            return new EmptyOperation();
         }
-        File result = transformer.transform(original, snapshot, cacheDir);
-        if (!result.equals(original)) {
-            fileAccessTracker.markAccessed(result);
+        if (shouldUseFromCache(original)) {
+            return getCachedJar(transformer, original, snapshot, cache.getBaseDir());
         }
-        return result;
+        return new RetainFile(original);
+    }
+
+    private CacheOperation getCachedJar(ClasspathFileTransformer transformer, File original, CompleteFileSystemLocationSnapshot snapshot, File cacheDir) {
+        return new TransformFile(transformer, original, snapshot, cacheDir);
     }
 
     private boolean shouldUseFromCache(File original) {
@@ -156,6 +163,130 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     @Override
     public void close() {
-        cache.close();
+        CompositeStoppable.stoppable(executor, cache).stop();
+    }
+
+    interface CacheOperation {
+        /**
+         * Starts work on producing the result of this operation.
+         */
+        void schedule(Executor executor);
+
+        /**
+         * Collects the result of this operation, blocking until complete.
+         */
+        void collect(Consumer<File> consumer);
+
+        /**
+         * Collects the result of this operation as a URL, blocking until complete.
+         */
+        default void collectUrl(Consumer<URL> consumer) {
+            collect(file -> {
+                try {
+                    consumer.accept(file.toURI().toURL());
+                } catch (MalformedURLException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            });
+        }
+    }
+
+    private static class RetainUrl implements CacheOperation {
+        private final URL original;
+
+        public RetainUrl(URL original) {
+            this.original = original;
+        }
+
+        @Override
+        public void schedule(Executor executor) {
+        }
+
+        @Override
+        public void collect(Consumer<File> consumer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void collectUrl(Consumer<URL> consumer) {
+            consumer.accept(original);
+        }
+    }
+
+    private static class RetainFile implements CacheOperation {
+        private final File original;
+
+        public RetainFile(File original) {
+            this.original = original;
+        }
+
+        @Override
+        public void schedule(Executor executor) {
+        }
+
+        @Override
+        public void collect(Consumer<File> consumer) {
+            consumer.accept(original);
+        }
+    }
+
+    private static class EmptyOperation implements CacheOperation {
+        @Override
+        public void schedule(Executor executor) {
+        }
+
+        @Override
+        public void collect(Consumer<File> consumer) {
+        }
+    }
+
+    private class TransformFile implements CacheOperation {
+        private final SynchronousQueue<Object> queue;
+        private final ClasspathFileTransformer transformer;
+        private final File original;
+        private final CompleteFileSystemLocationSnapshot snapshot;
+        private final File cacheDir;
+
+        public TransformFile(ClasspathFileTransformer transformer, File original, CompleteFileSystemLocationSnapshot snapshot, File cacheDir) {
+            this.transformer = transformer;
+            this.original = original;
+            this.snapshot = snapshot;
+            this.cacheDir = cacheDir;
+            queue = new SynchronousQueue<>();
+        }
+
+        @Override
+        public void schedule(Executor executor) {
+            executor.execute(() -> {
+                try {
+                    try {
+                        File result = transformer.transform(original, snapshot, cacheDir);
+                        queue.put(result);
+                    } catch (Throwable t) {
+                        queue.put(t);
+                    }
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            });
+        }
+
+        @Override
+        public void collect(Consumer<File> consumer) {
+            Object message;
+            try {
+                message = queue.take();
+            } catch (InterruptedException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+            if (message instanceof Throwable) {
+                throw UncheckedException.throwAsUncheckedException((Throwable) message);
+            }
+            File result = (File) message;
+            if (!result.equals(original)) {
+                fileAccessTracker.markAccessed(result);
+            }
+            consumer.accept(result);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -152,7 +152,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         FileAccessTimeJournal fileAccessTimeJournal,
         VirtualFileSystem virtualFileSystem,
         ClasspathWalker classpathWalker,
-        ClasspathBuilder classpathBuilder
+        ClasspathBuilder classpathBuilder,
+        ExecutorFactory executorFactory
     ) {
         return new DefaultCachedClasspathTransformer(
             cacheRepository,
@@ -160,7 +161,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
             fileAccessTimeJournal,
             classpathWalker,
             classpathBuilder,
-            virtualFileSystem);
+            virtualFileSystem,
+            executorFactory);
     }
 
     WorkerProcessFactory createWorkerProcessFactory(LoggingManagerInternal loggingManagerInternal, MessagingServer messagingServer, ClassPathRegistry classPathRegistry,

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -19,33 +19,28 @@ package org.gradle.internal.classpath
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
-import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.CacheScopeMapping
 import org.gradle.cache.internal.UsedGradleVersions
-import org.gradle.internal.Factory
 import org.gradle.internal.Pair
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.internal.hash.Hasher
+import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.testfixtures.internal.InMemoryCacheFactory
 import org.junit.Rule
-import spock.lang.Ignore
-import spock.lang.Specification
 import spock.lang.Subject
 
 import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic
 import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.None
 
-class DefaultCachedClasspathTransformerTest extends Specification {
+class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     @Rule
     TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     def testDir = testDirectoryProvider.testDirectory
 
     def cachedDir = testDir.file("cached")
-    def cache = Stub(PersistentCache) {
-        getBaseDir() >> cachedDir
-        useCache(_) >> { Factory f -> f.create() }
-    }
+    def cache = new InMemoryCacheFactory().open(cachedDir, "jars")
     def cacheBuilder = Stub(CacheBuilder) {
         open() >> cache
         withDisplayName(_) >> { cacheBuilder }
@@ -68,9 +63,37 @@ class DefaultCachedClasspathTransformerTest extends Specification {
     def virtualFileSystem = TestFiles.virtualFileSystem()
 
     @Subject
-    DefaultCachedClasspathTransformer transformer = new DefaultCachedClasspathTransformer(cacheRepository, cacheFactory, fileAccessTimeJournal, classpathWalker, classpathBuilder, virtualFileSystem)
+    DefaultCachedClasspathTransformer transformer = new DefaultCachedClasspathTransformer(cacheRepository, cacheFactory, fileAccessTimeJournal, classpathWalker, classpathBuilder, virtualFileSystem, executorFactory)
 
-    def "skips missing file when transform is none"() {
+    def "does nothing to empty classpath when transform is none"() {
+        given:
+        def classpath = DefaultClassPath.of()
+
+        when:
+        def cachedClasspath = transformer.transform(classpath, None)
+
+        then:
+        cachedClasspath.empty
+
+        and:
+        0 * fileAccessTimeJournal._
+    }
+
+    def "does nothing to empty classpath when transform is build logic"() {
+        given:
+        def classpath = DefaultClassPath.of()
+
+        when:
+        def cachedClasspath = transformer.transform(classpath, None)
+
+        then:
+        cachedClasspath.empty
+
+        and:
+        0 * fileAccessTimeJournal._
+    }
+
+    def "discards missing file when transform is none"() {
         given:
         def classpath = DefaultClassPath.of(testDir.file("missing"))
 
@@ -84,7 +107,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * fileAccessTimeJournal._
     }
 
-    def "skips missing file when tranform is build logic"() {
+    def "discards missing file when tranform is build logic"() {
         given:
         def classpath = DefaultClassPath.of(testDir.file("missing"))
 
@@ -98,7 +121,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * fileAccessTimeJournal._
     }
 
-    def "copies file to cache when transform is none"() {
+    def "copies file into cache when transform is none"() {
         given:
         def file = testDir.file("thing.jar")
         jar(file)
@@ -135,7 +158,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * fileAccessTimeJournal._
     }
 
-    def "copies file to cache when content has changed and transform is none"() {
+    def "copies file into cache when content has changed and transform is none"() {
         given:
         def file = testDir.file("thing.jar")
         jar(file)
@@ -171,7 +194,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * fileAccessTimeJournal._
     }
 
-    def "copies file to cache when transform is build logic"() {
+    def "transforms file into cache when transform is build logic"() {
         given:
         def file = testDir.file("thing.jar")
         jar(file)
@@ -199,7 +222,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * fileAccessTimeJournal._
     }
 
-    def "copies directory to cache when usage is build logic"() {
+    def "transforms directory into cache when usage is build logic"() {
         given:
         def dir = testDir.file("thing.dir")
         classesDir(dir)
@@ -223,6 +246,28 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         cachedClasspath2.asFiles == [cachedFile]
 
         and:
+        1 * fileAccessTimeJournal.setLastAccessTime(cachedFile.parentFile, _)
+        0 * fileAccessTimeJournal._
+    }
+
+    def "transforms multiple entries into cache when usage is build logic"() {
+        given:
+        def dir = testDir.file("thing.dir")
+        classesDir(dir)
+        def file = testDir.file("thing.jar")
+        jar(file)
+        def classpath = DefaultClassPath.of(dir, file)
+        def cachedDir = testDir.file("cached/eaacf77ab251121a64643cf529b7035d/thing.dir.jar")
+        def cachedFile = testDir.file("cached/8e4b9e80c38bd91c60da528b6bc0a28a/thing.jar")
+
+        when:
+        def cachedClasspath = transformer.transform(classpath, BuildLogic)
+
+        then:
+        cachedClasspath.asFiles == [cachedDir, cachedFile]
+
+        and:
+        1 * fileAccessTimeJournal.setLastAccessTime(cachedDir.parentFile, _)
         1 * fileAccessTimeJournal.setLastAccessTime(cachedFile.parentFile, _)
         0 * fileAccessTimeJournal._
     }
@@ -262,9 +307,22 @@ class DefaultCachedClasspathTransformerTest extends Specification {
         0 * _
     }
 
-    @Ignore
-    def "reuses non-file URL from origin"() {
-        expect: false
+    def "uses non-file URL from origin"() {
+        given:
+        def file = testDir.file("thing.jar")
+        jar(file)
+        def remote = new URL("https://somewhere")
+        def cachedFile = testDir.file("cached/o_d3714f1fd48ab27e701a9c39545ae221/thing.jar")
+
+        when:
+        def cachedClasspath = transformer.transform([file.toURI().toURL(), remote], None)
+
+        then:
+        cachedClasspath == [cachedFile.toURI().toURL(), remote]
+
+        and:
+        1 * fileAccessTimeJournal.setLastAccessTime(cachedFile.parentFile, _)
+        0 * fileAccessTimeJournal._
     }
 
     void classesDir(TestFile dir) {


### PR DESCRIPTION

### Context

Instrument each plugin classpath element in parallel and reduce unnecessary locking of the transfromed jars cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
