### PR TITLE
Add inputs for sample tests

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -95,7 +95,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
  */
 fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
     tasks.withType<IntegrationTest>() {
-        inputs.files(sampleDirs.map { rootProject.fileTree(it) }.toTypedArray())
+        inputs.files(rootProject.files(it))
             .withPropertyName("autoTestedSamples")
             .withPathSensitivity(PathSensitivity.RELATIVE)
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -93,7 +93,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
 /**
  * Distributed test requires all dependencies to be declared
  */
-fun Project.makeIntegrationTestsDependOnSampleDir(vararg sampleDirs: String) {
+fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
     tasks.withType<IntegrationTest>() {
         inputs.files(sampleDirs.map { rootProject.fileTree(it) }.toTypedArray())
             .withPropertyName("autoTestedSamples")

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -96,7 +96,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
 fun Project.makeIntegrationTestsDependOnSampleDir(vararg sampleDirs: String) {
     tasks.withType<IntegrationTest>() {
         inputs.files(sampleDirs.map { rootProject.fileTree(it) }.toTypedArray())
-            .withPropertyName("autoSampleTestFiles")
+            .withPropertyName("autoTestedSamples")
             .withPathSensitivity(PathSensitivity.RELATIVE)
     }
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -90,16 +90,19 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
         extraConfig.execute(this)
     }
 
+
 /**
  * Distributed test requires all dependencies to be declared
  */
 fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
     tasks.withType<IntegrationTest>() {
-        inputs.files(rootProject.files(it))
+        systemProperty("autoTestedSamplesDeclared", "true")
+        inputs.files(rootProject.files(sampleDirs))
             .withPropertyName("autoTestedSamples")
             .withPathSensitivity(PathSensitivity.RELATIVE)
     }
 }
+
 
 private
 fun IntegrationTest.addDebugProperties() {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -96,7 +96,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
  */
 fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
     tasks.withType<IntegrationTest>() {
-        systemProperty("autoTestedSamplesDeclared", "true")
+        systemProperty("declaredSampleInputs", sampleDirs.joinToString(";"))
         inputs.files(rootProject.files(sampleDirs))
             .withPropertyName("autoTestedSamples")
             .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/subprojects/ide-native/ide-native.gradle.kts
+++ b/subprojects/ide-native/ide-native.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -55,3 +56,5 @@ dependencies {
     testFixturesImplementation(library("guava"))
     testFixturesImplementation(testFixtures(project(":ide")))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/ide-native/src/main")

--- a/subprojects/ide-native/ide-native.gradle.kts
+++ b/subprojects/ide-native/ide-native.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -57,4 +57,4 @@ dependencies {
     testFixturesImplementation(testFixtures(project(":ide")))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/ide-native/src/main")
+integrationTestUsesSampleDir("subprojects/ide-native/src/main")

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -1,4 +1,6 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 /*
  * Copyright 2010 the original author or authors.
  *
@@ -82,3 +84,5 @@ classycle {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/ide/src/main")

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -1,5 +1,5 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 /*
  * Copyright 2010 the original author or authors.
@@ -85,4 +85,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/ide/src/main")
+integrationTestUsesSampleDir("subprojects/ide/src/main")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
@@ -18,9 +18,10 @@ package org.gradle.integtests.fixtures
 
 class AbstractAutoTestedSamplesTest extends AbstractIntegrationTest {
 
-     def util = new AutoTestedSamplesUtil()
+    def util = new AutoTestedSamplesUtil()
 
-     void runSamplesFrom(String dir) {
+    void runSamplesFrom(String dir) {
+        assert Boolean.getBoolean("autoTestedSamplesDeclared"): "Must declare samples dir as inputs!"
         util.findSamples(dir) { file, sample, tagSuffix ->
             println "Found sample: ${sample.split("\n")[0]} (...) in $file"
             def buildFile = testFile('build.gradle')

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
@@ -20,8 +20,14 @@ class AbstractAutoTestedSamplesTest extends AbstractIntegrationTest {
 
     def util = new AutoTestedSamplesUtil()
 
+    static void assertDeclaredAsInput(String dir) {
+        String inputs = System.getProperty("declaredSampleInputs")
+        assert inputs: "Must declare samples dir as inputs!"
+        assert inputs.split(";").contains(dir): "Must declare input: $dir"
+    }
+
     void runSamplesFrom(String dir) {
-        assert Boolean.getBoolean("autoTestedSamplesDeclared"): "Must declare samples dir as inputs!"
+        assertDeclaredAsInput(dir)
         util.findSamples(dir) { file, sample, tagSuffix ->
             println "Found sample: ${sample.split("\n")[0]} (...) in $file"
             def buildFile = testFile('build.gradle')

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -15,6 +15,8 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -76,3 +78,6 @@ dependencies {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+
+makeIntegrationTestsDependOnSampleDir("subprojects/ivy/src/main")

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -80,4 +80,4 @@ testFilesCleanup {
 }
 
 
-makeIntegrationTestsDependOnSampleDir("subprojects/ivy/src/main")
+integrationTestUsesSampleDir("subprojects/ivy/src/main")

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -80,5 +80,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-
 integrationTestUsesSampleDir("subprojects/language-java/src/main")

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -78,3 +79,6 @@ classycle {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+
+integrationTestUsesSampleDir("subprojects/language-java/src/main")

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -81,3 +82,6 @@ dependencies {
 classycle {
     excludePatterns.set(listOf("org/gradle/language/nativeplatform/internal/**"))
 }
+
+
+makeIntegrationTestsDependOnSampleDir("subprojects/language-native/src/main")

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -84,4 +84,4 @@ classycle {
 }
 
 
-makeIntegrationTestsDependOnSampleDir("subprojects/language-native/src/main")
+integrationTestUsesSampleDir("subprojects/language-native/src/main")

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -83,5 +83,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/language/nativeplatform/internal/**"))
 }
 
-
 integrationTestUsesSampleDir("subprojects/language-native/src/main")

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -89,3 +90,5 @@ classycle {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/maven/src/main")

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -91,4 +91,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/maven/src/main")
+integrationTestUsesSampleDir("subprojects/maven/src/main")

--- a/subprojects/platform-base/platform-base.gradle.kts
+++ b/subprojects/platform-base/platform-base.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -36,3 +38,5 @@ dependencies {
 classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/platform-base/src/main")

--- a/subprojects/platform-base/platform-base.gradle.kts
+++ b/subprojects/platform-base/platform-base.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -39,4 +39,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/platform-base/src/main")
+integrationTestUsesSampleDir("subprojects/platform-base/src/main")

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -40,3 +43,5 @@ dependencies {
 strictCompile {
     ignoreDeprecations() // most of this project has been deprecated
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/platform-jvm/src/main")

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 
 plugins {
@@ -44,4 +44,4 @@ strictCompile {
     ignoreDeprecations() // most of this project has been deprecated
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/platform-jvm/src/main")
+integrationTestUsesSampleDir("subprojects/platform-jvm/src/main")

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -78,3 +79,5 @@ classycle {
         "org/gradle/nativeplatform/toolchain/internal/**"
     ))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/platform-native/src/main")

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -80,4 +80,4 @@ classycle {
     ))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/platform-native/src/main")
+integrationTestUsesSampleDir("subprojects/platform-native/src/main")

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -114,3 +115,5 @@ tasks.withType<IntegrationTest>().configureEach {
         classpath = integTestRuntimeResourcesClasspath + classpath
     }
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/platform-play/src/main")

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -116,4 +116,4 @@ tasks.withType<IntegrationTest>().configureEach {
     }
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/platform-play/src/main")
+integrationTestUsesSampleDir("subprojects/platform-play/src/main")

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -75,3 +76,5 @@ dependencies {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/plugin-development/src/main")

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -77,4 +77,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/plugin-development/src/main")
+integrationTestUsesSampleDir("subprojects/plugin-development/src/main")

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -1,4 +1,6 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 /*
  * Copyright 2010 the original author or authors.
  *
@@ -108,3 +110,5 @@ sourceSets.main {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/plugins/src/main")

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -1,5 +1,5 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 /*
  * Copyright 2010 the original author or authors.
@@ -111,4 +111,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/plugins/src/main")
+integrationTestUsesSampleDir("subprojects/plugins/src/main")

--- a/subprojects/publish/publish.gradle.kts
+++ b/subprojects/publish/publish.gradle.kts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -42,3 +44,5 @@ dependencies {
     integTestRuntimeOnly(project(":ivy"))
     integTestRuntimeOnly(project(":maven"))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/publish/src/main")

--- a/subprojects/publish/publish.gradle.kts
+++ b/subprojects/publish/publish.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -45,4 +45,4 @@ dependencies {
     integTestRuntimeOnly(project(":maven"))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/publish/src/main")
+integrationTestUsesSampleDir("subprojects/publish/src/main")

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.internal.java
@@ -31,3 +32,5 @@ tasks.withType<IntegrationTest>().configureEach {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/core-api/src/main/java", "subprojects/core/src/main/java")

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.internal.java
@@ -33,4 +33,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/core-api/src/main/java", "subprojects/core/src/main/java")
+integrationTestUsesSampleDir("subprojects/core-api/src/main/java", "subprojects/core/src/main/java")

--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -69,3 +70,5 @@ classycle {
 tasks.named<Test>("integTest") {
     jvmArgs("-XX:MaxPermSize=1500m") // AntInProcessScalaCompilerIntegrationTest needs lots of permgen
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/scala/src/main")

--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -71,4 +71,4 @@ tasks.named<Test>("integTest") {
     jvmArgs("-XX:MaxPermSize=1500m") // AntInProcessScalaCompilerIntegrationTest needs lots of permgen
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/scala/src/main")
+integrationTestUsesSampleDir("subprojects/scala/src/main")

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -50,3 +52,5 @@ strictCompile {
 classycle {
     excludePatterns.set(listOf("org/gradle/plugins/signing/**"))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/signing/src/main")

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -53,4 +53,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/plugins/signing/**"))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/signing/src/main")
+integrationTestUsesSampleDir("subprojects/signing/src/main")

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -68,3 +70,5 @@ strictCompile {
 classycle {
     excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/testing-base/src/main")

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -71,4 +71,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/testing-base/src/main")
+integrationTestUsesSampleDir("subprojects/testing-base/src/main")

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -81,4 +81,4 @@ tasks.named<Test>("test").configure {
     exclude("org/gradle/api/internal/tasks/testing/junit/ABroken*TestClass*.*")
 }
 
-makeIntegrationTestsDependOnSampleDir("subprojects/testing-jvm/src/main")
+integrationTestUsesSampleDir("subprojects/testing-jvm/src/main")

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+
 plugins {
     gradlebuild.distribution.`plugins-api-java`
 }
@@ -78,3 +80,5 @@ tasks.named<Test>("test").configure {
     exclude("org/gradle/api/internal/tasks/testing/junit/ATestClass*.*")
     exclude("org/gradle/api/internal/tasks/testing/junit/ABroken*TestClass*.*")
 }
+
+makeIntegrationTestsDependOnSampleDir("subprojects/testing-jvm/src/main")

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -17,6 +17,7 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
+import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
 
 plugins {
     gradlebuild.distribution.`core-api-java`
@@ -108,3 +109,4 @@ tasks.withType<IntegrationTest>().configureEach {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+makeIntegrationTestsDependOnSampleDir("subprojects/tooling-api/src/main")

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -17,7 +17,7 @@
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
-import org.gradle.gradlebuild.test.integrationtests.makeIntegrationTestsDependOnSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     gradlebuild.distribution.`core-api-java`
@@ -109,4 +109,4 @@ tasks.withType<IntegrationTest>().configureEach {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
-makeIntegrationTestsDependOnSampleDir("subprojects/tooling-api/src/main")
+integrationTestUsesSampleDir("subprojects/tooling-api/src/main")


### PR DESCRIPTION
### Context

Some tests depend on sample directories (for example this one https://github.com/gradle/gradle/blob/96eecdf0f6c6c942470678ef4e2ce325ac3851fa/subprojects/ivy/src/integTest/groovy/org/gradle/api/AutoTestedSamplesIvyIntegrationTest.groovy#L26) but didn't mark them as inputs. This breaks distributed test.