### PR TITLE
Fix internal documentation link

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/authoring_maintainable_build_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/authoring_maintainable_build_scripts.adoc
@@ -233,7 +233,7 @@ Under no circumstance should you add the password to the build script in plain t
 Those files usually live in a version control repository and can be viewed by anyone that has access to it.
 
 Passwords together with any other sensitive data should be kept external from the version controlled project files.
-Gradle allows credentials to be externalized via <<build_environment.html#sec:gradle_configuration_properties,Gradle properties>> - they can be stored in the `gradle.properties` file that
+Gradle allows credentials to be externalized via <<build_environment#sec:gradle_configuration_properties,Gradle properties>> - they can be stored in the `gradle.properties` file that
 resides in the user's home directory or injected to the build using environment variables.
 
 Even better - consider encrypting your passwords. At the moment Gradle does not provide a built-in mechanism for encrypting, storing and accessing passwords.


### PR DESCRIPTION
`docs:check` task was failing with:
```
# Valid links are:
# * Inside the same file: <<(#)section-name(,text)>>
# * To a different file: <<other-file(.adoc)#(section-name),text>> - Note that the # is mandatory, otherwise the link is considered to be inside the file!
#
# The checker does not handle implicit section names, so they must be explicit and declared as: [[section-name]]
ERROR: authoring_maintainable_build_scripts.adoc:236 Looking for file named build_environment.html.adoc
    Gradle allows credentials to be externalized via <<build_environment.html#sec:gradle_configuration_properties,Gradle properties>> - they can be stored in the `gradle.properties` file that
```

The link in generated documentation was working fine though. Removed the HTML suffix as per the error message - the link still works in the generated docs and the `docs:check` task passes.