### PR TITLE
Update behaviour for exclude upper bound in range

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -558,8 +558,19 @@ class DependencyManagementBuildScopeServices {
         return new VersionParser();
     }
 
-    VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
-        return new CachingVersionSelectorScheme(new DefaultVersionSelectorScheme(versionComparator, versionParser));
+    VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser, FeaturePreviews featurePreviews, ListenerManager listenerManager) {
+        DefaultVersionSelectorScheme delegate = new DefaultVersionSelectorScheme(versionComparator, versionParser, featurePreviews);
+        CachingVersionSelectorScheme selectorScheme = new CachingVersionSelectorScheme(delegate, featurePreviews);
+        // This needs to be removed once the feature preview disappears
+        listenerManager.addListener(new BuildAdapter() {
+            @Override
+            public void settingsEvaluated(Settings settings) {
+                delegate.configure();
+                selectorScheme.configure();
+            }
+        });
+
+        return selectorScheme;
     }
 
     SimpleMapInterner createStringInterner() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/CachingVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/CachingVersionSelectorScheme.java
@@ -16,15 +16,22 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 import com.google.common.collect.Maps;
+import org.gradle.api.internal.FeaturePreviews;
 
 import java.util.Map;
 
 public class CachingVersionSelectorScheme implements VersionSelectorScheme {
     private final Map<String, VersionSelector> cachedSelectors = Maps.newConcurrentMap();
     private final VersionSelectorScheme delegate;
+    private final FeaturePreviews featurePreviews;
 
     public CachingVersionSelectorScheme(VersionSelectorScheme delegate) {
+        this(delegate, null);
+    }
+
+    public CachingVersionSelectorScheme(VersionSelectorScheme delegate, FeaturePreviews featurePreviews) {
         this.delegate = delegate;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -47,4 +54,9 @@ public class CachingVersionSelectorScheme implements VersionSelectorScheme {
         return delegate.complementForRejection(selector);
     }
 
+    public void configure() {
+        if (featurePreviews != null && featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.VERSION_SORTING_V2)) {
+            cachedSelectors.clear();
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -16,9 +16,13 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
+import org.gradle.api.internal.FeaturePreviews;
+
 public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
     private final VersionComparator versionComparator;
     private final VersionParser versionParser;
+    private final FeaturePreviews featurePreviews;
+    private boolean smartExcludeOnUpperBound;
 
     /**
      * This constructor is here to maintain backwards compatibility with the nebula plugins
@@ -28,12 +32,16 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
      */
     @Deprecated
     public DefaultVersionSelectorScheme(VersionComparator versionComparator) {
-        this(versionComparator, new VersionParser());
+        this(versionComparator, new VersionParser(), null);
     }
 
     public DefaultVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
+        this(versionComparator, versionParser, null);
+    }
+    public DefaultVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser, FeaturePreviews featurePreviews) {
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -54,7 +62,7 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
     }
 
     private VersionSelector maybeCreateRangeSelector(String selectorString) {
-        VersionRangeSelector rangeSelector = new VersionRangeSelector(selectorString, versionComparator.asVersionComparator(), versionParser);
+        VersionRangeSelector rangeSelector = new VersionRangeSelector(selectorString, versionComparator.asVersionComparator(), versionParser, smartExcludeOnUpperBound);
         if (isSingleVersionRange(rangeSelector)) {
             // it's a single version range, like [1.0] or [1.0, 1.0]
             return new ExactVersionSelector(rangeSelector.getUpperBound());
@@ -77,5 +85,11 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
     @Override
     public VersionSelector complementForRejection(VersionSelector selector) {
         return new InverseVersionSelector(selector);
+    }
+
+    public void configure() {
+        if (featurePreviews != null && featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.VERSION_SORTING_V2)) {
+            smartExcludeOnUpperBound = true;
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -107,10 +107,15 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
     private final boolean lowerInclusive;
     private final Version lowerBoundVersion;
     private final Comparator<Version> comparator;
+    private final boolean smartExcludeUpperBound;
 
     public VersionRangeSelector(String selector, Comparator<Version> comparator, VersionParser versionParser) {
+        this(selector, comparator, versionParser, false);
+    }
+    public VersionRangeSelector(String selector, Comparator<Version> comparator, VersionParser versionParser, boolean smartExcludeUpperBound) {
         super(versionParser, selector);
         this.comparator = comparator;
+        this.smartExcludeUpperBound = smartExcludeUpperBound;
 
         Matcher matcher;
         matcher = FINITE_RANGE.matcher(selector);
@@ -178,7 +183,20 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
      */
     private boolean isLower(Version version1, Version version2, boolean inclusive) {
         int result = comparator.compare(version1, version2);
-        return result <= (inclusive ? 0 : -1);
+        if (inclusive) {
+            return result <= 0;
+        } else {
+            // For non inclusive upper bound, we also check that the prefix does not match
+            if (result <= -1) {
+                if (smartExcludeUpperBound) {
+                    return !version1.toString().startsWith(version2.toString());
+                } else {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
     }
 
     /**

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
@@ -22,7 +22,8 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class DefaultVersionSelectorSchemeTest extends Specification {
-    def matcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator(new FeaturePreviews()), new VersionParser())
+    def previews = new FeaturePreviews()
+    def matcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator(previews), new VersionParser(), previews)
 
     def "creates version range selector"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
@@ -20,6 +20,9 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.internal.FeaturePreviews
 
 class VersionRangeSelectorTest extends AbstractStringVersionSelectorTest {
+
+    def featurePreviews = new FeaturePreviews()
+
     def "all handled selectors are dynamic"() {
         expect:
         isDynamic("[1.0,2.0]")
@@ -35,9 +38,11 @@ class VersionRangeSelectorTest extends AbstractStringVersionSelectorTest {
     }
 
     def "excluded upper bound corner cases"() {
+        given:
+        featurePreviews.enableFeature(FeaturePreviews.Feature.VERSION_SORTING_V2)
         expect:
-        accept("[1.0,2.0)", "2.0-final")
-        accept("[1.0,2.0)", "2.0-dev")
+        !accept("[1.0,2.0)", "2.0-final")
+        !accept("[1.0,2.0)", "2.0-dev")
         !accept("[1.0,2.0)", "2.0.0-dev")
     }
 
@@ -171,6 +176,6 @@ class VersionRangeSelectorTest extends AbstractStringVersionSelectorTest {
 
     @Override
     VersionSelector getSelector(String selector) {
-        return new VersionRangeSelector(selector, new DefaultVersionComparator(new FeaturePreviews()).asVersionComparator(), new VersionParser())
+        return new VersionRangeSelector(selector, new DefaultVersionComparator(featurePreviews).asVersionComparator(), new VersionParser(), featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.VERSION_SORTING_V2))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -36,8 +36,9 @@ import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResu
 public class TestModuleSelectorState implements ResolvableSelectorState {
 
     private static final VersionParser VERSION_PARSER = new VersionParser();
-    private static final DefaultVersionComparator VERSION_COMPARATOR = new DefaultVersionComparator(new FeaturePreviews());
-    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR, VERSION_PARSER);
+    private static final FeaturePreviews FEATURE_PREVIEWS = new FeaturePreviews();
+    private static final DefaultVersionComparator VERSION_COMPARATOR = new DefaultVersionComparator(FEATURE_PREVIEWS);
+    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR, VERSION_PARSER, FEATURE_PREVIEWS);
 
     private final DependencyToComponentIdResolver resolver;
     private final DefaultResolvedVersionConstraint resolvedVersionConstraint;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -85,6 +85,28 @@ dependencies {
 
 This is useful for plugin authors that need to supply different dependencies based upon other configuration that may be set by the user.
 
+## Preview of changes in dependency version ordering
+
+There are multiple version ordering schemes used in the Java ecosystem.
+A number relies on `SNAPSHOT` versions, a concept from Maven.
+These versions are special cased in the way they are sorted by Maven, amongst a number of other special suffixes.
+With this version, Gradle provides an opt-in feature preview that does the following changes to version sorting:
+
+* Consider `SNAPSHOT` to be a special suffix and sort it after `RC` but before `FINAL` and `RELEASE`
+* Consider `GA` to be a special suffix and sort it alphabetically with `FINAL` and `RELEASE`
+* Consider `SP` to be a special suffix and sort it higher than `RELEASE`
+
+In addition, this feature preview will also cause version ranges to behave different when the upper bound is an exclusion.
+In a range like `[1.2, 2.0[`, versions like `2.0-SNAPSHOT` or `2.0-alpha1` are now excluded.
+
+Activating the feature preview `VERSION_SORTING_V2` in `settings.gradle(.kts)` enables these changes:
+```
+enableFeaturePreview("VERSION_SORTING_V2")
+```
+
+Have a look at the [full documentation on version sorting](userguide/single_versions.html) to understand all the implications.
+These changes will become the default in Gradle 7.0.  
+
 ## Improvements for tooling providers
 
 Tooling API clients can now use a new method from [`GradleConnector`](javadoc/org/gradle/tooling/GradleConnector.html) to asynchronously cancel all Tooling API connections without waiting for the current build to finish. 

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
@@ -16,6 +16,22 @@ Gradle supports different ways of declaring a version string:
 ** Will match the highest versioned module with the specified status. See link:{javadocPath}/org/gradle/api/artifacts/ComponentMetadata.html#getStatus--[ComponentMetadata.getStatus()].
 * A Maven `SNAPSHOT` version identifier: e.g. `1.0-SNAPSHOT`, `1.4.9-beta1-SNAPSHOT`
 
+[NOTE]
+====
+Gradle 6.5 supports an alternate, opt-in, behaviour for version ranges.
+
+When an upper bound excludes a version, it also acts as a prefix exclude.
+This means that `[1.0, 2.0[` will also exclude all versions starting with `2.0` that are smaller than `2.0`.
+For example versions like `2.0-dev1` or `2.0-SNAPSHOT` are no longer included in the range.
+
+Activating the feature preview `VERSION_SORTING_V2` in `settings.gradle(.kts)` enables this change:
+```
+enableFeaturePreview("VERSION_SORTING_V2")
+```
+
+This change will become the default in Gradle 7.0.
+====
+
 == Version ordering
 
 Versions have an implicit ordering. Version ordering is used to:


### PR DESCRIPTION
The upper bound of a version range, when it is an exclusion, now acts as
a smart prefix. Versions that were excluded before remain excluded. In
addition, versions that start with the upper bound are also excluded.
This resolves the unexpected case where `2.0-dev1` is included when the
upper bound is `..., 2.0[`.