### PR TITLE
Fix precompiled plugin groovy tests for Java 14

### DIFF
--- a/subprojects/docs/src/samples/templates/precompiled-script-plugin-groovy/src/test/groovy/com/example/LibraryPluginTest.groovy
+++ b/subprojects/docs/src/samples/templates/precompiled-script-plugin-groovy/src/test/groovy/com/example/LibraryPluginTest.groovy
@@ -75,10 +75,10 @@ class LibraryPluginTest extends PluginTest {
     def "fails when README does not have API section"() {
         given:
         testProjectDir.newFile('README.md') << """
-            ## Changelog
-            - change 1
-            - change 2
-        """.stripIndent()
+## Changelog
+- change 1
+- change 2
+        """
 
         when:
         def result = runTaskWithFailure('check')
@@ -91,9 +91,9 @@ class LibraryPluginTest extends PluginTest {
     def "fails when README does not have Changelog section"() {
         given:
         testProjectDir.newFile('README.md') << """
-            ## API
-            public API description
-        """.stripIndent()
+## API
+public API description
+        """
 
         when:
         def result = runTaskWithFailure('check')
@@ -105,12 +105,12 @@ class LibraryPluginTest extends PluginTest {
 
     private def readmeContainingMandatorySectionsExists() {
         testProjectDir.newFile('README.md') << """
-            ## API
-            public API description
+## API
+public API description
 
-            ## Changelog
-            - change 1
-            - change 2
-        """.stripIndent()
+## Changelog
+- change 1
+- change 2
+        """
     }
 }

--- a/subprojects/docs/src/samples/templates/precompiled-script-plugin-groovy/src/test/groovy/com/example/ServicePluginTest.groovy
+++ b/subprojects/docs/src/samples/templates/precompiled-script-plugin-groovy/src/test/groovy/com/example/ServicePluginTest.groovy
@@ -16,9 +16,9 @@ class ServicePluginTest extends PluginTest {
     def "integrationTest and readmeCheck tasks run with check task"() {
         given:
         testProjectDir.newFile('README.md') << """
-            ## Service API
-            
-        """.stripIndent()
+## Service API
+
+        """
 
         when:
         def result = runTask('check')
@@ -40,9 +40,9 @@ class ServicePluginTest extends PluginTest {
         testProjectDir.newFolder('src', 'integrationTest', 'java', 'com', 'example')
         testProjectDir.newFile('src/integrationTest/java/com/example/SomeIntegrationTest.java') << """
             package com.example;
-            
+
             import org.junit.Test;
-            
+
             public class SomeIntegrationTest {
                 @Test
                 public void sampleTest() {
@@ -68,8 +68,8 @@ class ServicePluginTest extends PluginTest {
     def "fails when README does not have service API section"() {
         given:
         testProjectDir.newFile('README.md') << """
-            asdfadfsasf
-        """.stripIndent()
+asdfadfsasf
+        """
 
         when:
         def result = runTaskWithFailure('check')


### PR DESCRIPTION
Groovy's stripIndent() behaves differently on JDK14 and does not remove all leading whitespace - this was causing the tests in buildSrc to fail.
