### PR TITLE
Re-enable publishing credentials sample

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -492,8 +492,7 @@ samples {
             category = "Build organization"
         }
 
-        // temporarily disabled - tests failing after merge - investigating
-        /*publishingCredentials {
+        publishingCredentials {
             sampleDirectory = samplesRoot.dir("credentials-handling/publishing-credentials")
             description = "Publish to a password protected repository"
             category = "Using Credentials"
@@ -501,7 +500,7 @@ samples {
                 from(templates.javaListLibrary)
                 from(templates.javaUtilitiesLibrary)
             }
-        }*/
+        }
 
         credentialsForExternalToolViaStdin {
             sampleDirectory = samplesRoot.dir("credentials-handling/pass-credentials-to-external-tool-via-stdin")

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/common/maven-repository-stub/src/main/java/com/example/MavenRepositoryStub.java
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/common/maven-repository-stub/src/main/java/com/example/MavenRepositoryStub.java
@@ -26,7 +26,7 @@ public class MavenRepositoryStub {
         SERVER.stubFor(put(anyUrl()).withBasicAuth(USERNAME, PASSWORD).willReturn(ok()));
         SERVER.stubFor(get(anyUrl()).withBasicAuth(USERNAME, PASSWORD).willReturn(notFound()));
 
-        return String.format("http://localhost:%d", SERVER.port());
+        return String.format("http://127.0.0.1:%d", SERVER.port());
     }
 
     public static void stop() {

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
@@ -1,6 +1,4 @@
 commands: [{
     executable: gradle
     args: "publish -PmavenUser=secret-user -PmavenPassword=secret-password"
-    # Do not fail for deprecation warnings: using http
-    flags: "--warning-mode=all"
 }]

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
@@ -1,4 +1,6 @@
 commands: [{
     executable: gradle
     args: "publish -PmavenUser=secret-user -PmavenPassword=secret-password"
+    # Do not fail for deprecation warnings: using http
+    flags: "--warning-mode=all"
 }]


### PR DESCRIPTION
Tests were failing for this sample because of a deprecation warning nagging about use of http.

This change re-adds the sample to the samples page and works around the deprecation message by using 127.0.0.1 address instead of localhost in the sample.