### PR TITLE
Load gradle properties earlier

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -25,9 +25,13 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.GradleLauncherFactory;
+import org.gradle.initialization.GradlePropertiesController;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.initialization.SettingsLocation;
+import org.gradle.initialization.layout.BuildLayoutConfiguration;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.concurrent.Stoppable;
@@ -75,6 +79,7 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
         final GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         RootBuildLifecycleListener buildLifecycleListener = listenerManager.getBroadcaster(RootBuildLifecycleListener.class);
         GradleInternal gradle = buildController.getGradle();
+        loadGradleProperties();
         buildLifecycleListener.afterStart(gradle);
         try {
             return buildAction.transform(buildController);
@@ -106,5 +111,19 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
     @Override
     public Path getIdentityPathForProject(Path path) {
         return path;
+    }
+
+    private void loadGradleProperties() {
+        BuildLayoutConfiguration layoutConfiguration = new BuildLayoutConfiguration(getStartParameter());
+        SettingsLocation settingsLocation = getBuildLayoutFactory().getLayoutFor(layoutConfiguration);
+        getGradlePropertiesController().loadGradlePropertiesFrom(settingsLocation.getSettingsDir());
+    }
+
+    private BuildLayoutFactory getBuildLayoutFactory() {
+        return gradleLauncher.getGradle().getServices().get(BuildLayoutFactory.class);
+    }
+
+    private GradlePropertiesController getGradlePropertiesController() {
+        return gradleLauncher.getGradle().getServices().get(GradlePropertiesController.class);
     }
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -19,11 +19,14 @@ package org.gradle.composite.internal
 import org.gradle.api.Transformer
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.initialization.GradleLauncher
 import org.gradle.initialization.GradleLauncherFactory
+import org.gradle.initialization.GradlePropertiesController
 import org.gradle.initialization.RootBuildLifecycleListener
+import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.invocation.BuildController
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -50,8 +53,11 @@ class DefaultRootBuildStateTest extends Specification {
         _ * sessionServices.get(ProjectStateRegistry) >> projectStateRegistry
         _ * sessionServices.get(BuildOperationExecutor) >> Stub(BuildOperationExecutor)
         _ * sessionServices.get(WorkerLeaseService) >> new TestWorkerLeaseService()
+        _ * sessionServices.get(BuildLayoutFactory) >> Stub(BuildLayoutFactory)
+        _ * sessionServices.get(GradlePropertiesController) >> Stub(GradlePropertiesController)
         _ * launcher.gradle >> gradle
         _ * gradle.services >> sessionServices
+        _ * gradle.startParameter >> Stub(StartParameterInternal)
         _ * projectStateRegistry.withLenientState(_) >> { args -> return args[0].create() }
 
         build = new DefaultRootBuildState(buildDefinition, factory, listenerManager, sessionServices)

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
@@ -100,10 +100,9 @@ public class DefaultGradlePropertiesLoader implements IGradlePropertiesLoader {
             if (propertyFile != null && propertyFile.isFile()) {
                 Properties properties = GUtil.loadProperties(propertyFile);
                 for (String name : properties.stringPropertyNames()) {
+                    gradleProperties.put(name, properties.getProperty(name));
                     if (name.startsWith(systemPropPrefix)) {
                         systemProperties.put(name.substring(systemPropPrefix.length()), properties.getProperty(name));
-                    } else {
-                        gradleProperties.put(name, properties.getProperty(name));
                     }
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -34,7 +34,7 @@ import org.gradle.util.Path;
  */
 public class DefaultSettingsLoader implements SettingsLoader {
     public static final String BUILD_SRC_PROJECT_PATH = ":" + SettingsInternal.BUILD_SRC;
-    private SettingsProcessor settingsProcessor;
+    private final SettingsProcessor settingsProcessor;
     private final BuildLayoutFactory buildLayoutFactory;
     private final GradlePropertiesController gradlePropertiesController;
 
@@ -53,7 +53,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
         StartParameter startParameter = gradle.getStartParameter();
 
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
-        loadGradlePropertiesFrom(settingsLocation);
+        applyGradlePropertiesToSystemProperties(settingsLocation);
 
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter, settingsLocation, gradle.getClassLoaderScope());
         ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
@@ -65,8 +65,8 @@ public class DefaultSettingsLoader implements SettingsLoader {
         return settings;
     }
 
-    private void loadGradlePropertiesFrom(SettingsLocation settingsLocation) {
-        gradlePropertiesController.loadGradlePropertiesFrom(
+    private void applyGradlePropertiesToSystemProperties(SettingsLocation settingsLocation) {
+        gradlePropertiesController.applyToSystemProperties(
             settingsLocation.getSettingsDir()
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesController.java
@@ -21,8 +21,8 @@ import org.gradle.api.internal.properties.GradleProperties;
 import java.io.File;
 
 /**
- * Controls the state (not loaded / loaded) of the attached {@link GradleProperties} instance
- * so that the set of Gradle properties is deterministically loaded only once per build.
+ * Controls the state (not loaded / loaded / applied) of the attached {@link GradleProperties} instance
+ * so that the set of Gradle properties is deterministically loaded/applied only once per build.
  */
 public interface GradlePropertiesController {
 
@@ -42,4 +42,15 @@ public interface GradlePropertiesController {
      * @throws IllegalStateException if called with a different argument in the same build
      */
     void loadGradlePropertiesFrom(File settingsDir);
+
+    /**
+     * Applies system properties from gradle properties, mutating <code>System.properties</code>.
+     *
+     * This method should be called only once per build but multiple calls with the
+     * same argument are allowed.
+
+     * @param settingsDir directory where from which the {@code gradle.properties} files must have been loaded
+     * @throws IllegalStateException if called with a different argument in the same build
+     */
+    void applyToSystemProperties(File settingsDir);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/LoadedGradleProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LoadedGradleProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2008 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.initialization;
 
-import java.io.File;
+import org.gradle.api.internal.properties.GradleProperties;
 
-public interface IGradlePropertiesLoader {
+import java.util.Map;
 
-    String SYSTEM_PROJECT_PROPERTIES_PREFIX = "org.gradle.project.";
-
-    String ENV_PROJECT_PROPERTIES_PREFIX = "ORG_GRADLE_PROJECT_";
+public interface LoadedGradleProperties {
 
     /**
-     * Loads the immutable set of Gradle properties.
-     *
-     * @since 6.2
+     * Immutable set of gradle properties.
      */
-    LoadedGradleProperties loadGradleProperties(File rootDir);
+    GradleProperties getGradleProperties();
+
+    /**
+     * Immutable set of system properties defined from gradle properties.
+     */
+    Map<String, String> getSystemProperties();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesControllerTest.groovy
@@ -59,10 +59,13 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def subject = new DefaultGradlePropertiesController(propertiesLoader)
         def properties = subject.gradleProperties
-        def loadedProperties = Mock(GradleProperties)
+        def gradleProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
         1 * propertiesLoader.loadGradleProperties(settingsDir) >> loadedProperties
-        1 * loadedProperties.mergeProperties(_) >> [property: '42']
-        1 * loadedProperties.find(_) >> '42'
+        2 * loadedProperties.gradleProperties >> gradleProperties
+        0 * loadedProperties.systemProperties >> [:]
+        1 * gradleProperties.mergeProperties(_) >> [property: '42']
+        1 * gradleProperties.find(_) >> '42'
 
         when:
         subject.loadGradlePropertiesFrom(settingsDir)
@@ -79,10 +82,13 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def subject = new DefaultGradlePropertiesController(propertiesLoader)
         def properties = subject.gradleProperties
-        def loadedProperties = Mock(GradleProperties)
+        def gradleProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
         1 * propertiesLoader.loadGradleProperties(settingsDir) >> loadedProperties
-        2 * loadedProperties.mergeProperties(_) >> [property: '42']
-        1 * loadedProperties.find(_) >> '42'
+        1 * loadedProperties.gradleProperties >> gradleProperties
+        1 * loadedProperties.systemProperties >> [:]
+        1 * gradleProperties.mergeProperties(_) >> [property: '42']
+        1 * gradleProperties.find(_) >> '42'
 
         when:
         subject.applyToSystemProperties(settingsDir)
@@ -99,7 +105,7 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def currentDir = { new File('.') }
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def subject = new DefaultGradlePropertiesController(propertiesLoader)
-        def loadedProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
 
         when: "calling the method multiple times with the same value"
         subject.loadGradlePropertiesFrom(currentDir())
@@ -117,9 +123,11 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def systemPropertySetter = Mock(BiConsumer)
         def subject = new DefaultGradlePropertiesController(propertiesLoader, systemPropertySetter)
-        def loadedProperties = Mock(GradleProperties)
+        def gradleProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
         1 * propertiesLoader.loadGradleProperties(currentDir()) >> loadedProperties
-        1 * loadedProperties.mergeProperties(_) >> ['systemProp.property': '42']
+        1 * loadedProperties.gradleProperties >> gradleProperties
+        1 * loadedProperties.systemProperties >> [property: '42']
 
         when: "calling the method multiple times with the same value"
         subject.applyToSystemProperties(currentDir())
@@ -135,7 +143,7 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def settingsDir = new File('a')
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def subject = new DefaultGradlePropertiesController(propertiesLoader)
-        def loadedProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
         1 * propertiesLoader.loadGradleProperties(settingsDir) >> loadedProperties
 
         when:
@@ -152,7 +160,7 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def settingsDir = new File('a')
         def propertiesLoader = Mock(IGradlePropertiesLoader)
         def subject = new DefaultGradlePropertiesController(propertiesLoader)
-        def loadedProperties = Mock(GradleProperties)
+        def loadedProperties = Mock(LoadedGradleProperties)
         1 * propertiesLoader.loadGradleProperties(settingsDir) >> loadedProperties
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -17,7 +17,6 @@ package org.gradle.initialization;
 
 import org.gradle.api.Project;
 import org.gradle.api.internal.StartParameterInternal;
-import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.GUtil;
 import org.gradle.util.WrapUtil;
@@ -241,7 +240,7 @@ public class DefaultGradlePropertiesLoaderTest {
         assertEquals("value", properties.get("prop1"));
         assertEquals("value", properties.get("prop2"));
 
-        properties = loadPropertiesFrom(otherSettingsDir).mergeProperties(emptyMap());
+        properties = loadPropertiesFrom(otherSettingsDir).getGradleProperties().mergeProperties(emptyMap());
         assertEquals("otherValue", properties.get("prop1"));
         assertNull(properties.get("prop2"));
     }
@@ -272,21 +271,23 @@ public class DefaultGradlePropertiesLoaderTest {
             "org.gradle.project.property", "commandline val"
         )));
 
-        GradleProperties loaded = loadProperties();
+        LoadedGradleProperties loaded = loadProperties();
 
-        assertEquals("commandline value", loaded.find("systemProp.prop"));
-        assertEquals("commandline val", loaded.find("property"));
+        assertEquals("commandline value", loaded.getSystemProperties().get("prop"));
+        assertNull(loaded.getGradleProperties().find("systemProp.prop"));
+
+        assertEquals("commandline val", loaded.getGradleProperties().find("property"));
     }
 
     private Map<String, String> loadAndMergePropertiesWith(Map<String, String> properties) {
-        return loadProperties().mergeProperties(properties);
+        return loadProperties().getGradleProperties().mergeProperties(properties);
     }
 
-    private GradleProperties loadProperties() {
+    private LoadedGradleProperties loadProperties() {
         return loadPropertiesFrom(settingsDir);
     }
 
-    private GradleProperties loadPropertiesFrom(File settingsDir) {
+    private LoadedGradleProperties loadPropertiesFrom(File settingsDir) {
         return gradlePropertiesLoader.loadProperties(
             settingsDir,
             startParameter,

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -274,8 +274,6 @@ public class DefaultGradlePropertiesLoaderTest {
         LoadedGradleProperties loaded = loadProperties();
 
         assertEquals("commandline value", loaded.getSystemProperties().get("prop"));
-        assertNull(loaded.getGradleProperties().find("systemProp.prop"));
-
         assertEquals("commandline val", loaded.getGradleProperties().find("property"));
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -18,10 +18,8 @@ package org.gradle.initialization;
 import org.gradle.api.Project;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.properties.GradleProperties;
-import org.gradle.internal.Cast;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.GUtil;
-import org.gradle.util.SetSystemProperties;
 import org.gradle.util.WrapUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,6 +33,7 @@ import java.util.Properties;
 import static java.util.Collections.emptyMap;
 import static org.gradle.api.Project.SYSTEM_PROP_PREFIX;
 import static org.gradle.initialization.IGradlePropertiesLoader.*;
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -46,11 +45,9 @@ public class DefaultGradlePropertiesLoaderTest {
     private File gradleInstallationHomeDir;
     private Map<String, String> systemProperties = new HashMap<>();
     private Map<String, String> envProperties = new HashMap<>();
-    private StartParameterInternal startParameter = new StartParameterInternal();
+    private final StartParameterInternal startParameter = new StartParameterInternal();
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
-    @Rule
-    public SetSystemProperties sysProp = new SetSystemProperties();
 
     @Before
     public void setUp() {
@@ -70,7 +67,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromInstallationPropertiesFile() {
-        writePropertyFile(gradleInstallationHomeDir, Cast.uncheckedNonnullCast(Cast.uncheckedNonnullCast(GUtil.map("settingsProp", "settings value"))));
+        writePropertyFile(gradleInstallationHomeDir, uncheckedNonnullCast(uncheckedNonnullCast(GUtil.map("settingsProp", "settings value"))));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -79,7 +76,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromUserPropertiesFile() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("userProp", "user value")));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("userProp", "user value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -88,7 +85,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromSettingsPropertiesFile() {
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("settingsProp", "settings value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("settingsProp", "settings value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -97,7 +94,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromEnvironmentVariablesWithPrefix() {
-        envProperties = Cast.uncheckedNonnullCast(GUtil.map(
+        envProperties = uncheckedNonnullCast(GUtil.map(
             ENV_PROJECT_PROPERTIES_PREFIX + "envProp", "env value",
             "ignoreMe", "ignored"));
 
@@ -108,7 +105,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromSystemPropertiesWithPrefix() {
-        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(
+        systemProperties = uncheckedNonnullCast(GUtil.map(
             SYSTEM_PROJECT_PROPERTIES_PREFIX + "systemProp", "system value",
             "ignoreMe", "ignored"));
 
@@ -119,7 +116,7 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void mergeAddsPropertiesFromStartParameter() {
-        startParameter.setProjectProperties(Cast.uncheckedNonnullCast(GUtil.map("paramProp", "param value")));
+        startParameter.setProjectProperties(uncheckedNonnullCast(GUtil.map("paramProp", "param value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -128,8 +125,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void projectPropertiesHavePrecedenceOverInstallationPropertiesFile() {
-        writePropertyFile(gradleInstallationHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        writePropertyFile(gradleInstallationHomeDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -138,8 +135,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void projectPropertiesHavePrecedenceOverSettingsPropertiesFile() {
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -148,8 +145,8 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void userPropertiesFileHasPrecedenceOverSettingsPropertiesFile() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
 
@@ -158,9 +155,9 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void userPropertiesFileHasPrecedenceOverProjectProperties() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -169,10 +166,10 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void environmentVariablesHavePrecedenceOverProjectProperties() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
-        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -181,11 +178,11 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void systemPropertiesHavePrecedenceOverEnvironmentVariables() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
-        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
-        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
+        systemProperties = uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -194,12 +191,12 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void startParameterPropertiesHavePrecedenceOverSystemProperties() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop", "settings value")));
-        Map<String, String> projectProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "project value"));
-        envProperties = Cast.uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
-        systemProperties = Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
-        startParameter.setProjectProperties(Cast.uncheckedNonnullCast(GUtil.map("prop", "param value")));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map("prop", "user value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop", "settings value")));
+        Map<String, String> projectProperties = uncheckedNonnullCast(GUtil.map("prop", "project value"));
+        envProperties = uncheckedNonnullCast(GUtil.map(ENV_PROJECT_PROPERTIES_PREFIX + "prop", "env value"));
+        systemProperties = uncheckedNonnullCast(GUtil.map(SYSTEM_PROJECT_PROPERTIES_PREFIX + "prop", "system value"));
+        startParameter.setProjectProperties(uncheckedNonnullCast(GUtil.map("prop", "param value")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(projectProperties);
 
@@ -207,18 +204,18 @@ public class DefaultGradlePropertiesLoaderTest {
     }
 
     @Test
-    public void loadSetsSystemProperties() {
+    public void loadDoesNotSetSystemProperties() {
         startParameter.setSystemPropertiesArgs(WrapUtil.toMap("systemPropArgKey", "systemPropArgValue"));
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map(SYSTEM_PROP_PREFIX + ".userSystemProp", "userSystemValue")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map(
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map(SYSTEM_PROP_PREFIX + ".userSystemProp", "userSystemValue")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map(
             SYSTEM_PROP_PREFIX + ".userSystemProp", "settingsSystemValue",
             SYSTEM_PROP_PREFIX + ".settingsSystemProp2", "settingsSystemValue2")));
 
         loadProperties();
 
-        assertEquals("userSystemValue", System.getProperty("userSystemProp"));
-        assertEquals("settingsSystemValue2", System.getProperty("settingsSystemProp2"));
-        assertEquals("systemPropArgValue", System.getProperty("systemPropArgKey"));
+        assertNull(System.getProperty("userSystemProp"));
+        assertNull(System.getProperty("settingsSystemProp2"));
+        assertNull(System.getProperty("systemPropArgKey"));
     }
 
     @Test
@@ -235,10 +232,10 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void reloadsProperties() {
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop1", "value", "prop2", "value")));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map("prop1", "value", "prop2", "value")));
 
         File otherSettingsDir = tmpDir.createDir("otherSettingsDir");
-        writePropertyFile(otherSettingsDir, Cast.uncheckedNonnullCast(GUtil.map("prop1", "otherValue")));
+        writePropertyFile(otherSettingsDir, uncheckedNonnullCast(GUtil.map("prop1", "otherValue")));
 
         Map<String, String> properties = loadAndMergePropertiesWith(emptyMap());
         assertEquals("value", properties.get("prop1"));
@@ -258,14 +255,27 @@ public class DefaultGradlePropertiesLoaderTest {
 
     @Test
     public void startParameterSystemPropertiesHavePrecedenceOverPropertiesFiles() {
-        writePropertyFile(gradleUserHomeDir, Cast.uncheckedNonnullCast(GUtil.map("systemProp.prop", "user value")));
-        writePropertyFile(settingsDir, Cast.uncheckedNonnullCast(GUtil.map("systemProp.prop", "settings value")));
-        systemProperties = Cast.uncheckedNonnullCast(GUtil.map("prop", "system value"));
-        startParameter.setSystemPropertiesArgs(WrapUtil.toMap("prop", "commandline value"));
+        writePropertyFile(gradleUserHomeDir, uncheckedNonnullCast(GUtil.map(
+            "systemProp.prop", "user value",
+            "property", "user val"
+        )));
+        writePropertyFile(settingsDir, uncheckedNonnullCast(GUtil.map(
+            "systemProp.prop", "settings value",
+            "property", "settings val"
+        )));
+        systemProperties = uncheckedNonnullCast(GUtil.map(
+            "prop", "system value",
+            "property", "system val"
+        ));
+        startParameter.setSystemPropertiesArgs(uncheckedNonnullCast(GUtil.map(
+            "prop", "commandline value",
+            "org.gradle.project.property", "commandline val"
+        )));
 
-        loadProperties();
+        GradleProperties loaded = loadProperties();
 
-        assertEquals("commandline value", System.getProperty("prop"));
+        assertEquals("commandline value", loaded.find("systemProp.prop"));
+        assertEquals("commandline val", loaded.find("property"));
     }
 
     private Map<String, String> loadAndMergePropertiesWith(Map<String, String> properties) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -63,7 +63,7 @@ class DefaultSettingsLoaderTest extends Specification {
         1 * settingsProcessor.process(gradle, buildLayout, classLoaderScope, startParameter) >> settings
         1 * settings.settingsScript >> settingsScript
         1 * settingsScript.displayName >> "foo"
-        1 * gradlePropertiesController.loadGradlePropertiesFrom(buildLayout.settingsDir)
+        1 * gradlePropertiesController.applyToSystemProperties(buildLayout.settingsDir)
 
         then:
         settingsHandler.findAndLoadSettings(gradle).is(settings)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -268,7 +268,7 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun checkFingerprint(): InvalidationReason? {
-        loadGradleProperties()
+        applyGradlePropertiesToSystemProperties()
         return checkInstantExecutionFingerprintFile()
     }
 
@@ -283,8 +283,8 @@ class DefaultInstantExecution internal constructor(
         }
 
     private
-    fun loadGradleProperties() {
-        gradlePropertiesController.loadGradlePropertiesFrom(
+    fun applyGradlePropertiesToSystemProperties() {
+        gradlePropertiesController.applyToSystemProperties(
             startParameter.settingsDirectory
         )
     }


### PR DESCRIPTION
As early as required for both the configuration cache and file watching on the root build while keeping the system properties mutation at the same point in time, and without changing nested builds behaviour.

This allows to check for system properties persistently set in `gradle.properties` as `systemProp.something` very early. They aren't available as `System.getProperty("something")` yet but can be queried on `GradleProperties.find("systemProp.something")`.

Without loading the properties earlier the behaviour is quite undefined. Observations are that if you are using [the wrapper](https://github.com/gradle/gradle/blob/982d3999a0fbb9aa1a236a517e50c3e95631f925/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java#L69-L72) you can query early for system properties defined in `gradle.properties` files but not when not using the wrapper or using TAPI, from an IDE for example.

Proper build options (`--configuration-cache` or `--watch-fs`) don't require this change.