### PR TITLE
Move `isWatchFileSystem` to StartParameterInternal

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CodeNarc
 import org.gradle.api.reporting.Reporting
@@ -269,7 +270,7 @@ open class BuildScanPlugin : Plugin<Project> {
 
     private
     fun Project.extractVfsRetentionData() {
-        val watchFileSystem = project.gradle.startParameter.isWatchFileSystem
+        val watchFileSystem = (project.gradle.startParameter as StartParameterInternal).isWatchFileSystem
         buildScan.value(watchFileSystemName, watchFileSystem.toString())
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -91,7 +91,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean refreshDependencies;
     private boolean buildCacheEnabled;
     private boolean buildCacheDebugLogging;
-    private boolean watchFileSystem;
     private boolean configureOnDemand;
     private boolean continuous;
     private List<File> includedBuilds = new ArrayList<>();
@@ -716,26 +715,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public void setBuildCacheDebugLogging(boolean buildCacheDebugLogging) {
         this.buildCacheDebugLogging = buildCacheDebugLogging;
-    }
-
-    /**
-     * Whether watching the file system for faster up-to-date checking is enabled.
-     *
-     * @since 6.5
-     */
-    @Incubating
-    public boolean isWatchFileSystem() {
-        return watchFileSystem;
-    }
-
-    /**
-     * Whether watching the file system for faster up-to-date checking is enabled.
-     *
-     * @since 6.5
-     */
-    @Incubating
-    public void setWatchFileSystem(boolean watchFileSystem) {
-        this.watchFileSystem = watchFileSystem;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -26,6 +26,8 @@ import java.util.Set;
 public class StartParameterInternal extends StartParameter implements Deprecatable {
     private final Deprecatable deprecationHandler = new LoggingDeprecatable();
 
+    private boolean watchFileSystem;
+
     @Override
     public StartParameter newInstance() {
         return prepareNewInstance(new StartParameterInternal());
@@ -34,6 +36,13 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
     @Override
     public StartParameter newBuild() {
         return prepareNewBuild(new StartParameterInternal());
+    }
+
+    @Override
+    protected StartParameter prepareNewBuild(StartParameter startParameter) {
+        StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
+        p.watchFileSystem = watchFileSystem;
+        return p;
     }
 
     @Override
@@ -73,5 +82,13 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
 
     public void setSearchUpwardsWithoutDeprecationWarning(boolean searchUpwards) {
         super.searchUpwards = searchUpwards;
+    }
+
+    public boolean isWatchFileSystem() {
+        return watchFileSystem;
+    }
+
+    public void setWatchFileSystem(boolean watchFileSystem) {
+        this.watchFileSystem = watchFileSystem;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.execution.internal.TaskInputsListeners;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.TaskExecutionModeResolver;
 import org.gradle.api.internal.changedetection.changes.DefaultTaskExecutionModeResolver;
@@ -136,15 +137,15 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         TaskSnapshotter taskSnapshotter,
         WorkExecutor<ExecutionRequestContext, CachingResult> workExecutor
     ) {
-
-        ExecuteActionsTaskExecuter.VfsInvalidationStrategy vfsInvalidationStrategy = VirtualFileSystemServices.isPartialInvalidationEnabled(startParameter)
+        StartParameterInternal startParameterInternal = (StartParameterInternal) startParameter;
+        ExecuteActionsTaskExecuter.VfsInvalidationStrategy vfsInvalidationStrategy = VirtualFileSystemServices.isPartialInvalidationEnabled(startParameterInternal)
             ? ExecuteActionsTaskExecuter.VfsInvalidationStrategy.PARTIAL
             : ExecuteActionsTaskExecuter.VfsInvalidationStrategy.COMPLETE;
 
         // TODO: The incubation message should be printed in VirtualFileSystemServices.
         //   The problem is that `RootBuildLifecycleListener.afterStart` is called to early to have the system properties from gradle.properties available
         //   We log the message now here as a workaround.
-        if (vfsInvalidationStrategy == ExecuteActionsTaskExecuter.VfsInvalidationStrategy.PARTIAL && !startParameter.isWatchFileSystem()) {
+        if (vfsInvalidationStrategy == ExecuteActionsTaskExecuter.VfsInvalidationStrategy.PARTIAL && !startParameterInternal.isWatchFileSystem()) {
             IncubationLogger.incubatingFeatureUsed("Partial virtual file system invalidation");
         }
         TaskExecuter executer = new ExecuteActionsTaskExecuter(

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.service.scopes;
 
-import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -34,7 +34,7 @@ class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListe
 
     @Override
     public void afterStart(GradleInternal gradle) {
-        StartParameter startParameter = gradle.getStartParameter();
+        StartParameterInternal startParameter = (StartParameterInternal) gradle.getStartParameter();
         if (VirtualFileSystemServices.isDeprecatedVfsRetentionPropertyPresent(startParameter)) {
             DeprecationLogger.deprecateIndirectUsage("Using the system property " + VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY + " to enable watching the file system")
                 .withAdvice("Use the gradle property " + StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY + " instead.")
@@ -55,6 +55,6 @@ class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListe
 
     @Override
     public void beforeComplete(GradleInternal gradle) {
-        virtualFileSystem.beforeBuildFinished(gradle.getStartParameter().isWatchFileSystem());
+        virtualFileSystem.beforeBuildFinished(((StartParameterInternal) gradle.getStartParameter()).isWatchFileSystem());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildScopeFileTimeStampInspector;
 import org.gradle.api.internal.changedetection.state.CachingFileHasher;
@@ -113,7 +114,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
      */
     public static final String VFS_DROP_PROPERTY = "org.gradle.unsafe.vfs.drop";
 
-    public static boolean isPartialInvalidationEnabled(StartParameter startParameter) {
+    public static boolean isPartialInvalidationEnabled(StartParameterInternal startParameter) {
         return startParameter.isWatchFileSystem()
             || isSystemPropertyEnabled(VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY, startParameter.getSystemPropertiesArgs());
     }
@@ -257,6 +258,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             StringInterner stringInterner,
             VirtualFileSystem gradleUserHomeVirtualFileSystem
         ) {
+            StartParameterInternal startParameterInternal = (StartParameterInternal) startParameter;
             VirtualFileSystem buildSessionsScopedVirtualFileSystem = new DefaultVirtualFileSystem(
                 hasher,
                 stringInterner,
@@ -269,7 +271,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 additiveCacheLocations,
                 gradleUserHomeVirtualFileSystem,
                 buildSessionsScopedVirtualFileSystem,
-                startParameter::isWatchFileSystem
+                startParameterInternal::isWatchFileSystem
             );
 
             listenerManager.addListener(new RootBuildLifecycleListener() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.service.scopes
 
-import org.gradle.StartParameter
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.initialization.RootBuildLifecycleListener
 import org.gradle.internal.event.ListenerManager
@@ -36,7 +36,7 @@ class VirtualFileSystemServicesTest extends Specification {
     def fileHasher = Mock(FileHasher)
     def fileSystem = Mock(FileSystem)
     def listenerManager = Mock(ListenerManager)
-    def startParameter = Mock(StartParameter)
+    def startParameter = Mock(StartParameterInternal)
     def stringInterner = Mock(StringInterner)
     def gradle = Mock(GradleInternal)
 


### PR DESCRIPTION
so it is not exposed via the public API.