### PR TITLE
Documentation for testing the configuration cache with TestKit

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -132,7 +132,7 @@ For general guidance on how to use TestKit see the <<test_kit.adoc#test_kit,dedi
 To enable configuration caching in your tests, you can pass the `--configuration-cache=on` argument to link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html[GradleRunner] or use one of the other methods described in <<configuration_cache.adoc#enable,Enabling the configuration cache>>.
 
 You need to run your tasks twice.
-Once to store the configuration cache.
+Once to prime the configuration cache.
 Once to reuse the configuration cache.
 
 .Testing the configuration cache
@@ -140,7 +140,7 @@ Once to reuse the configuration cache.
 include::sample[dir="snippets/configurationCache/testKit/groovy",files="src/test/groovy/org/example/BuildLogicFunctionalTest.groovy[tags=functional-test-configuration-cache]"]
 include::sample[dir="snippets/configurationCache/testKit/kotlin",files="src/test/kotlin/org/example/BuildLogicFunctionalTest.kt[tags=functional-test-configuration-cache]"]
 ====
-<1> First run stores the configuration cache.
+<1> First run primes the configuration cache.
 <2> Second run reuses the configuration cache.
 <3> Assert that the configuration cache gets reused.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -8,6 +8,12 @@
 - Diagnosing problems?
 
 
+[NOTE]
+====
+The configuration cache is an incubating feature: details are subject to change.
+====
+
+
 == Usage
 
 [[enable]]

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -121,3 +121,29 @@ def enabled = providers.systemProperty("some-property").forUseAtConfigurationTim
 Support for using configuration caching with certain Gradle features is not yet implemented.
 
 - Composite builds
+
+
+[[testkit]]
+== Testing Build Logic with TestKit
+
+The Gradle TestKit (a.k.a. just TestKit) is a library that aids in testing Gradle plugins and build logic generally.
+For general guidance on how to use TestKit see the <<test_kit.adoc#test_kit,dedicated chapter>>.
+
+To enable configuration caching in your tests, you can pass the `--configuration-cache=on` argument to link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html[GradleRunner] or use one of the other methods described in <<configuration_cache.adoc#enable,Enabling the configuration cache>>.
+
+You need to run your tasks twice.
+Once to store the configuration cache.
+Once to reuse the configuration cache.
+
+.Testing the configuration cache
+====
+include::sample[dir="snippets/configurationCache/testKit/groovy",files="src/test/groovy/org/example/BuildLogicFunctionalTest.groovy[tags=functional-test-configuration-cache]"]
+include::sample[dir="snippets/configurationCache/testKit/kotlin",files="src/test/kotlin/org/example/BuildLogicFunctionalTest.kt[tags=functional-test-configuration-cache]"]
+====
+<1> First run stores the configuration cache.
+<2> Second run reuses the configuration cache.
+<3> Assert that the configuration cache gets reused.
+
+If problems with the configuration cache are found then Gradle will fail the build reporting the problems, and the test will fail.
+
+When gradually improving your plugin or build logic to support the configuration cache it can be useful to temporarily <<configuration_cache.adoc#ignore_problems,ignore problems>> or <<configuration_cache.adoc#max_problems,allow a given number of problems>>.

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'groovy'
+    id 'java-gradle-plugin'
+}
+
+dependencies {
+    testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {
+        exclude module: 'groovy-all'
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        myPlugin {
+            id = "org.example.my-plugin"
+            implementationClass = "org.example.MyPlugin"
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testkit-configuration-cache'

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/main/groovy/org/example/MyPlugin.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/main/groovy/org/example/MyPlugin.groovy
@@ -1,0 +1,12 @@
+package org.example
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class MyPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.tasks.register("myTask", MyTask)
+    }
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/main/groovy/org/example/MyTask.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/main/groovy/org/example/MyTask.groovy
@@ -1,0 +1,10 @@
+package org.example
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+abstract class MyTask extends DefaultTask {
+
+    @TaskAction
+    void action() {}
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
@@ -1,0 +1,50 @@
+package org.example
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class BuildLogicFunctionalTest extends Specification {
+
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+
+    def setup() {
+        testProjectDir.newFile('settings.gradle') << ""
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    // tag::functional-test-configuration-cache[]
+    def "my task can be loaded from the configuration cache"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.example.my-plugin'
+            }
+        """
+
+        when:
+        runner()
+            .withArguments( '--configuration-cache=on', 'myTask')   // <1>
+            .build()
+
+        and:
+        def result = runner()
+            .withArguments( '--configuration-cache=on', 'myTask')   // <2>
+            .build()
+
+        then:
+        result.output.contains("Reusing configuration cache.")      // <3>
+        // ... more assertions on your task behavior
+    }
+    // end::functional-test-configuration-cache[]
+
+    def runner() {
+        return GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+    }
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
@@ -28,16 +28,16 @@ class BuildLogicFunctionalTest extends Specification {
 
         when:
         runner()
-            .withArguments( '--configuration-cache=on', 'myTask')   // <1>
+            .withArguments('--configuration-cache=on', 'myTask')    // <1>
             .build()
 
         and:
         def result = runner()
-            .withArguments( '--configuration-cache=on', 'myTask')   // <2>
+            .withArguments('--configuration-cache=on', 'myTask')    // <2>
             .build()
 
         then:
-        result.output.contains("Reusing configuration cache.")      // <3>
+        result.output.contains('Reusing configuration cache.')      // <3>
         // ... more assertions on your task behavior
     }
     // end::functional-test-configuration-cache[]

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("junit:junit:4.12")
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "testkit-configuration-cache"

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/main/kotlin/org/example/MyTask.kt
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/main/kotlin/org/example/MyTask.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+abstract class MyTask : DefaultTask() {
+
+    @TaskAction
+    fun action() = Unit
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/main/kotlin/org/example/my-plugin.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/main/kotlin/org/example/my-plugin.gradle.kts
@@ -1,0 +1,3 @@
+package org.example
+
+tasks.register<MyTask>("myTask")

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/test/kotlin/org/example/BuildLogicFunctionalTest.kt
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/test/kotlin/org/example/BuildLogicFunctionalTest.kt
@@ -1,0 +1,53 @@
+package org.example
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import java.io.File
+
+class BuildLogicFunctionalTest {
+
+    @Rule
+    @JvmField
+    val testProjectDir: TemporaryFolder = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    @Before
+    fun setup() {
+        testProjectDir.newFile("settings.gradle").writeText("")
+        buildFile = testProjectDir.newFile("build.gradle")
+    }
+
+    // tag::functional-test-configuration-cache[]
+    @Test
+    fun `my task can be loaded from the configuration cache`() {
+
+        buildFile.writeText("""
+            plugins {
+                id 'org.example.my-plugin'
+            }
+        """)
+
+        runner()
+            .withArguments("--configuration-cache=on", "myTask")        // <1>
+            .build()
+
+        val result = runner()
+            .withArguments("--configuration-cache=on", "myTask")        // <2>
+            .build()
+
+        require(result.output.contains("Reusing configuration cache.")) // <3>
+        // ... more assertions on your task behavior
+    }
+    // end::functional-test-configuration-cache[]
+
+    private
+    fun runner() =
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+}

--- a/subprojects/docs/src/snippets/configurationCache/testKit/tests/configurationCacheTestKit.sample.conf
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/tests/configurationCacheTestKit.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: build


### PR DESCRIPTION
In the separate configuration cache chapter for now. This is somewhat symmetrical with https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-build-cache

We could detail all possible scenarios one can test, but this PR aims at short good enough content instead.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
