### PR TITLE
Add retries for SocketException

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.repositories.transport;
 
 import org.apache.http.HttpStatus;
-import org.apache.http.conn.HttpHostConnectException;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 
@@ -36,9 +35,7 @@ public class NetworkingIssueVerifier {
      * </ul>
      */
     public static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
-        if (failure instanceof SocketException
-                || failure instanceof SocketTimeoutException
-                || failure instanceof HttpHostConnectException) {
+        if (failure instanceof SocketException || failure instanceof SocketTimeoutException) {
             return true;
         }
         if (failure instanceof DefaultMultiCauseException) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
@@ -21,6 +21,7 @@ import org.apache.http.conn.HttpHostConnectException;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.List;
 
@@ -35,7 +36,9 @@ public class NetworkingIssueVerifier {
      * </ul>
      */
     public static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
-        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
+        if (failure instanceof SocketException
+                || failure instanceof SocketTimeoutException
+                || failure instanceof HttpHostConnectException) {
             return true;
         }
         if (failure instanceof DefaultMultiCauseException) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -53,6 +53,8 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
     @Shared
     def runtimeError = new RuntimeException('Something went wrong')
     @Shared
+    def socketError = new SocketException()
+    @Shared
     def connectTimeout = new SocketTimeoutException()
     @Shared
     def cannotConnect = new HttpHostConnectException(null, null)
@@ -279,6 +281,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
             retries << [ret, cannotConnect, ret]
             retries << [ret, tooManyRequests, ret]
             retries << [ret, clientTimeout, ret]
+            retries << [ret, socketError, ret]
             // retries on server errors
             if (ret < 3) {
                 // testing 1 and 2 is good enough coverage

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
@@ -46,6 +46,7 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
 
         where:
         ex << [
+            new SocketException("something went wrong"),
             new SocketTimeoutException("something went wrong"),
             new HttpHostConnectException(new IOException("something went wrong"), null, null),
             new HttpErrorStatusCodeException("something", "something", 503, "something"),
@@ -71,6 +72,7 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
 
         where:
         ex << [
+                new SocketException("something went wrong"),
                 new SocketTimeoutException("something went wrong"),
                 new HttpHostConnectException(new IOException("something went wrong"), null, null),
                 new HttpErrorStatusCodeException("something", "something", 503, "something"),

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
@@ -33,6 +33,7 @@ class NetworkingIssueVerifierTest extends Specification {
 
         where:
         description                                                 | failure
+        "SocketException"                                           | new SocketException()
         "SocketTimeoutException"                                    | new SocketTimeoutException()
         "HttpHostConnectException"                                  | new HttpHostConnectException(new IOException("something went wrong"), null, null)
         "DefaultMultiCauseException"                                | new DefaultMultiCauseException("something went wrong", new SocketTimeoutException())


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #8264

### Context
This will allow to improve Gradle build reliability when downloading dependencies

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
