### PR TITLE
Fix more issues for distributed test

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -4,11 +4,13 @@ import accessors.groovy
 import accessors.java
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.tasks.ClasspathNormalizer
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.gradlebuild.versioning.buildVersion
 
 
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
@@ -99,6 +101,44 @@ fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
         systemProperty("declaredSampleInputs", sampleDirs.joinToString(";"))
         inputs.files(rootProject.files(sampleDirs))
             .withPropertyName("autoTestedSamples")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    }
+}
+
+
+fun Project.integrationTestUsesKotlinDslPlugins() {
+    tasks.withType<IntegrationTest>().configureEach {
+        inputs.dir(project(":kotlinDslPlugins").buildDir.resolve("repository"))
+            .withPropertyName("localRepository")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    }
+}
+
+
+fun Project.integrationTestUsesToolingApiFatJar() {
+    tasks.withType<IntegrationTest>().configureEach {
+        inputs.file(project(":toolingApi").buildDir.resolve("shaded-jar/gradle-tooling-api-shaded-${rootProject.buildVersion.baseVersion}.jar"))
+            .withPropertyName("fatToolingApiJar")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+            .withNormalizer(ClasspathNormalizer::class)
+    }
+}
+
+
+fun Project.integrationTestUsesToolingApiJar() {
+    tasks.withType<IntegrationTest>().configureEach {
+        inputs.dir(rootProject.buildDir.resolve("repo"))
+            .withPropertyName("toolingApiJarRepo")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    }
+}
+
+
+// ""/bin/all/docs/src
+fun Project.integrationTestUsesDistribution(type: String = "bin") {
+    tasks.withType<IntegrationTest>().configureEach {
+        inputs.file(rootProject.buildDir.resolve("distributions/gradle-${rootProject.buildVersion.baseVersion}${if (type == "") ".jar" else "-$type.zip"}"))
+            .withPropertyName("distribution")
             .withPathSensitivity(PathSensitivity.RELATIVE)
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScriptExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScriptExecuter.groovy
@@ -34,6 +34,7 @@ class ScriptExecuter {
         } else {
             executable = "${workingDir}/${executable}"
         }
+        builder.environment("JAVA_HOME", System.getProperty("java.home"))
         return builder.build()
     }
 

--- a/subprojects/kotlin-dsl-integ-tests/kotlin-dsl-integ-tests.gradle.kts
+++ b/subprojects/kotlin-dsl-integ-tests/kotlin-dsl-integ-tests.gradle.kts
@@ -17,6 +17,7 @@
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import plugins.futurePluginVersionsFile
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesKotlinDslPlugins
 
 plugins {
     gradlebuild.internal.kotlin
@@ -86,3 +87,5 @@ tasks {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+integrationTestUsesKotlinDslPlugins()

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -20,6 +20,7 @@ import codegen.GenerateKotlinDslPluginsExtensions
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import plugins.bundledGradlePlugin
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesKotlinDslPlugins
 
 plugins {
     gradlebuild.portalplugin.kotlin
@@ -153,3 +154,5 @@ afterEvaluate {
         it.name == "java"
     }
 }
+
+integrationTestUsesKotlinDslPlugins()

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/DistributionTestExecHandleBuilder.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/DistributionTestExecHandleBuilder.groovy
@@ -39,6 +39,7 @@ class DistributionTestExecHandleBuilder {
 
         this.setExecutable("${baseDirName}/playBinary/bin/playBinary${extension}")
         this.environment("PLAY_BINARY_OPTS": "-Dhttp.port=${port}")
+        this.environment("JAVA_HOME", System.getProperty("java.home"))
         this.setWorkingDir(baseDirName)
     }
 

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -16,6 +16,8 @@
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesToolingApiFatJar
+import org.gradle.gradlebuild.versioning.buildVersion
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -77,4 +79,5 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
+integrationTestUsesToolingApiFatJar()
 integrationTestUsesSampleDir("subprojects/plugin-development/src/main")

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -18,6 +18,7 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesToolingApiJar
 
 plugins {
     gradlebuild.distribution.`core-api-java`
@@ -110,3 +111,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 integrationTestUsesSampleDir("subprojects/tooling-api/src/main")
+integrationTestUsesToolingApiJar()

--- a/subprojects/wrapper/wrapper.gradle.kts
+++ b/subprojects/wrapper/wrapper.gradle.kts
@@ -15,6 +15,7 @@
  */
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import java.util.jar.Attributes
+import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesDistribution
 
 plugins {
     gradlebuild.distribution.`core-api-java`
@@ -63,3 +64,5 @@ tasks.register<Jar>("executableJar") {
 tasks.withType<IntegrationTest>().configureEach {
     binaryDistributions.binZipRequired = true
 }
+
+integrationTestUsesDistribution()


### PR DESCRIPTION
We found several issues breaking distributed test:

- ScriptExecuter not using same java version.
- Task depends on tooling api fat jar but not declares inputs.

This commit fixes these issues.

