### PR TITLE
Remove @ToBeFixedForInstantExecution on a bunch of tests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptExecutionIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
@@ -56,7 +55,6 @@ try {
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     void buildScriptCanContainATaskDefinition() {
 
         testFile('build.gradle') << '''
@@ -66,11 +64,10 @@ try {
             }
 '''
 
-        inTestDirectory().withTaskList().run()
+        inTestDirectory().withTasks("help").run()
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     void buildScriptCanContainOnlyClassDefinitions() {
 
         testFile('build.gradle') << '''
@@ -86,6 +83,6 @@ try {
             }
 '''
 
-        inTestDirectory().withTaskList().run()
+        inTestDirectory().withTasks("help").run()
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
@@ -265,7 +265,6 @@ class CrossBuildScriptCachingIntegrationSpec extends AbstractIntegrationSpec {
         failure.assertHasLineNumber(5)
     }
 
-    @ToBeFixedForInstantExecution
     def "caches scripts applied from remote locations"() {
         server.start()
 
@@ -279,7 +278,7 @@ class CrossBuildScriptCachingIntegrationSpec extends AbstractIntegrationSpec {
         """))
 
         when:
-        run 'tasks'
+        run 'help'
 
         then:
         outputContains 'Echo'
@@ -309,7 +308,7 @@ class CrossBuildScriptCachingIntegrationSpec extends AbstractIntegrationSpec {
         """))
 
         when:
-        run 'tasks'
+        run 'help'
 
         then:
         outputContains 'Echo 0'
@@ -324,7 +323,7 @@ class CrossBuildScriptCachingIntegrationSpec extends AbstractIntegrationSpec {
             println 'Echo 1'
         """))
 
-        run 'tasks'
+        run 'help'
 
         then:
         outputContains 'Echo 1'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
@@ -109,14 +108,13 @@ assert 'value' == doStuff.someProp
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     void canExecuteExternalScriptFromSettingsScript() {
 
         testFile('settings.gradle') << ''' apply { from 'other.gradle' } '''
         testFile('other.gradle') << ''' include 'child' '''
         testFile('build.gradle') << ''' assert ['child'] == subprojects*.name '''
 
-        inTestDirectory().withTaskList().run()
+        inTestDirectory().withTasks("help").run()
     }
 
     @Test

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -386,7 +386,7 @@ task check {
         args('-I', 'init.gradle')
 
         then:
-        succeeds 'tasks'
+        succeeds 'help'
         output.count('loaded external script') == 4
 
         when:
@@ -395,7 +395,7 @@ task check {
         args('-I', 'init.gradle')
 
         then:
-        succeeds 'tasks'
+        succeeds 'help'
         output.count('loaded external script') == 4
     }
 
@@ -414,7 +414,7 @@ task check {
         server.expectGet('/' + scriptName, scriptFile)
 
         then:
-        succeeds 'tasks'
+        succeeds 'help'
         output.contains('loaded external script 1')
 
         when:
@@ -423,7 +423,7 @@ task check {
         server.expectGet('/' + scriptName, scriptFile)
 
         then:
-        succeeds 'tasks'
+        succeeds 'help'
         output.contains('loaded external script 2')
 
         when:
@@ -431,7 +431,7 @@ task check {
         args("--offline")
 
         then:
-        succeeds 'tasks'
+        succeeds 'help'
         output.contains('loaded external script 2')
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
@@ -61,7 +61,7 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         detectedBy << JAVA_PLUGIN_IDS + JAVA_PLUGIN_IDS.reverse()
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "Gradle.buildFinishedl")
     def "unqualified ids from classpath are detectable"() {
         def pluginBuilder = new PluginBuilder(testDirectory)
         pluginBuilder.addPlugin("")
@@ -103,7 +103,6 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         run("verify")
     }
 
-    @ToBeFixedForInstantExecution
     def "plugin manager with id is fired after the plugin is applied for imperative plugins"() {
         when:
         buildFile << """
@@ -115,10 +114,9 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
-    @ToBeFixedForInstantExecution
     def "plugin manager with id is fired after the plugin is applied for hybrid plugins"() {
         when:
         file("buildSrc/src/main/groovy/MyPlugin.groovy") << """
@@ -154,10 +152,9 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
-    @ToBeFixedForInstantExecution
     def "plugin manager with id is fired after the plugin is applied for rule plugins"() {
         when:
         file("buildSrc/src/main/groovy/MyPlugin.groovy") << """
@@ -184,7 +181,7 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
     @Issue("http://discuss.gradle.org/t/concurrentmodification-exception-on-java-8-for-plugins-withid-with-gradle-2-4/8928")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks
 import org.apache.commons.io.FileUtils
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.IgnoreIf
@@ -33,7 +32,6 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("buildSrc/settings.gradle") << localCacheConfiguration()
     }
 
-    @ToBeFixedForInstantExecution(because = "TaskReportTask")
     def "buildSrc is loaded from cache"() {
         configureCacheForBuildSrc()
         file("buildSrc/src/main/groovy/MyTask.groovy") << """
@@ -43,7 +41,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         """
         assert listCacheFiles().size() == 0
         when:
-        withBuildCache().run "tasks"
+        withBuildCache().run "help"
         then:
         result.assertTaskNotSkipped(":buildSrc:compileGroovy")
         listCacheFiles().size() == 1 // compileGroovy
@@ -52,7 +50,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("buildSrc/build").assertIsDir().deleteDir()
 
         when:
-        withBuildCache().run "tasks"
+        withBuildCache().run "help"
         then:
         result.groupedOutput.task(":buildSrc:compileGroovy").outcome == "FROM-CACHE"
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.cache.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
@@ -26,7 +25,6 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 
 class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements GradleUserHomeCleanupFixture {
 
-    @ToBeFixedForInstantExecution
     def "cleans up unused version-specific cache directories and corresponding distributions"() {
         given:
         requireOwnGradleUserHomeDir() // because we delete caches and distributions
@@ -46,7 +44,7 @@ class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpe
         def currentDist = createDistributionChecksumDir(GradleVersion.current()).parentFile
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         oldButRecentlyUsedCacheDir.assertExists()

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.caching.configuration.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestBuildCache
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
@@ -193,35 +192,32 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         failureHasCause("Build cache type 'CustomBuildCache' has not been registered.")
     }
 
-    @ToBeFixedForInstantExecution
     def "emits a useful message when using the build cache"() {
         when:
         executer.withBuildCacheEnabled()
-        succeeds("tasks", "--info")
+        succeeds("help", "--info")
         then:
         outputContains("Using local directory build cache")
     }
 
-    @ToBeFixedForInstantExecution
     def "command-line --no-build-cache wins over system property"() {
         file("gradle.properties") << """
             org.gradle.caching=true
         """
         executer.withArgument("--no-build-cache")
         when:
-        succeeds("tasks", "--info")
+        succeeds("help", "--info")
         then:
         outputDoesNotContain("Using local directory build cache")
     }
 
-    @ToBeFixedForInstantExecution
     def "command-line --build-cache wins over system property"() {
         file("gradle.properties") << """
             org.gradle.caching=false
         """
         executer.withArgument("--build-cache")
         when:
-        succeeds("tasks", "--info")
+        succeeds("help", "--info")
         then:
         outputContains("Using local directory build cache")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/StatementLabelsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/StatementLabelsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.groovy.scripts
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.hamcrest.CoreMatchers
 
 class StatementLabelsIntegrationTest extends AbstractIntegrationSpec {
@@ -76,7 +75,6 @@ def foo() {
         failure.assertThatCause(CoreMatchers.containsString("build file '${buildFile}': 5: Statement labels may not be used in build scripts."))
     }
 
-    @ToBeFixedForInstantExecution
     def "use of statement label in class inside build script is allowed"() {
         buildFile << """
 class Foo {
@@ -88,6 +86,6 @@ class Foo {
         """
 
         expect:
-        succeeds("tasks")
+        succeeds("help")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcVisibilityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcVisibilityIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.initialization.buildsrc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class BuildSrcVisibilityIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "buildSrc classes are not visible in settings"() {
         file('buildSrc/build.gradle') << """
             apply plugin: 'groovy'
@@ -78,7 +76,7 @@ class BuildSrcVisibilityIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         outputContains("NOT FOUND [settings] $localClassName")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/layout/ProjectCacheDirIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/layout/ProjectCacheDirIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.initialization.layout
 
 import org.gradle.cache.internal.VersionSpecificCacheCleanupFixture
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
@@ -27,7 +26,6 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 
 class ProjectCacheDirIntegrationTest extends AbstractIntegrationSpec implements VersionSpecificCacheCleanupFixture {
 
-    @ToBeFixedForInstantExecution
     def "cleans up unused version-specific cache directories from project directory"() {
         given:
         def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), USED_TODAY)
@@ -35,7 +33,7 @@ class ProjectCacheDirIntegrationTest extends AbstractIntegrationSpec implements 
         def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_USED_WITHIN_7_DAYS)
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         oldButRecentlyUsedCacheDir.assertExists()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -256,7 +256,6 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         jar.assertExists()
     }
 
-    @ToBeFixedForInstantExecution
     def "cleans up unused versions of jars cache"() {
         given:
         requireOwnGradleUserHomeDir() // messes with caches
@@ -267,7 +266,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         gcFile.createFile().lastModified = daysAgo(2)
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         oldCacheDirs.each {

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -94,7 +94,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasFileName("Script '${file("script2.gradle").absolutePath}'")
@@ -112,7 +112,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
@@ -130,14 +130,13 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks", "-I", file("init.gradle").absolutePath
+        fails "help", "-I", file("init.gradle").absolutePath
 
         then:
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertThatCause(containsText("Could not find method someMethod()"))
     }
 
-    @ToBeFixedForInstantExecution
     def "methods defined in a build script are visible to scripts applied to sub projects"() {
         given:
         settingsFile << "include 'sub'"
@@ -152,7 +151,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         file("sub/script.gradle") << "someMethod()"
 
         when:
-        run "tasks"
+        run "help"
 
         then:
         output.contains("from some method")
@@ -192,7 +191,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         file("script2.gradle") << "new Foo()"
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasFileName("Script '${file("script2.gradle").absolutePath}'")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
@@ -39,7 +39,6 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         requireOwnGradleUserHomeDir()
     }
 
-    @ToBeFixedForInstantExecution
     def "does not clean up resources and files that were recently used from caches"() {
         given:
         buildscriptWithDependency(snapshotModule)
@@ -56,7 +55,7 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         forceCleanup(gcFile)
 
         and:
-        succeeds 'tasks'
+        succeeds 'help'
 
         then:
         resource.assertExists()
@@ -64,7 +63,6 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         files[1].assertExists()
     }
 
-    @ToBeFixedForInstantExecution
     def "cleans up resources and files that were not recently used from caches"() {
         given:
         buildscriptWithDependency(snapshotModule)
@@ -91,7 +89,7 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
 
         and:
         // start as new process so journal is not restored from in-memory cache
-        executer.withTasks('tasks').start().waitForFinish()
+        executer.withTasks('help').start().waitForFinish()
 
         then:
         resource.assertDoesNotExist()
@@ -248,7 +246,6 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         jarFile.assertExists()
     }
 
-    @ToBeFixedForInstantExecution
     def "cleans up unused versions of caches"() {
         given:
         requireOwnGradleUserHomeDir() // messes with caches
@@ -260,7 +257,7 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         gcFile.createFile().lastModified = daysAgo(2)
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         oldCacheDirs.each {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1423,7 +1423,6 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         outputDir("snapshot-1.2-SNAPSHOT.jar", "snapshot-1.2-SNAPSHOT.jar.txt") != outputDir2
     }
 
-    @ToBeFixedForInstantExecution
     def "cleans up cache"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform()
@@ -1449,7 +1448,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         and:
         // start as new process so journal is not restored from in-memory cache
-        executer.withTasks("tasks").start().waitForFinish()
+        executer.withTasks("help").start().waitForFinish()
 
         then:
         outputDir1.assertDoesNotExist()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.gradle.integtests;
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest;
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution;
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder;
 import org.gradle.integtests.fixtures.executer.ExecutionFailure;
 import org.junit.Ignore;
@@ -27,15 +26,13 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest {
     @Test
-    @ToBeFixedForInstantExecution
     public void providesADefaultBuildForBuildSrcProject() {
         testFile("buildSrc/src/main/java/BuildClass.java").writelns("public class BuildClass { }");
         testFile("build.gradle").writelns("new BuildClass()");
-        inTestDirectory().withTaskList().run();
+        inTestDirectory().withTasks("help").run();
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     public void canExtendTheDefaultBuildForBuildSrcProject() {
         ArtifactBuilder builder = artifactBuilder();
         builder.sourceFile("org/gradle/test/DepClass.java").writelns(
@@ -49,7 +46,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
                 "dependencies { implementation name: 'test', version: '1.3' }");
         testFile("buildSrc/src/main/java/BuildClass.java").writelns("public class BuildClass extends org.gradle.test.DepClass { }");
         testFile("build.gradle").writelns("new BuildClass()");
-        inTestDirectory().withTaskList().run();
+        inTestDirectory().withTasks("help").run();
     }
 
     @Test
@@ -72,7 +69,6 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     public void gradleImplementationClassesDoNotLeakOntoBuildScriptClassPathWhenUsingBuildSrc() {
         testFile("buildSrc/src/main/java/BuildClass.java").writelns("public class BuildClass { }");
 
@@ -83,7 +79,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
                 "} catch(ClassNotFoundException e) { /* expected */ }",
                 "gradle.class.classLoader.loadClass('com.google.common.collect.Multimap')");
 
-        inTestDirectory().withTaskList().run();
+        inTestDirectory().withTasks("help").run();
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -40,11 +40,10 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     public void handlesWhitespaceOnlySettingsAndBuildFiles() {
         testFile("settings.gradle").write("   \n  ");
         testFile("build.gradle").write("   ");
-        inTestDirectory().withTaskList().run();
+        inTestDirectory().withTasks("help").run();
     }
 
     @Test

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftMissingToolchainIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftMissingToolchainIntegrationTest.groovy
@@ -17,12 +17,10 @@
 package org.gradle.language.swift
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.nativeplatform.fixtures.HostPlatform
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
 
 class SwiftMissingToolchainIntegrationTest extends AbstractIntegrationSpec implements HostPlatform {
-    @ToBeFixedForInstantExecution
     def "user receives reasonable error message when no tool chains are available"() {
         given:
         buildFile << """
@@ -38,7 +36,7 @@ class SwiftMissingToolchainIntegrationTest extends AbstractIntegrationSpec imple
         new SwiftApp().writeToProject(testDirectory)
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         noExceptionThrown()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.launcher.daemon
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.launcher.daemon.logging.DaemonMessages
@@ -47,7 +46,6 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         daemons.daemons.size() == 1
     }
 
-    @ToBeFixedForInstantExecution
     def "canceled daemon is reused when it becomes available"() {
         buildFile << """
             task block {
@@ -71,7 +69,7 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         daemons.daemon.becomesCanceled()
 
         when:
-        def build = executer.withTasks("tasks").withArguments("--info").start()
+        def build = executer.withTasks("help").withArguments("--info").start()
         ConcurrentTestUtil.poll {
             assert build.standardOutput.contains(DaemonMessages.WAITING_ON_CANCELED)
         }
@@ -84,7 +82,6 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         daemons.daemons.size() == 1
     }
 
-    @ToBeFixedForInstantExecution
     def "does not attempt to reuse a canceled daemon that is not compatible"() {
         buildFile << """
             task block {
@@ -106,7 +103,7 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         daemons.daemon.becomesCanceled()
 
         when:
-        def build = executer.withTasks("tasks").withArguments("--info").start()
+        def build = executer.withTasks("help").withArguments("--info").start()
 
         then:
         build.waitForFinish()
@@ -118,7 +115,6 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         !build.standardOutput.contains(DaemonMessages.WAITING_ON_CANCELED)
     }
 
-    @ToBeFixedForInstantExecution
     def "starts a new daemon when daemons with canceled builds do not become available"() {
         buildFile << """
             task block {
@@ -141,7 +137,7 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         canceledDaemon.becomesCanceled()
 
         when:
-        def build = executer.withTasks("tasks").withArguments("--info").start()
+        def build = executer.withTasks("help").withArguments("--info").start()
         ConcurrentTestUtil.poll {
             assert build.standardOutput.contains(DaemonMessages.WAITING_ON_CANCELED)
         }
@@ -155,15 +151,15 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
 
     // GradleHandle.abort() does not work reliably on windows and creates flakiness
     @Requires(TestPrecondition.NOT_WINDOWS)
-    @ToBeFixedForInstantExecution
     def "prefers an idle daemon when daemons with canceled builds are available"() {
         given:
         expectEvent("started1")
         expectEvent("started2")
         buildFile << """
             task block {
+                def buildNum = providers.gradleProperty("buildNum")
                 doLast {
-                    new URL("${getUrl('started')}\$buildNum").text
+                    new URL("${getUrl('started')}\${buildNum.get()}").text
 
                     // Block indefinitely for the daemon to appear busy
                     new java.util.concurrent.Semaphore(0).acquireUninterruptibly()
@@ -180,7 +176,7 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         def canceledDaemon2 = daemons.daemons.find { it.context.pid != canceledDaemon1.context.pid }
 
         // 1 daemon we can reuse
-        def build3 = executer.withTasks("tasks").start()
+        def build3 = executer.withTasks("help").start()
 
         when:
         build3.waitForFinish()
@@ -213,14 +209,14 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
         !build3.standardOutput.contains(DaemonMessages.WAITING_ON_CANCELED)
     }
 
-    @ToBeFixedForInstantExecution
     def "handles two clients that attempt to connect to an idle daemon simultaneously"() {
         given:
         succeeds("help")
         buildFile << """
             task block {
+                def buildNum = providers.gradleProperty("buildNum")
                 doLast {
-                    new URL("${getUrl('started')}\$buildNum").text
+                    new URL("${getUrl('started')}\${buildNum.get()}").text
                 }
             }
         """

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.launcher.daemon
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.launcher.daemon.logging.DaemonMessages
@@ -151,6 +152,7 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
 
     // GradleHandle.abort() does not work reliably on windows and creates flakiness
     @Requires(TestPrecondition.NOT_WINDOWS)
+    @ToBeFixedForInstantExecution
     def "prefers an idle daemon when daemons with canceled builds are available"() {
         given:
         expectEvent("started1")

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -28,7 +28,6 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsTestCodeInt
         buildFile << testablePluginProject(applyJavaPlugin())
     }
 
-    @ToBeFixedForInstantExecution
     def "gradle api jar is generated only when requested"() {
         setup:
         productionCode()
@@ -37,7 +36,7 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsTestCodeInt
         def generatedJarsDirectory = "user-home/caches/$version/generated-gradle-jars"
 
         when:
-        succeeds("tasks")
+        succeeds("help")
 
         then:
         file(generatedJarsDirectory).assertIsEmptyDir()

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugin.use
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 import static org.hamcrest.CoreMatchers.startsWith
 
@@ -59,7 +58,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasDescription("Error resolving plugin [id: 'java', version: '1.0']")
@@ -77,7 +76,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasDescription("Error resolving plugin [id: 'org.gradle.java', version: '1.0']")
@@ -95,7 +94,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertHasDescription("Error resolving plugin [id: 'java', apply: false]")
@@ -114,7 +113,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested at line 3"))
@@ -133,7 +132,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
-        fails "tasks"
+        fails "help"
 
         then:
         failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested at line 4"))
@@ -141,7 +140,6 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         failure.assertHasLineNumber(5)
     }
 
-    @ToBeFixedForInstantExecution
     def "can reapply core plugin applied via plugins block"() {
         when:
         buildScript """
@@ -155,10 +153,9 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
-    @ToBeFixedForInstantExecution
     def "can reapply core plugin applied via qualified id in plugins block"() {
         when:
         buildScript """
@@ -172,10 +169,9 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
-    @ToBeFixedForInstantExecution
     def "can use qualified and unqualified ids to detect core plugins"() {
         when:
         buildScript """
@@ -197,7 +193,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
 
         where:
         pluginId << [QUALIFIED_JAVA, UNQUALIFIED_JAVA]

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugin.use
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
@@ -41,7 +40,6 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         succeeds "help"
     }
 
-    @ToBeFixedForInstantExecution
     def "buildscript blocks are allowed before plugin statements"() {
         when:
         buildScript """
@@ -50,7 +48,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        succeeds "tasks"
+        succeeds "help"
     }
 
     def "buildscript blocks are not allowed after plugin blocks"() {
@@ -61,7 +59,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        fails "tasks"
+        fails "help"
 
         and:
         failure.assertHasLineNumber 3
@@ -82,7 +80,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        fails "tasks"
+        fails "help"
 
         and:
         failure.assertHasLineNumber 3
@@ -100,7 +98,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         then:
-        fails "tasks"
+        fails "help"
 
         and:
         failure.assertHasLineNumber 4


### PR DESCRIPTION
Remove `@ToBeFixedForInstantExecution` on tests that were using the `tasks` task just to run a build, using `help` instead. There's already plenty of coverage for `tasks` and it doesn't work with the configuration cache yet. This PR lets more coverage be exercised.
