### PR TITLE
Add some placeholder user manual content for configuration caching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -34,7 +34,7 @@ import org.gradle.util.Path;
  */
 public class DefaultSettingsLoader implements SettingsLoader {
     public static final String BUILD_SRC_PROJECT_PATH = ":" + SettingsInternal.BUILD_SRC;
-    private SettingsProcessor settingsProcessor;
+    private final SettingsProcessor settingsProcessor;
     private final BuildLayoutFactory buildLayoutFactory;
     private final GradlePropertiesController gradlePropertiesController;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -27,8 +27,8 @@ import java.io.File;
  */
 @UsedByScanPlugin
 public class BuildLayoutConfiguration {
-    private File currentDir;
-    private boolean searchUpwards;
+    private final File currentDir;
+    private final boolean searchUpwards;
     private final File settingsFile;
     private final boolean useEmptySettings;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -124,8 +124,7 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.initialization.InternalBuildFinishedListener;
 import org.gradle.initialization.ProjectAccessListener;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
-import org.gradle.initialization.layout.BuildLayoutFactory;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -452,8 +451,8 @@ class DependencyManagementBuildScopeServices {
         return new ConnectionFailureRepositoryBlacklister();
     }
 
-    StartParameterResolutionOverride createStartParameterResolutionOverride(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory) {
-        File rootDirectory = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter)).getRootDirectory();
+    StartParameterResolutionOverride createStartParameterResolutionOverride(StartParameter startParameter, BuildLayout buildLayout) {
+        File rootDirectory = buildLayout.getRootDirectory();
         File gradleDir = new File(rootDirectory, "gradle");
         return new StartParameterResolutionOverride(startParameter, gradleDir);
     }

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -1,0 +1,30 @@
+[[config_cache]]
+= Configuration cache
+
+- What is it?
+- How to enable it?
+- How does it work?
+- Limitations?
+- Diagnosing problems?
+
+== Constraints
+
+Constraints and how to change your build
+
+[[undeclared_sys_prop_reads]]
+=== Reading system properties
+
+Plugins and build scripts should not read system properties directly using the Java APIs. Instead, these system properties should be declared as a potential build input by
+using the value supplier APIs.
+
+Before:
+
+```
+def enabled = System.getProperty("some-property")
+```
+
+After:
+
+```
+def enabled = providers.systemProperty("some-property").forUseAtConfigurationTime().present
+```

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -39,7 +39,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
 
         then:
         // TODO - use problems fixture, need to be able to tweak the problem matching as build script class name is included in the message and this is generated
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from '"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
 
         when:
         problems.withDoNotFailOnProblems()
@@ -48,7 +48,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         then:
         fixture.assertStateStored()
         // TODO - use problems fixture, need to be able to tweak the problem matching as build script class name is included in the message and this is generated
-        outputContains("- unknown location: read system property 'CI' from '")
+        outputContains("- unknown location: read system property 'CI' from class '")
         outputContains("apply = $value")
         outputContains("task = $value")
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -36,10 +36,10 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
 
         then:
         // TODO - use problems fixture, however build script class is generated
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from 'build_"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class 'build_"))
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(3)
-        failure.assertThatCause(containsNormalizedString("Read system property 'CI' from 'build_"))
+        failure.assertThatCause(containsNormalizedString("Read system property 'CI' from class 'build_"))
 
         where:
         mechanism << SystemPropertyInjection.all("CI", "false")
@@ -60,11 +60,11 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
 
         then:
         // TODO - use problems fixture, however build script class is generated
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from 'build_"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class 'build_"))
         failure.assertHasFileName("Build file '${file("buildSrc/build.gradle").absolutePath}'")
         failure.assertHasLineNumber(2)
-        failure.assertThatCause(containsNormalizedString("Read system property 'CI' from 'build_"))
-        failure.assertThatCause(containsNormalizedString("Read system property 'CI2' from 'build_"))
+        failure.assertThatCause(containsNormalizedString("Read system property 'CI' from class 'build_"))
+        failure.assertThatCause(containsNormalizedString("Read system property 'CI2' from class 'build_"))
 
         where:
         mechanism << SystemPropertyInjection.all("CI", "false")
@@ -105,7 +105,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         instantFails(*mechanism.gradleArgs)
 
         then:
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from '"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
 
         where:
         mechanism << SystemPropertyInjection.all("CI", "false")
@@ -145,13 +145,13 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         instantFails("-DCI=$defaultValue") // use the default value
 
         then:
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from '"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
 
         when:
         instantFails("-DCI=$newValue")
 
         then:
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from '"))
+        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
 
         where:
         read                                                                        | defaultValue | newValue

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
@@ -64,10 +64,10 @@ class SystemPropertyAccessListener(
         val message = StructuredMessage.build {
             text("read system property '")
             text(key)
-            text("' from ")
+            text("' from class ")
             reference(consumer)
         }
         val exception = InvalidUserCodeException(message.toString().capitalize())
-        problems.onProblem(PropertyProblem(PropertyTrace.Unknown, message, exception))
+        problems.onProblem(PropertyProblem(PropertyTrace.Unknown, message, exception, "undeclared_sys_prop_reads"))
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/PropertyProblem.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/PropertyProblem.kt
@@ -25,7 +25,8 @@ import kotlin.reflect.KClass
 data class PropertyProblem internal constructor(
     val trace: PropertyTrace,
     val message: StructuredMessage,
-    val exception: Throwable? = null
+    val exception: Throwable? = null,
+    val documentationSection: String? = null
 )
 
 


### PR DESCRIPTION

### Context

Add an unlinked user manual chapter where details about configuration caching can be added.

Allow a configuration cache problem definition to include a link to this chapter. Include this in a basic way in the console summary (but not the report yet). Only the 'undeclared system property read' problem includes a link.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
