### PR TITLE
Detect special multicause exceptions

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -197,12 +197,13 @@ class HtmlTestExecutionResult implements TestExecutionResult {
             if (testCase.isEmpty()) {
                 return false
             }
-            def messages = testCase.first().messages.collect { it.readLines().first() }
+            def fullMessages = testCase.first().messages
+            def messages = fullMessages.collect { it.readLines().first() }
             if (messages.size() != messageMatchers.length) {
                 return false
             }
             for (int i = 0; i < messageMatchers.length; i++) {
-                if (!messageMatchers[i].matches(messages[i])) {
+                if (!messageMatchers[i].matches(messages[i]) && !messageMatchers[i].matches(fullMessages[i])) {
                     return false
                 }
             }

--- a/subprojects/messaging/messaging.gradle.kts
+++ b/subprojects/messaging/messaging.gradle.kts
@@ -18,4 +18,5 @@ dependencies {
     testFixturesImplementation(library("slf4j_api"))
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
+    integTestRuntimeOnly(project(":testingJunitPlatform"))
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.serialize;
 
 import org.gradle.api.Transformer;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
@@ -31,11 +32,22 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class ExceptionPlaceholder implements Serializable {
+    private static final Set<String> CANDIDATE_GET_CAUSES = Collections.unmodifiableSet(
+        new HashSet<String>() {{
+            add("getCauses");
+            add("getFailures");
+        }}
+    );
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionPlaceholder.class);
     private final String type;
@@ -194,6 +206,10 @@ class ExceptionPlaceholder implements Serializable {
         if (throwable instanceof MultiCauseException) {
             return ((MultiCauseException) throwable).getCauses();
         } else {
+            List<? extends Throwable> causes = tryExtractMultiCauses(throwable);
+            if (causes != null) {
+                return causes;
+            }
             Throwable causeTmp;
             try {
                 causeTmp = throwable.getCause();
@@ -204,6 +220,53 @@ class ExceptionPlaceholder implements Serializable {
             }
             return causeTmp == null ? Collections.<Throwable>emptyList() : Collections.singletonList(causeTmp);
         }
+    }
+
+    private static Method findCandidateGetCausesMethod(Throwable throwable) {
+        Method[] declaredMethods = throwable.getClass().getDeclaredMethods();
+        for (Method method : declaredMethods) {
+            if (CANDIDATE_GET_CAUSES.contains(method.getName())) {
+                Class<?> returnType = method.getReturnType();
+                if (Collection.class.isAssignableFrom(returnType)) {
+                    return method;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Does best effort to find a method which potentially returns multiple causes
+     * for an exception. This is for classes of external projects which actually do
+     * something similar to what we do in Gradle with {@link DefaultMultiCauseException}.
+     * It is, in particular, the case for opentest4j.
+     */
+    private static List<? extends Throwable> tryExtractMultiCauses(Throwable throwable) {
+        Method causesMethod = findCandidateGetCausesMethod(throwable);
+        if (causesMethod != null) {
+            Collection<?> causes;
+            try {
+                causes = Cast.uncheckedCast(causesMethod.invoke(throwable));
+            } catch (IllegalAccessException e) {
+                return null;
+            } catch (InvocationTargetException e) {
+                return null;
+            }
+            if (causes == null) {
+                return null;
+            }
+            for (Object cause : causes) {
+                if (!(cause instanceof Throwable)) {
+                    return null;
+                }
+            }
+            List<Throwable> result = new ArrayList<Throwable>(causes.size());
+            for (Object cause : causes) {
+                result.add(Cast.<Throwable>uncheckedCast(cause));
+            }
+            return result;
+        }
+        return null;
     }
 
     private List<Throwable> recreateCauses(Transformer<Class<?>, String> classNameTransformer, Transformer<ExceptionReplacingObjectInputStream, InputStream> objectInputStreamCreator) throws IOException {


### PR DESCRIPTION
This commit fixes an issue where test reports and build scans didn't capture
all the causes of an exception, in case the "multi-cause" exception isn't
a type known of the daemon. By that, we mean a type which is not available
at runtime in the daemon process, but is used in the worker process.

Typically, the `org.opentest4j.MultipleFailuresError` type used by
JUnit is such an example: the type is used in a test process, but
not loaded in Gradle. In such cases, Gradle builds a placeholder
exception type which collects the root cause. But in case the
exception is actually collecting multiple causes like in this test
class, Gradle lost some information in the process.

Therefore, this commit introduces a heuristic to figure out if an
exception is collecting multiple causes instead of a single one.
The heuristic is kept very simple: one has to find a method which
name is either `getCauses` (like for Gradle's own default multi
cause exception) or `getFailures` (like in opentest4j), and it
has to return a collection of failures.

This will not fix all problems but it should capture a good amount
of them.

Fixes #9487
