### PR TITLE
Instrumentation handles plugin jar that contains duplicate resources

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -16,32 +16,31 @@
 
 package org.gradle.internal.classpath;
 
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 @ServiceScope(Scopes.UserHome)
 public class ClasspathBuilder {
-    private static final int BUFFER_SIZE = 8192;
-
+    /**
+     * Creates a Jar file using the given action to add entries to the file.
+     */
     public void jar(File jarFile, Action action) {
         try {
             buildJar(jarFile, action);
         } catch (Exception e) {
-            throw new GradleException(String.format("Failed to create %s.", jarFile), e);
+            throw new GradleException(String.format("Failed to create Jar file %s.", jarFile), e);
         }
     }
 
@@ -50,7 +49,7 @@ public class ClasspathBuilder {
         File tmpFile = new File(parentDir, jarFile.getName() + ".tmp");
         try {
             Files.createDirectories(parentDir.toPath());
-            try (ZipOutputStream outputStream = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tmpFile), BUFFER_SIZE))) {
+            try (ZipOutputStream outputStream = new ZipOutputStream(tmpFile)) {
                 outputStream.setLevel(0);
                 action.execute(new ZipEntryBuilder(outputStream));
             }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/ClasspathBuilderTest.groovy
@@ -70,4 +70,21 @@ class ClasspathBuilderTest extends Specification {
         zip.hasDescendants("a.class", "dir/b.class", "dir/c.class", "dir/sub/d.class")
         zip.hasDirs("dir", "dir/sub")
     }
+
+    def "can construct jar with duplicate entries"() {
+        def file = tmpDir.file("thing.zip")
+
+        when:
+        builder.jar(file) {
+            it.put("a.txt", "bytes".bytes)
+            it.put("a.txt", "other bytes".bytes)
+            it.put("dir/b.txt", "bytes".bytes)
+            it.put("dir/b.txt", "other bytes".bytes)
+        }
+
+        then:
+        def zip = new ZipTestFixture(file)
+        zip.hasDescendants("a.txt", "a.txt", "dir/b.txt", "dir/b.txt")
+        zip.hasDirs("dir")
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -134,7 +134,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
+        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, None)
@@ -152,7 +152,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
+        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
         transformer.transform(classpath, None)
 
         when:
@@ -171,7 +171,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
+        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
         transformer.transform(classpath, None)
         modifiedJar(file)
 
@@ -207,7 +207,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/530c6bbffbdcca1d28d8e9445ae3d710/thing.jar")
+        def cachedFile = testDir.file("cached/396146b843a8f87e95864ef58964482f/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -266,7 +266,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
         def cachedDir = testDir.file("cached/242050944f8d64367cc4fb4427e7968a/thing.dir.jar")
-        def cachedFile = testDir.file("cached/530c6bbffbdcca1d28d8e9445ae3d710/thing.jar")
+        def cachedFile = testDir.file("cached/396146b843a8f87e95864ef58964482f/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -286,7 +286,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/6b9668d41759de943201082f7963d427/thing.jar")
+        def cachedFile = testDir.file("cached/504af72ac0b2238332034919ee747fc2/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)
@@ -320,7 +320,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def remote = new URL("https://somewhere")
-        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
+        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform([file.toURI().toURL(), remote], None)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -165,7 +165,7 @@ org.gradle.api.internal.tasks.CompileServices
                 'META-INF/services/org.gradle.internal.other.Service',
                 'META-INF/.gradle-runtime-shaded']
         }
-        outputJar.md5Hash == "dee78866d881612695b2875ef948d5d5"
+        outputJar.md5Hash == "18aea65849b2aebd52d160f59823d635"
     }
 
     def "excludes module-info.class from jar"() {


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
