### PR TITLE
Fix file watching soak test

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -90,9 +90,9 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
             daemon.assertIdle()
             assertWatchingSucceeded()
             boolean overflowDetected = detectOverflow(daemon, endOfDaemonLog)
-            int expectedNumberOfRetainedFiles = retainedFilesInLastBuild - numberOfChangesBetweenBuilds
-            int retainedFilesAtTheBeginningOfTheCurrentBuild = retainedFilesSinceLastBuild
             if (!overflowDetected) {
+                int expectedNumberOfRetainedFiles = retainedFilesInLastBuild - numberOfChangesBetweenBuilds
+                int retainedFilesAtTheBeginningOfTheCurrentBuild = retainedFilesSinceLastBuild
                 assert retainedFilesAtTheBeginningOfTheCurrentBuild <= expectedNumberOfRetainedFiles
                 assert expectedNumberOfRetainedFiles - 100 <= retainedFilesAtTheBeginningOfTheCurrentBuild
             }
@@ -122,7 +122,6 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
             waitBetweenChangesToAvoidOverflow()
         }
         boolean overflowDetected = detectOverflow(daemon, 0)
-        int expectedNumberOfRetainedFiles = retainedFilesInCurrentBuild - numberOfChangedSourcesFilesPerBatch
         then:
         succeeds("assemble")
         daemons.daemon.logFile == daemon.logFile
@@ -130,6 +129,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
         assertWatchingSucceeded()
         receivedFileSystemEventsSinceLastBuild >= minimumExpectedFileSystemEvents(numberOfChangedSourcesFilesPerBatch, numberOfChangeBatches)
         if (!overflowDetected) {
+            int expectedNumberOfRetainedFiles = retainedFilesInCurrentBuild - numberOfChangedSourcesFilesPerBatch
             assert retainedFilesSinceLastBuild == expectedNumberOfRetainedFiles
         }
     }


### PR DESCRIPTION
We now don't invalidate the whole VFS if we
receive an overflow for some location. So
the number of retained files won't be 0.

Moreover, sometimes changing the files takes
more than 2 minutes which may cause the daemon
to time out.

Fixes https://github.com/gradle/gradle-private/issues/3093.