### PR TITLE
Fix potential NPE in NodeState exclude management

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -84,6 +84,7 @@ public class NodeState implements DependencyGraphNode {
     private final boolean dependenciesMayChange;
     private boolean doesNotHaveDependencies;
 
+    @Nullable
     ExcludeSpec previousTraversalExclusions;
 
     // In opposite to outgoing edges, virtual edges are for now pretty rare, so they are created lazily


### PR DESCRIPTION
This is a consequence of a too eager removal of a null check, induced by
a missing @Nullable annotation.