### PR TITLE
Avoid resolving a repository url eagerly

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryContentFilteringIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryContentFilteringIntegrationTest.groovy
@@ -655,7 +655,7 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
         """
 
         expect:
-        succeeds("tasks")
+        succeeds("help")
     }
 
     static String checkConfIsUnresolved() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryContentFilteringIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryContentFilteringIntegrationTest.groovy
@@ -26,7 +26,7 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
 
     def setup() {
         settingsFile << "rootProject.name = 'test'"
-        buildFile << """                      
+        buildFile << """
             configurations {
                 conf
             }
@@ -316,7 +316,7 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
 
         given:
         repositories {
-            maven("""content { 
+            maven("""content {
                 onlyForConfigurations("conf2")
             }""")
         }
@@ -330,7 +330,7 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
             }
             tasks.register("verify") {
                 doFirst {
-                    $check1               
+                    $check1
                     $check2
                 }
             }
@@ -360,7 +360,7 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
         """
         given:
         repositories {
-            maven("""content { 
+            maven("""content {
                 onlyForAttribute(colorAttribute, 'red')
             }""")
             ivy()
@@ -638,6 +638,24 @@ class RepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyRe
                 snapshot('org:foo:1.0-SNAPSHOT', latestSnapshot.uniqueSnapshotVersion, 'latest.integration')
             }
         }
+    }
+
+    def "mavenContent does not resolve repository url eagerly"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = { throw new RuntimeException("url resolved") }
+                    mavenContent { snapshotsOnly() }
+                }
+            }
+            dependencies {
+                conf "org:foo:latest.integration"
+            }
+        """
+
+        expect:
+        succeeds("tasks")
     }
 
     static String checkConfIsUnresolved() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -110,7 +110,7 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
     }
 
     protected RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultRepositoryContentDescriptor(getDisplayName());
+        return new DefaultRepositoryContentDescriptor(this::getDisplayName);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -349,7 +349,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     @Override
     protected RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultMavenRepositoryContentDescriptor(getDisplayName());
+        return new DefaultMavenRepositoryContentDescriptor(this::getDisplayName);
     }
 
     private static class DefaultDescriber implements Transformer<String, MavenArtifactRepository> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
@@ -19,12 +19,14 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.internal.Actions;
 
+import java.util.function.Supplier;
+
 class DefaultMavenRepositoryContentDescriptor extends DefaultRepositoryContentDescriptor implements MavenRepositoryContentDescriptor {
     private boolean snapshots = true;
     private boolean releases = true;
 
-    public DefaultMavenRepositoryContentDescriptor(String repositoryName) {
-        super(repositoryName);
+    public DefaultMavenRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier) {
+        super(repositoryNameSupplier);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorInternal {
@@ -42,16 +43,16 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private boolean locked;
 
     private Action<? super ArtifactResolutionDetails> cachedAction;
-    private final String repositoryName;
+    private final Supplier<String> repositoryNameSupplier;
 
-    public DefaultRepositoryContentDescriptor(String repositoryName) {
-        this.repositoryName = repositoryName;
+    public DefaultRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier) {
+        this.repositoryNameSupplier = repositoryNameSupplier;
     }
 
     private void assertMutable() {
         if (locked) {
             throw new IllegalStateException("Cannot mutate content repository descriptor '" +
-                repositoryName +
+                repositoryNameSupplier.get() +
                 "' after repository has been used");
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Unroll
 class DefaultRepositoryContentDescriptorTest extends Specification {
 
     @Subject
-    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor("repoName")
+    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor({ throw new RuntimeException("only required in error cases") })
 
     @Unroll
     def "reasonable error message when input is incorrect (include string)"() {
@@ -355,6 +355,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
     def "cannot update repository content filter after resolution happens"() {
         given:
+        def descriptor = new DefaultRepositoryContentDescriptor({ "repoName" })
         descriptor.toContentFilter()
 
         when:


### PR DESCRIPTION
Given we only need the repository name for error messages, there is
no need to resolve it directly (which also resolves the url of the
repository which may be a provider).

Fixes #13152