### PR TITLE
Resolve unstable dependency resolution ordering

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -33,7 +33,7 @@ public class VirtualPlatformState {
     private final ModuleResolveState platformModule;
     private final ResolveOptimizations resolveOptimizations;
 
-    private final Set<ModuleResolveState> participatingModules = Sets.newHashSet();
+    private final Set<ModuleResolveState> participatingModules = Sets.newLinkedHashSet();
     private final List<EdgeState> orphanEdges = Lists.newArrayListWithExpectedSize(2);
 
     private boolean hasForcedParticipatingModule;


### PR DESCRIPTION
The use of a `HashSet` to store virtual platform participants is a
problem because the information is also used to determine the
"dependencies" of the platform.
The consequence was a difference in resolution ordering.