### PR TITLE
Fix TestReport task for configuration caching

### DIFF
--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -86,7 +86,6 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testReport/groovy")
-    @ToBeFixedForInstantExecution
     def "can create a custom TestReport task"() {
         given:
         executer.inDirectory(sample.dir)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.junit.Rule
@@ -86,7 +85,6 @@ public class LoggingTest {
     }
 
     @UsesSample("testing/testReport/groovy")
-    @ToBeFixedForInstantExecution
     def "can generate report for subprojects"() {
         given:
         sample sample
@@ -100,7 +98,6 @@ public class LoggingTest {
         htmlReport.testClass("org.gradle.sample.UtilTest").assertTestCount(1, 0, 0).assertTestPassed("ok").assertStdout(equalTo("hello from UtilTest.\n"))
     }
 
-    @ToBeFixedForInstantExecution
     def "merges report with duplicated classes and methods"() {
         given:
         ignoreWhenJupiter()
@@ -198,7 +195,6 @@ public class SubClassTests extends SuperClassTests {
     }
 
     @Issue("https://issues.gradle.org//browse/GRADLE-2821")
-    @ToBeFixedForInstantExecution
     def "test report task can handle test tasks that did not run tests"() {
         given:
         buildScript """
@@ -251,7 +247,6 @@ public class SubClassTests extends SuperClassTests {
         succeeds "testReport"
     }
 
-    @ToBeFixedForInstantExecution
     def "test report task is skipped when there are no results"() {
         given:
         buildScript """

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -35,7 +35,6 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -47,7 +46,7 @@ import static org.gradle.util.CollectionUtils.collect;
  */
 public class TestReport extends DefaultTask {
     private File destinationDir;
-    private List<Object> results = new ArrayList<Object>();
+    private ConfigurableFileCollection resultDirs = getObjectFactory().fileCollection();
 
     @Inject
     protected BuildOperationExecutor getBuildOperationExecutor() {
@@ -81,11 +80,7 @@ public class TestReport extends DefaultTask {
     @InputFiles
     @SkipWhenEmpty
     public FileCollection getTestResultDirs() {
-        ConfigurableFileCollection dirs = getObjectFactory().fileCollection();
-        for (Object result : results) {
-            addTo(result, dirs);
-        }
-        return dirs;
+        return resultDirs;
     }
 
     private void addTo(Object result, ConfigurableFileCollection dirs) {
@@ -107,7 +102,7 @@ public class TestReport extends DefaultTask {
      * task.
      */
     public void setTestResultDirs(Iterable<File> testResultDirs) {
-        this.results.clear();
+        resultDirs = getObjectFactory().fileCollection();
         reportOn(testResultDirs);
     }
 
@@ -132,7 +127,7 @@ public class TestReport extends DefaultTask {
      */
     public void reportOn(Object... results) {
         for (Object result : results) {
-            this.results.add(result);
+            addTo(result, resultDirs);
         }
     }
 


### PR DESCRIPTION
by using a `FileCollection` instead of a list of arbitrary things.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
