### PR TITLE
Serialize Java lambda backed Action instances to the configuration cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
@@ -108,7 +108,6 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Dir
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5510")
-    @ToBeFixedForInstantExecution
     def "caching is disabled for task with nested property defined by Java lambda"() {
         setupTaskClassWithActionProperty()
         file("buildSrc/src/main/java/LambdaAction.java") << classWithLambda("LambdaAction", lambdaWritingFile("ACTION", "original"))
@@ -190,7 +189,7 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Dir
         """
 
         buildFile << script <<
-        """
+            """
             myTask.doLast(project.hasProperty("changed") ? LambdaActionChanged.ACTION : LambdaActionOriginal.ACTION)
         """
         def outOfDateMessage = { String enclosingClass ->
@@ -216,14 +215,13 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Dir
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5510")
-    @ToBeFixedForInstantExecution
     def "caching is disabled for task with Java lambda action"() {
         file("buildSrc/src/main/java/LambdaAction.java") << classWithLambda("LambdaAction", lambdaPrintingString("ACTION", "From Lambda: original"))
 
         setupCustomTask()
 
         buildFile <<
-        """
+            """
             task myTask(type: CustomTask) {
                 outputs.cacheIf { true }
             }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/TestLambdas.java
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/TestLambdas.java
@@ -16,8 +16,12 @@
 
 package org.gradle.internal.classpath;
 
-public class SystemPropertyAccessingThing {
-    public static String readProperty() {
-        return System.getProperty("prop");
+import org.gradle.api.Action;
+
+public class TestLambdas {
+    public static Action<StringBuilder> action(int value) {
+        return s -> {
+            s.append(value);
+        };
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -914,6 +914,48 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
     }
 
     @Unroll
+    def "restores task with action that is Java lambda"() {
+        given:
+        file("buildSrc/src/main/java/my/LambdaPlugin.java").tap {
+            parentFile.mkdirs()
+            text = """
+                package my;
+
+                import org.gradle.api.*;
+                import org.gradle.api.tasks.*;
+
+                public class LambdaPlugin implements Plugin<Project> {
+                    public void apply(Project project) {
+                        $type value = $expression;
+                        project.getTasks().register("ok", task -> {
+                            task.doLast(t -> {
+                                System.out.println(task.getName() + " value is " + value);
+                            });
+                        });
+                    }
+                }
+            """
+        }
+
+        buildFile << """
+            apply plugin: my.LambdaPlugin
+        """
+
+        when:
+        instantRun "ok"
+        instantRun "ok"
+
+        then:
+        outputContains("ok value is ${value}")
+
+        where:
+        type      | expression | value
+        "String"  | '"value"'  | "value"
+        "int"     | "12"       | "12"
+        "boolean" | "true"     | "true"
+    }
+
+    @Unroll
     def "restores task fields whose value is #kind TextResource"() {
 
         given:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -24,10 +24,6 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
 
         given:
         new JavaProjectUnderTest(testDirectory).writeBuildScript().writeSourceFiles()
-        // jacoco plugin makes jacocoTestReport mustRunAfter test, not dependsOn
-        // mustRunAfter is not captured by instant execution currently
-        // https://github.com/gradle/instant-execution/issues/86
-        buildFile << '\njacocoTestReport.dependsOn test'
         def htmlReportDir = file("build/reports/jacoco/test/html")
 
         and:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.TasksWithInputsAndOutputs
 class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
 
     def "task can have doFirst/doLast Groovy script closures"() {
-
         given:
         settingsFile << """
             include 'a', 'b'
@@ -84,7 +83,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "task can have doFirst/doLast anonymous Groovy script actions"() {
-
         given:
         buildFile << """
             tasks.register("some") {
@@ -136,7 +134,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "task can have doFirst/doLast Kotlin script lambdas"() {
-
         given:
         settingsFile << """
             include 'a', 'b'
@@ -222,7 +219,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "task with type declared in Groovy script is up-to-date when no inputs have changed"() {
-
         given:
         taskTypeWithOutputFileProperty()
         buildFile << """
@@ -255,7 +251,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "task with type declared in Kotlin script is up-to-date when no inputs have changed"() {
-
         given:
         kotlinTaskTypeWithOutputFileProperty()
         buildKotlinFile << """
@@ -288,7 +283,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "name conflicts of types declared in Groovy scripts"() {
-
         given:
         settingsFile << """include("a", "b")"""
         file("a/build.gradle") << """
@@ -320,7 +314,6 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
     }
 
     def "name conflicts of types declared in Kotlin scripts"() {
-
         given:
         settingsFile << """include("a", "b")"""
         file("a/build.gradle.kts") << """

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -87,6 +87,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.getterSignature;
 import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.signature;
+import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.unboxOrCast;
 import static org.objectweb.asm.Opcodes.AALOAD;
 import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
@@ -1292,7 +1293,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 methodVisitor.visitVarInsn(ALOAD, 1);
                 methodVisitor.visitLdcInsn(propertyIndex);
                 methodVisitor.visitInsn(AALOAD);
-                unboxOrCast(methodVisitor, propertyMetaData.getType(), Type.getType(propertyMetaData.getType()));
+                unboxOrCast(methodVisitor, Type.getType(propertyMetaData.getType()));
                 String propFieldName = propFieldName(propertyMetaData);
                 methodVisitor.visitFieldInsn(PUTFIELD, generatedType.getInternalName(), propFieldName, Type.getType(propertyMetaData.getType()).getDescriptor());
                 propertyIndex++;
@@ -1304,7 +1305,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 methodVisitor.visitVarInsn(ALOAD, 1);
                 methodVisitor.visitLdcInsn(propertyIndex + mutablePropertySize);
                 methodVisitor.visitInsn(AALOAD);
-                unboxOrCast(methodVisitor, propertyMetaData.getType(), Type.getType(propertyMetaData.getType()));
+                unboxOrCast(methodVisitor, Type.getType(propertyMetaData.getType()));
                 String propFieldName = propFieldName(propertyMetaData);
                 methodVisitor.visitFieldInsn(PUTFIELD, generatedType.getInternalName(), propFieldName, Type.getType(propertyMetaData.getType()).getDescriptor());
                 propertyIndex++;
@@ -1422,7 +1423,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
                 methodVisitor.visitMethodInsn(INVOKEINTERFACE, CONVENTION_MAPPING_TYPE.getInternalName(), "getConventionValue", RETURN_OBJECT_FROM_STRING_OBJECT_BOOLEAN, true);
 
-                unboxOrCast(methodVisitor, getter.getReturnType(), returnType);
+                unboxOrCast(methodVisitor, returnType);
 
                 methodVisitor.visitLabel(finish);
             } else {
@@ -1448,24 +1449,6 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             methodVisitor.visitInsn(returnType.getOpcode(IRETURN));
             methodVisitor.visitMaxs(0, 0);
             methodVisitor.visitEnd();
-        }
-
-        /**
-         * Unboxes or casts the value at the top of the stack.
-         */
-        private void unboxOrCast(MethodVisitor methodVisitor, Class<?> targetClass, Type targetType) {
-            if (targetClass.isPrimitive()) {
-                // Unbox value
-                Type boxedType = Type.getType(JavaReflectionUtil.getWrapperTypeForPrimitiveType(targetClass));
-                methodVisitor.visitTypeInsn(CHECKCAST, boxedType.getInternalName());
-                String valueMethodDescriptor = Type.getMethodDescriptor(targetType);
-                methodVisitor.visitMethodInsn(INVOKEVIRTUAL, boxedType.getInternalName(), targetClass.getName() + "Value", valueMethodDescriptor, false);
-            } else {
-                // Cast to return type
-                methodVisitor.visitTypeInsn(CHECKCAST,
-                    targetClass.isArray() ? "[" + targetType.getElementType().getDescriptor()
-                        : targetType.getInternalName());
-            }
         }
 
         /**

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
@@ -16,8 +16,11 @@
 
 package org.gradle.model.internal.asm;
 
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -26,6 +29,65 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 
 public class AsmClassGeneratorUtils {
+    private static final Type BOOLEAN_TYPE = Type.getType(Boolean.class);
+    private static final Type CHARACTER_TYPE = Type.getType(Character.class);
+    private static final Type BYTE_TYPE = Type.getType(ByteArrayOutputStream.class);
+    private static final Type SHORT_TYPE = Type.getType(Short.class);
+    private static final Type INTEGER_TYPE = Type.getType(Integer.class);
+    private static final Type LONG_TYPE = Type.getType(Long.class);
+    private static final Type FLOAT_TYPE = Type.getType(Float.class);
+    private static final Type DOUBLE_TYPE = Type.getType(Double.class);
+
+    private static final String RETURN_PRIMITIVE_BOOLEAN = Type.getMethodDescriptor(Type.BOOLEAN_TYPE);
+    private static final String RETURN_CHAR = Type.getMethodDescriptor(Type.CHAR_TYPE);
+    private static final String RETURN_PRIMITIVE_BYTE = Type.getMethodDescriptor(Type.BYTE_TYPE);
+    private static final String RETURN_PRIMITIVE_SHORT = Type.getMethodDescriptor(Type.SHORT_TYPE);
+    private static final String RETURN_INT = Type.getMethodDescriptor(Type.INT_TYPE);
+    private static final String RETURN_PRIMITIVE_LONG = Type.getMethodDescriptor(Type.LONG_TYPE);
+    private static final String RETURN_PRIMITIVE_FLOAT = Type.getMethodDescriptor(Type.FLOAT_TYPE);
+    private static final String RETURN_PRIMITIVE_DOUBLE = Type.getMethodDescriptor(Type.DOUBLE_TYPE);
+
+    /**
+     * Unboxes or casts the value at the top of the stack.
+     */
+    public static void unboxOrCast(MethodVisitor methodVisitor, Type targetType) {
+        switch (targetType.getSort()) {
+            case Type.BOOLEAN:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, BOOLEAN_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, BOOLEAN_TYPE.getInternalName(), "booleanValue", RETURN_PRIMITIVE_BOOLEAN, false);
+                return;
+            case Type.CHAR:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, CHARACTER_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, CHARACTER_TYPE.getInternalName(), "charValue", RETURN_CHAR, false);
+                return;
+            case Type.BYTE:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, BYTE_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, BYTE_TYPE.getInternalName(), "byteValue", RETURN_PRIMITIVE_BYTE, false);
+                break;
+            case Type.SHORT:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, SHORT_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, SHORT_TYPE.getInternalName(), "shortValue", RETURN_PRIMITIVE_SHORT, false);
+                break;
+            case Type.INT:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, INTEGER_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, INTEGER_TYPE.getInternalName(), "intValue", RETURN_INT, false);
+                return;
+            case Type.LONG:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, LONG_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, LONG_TYPE.getInternalName(), "longValue", RETURN_PRIMITIVE_LONG, false);
+                return;
+            case Type.FLOAT:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, FLOAT_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, FLOAT_TYPE.getInternalName(), "floatValue", RETURN_PRIMITIVE_FLOAT, false);
+                return;
+            case Type.DOUBLE:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, DOUBLE_TYPE.getInternalName());
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, DOUBLE_TYPE.getInternalName(), "doubleValue", RETURN_PRIMITIVE_DOUBLE, false);
+                return;
+            default:
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, targetType.getInternalName());
+        }
+    }
 
     /**
      * Generates the signature for the given constructor

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -99,12 +99,12 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1484,6 +1484,10 @@ public class AsmBackedClassGeneratorTest {
             return 12L;
         }
 
+        public int[] getIntsProperty() {
+            return new int[0];
+        }
+
         public String getReturnValueProperty() {
             return "value";
         }
@@ -1847,6 +1851,14 @@ public class AsmBackedClassGeneratorTest {
         double getProp6();
 
         void setProp6(double value);
+
+        float getProp7();
+
+        void setProp7(float value);
+
+        char getProp8();
+
+        void setProp8(char value);
     }
 
     public interface InterfaceFileCollectionBean {


### PR DESCRIPTION

### Context

During build logic instrumentation, change `Action` implementations that are backed by Java lambdas so they are `Serializable` and can be written to the configuration cache and read back out again.

In this PR, the instrumentation is only applied for `Action` and only to user build logic code.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
