### PR TITLE
De-incubate Java 13 and 14 enum values

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -48,7 +48,6 @@ public enum JavaVersion {
      *
      * @since 6.0
      */
-    @Incubating
     VERSION_13,
 
     /**
@@ -56,7 +55,6 @@ public enum JavaVersion {
      *
      * @since 6.3
      */
-    @Incubating
     VERSION_14,
 
     /**


### PR DESCRIPTION
After all, these Java versions are GA and supported by Gradle!