### PR TITLE
Add support for "useful NPE messages"

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -305,7 +305,13 @@ class ExceptionPlaceholder implements Serializable {
         private static Throwable maybeReplaceUsefulNullPointerMessage(Throwable throwable) {
             if (throwable instanceof NullPointerException) {
                 StackTraceElement[] stackTrace = throwable.getStackTrace();
-                throwable = new NullPointerException(throwable.getMessage());
+                try {
+                    throwable = new NullPointerException(throwable.getMessage());
+                } catch (Exception e) {
+                    // if calling `getMessage()` fails for whatever reason, just ignore
+                    // the replacement
+                    return throwable;
+                }
                 throwable.setStackTrace(stackTrace);
             }
             return throwable;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -509,6 +509,15 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
                     other(null);
                 }
 
+                @Test
+                public void testFailingGetMessage() {
+                    throw new NullPointerException() {
+                        public String getMessage() {
+                            throw new RuntimeException();
+                        }
+                    };
+                }
+
                 void other(Object param) {
                     try {
                        System.out.println(param.toString());
@@ -516,6 +525,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
                         throw new RuntimeException(ex);
                     }
                 }
+
             }
         """
 
@@ -528,5 +538,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             .testFailed("testUsefulNPE", equalTo('java.lang.NullPointerException: Cannot invoke "Object.toString()" because "o" is null'))
         result.testClass("UsefulNPETest")
             .testFailed("testDeepUsefulNPE", equalTo('java.lang.RuntimeException: java.lang.NullPointerException: Cannot invoke "Object.toString()" because "param" is null'))
+        result.testClass("UsefulNPETest")
+            .testFailed("testFailingGetMessage", equalTo('Could not determine failure message for exception of type UsefulNPETest$1: java.lang.RuntimeException'))
     }
 }


### PR DESCRIPTION
This commit adds special handling of null pointer exceptions
in case the current process is running on Java 14+. Without
this hack, the "improved NullPointerException messages" are
not serialized. As a consequence, the daemon cannot display
them, despite being generated on the worker.

Fixes #13096 
