### PR TITLE
Roll back setting main class in manifest

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import spock.lang.Ignore
 import spock.lang.Issue
 
 class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
@@ -101,6 +102,7 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
         file("out.txt").text == """helloworld"""
     }
 
+    @Ignore("Change rolled back, to be added again in 7.0")
     @ToBeFixedForInstantExecution(because = "Task.getProject() during execution")
     def "can run JavaExec with an executable jar configured in the application plugin"() {
 
@@ -118,6 +120,7 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
         file("out.txt").text == """helloworld"""
     }
 
+    @Ignore("Change rolled back, to be added again in 7.0")
     @ToBeFixedForInstantExecution
     def "can run javaexec with executable jar configured in the application plugin"() {
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -69,7 +69,6 @@ public class ApplicationPlugin implements Plugin<Project> {
         addRunTask(project, pluginExtension, pluginConvention);
         addCreateScriptsTask(project, pluginExtension, pluginConvention);
         configureJavaCompileTask(tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class), pluginExtension);
-        configureJarTask(tasks.named(JavaPlugin.JAR_TASK_NAME, Jar.class), pluginExtension);
         configureInstallTask(tasks.named(TASK_INSTALL_NAME, Sync.class), pluginConvention);
 
         DistributionContainer distributions = (DistributionContainer) project.getExtensions().getByName("distributions");
@@ -81,6 +80,7 @@ public class ApplicationPlugin implements Plugin<Project> {
         javaCompile.configure(j -> j.getOptions().getJavaModuleMainClass().convention(pluginExtension.getMainClass()));
     }
 
+    // Enable this back for Gradle 7.0
     private void configureJarTask(TaskProvider<Jar> jar, JavaApplication pluginExtension) {
         jar.configure(j -> j.getManifest().attributes(Collections.singletonMap("Main-Class", pluginExtension.getMainClass())));
     }


### PR DESCRIPTION
This change can be considered breaking and is postponed to Gradle 7.0.