### PR TITLE
Some usability improvements for configuration cache problem reporting

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
@@ -35,6 +35,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
         checkStyleReportFile(testDirectory).text.contains('Dummy.java')
     }
 
+    @ToBeFixedForInstantExecution
     def "fails when root project does contain config in default location"() {
         given:
         settingsFile << "include 'child'"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
@@ -26,7 +26,7 @@ class DistributionPropertiesLoaderIntegrationTest extends AbstractIntegrationSpe
     @ToBeFixedForInstantExecution(because = "composite builds")
     def "System properties defined in gradle.properties are available in buildSrc and in included builds"() {
         given:
-        requireIsolatedGradleDistribution()
+        executer.requireGradleDistribution()
 
         settingsFile << '''
             includeBuild 'includedBuild'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.maven.MavenFileRepository
@@ -84,6 +85,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails single application dependency resolution if #protocol connection exceeds timeout (retries = #maxRetries)"() {
         maxHttpRetries = maxRetries
 
@@ -113,6 +115,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails concurrent application dependency resolution if #protocol connection exceeds timeout"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
@@ -179,6 +182,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         output.contains "Resolved: [a-1.0.jar] [] []"
     }
 
+    @ToBeFixedForInstantExecution
     def "repository is blacklisted only for the current build execution"() {
         given:
 
@@ -229,6 +233,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails build and #abortDescriptor repository search if HTTP connection #reason when resolving metadata"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -262,6 +267,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails build and aborts repository search if HTTP connection #reason when resolving artifact for found module"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -291,6 +297,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails build and #abortDescriptor repository search if HTTP connection #reason when resolving dynamic version"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -362,6 +362,7 @@ project(":b") {
         executedAndNotSkipped ":a:yJar"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports project dependency that refers to an unknown artifact"() {
         given:
         file('settings.gradle') << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
+    @ToBeFixedForInstantExecution
     def "should not downgrade dependency version when an external transitive dependency has strict version"() {
         given:
         repository {
@@ -218,6 +220,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
     }
 
+    @ToBeFixedForInstantExecution
     def "should fail during conflict resolution transitive dependency rejects"() {
         given:
         repository {
@@ -255,6 +258,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     void "honors multiple rejections #rejects using dynamic versions using dependency notation #notation"() {
         given:
         repository {
@@ -298,6 +302,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
     }
 
+    @ToBeFixedForInstantExecution
     def "should fail if required module is rejected"() {
         given:
         repository {
@@ -333,6 +338,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
     }
 
+    @ToBeFixedForInstantExecution
     def "shows only one path to dependency when node is already visited"() {
         given:
         repository {
@@ -391,6 +397,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
+    @ToBeFixedForInstantExecution
     def "handles dependency cycles"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -164,6 +164,7 @@ configurations.compile.withDependencies { deps ->
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "provides useful error message when withDependencies action fails to execute"() {
         when:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ResolutionOverrideIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ResolutionOverrideIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.artifactreuse
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class ResolutionOverrideIntegrationTest extends AbstractHttpDependencyResolutionTest {
     public void "will refresh non-changing module when run with --refresh-dependencies"() {
@@ -98,6 +99,7 @@ task showMissing { doLast { println configurations.missing.files } }
         succeeds('showMissing')
     }
 
+    @ToBeFixedForInstantExecution
     public void "will recover from missing artifact when run with --refresh-dependencies"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -25,6 +26,7 @@ import spock.lang.Unroll
 class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @Unroll("#outcome if component-level attribute is #requested")
+    @ToBeFixedForInstantExecution(iterationMatchers = ['fails.*'])
     def "component attributes are used to reject fixed version"() {
         given:
         repository {
@@ -205,6 +207,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
         requested << ["[1.0,)", latestNotation(), "1.+", "1+", "+"]
     }
 
+    @ToBeFixedForInstantExecution
     def "reasonable error message whenever a dynamic version doesn't match any version because of single attribute mismatch"() {
         given:
         repository {
@@ -255,6 +258,7 @@ Versions rejected by attribute matching:
 """)
     }
 
+    @ToBeFixedForInstantExecution
     def "reasonable error message whenever a dynamic version doesn't match any version because of multiple attributes"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -156,6 +157,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution
     def "Fails resolution because dependency attributes and constraint attributes conflict"() {
         given:
         repository {
@@ -258,6 +260,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Issue("gradle/gradle#5232")
+    @ToBeFixedForInstantExecution
     def "Serializes and reads back failed resolution when failure comes from an unmatched typed attribute"() {
         given:
         repository {
@@ -352,6 +355,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution
     def "Fails resolution because consumer configuration attributes and dependency attributes conflict"() {
         given:
         repository {
@@ -503,6 +507,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution
     def "Fails resolution because consumer configuration attributes and constraint attributes conflict"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -101,6 +102,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         }
     }
 
+    @ToBeFixedForInstantExecution
     void "fails selecting distinct variants of the same component by using attributes if they have different capabilities but incompatible values"() {
         given:
         repository {
@@ -159,6 +161,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
    - Variant org:test:1.0 variant runtime2 has attributes {custom=c2, org.gradle.status=${defaultStatus()}}""")
     }
 
+    @ToBeFixedForInstantExecution
     void "cannot select distinct variants of the same component by using different attributes if they have the same capabilities"() {
         given:
         repository {
@@ -201,6 +204,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
     }
 
     @Unroll("can select distinct variants of the same component by using different attributes with capabilities (conflict=#conflict)")
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*conflict=true.*"])
     void "can select distinct variants of the same component by using different attributes with capabilities"() {
         given:
         repository {
@@ -211,7 +215,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                 }
                 variant('runtime') {
                     attribute('custom', 'c2')
-                    capability('org.test', 'cap', conflict?'1.0':'1.1')
+                    capability('org.test', 'cap', conflict ? '1.0' : '1.1')
                 }
             }
         }
@@ -371,6 +375,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
     }
 
+    @ToBeFixedForInstantExecution
     def "prevents selection of 2 variants of the same component with transitive dependency if they have different capabilities but incompatible attributes"() {
         given:
         repository {
@@ -452,6 +457,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot select 2 variants of the same component with transitive dependency if they use the same capability"() {
         given:
         repository {
@@ -646,6 +652,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "detects conflicts between component with a capability and a variant with the same capability"() {
         given:
         repository {
@@ -686,10 +693,11 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
    Cannot select module with conflict on capability 'org:foo:1.0' also provided by [org:foo:1.0(runtime)]""")
     }
 
+    @ToBeFixedForInstantExecution
     def "detects conflicts between 2 variants of 2 different components with the same capability"() {
         given:
         repository {
-            'org:foo:1.0'{
+            'org:foo:1.0' {
                 variant('api') {
                     capability('org', 'foo', '1.0')
                     capability('org', 'blah', '1.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -109,6 +110,7 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
         bundling << [Bundling.EMBEDDED, Bundling.SHADOWED]
     }
 
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*selected=null.*"])
     @Unroll
     def "selects the appropriate variant (producer=#bundling, requested=#requested, selected=#selected)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -145,6 +145,7 @@ task showMissing { doLast { println configurations.missing.files } }
         succeeds("showMissing")
     }
 
+    @ToBeFixedForInstantExecution
     def "cached empty version list is ignored when no module for dynamic version is available in any repo"() {
         given:
         def repo1 = mavenHttpRepo("repo1")
@@ -159,7 +160,7 @@ task showMissing { doLast { println configurations.missing.files } }
                 maven {
                     name 'repo2'
                     url '${repo2.uri}'
-                    metadataSources { 
+                    metadataSources {
                         mavenPom()
                         artifact()
                     }
@@ -366,6 +367,7 @@ Required by:
 
     }
 
+    @ToBeFixedForInstantExecution
     def "cached missing module is ignored if module is not available in any repo"() {
         given:
         def repo1 = mavenHttpRepo("repo1")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -19,12 +19,14 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution
     @Unroll
     def "reasonable error message when a user rule throws an exception (#rule)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Issue
 import spock.lang.Unroll
 
 class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    @ToBeFixedForInstantExecution
     def "can declare capabilities using a component metadata rule"() {
         given:
         repository {
@@ -77,6 +79,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
    Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5($variant)]""")
     }
 
+    @ToBeFixedForInstantExecution
     def "implicit capability conflict is detected if implicit capability is discovered late"() {
         given:
         repository {
@@ -200,6 +203,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
         'all { select(candidates.find { it.id.module == "cglib" }) because "custom reason" }' | 'On capability cglib:cglib custom reason'
     }
 
+    @ToBeFixedForInstantExecution
     def "can detect conflict between local project and capability from external dependency"() {
         given:
         repository {
@@ -309,6 +313,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
     }
 
     @Issue("gradle/gradle#12011")
+    @ToBeFixedForInstantExecution
     @Unroll
     def "can detect capability conflict even when participants belong to a virtual platform (#first, #second)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -37,6 +38,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      * enforce the use of only one of them at the same time.
      */
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*conflict fix not applied.*"])
     def "can choose between cglib and cglib-nodep by declaring capabilities (#description)"() {
         given:
         repository {
@@ -130,6 +132,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      * This is from the consumer point of view, fixing the fact the library doesn't declare capabilities.
      */
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*conflict fix not applied.*"])
     def "can select groovy-all over individual groovy-whatever (#description)"() {
         given:
         repository {
@@ -252,6 +255,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      * This is from the consumer point of view, fixing the fact the library doesn't declare capabilities.
      */
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*conflict fix not applied.*"])
     def "can select individual groovy-whatever over individual groovy-all (#description)"() {
         given:
         repository {
@@ -370,6 +374,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      * This test also makes sure that the order in which dependencies are seen in the graph do not matter.
      */
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*failOnVersionConflict=true.*"])
     @Unroll
     def "published module can declare relocation (first in graph = #first, second in graph = #second, failOnVersionConflict=#failOnVersionConflict)"() {
         given:
@@ -438,6 +443,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      */
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*conflict fix not applied.*"])
     @Unroll
     def "can express preference for capabilities declared in published modules (#description)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    @ToBeFixedForInstantExecution
     def "can consume published capabilities"() {
         given:
         repository {
@@ -112,6 +114,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
     }
 
+    @ToBeFixedForInstantExecution
     def "can detect conflict between local project and capability from external dependency"() {
         given:
         repository {
@@ -156,6 +159,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
      * This test illustrates that published modules can declare capabilities, which are then discovered
      * as we visit the graph. And if no published module declares a preference, then build should fail.
      */
+    @ToBeFixedForInstantExecution
     def "fails with reasonable error message if no module express preference for conflict of modules that publish the same capability"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.constraints
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 /**
@@ -72,6 +73,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         }
     }
 
+    @ToBeFixedForInstantExecution
     void "fail-on-conflict resolution strategy is applied to dependency constraints"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -96,6 +96,7 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         }
     }
 
+    @ToBeFixedForInstantExecution
     void "dependency constraint can be used to declare incompatibility"() {
         given:
         mavenRepo.module("org", "foo", '1.1').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.features
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
@@ -81,6 +82,7 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "reasonable error message when no variant provides required capability"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.AuthScheme
 import org.gradle.util.Requires
@@ -78,6 +79,7 @@ abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDepen
         file('libs').assertHasDescendants('my-module-1.0.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "decent error message when client can't authenticate server"() {
         keyStore = TestKeyStore.init(resources.dir)
         keyStore.enableSslWithServerCert(server)
@@ -94,6 +96,7 @@ abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDepen
         failure.assertThatCause(containsText("java.security.cert.CertPathValidatorException"))
     }
 
+    @ToBeFixedForInstantExecution
     def "build fails when server can't authenticate client"() {
         keyStore = TestKeyStore.init(resources.dir)
         keyStore.enableSslWithServerAndBadClientCert(server)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/ArtifactLookupResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/ArtifactLookupResolveIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.integtests.resolve.http
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class ArtifactLookupResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    @ToBeFixedForInstantExecution
     def "does not try to fetch the jar whenever the metadata artifact is not found"() {
         buildFile << """
             dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.HttpRepository
 
@@ -147,6 +148,7 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "will only search for defined metadata sources"() {
         def metadataSource = isGradleMetadataPublished() ? "gradleMetadata" : useIvy() ? "ivyDescriptor" : "mavenPom"
         def metadataType = isGradleMetadataPublished() ? HttpRepository.MetadataType.ONLY_GRADLE : HttpRepository.MetadataType.ONLY_ORIGINAL

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -117,6 +117,7 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "uses '#rule' rule to reject all candidates for dynamic version #selector"() {
         given:
         Assume.assumeTrue isWellBehaved(mavenCompatible)
@@ -189,6 +190,7 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
         "latest.milestone"   | "select 1.1"               | '["2.0"]'               | ['2.1', '2.0']        | false
     }
 
+    @ToBeFixedForInstantExecution
     def "reports all candidates rejected by rule"() {
         buildFile << """
 
@@ -256,6 +258,7 @@ Required by:
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "uses '#rule' rule to reject candidate for static version #selector"() {
         given:
         Assume.assumeTrue isWellBehaved(mavenCompatible, gradleCompatible)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
@@ -225,6 +225,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         failure.assertHasCause("java.lang.Exception: thrown from rule")
     }
 
+    @ToBeFixedForInstantExecution
     def "reports missing module when component selection rule requires meta-data"() {
         buildFile << """
 configurations {
@@ -276,6 +277,7 @@ Required by:
         succeeds ":checkDeps"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports broken module when component selection rule requires meta-data"() {
         buildFile << """
 configurations {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -396,7 +396,8 @@ task showBroken { doLast { println configurations.broken.files } }
         succeeds("showBroken")
     }
 
-    public void "reports and caches missing artifact"() {
+    @ToBeFixedForInstantExecution
+    void "reports and caches missing artifact"() {
         given:
         buildFile << """
 repositories {
@@ -439,6 +440,7 @@ Searched in the following locations:
     ${module.jar.uri}""")
     }
 
+    @ToBeFixedForInstantExecution
     public void "reports and recovers from failed artifact download"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyComponentMetadataRulesStatusIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyComponentMetadataRulesStatusIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.integtests.resolve.ivy
 
-
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.rules.ComponentMetadataRulesStatusIntegrationTest
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
 
@@ -61,12 +61,14 @@ dependencies {
         file('libs').assertHasDescendants('projectA-1.0.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "resolve fails if status doesn't match default status scheme"() {
         expect:
         fails 'resolve'
         failure.assertHasCause(/Unexpected status 'silver' specified for org.test:projectA:1.0. Expected one of: [integration, milestone, release]/)
     }
 
+    @ToBeFixedForInstantExecution
     def "resolve fails if status doesn't match custom status scheme"() {
         buildFile <<
                 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -380,6 +380,7 @@ dependencies {
         checkResolve "group:projectA:1.+": "group:projectA:1.2"
     }
 
+    @ToBeFixedForInstantExecution
     def "fails on broken directory listing in subsequent resolution"() {
         def repo1 = ivyHttpRepo("repo1")
         def repo2 = ivyHttpRepo("repo2")
@@ -953,6 +954,7 @@ configurations.all {
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from no matching version for dynamic version"() {
         def repo2 = ivyHttpRepo("repo-2")
 
@@ -1042,6 +1044,7 @@ Required by:
         checkResolve "group:projectA:2.+": ["group:projectA:2.2", "didn't match versions 3.0, 1.2, 1.1, 4.4"]
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from missing directory available for dynamic version"() {
         given:
         useRepository ivyHttpRepo
@@ -1087,6 +1090,7 @@ Required by:
         checkResolve "group:projectA:2.+": "group:projectA:2.2"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from missing dynamic version when no repositories defined"() {
         given:
         buildFile << """
@@ -1109,6 +1113,7 @@ dependencies {
         checkResolve "group:projectA:2.+": "group:projectA:2.2"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from broken directory available for dynamic version"() {
         given:
         useRepository ivyHttpRepo
@@ -1140,6 +1145,7 @@ dependencies {
         checkResolve "group:projectA:2.+": "group:projectA:2.2"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from missing module for dynamic version that requires meta-data"() {
         given:
         useRepository ivyHttpRepo
@@ -1174,6 +1180,7 @@ Required by:
         checkResolve "group:projectA:latest.release": "group:projectA:1.2"
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from broken module for dynamic version that requires meta-data"() {
         given:
         useRepository ivyHttpRepo

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.ivy
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.IgnoreIf
@@ -28,6 +29,7 @@ import spock.lang.Issue
 class IvyDynamicRevisionResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @Issue("GRADLE-2502")
+    @ToBeFixedForInstantExecution
     def "latest.integration selects highest version regardless of status"() {
         given:
         buildFile << """
@@ -112,6 +114,7 @@ class IvyDynamicRevisionResolveIntegrationTest extends AbstractModuleDependencyR
     }
 
     @Issue("GRADLE-2502")
+    @ToBeFixedForInstantExecution
     def "latest.milestone selects highest version with milestone or release status"() {
         given:
         buildFile << """
@@ -254,6 +257,7 @@ Searched in the following locations:
     }
 
     @Issue("GRADLE-2502")
+    @ToBeFixedForInstantExecution
     void "latest.release selects highest version with release status"() {
         given:
         buildFile << """
@@ -388,6 +392,7 @@ Searched in the following locations:
     }
 
     @Issue(["GRADLE-2502", "GRADLE-2794"])
+    @ToBeFixedForInstantExecution
     def "version selector ending in + selects highest matching version"() {
         given:
         buildFile << """
@@ -483,6 +488,7 @@ Searched in the following locations:
     }
 
     @Issue("GRADLE-2502")
+    @ToBeFixedForInstantExecution
     def "version range selects highest matching version"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
@@ -126,6 +126,7 @@ task retrieve(type: Sync) {
         jarC1.assertHasChangedSince(jarCsnapshot)
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot define authentication for local file repo"() {
         given:
         def repo = ivyRepo()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -88,6 +88,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.2.jar', 'projectB-other-1.6.jar', 'projectD-1.0.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "fails when project dependency references a configuration that does not exist"() {
         ivyRepo.module('test', 'target', '1.0').publish()
 
@@ -112,6 +113,7 @@ task retrieve(type: Sync) {
         failure.assertHasCause("Project : declares a dependency from configuration 'compile' to configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
     }
 
+    @ToBeFixedForInstantExecution
     def "fails when ivy module references a configuration that does not exist"() {
         def b = ivyRepo.module('test', 'b', '1.0').publish()
         ivyRepo.module('test', 'a', '1.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
@@ -23,6 +23,7 @@ import spock.lang.Unroll
 abstract class AbstractValidatingLockingIntegrationTest extends AbstractLockingIntegrationTest {
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def 'fails when lock file conflicts with declared strict constraint (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
@@ -70,6 +71,7 @@ dependencies {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def 'fails when lock file conflicts with declared version constraint (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.Issue
@@ -183,6 +184,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "a parent pom is not a bom"() {
         mavenHttpRepo.module('group', 'main', '5.0').allowAll().parent(bom.group, bom.artifactId, bom.version).publish()
         bomDependency('moduleA')
@@ -253,6 +255,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "fails late for dependency entries that fail to provide a missing version"() {
         given:
         bomDependency('moduleA')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -407,6 +407,7 @@ task showBroken { doLast { println configurations.broken.files } }
         retries << (1..3)
     }
 
+    @ToBeFixedForInstantExecution
     public void "reports and recovers from failed artifact download"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 
 import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
@@ -168,6 +169,7 @@ task retrieve(type: Sync) {
         file('libs/projectA-1.5.jar').assertHasNotChangedSince(snapshot)
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from broken maven-metadata.xml and directory listing"() {
         given:
         mavenHttpRepo.module('group', 'projectA', '1.0').publish()
@@ -224,6 +226,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.5.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "dynamic version reports and recovers from broken module"() {
         given:
         def repo = mavenHttpRepo("repo1")
@@ -265,6 +268,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.1.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "dynamic version reports and recovers from missing module"() {
         given:
         def repo = mavenHttpRepo("repo1")
@@ -372,6 +376,7 @@ Searched in the following locations:
         file('libs').assertHasDescendants('projectA-1.4.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "dynamic version fails on broken module in one repository when available in another repository"() {
         given:
         def repo1 = mavenHttpRepo("repo1")
@@ -409,6 +414,7 @@ Searched in the following locations:
         file('libs').assertHasDescendants('projectA-1.5.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "dynamic version fails on timeout in one repository even when available in another repository"() {
         given:
         def repo1 = mavenHttpRepo("repo1")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
@@ -137,6 +137,7 @@ task retrieve(type: Sync) {
         buildDir.file('projectB-9.1.jar').assertIsCopyOf(moduleB.artifactFile)
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot define authentication for local file repo"() {
         given:
         def repo = mavenRepo()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLatestResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLatestResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class MavenLatestResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -53,6 +54,7 @@ class MavenLatestResolveIntegrationTest extends AbstractHttpDependencyResolution
         status << ["integration", "milestone", "release"]
     }
 
+    @ToBeFixedForInstantExecution
     def "latest selector with unknown status leads to failure"() {
         mavenRepo().module('group', 'projectA', '1.0').publish()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.Issue
 
@@ -154,6 +155,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
     }
 
     @Issue('GRADLE-2034')
+    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2').publishPom()
@@ -165,6 +167,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         failure.assertHasCause('Could not find group:projectA:1.2')
     }
 
+    @ToBeFixedForInstantExecution
     def "mavenLocal reports and recovers from missing module"() {
         def module = m2.mavenRepo().module('group', 'projectA', '1.2')
 
@@ -241,6 +244,7 @@ Required by:
     }
 
     @Issue('GRADLE-2034')
+    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve snapshot artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').publishPom()
@@ -268,6 +272,7 @@ Required by:
     }
 
     @Issue('GRADLE-2034')
+    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve non-unique snapshot artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').withNonUniqueSnapshots().publishPom()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
@@ -207,6 +207,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('child-1.0.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "fails with reasonable message if parent module is an ivy module"() {
         given:
         def child = mavenHttpRepo.module("org", "child")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
@@ -222,6 +222,7 @@ if (project.hasProperty('skipCache')) {
         succeeds 'retrieve'
     }
 
+    @ToBeFixedForInstantExecution
     def "fails and reports type-based location if neither packaging-based or type-based artifact can be located"() {
         when:
         buildWithDependencies("compile 'group:projectA:1.0'")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -109,6 +110,7 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         file("compileClasspath").assertHasDescendants("artifactC-1.0.jar")
     }
 
+    @ToBeFixedForInstantExecution
     def "fails to resolve module if published artifact does not exist with relocated coordinates"() {
         given:
         def original = publishPomWithRelocation('groupA', 'artifactA', 'notExist', 'notExist')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -794,6 +794,7 @@ dependencies {
         failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
     }
 
+    @ToBeFixedForInstantExecution
     def "reports failure to locate files"() {
         def m = mavenHttpRepo.module("test", "a", "1.2").withModuleMetadata()
         m.artifact(classifier: 'extra')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 class MavenScopesIntegrationTest extends AbstractDependencyResolutionTest {
@@ -365,6 +366,7 @@ dependencies {
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "fails when referencing a scope that does not exist"() {
         mavenRepo.module('test', 'target', '1.0')
             .publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -690,6 +690,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.0-SNAPSHOT.jar', 'projectB-2.0.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from missing snapshot"() {
         given:
         def projectA = createModule('group', 'projectA', "1.0-SNAPSHOT")
@@ -729,6 +730,7 @@ Required by:
         file('libs').assertHasDescendants('projectA-1.0-SNAPSHOT.jar')
     }
 
+    @ToBeFixedForInstantExecution
     def "reports missing unique snapshot artifact"() {
         given:
         def projectA = publishModule('group', 'projectA', "1.0-SNAPSHOT")
@@ -772,6 +774,7 @@ Searched in the following locations:
     ${projectA.artifact.uri}""")
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from broken maven-metadata.xml"() {
         given:
         def projectA = publishModule('group', 'projectA', "1.0-SNAPSHOT")
@@ -946,6 +949,7 @@ dependencies {
         file('libs').assertHasDescendants("projectA-1.0.jar")
     }
 
+    @ToBeFixedForInstantExecution
     def "reports failure to find a missing unique snapshot in a Maven HTTP repository"() {
         given:
         def projectA = createModule("org.gradle.integtests.resolve", "projectA", "1.0-SNAPSHOT")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
@@ -153,6 +154,7 @@ dependencies {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/1898")
+    @ToBeFixedForInstantExecution
     def "error when parent pom with specified version range cannot be found"() {
         given:
         settingsFile << "rootProject.name = 'test' "

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.override
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -225,6 +226,7 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "clashing client modules fail the build"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.reproducibility
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -35,6 +36,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
         """
     }
 
+    @ToBeFixedForInstantExecution
     def "fails to resolve a direct changing dependency"() {
         buildFile << """
             dependencies {
@@ -60,6 +62,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
         failure.assertHasCause("Could not resolve org:test:1.0: Resolution strategy disallows usage of changing versions")
     }
 
+    @ToBeFixedForInstantExecution
     def "fails to resolve a transitive changing dependency"() {
         buildFile << """
             dependencies {
@@ -95,6 +98,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    @ToBeFixedForInstantExecution
     @Unroll
     def "can deny a direct snapshot dependency (unique = #unique)"() {
         buildFile << """
@@ -129,6 +133,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    @ToBeFixedForInstantExecution
     @Unroll
     def "can deny a transitive snapshot dependency (unique = #unique)"() {
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.reproducibility
 
 import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -73,6 +74,7 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "fails to resolve a direct dependency using a dynamic version"() {
         buildFile << """
             dependencies {
@@ -99,6 +101,7 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
         failure.assertHasCause("Could not resolve org:test:1.+: Resolution strategy disallows usage of dynamic versions")
     }
 
+    @ToBeFixedForInstantExecution
     def "fails to resolve a transitive dependency which uses a dynamic version"() {
         buildFile << """
             dependencies {
@@ -132,6 +135,7 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
         failure.assertHasCause("Could not resolve org:transitive:1.+: Resolution strategy disallows usage of dynamic versions")
     }
 
+    @ToBeFixedForInstantExecution
     def "fails if a transitive dynamic selector participates in selection"() {
         buildFile << """
             dependencies {
@@ -284,6 +288,7 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "fails if exact selector is below the range"() {
         buildFile << """
             dependencies {
@@ -314,6 +319,7 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "fails with combination of selectors (#selector1 and #selector2)"() {
         buildFile << """
             dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.rules
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import spock.lang.Unroll
@@ -25,6 +26,7 @@ import spock.lang.Unroll
 class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @Unroll("#outcome if attribute is #mutation via component metadata rule")
+    @ToBeFixedForInstantExecution(iterationMatchers = ["fails.*"])
     def "check that attribute rules modify the result of dependency resolution"() {
         given:
         repository {
@@ -97,6 +99,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*component level = false.*"])
     @Unroll
     def "variant attributes take precedence over component attributes (component level = #componentLevel)"() {
         given:
@@ -230,6 +233,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution(iterationMatchers = [".*fix applied = false.*"])
     @Unroll
     def "published component metadata can be overwritten (fix applied = #fixApplied)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -801,6 +801,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "can make #thing strict"() {
         given:
         repository {
@@ -865,6 +866,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "can add rejections to #thing"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.rules
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -202,6 +203,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "using a non-existing base throws and error"() {
         given:
         repository {
@@ -396,6 +398,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot add file with the same name multiple times"() {
         def dependencyDeclaration = (useMaven() || gradleMetadataPublished)
             ? "'org.test:moduleA:1.0'" // variant matching

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -144,6 +144,7 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "multiple endorsed strict versions that target the same module fail the build if they conflict"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsFeatureInteractionIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -197,6 +198,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot force a version over an ancestor provided version"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -231,6 +232,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
     }
 
     @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
+    @ToBeFixedForInstantExecution
     def "conflicting version constraints fail resolution"() {
         given:
         repository {
@@ -501,6 +503,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @ToBeFixedForInstantExecution
     def "original version constraint is not ignored if there is another parent"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -267,6 +268,11 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = [
+        ".*\\[PLATFORM\\].*",
+        ".*\\[LEGACY_PLATFORM\\].*",
+        ".*\\[MODULE\\].*"
+    ])
     void "(3) library developer has issues with org:foo:3.1.1 and overrides platform decision with 3.2 which fails due to reject [#platformType]"() {
         updatedRepository(platformType)
         singleLibraryBuildFile(platformType)
@@ -322,6 +328,9 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = [
+        ".*\\[ENFORCED_PLATFORM\\].*"
+    ])
     void "(4) library developer has issues with org:foo:3.1.1 and forces an override of the platform decision with strictly [#platformType]"() {
         // issue with enforced platform: consumer can not override platform decision via constraint
         //                               (an override via an own forced dependency is possible)
@@ -404,6 +413,7 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     void "(5) if two libraries are combined without agreeing on an override, the original platform constraint is brought back [#platformType]"() {
         updatedRepository(platformType)
         settingsFile << "\ninclude 'recklessLibrary', 'secondLibrary'"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
@@ -78,6 +78,7 @@ class CustomVersionListerIntegrationTest extends AbstractModuleDependencyResolve
         succeeds 'checkDeps'
     }
 
+    @ToBeFixedForInstantExecution
     void "doesn't fallback to repository listing when empty list version is returned"() {
         withLister([testA: []])
         given:
@@ -187,6 +188,7 @@ class CustomVersionListerIntegrationTest extends AbstractModuleDependencyResolve
         'file on repository' | [testA: [1, 2, 3]]
     }
 
+    @ToBeFixedForInstantExecution
     void "can recover from broken lister"() {
         withBrokenLister()
         given:
@@ -222,6 +224,7 @@ class CustomVersionListerIntegrationTest extends AbstractModuleDependencyResolve
         succeeds 'checkDeps'
     }
 
+    @ToBeFixedForInstantExecution
     def "can recover from --offline mode"() {
         withLister(['testA': [1, 2, 3]])
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -293,6 +293,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
     }
 
+    @ToBeFixedForInstantExecution
     def "can recover from --offline mode"() {
         given:
         def supplierInteractions = withPerVersionStatusSupplier()
@@ -399,6 +400,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         failure.assertHasCause("No cached resource '${server.uri}/repo/group/projectB/2.2/status-offline.txt' available for offline mode.")
     }
 
+    @ToBeFixedForInstantExecution
     def "reports and recovers from remote failure"() {
         given:
         def supplierInteractions = withPerVersionStatusSupplier()
@@ -505,6 +507,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         succeeds 'checkDeps'
     }
 
+    @ToBeFixedForInstantExecution
     def "handles and recovers from errors in a custom metadata provider"() {
         given:
         buildFile << """
@@ -554,6 +557,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         succeeds 'checkDeps'
     }
 
+    @ToBeFixedForInstantExecution
     def "handles failure to create custom metadata provider"() {
         given:
         buildFile << """
@@ -1193,6 +1197,7 @@ group:projectB:2.2;release
 
     }
 
+    @ToBeFixedForInstantExecution
     def "cross-build caching is resilient to failure"() {
         def metadataFile = file("buildSrc/src/main/groovy/MP.groovy")
         executer.requireIsolatedDaemons() // because we're going to --stop

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -36,7 +36,8 @@ import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture {
     private final static long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES
 
-    @Rule BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
+    @Rule
+    BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
 
     def setup() {
         settingsFile << """
@@ -1220,7 +1221,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         // change the implementation
         buildFile.text = ""
-        buildFile << resolveTask << declareAttributes() << multiProjectWithJarSizeTransform(fileValue:  "'new value'", parameterObject: useParameterObject) << withClassesSizeTransform(useParameterObject)
+        buildFile << resolveTask << declareAttributes() << multiProjectWithJarSizeTransform(fileValue: "'new value'", parameterObject: useParameterObject) << withClassesSizeTransform(useParameterObject)
         succeeds ":util:resolve", ":app:resolve"
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1692,6 +1692,7 @@ Found the following transforms:
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "directories are not created for output #method which is part of the input"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -332,6 +332,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         outputContains("Transforming b.jar to b.jar.txt")
     }
 
+    @ToBeFixedForInstantExecution
     def "failures are collected from transformations applied parallel"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -433,7 +433,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
 
     def "transform parameters type cannot use caching annotations"() {
         settingsFile << """
-            include 'a', 'b', 'c'
+            include 'a', 'b'
         """
         setupBuildWithColorTransform {
             params("""
@@ -444,7 +444,6 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
             project(':a') {
                 dependencies {
                     implementation project(':b')
-                    implementation project(':c')
                 }
             }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.validation
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
 import spock.lang.Issue
@@ -55,6 +56,7 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
         GradleFileModuleAdapter.printComponentGAV = true
     }
 
+    @ToBeFixedForInstantExecution
     def "fails with proper error if a mandatory attribute is not defined"() {
         buildFile << """
             dependencies {
@@ -82,6 +84,7 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
     }
 
     @Issue("gradle/gradle#7888")
+    @ToBeFixedForInstantExecution
     def "fails with reasonable error message if Gradle Module Metadata doesn't declare any variant"() {
         buildFile << """
             dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -322,11 +322,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
 
     @Unroll
     @ToBeFixedForInstantExecution(
-        because = "broken file collection",
-        iterationMatchers = [
-            ".*artifactView \\{ componentFilter.*",
-            ".*using query.*"
-        ]
+        because = "broken file collection"
     )
     def "fails on the first access to an artifact (not at the end of the build) using #firstResolution"() {
         createMetadataFile {
@@ -936,6 +932,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
         "sha512" | "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b" | "3d890ff72a2d6fcb2a921715143e6489d8f650a572c33070b7f290082a07bfc4af0b64763bcf505e1c07388bc21b7d5707e50a3952188dc604814e09387fbbfe"
     }
 
+    @ToBeFixedForInstantExecution
     def "reasonable error message when the verification file can't be parsed"() {
         given:
         javaLibrary()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -657,6 +657,7 @@ If the artifacts are trustworthy, you will need to update the gradle/verificatio
         terse << [true, false]
     }
 
+    @ToBeFixedForInstantExecution
     @Unroll
     def "caches missing keys (terse output=#terse)"() {
         createMetadataFile {
@@ -726,6 +727,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
     }
 
 
+    @ToBeFixedForInstantExecution
     def "cache takes ignored keys into consideration"() {
         createMetadataFile {
             keyServer(keyServerFixture.uri)

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -1,20 +1,57 @@
 [[config_cache]]
 = Configuration cache
 
-- What is it?
-- How to enable it?
-- How does it work?
-- Limitations?
-- Diagnosing problems?
-
-
 [NOTE]
 ====
-The configuration cache is an incubating feature: details are subject to change.
+The configuration cache is an <<feature_lifecycle.adoc#feature_lifecycle,incubating>> feature, and the details described here may change.
 ====
 
+== Introduction
 
-== Usage
+The configuration cache is a feature that significantly improves build performance by caching the result of the configuration phase and reusing this for subsequent builds.
+This allows Gradle to skip the configuration phase entirely when nothing has changed to affect the build configuration, and in addition allows Gradle to apply some
+performance improvements to task execution as well. (TODO - link to build lifecycle reference)
+
+The configuration cache is similar to the build cache, but caches different information. The build cache takes care of caching the outputs and intermediate files of the build,
+such as task outputs or artifact transform outputs. The configuration cache takes care of caching the build configuration for a particular set of tasks. You can think of this
+as caching the output of the configuration phase, which is an input to the execution phase.
+
+This feature is currently experimental and not enabled by default.
+
+=== How does it work?
+
+When the configuration cache is enabled and you run Gradle for a particular set of tasks, for example by running `gradlew check`, Gradle checks whether a configuration cache entry is available for
+the requested set of tasks and if available will use this instead of running the configuration phase.
+
+The first time you run a set of tasks, there will be no entry in the configuration cache for these tasks and so Gradle will run the configuration phase as normal. Gradle will:
+
+1. Run any init scripts.
+2. Run the settings script for the build, applying any requested settings plugins.
+3. Run the builds scripts for the build, applying any requested project plugins.
+4. Calculate the task graph for the requested tasks, running any deferred configuration actions.
+
+Following the configuration phase, Gradle writes the state of the task graph to the configuration cache, taking a snapshot for later Gradle invocations. The execution phase then runs as normal.
+This means you will not see any build performance improvement the first time you run a particular set of tasks.
+
+When you subsequently run Gradle with this set of tasks, for example by running `gradlew check` again, Gradle will load the tasks and their configuration directly from the configuration cache
+and skip the configuration phase entirely.
+Before using a configuration cache entry, Gradle checks that none of the "build inputs" for the entry have changed. If a build input has changed, Gradle will not use the entry and will
+run the configuration phase again as above, saving the result for later reuse.
+
+Build inputs include:
+
+- Init scripts, settings scripts, build scripts.
+- System properties, Gradle properties and configuration files used during the configuration phase, accessed using value suppliers (TODO - add docs for this).
+- build inputs and source files for `buildSrc` projects.
+
+=== Performance improvements
+
+Apart from the clear advantage of skipping the configuration phase, the configuration cache provides some additional performance improvements:
+
+- All tasks run in parallel by default.
+- Dependency resolution is cached as well.
+
+== Using the configuration cache
 
 [[enable]]
 === Enabling the configuration cache
@@ -122,7 +159,6 @@ Support for using configuration caching with certain Gradle features is not yet 
 
 - Composite builds
 
-
 [[testkit]]
 == Testing Build Logic with TestKit
 
@@ -147,3 +183,7 @@ include::sample[dir="snippets/configurationCache/testKit/kotlin",files="src/test
 If problems with the configuration cache are found then Gradle will fail the build reporting the problems, and the test will fail.
 
 When gradually improving your plugin or build logic to support the configuration cache it can be useful to temporarily <<configuration_cache.adoc#ignore_problems,ignore problems>> or <<configuration_cache.adoc#max_problems,allow a given number of problems>>.
+
+== Troubleshooting
+
+TODO

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -367,6 +367,7 @@ idea.project {
     }
 
     @Test
+    @ToBeFixedForInstantExecution
     void showDecentMessageWhenInputFileWasTinkeredWith() {
         //given
         file('root.iml') << 'messed up iml file'

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -41,9 +41,9 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         instantRunLenient("help")
 
         then:
-        instantExecution.assertStateStored()
+        instantExecution.assertStateLoaded()
         problems.assertResultHasProblems(result) {
-            withUniqueProblems(expectedProblem)
+            // TODO - should inform the user that composite builds do not work
         }
 
         when:
@@ -51,5 +51,8 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
 
         then:
         instantExecution.assertStateLoaded()
+        problems.assertResultHasProblems(result) {
+            // TODO - should inform the user that composite builds do not work
+        }
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -55,10 +55,10 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         instantRunLenient 'test', 'jacocoTestReport'
 
         then:
-        instantExecution.assertStateStored()
+        instantExecution.assertStateLoaded()
         problems.assertResultHasProblems(result) {
-            withTotalProblemsCount(expectedStoreProblemCount)
-            withUniqueProblems(expectedStoreProblems)
+            withTotalProblemsCount(expectedLoadProblemCount)
+            withUniqueProblems(expectedLoadProblems)
         }
         htmlReportDir.assertIsDir()
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
@@ -54,7 +54,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Instant execution state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
         }
@@ -70,7 +70,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Instant execution state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
         }
@@ -110,11 +110,11 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Instant execution state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
-            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
-            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
+            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
         }
 
         when:
@@ -128,11 +128,11 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Instant execution state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
-            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
-            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
+            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
         }
     }
 
@@ -167,10 +167,10 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         executed(':problems', ':moreProblems', ':ok', ':all')
         instantExecution.assertStateStored() // does not fail
         problems.assertFailureHasProblems(failure) {
-            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with instant execution.")
-            withProblem("field 'prop' from type 'BrokenTaskType': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
-            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
-            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.")
+            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
+            withProblem("field 'prop' from type 'BrokenTaskType': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("input property 'brokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("input property 'otherBrokenProperty' of ':problems': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
         }
         failure.assertHasFailures(1)
 
@@ -181,10 +181,10 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         executed(':problems', ':moreProblems', ':ok', ':all')
         instantExecution.assertStateLoaded()
         problems.assertResultHasProblems(result) {
-            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with instant execution.")
-            withProblem("field 'prop' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
-            withProblem("input property 'brokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
-            withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
+            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with the configuration cache.")
+            withProblem("field 'prop' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("input property 'brokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
         }
 
         when:
@@ -194,10 +194,10 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         executed(':problems', ':moreProblems', ':ok', ':all')
         instantExecution.assertStateLoaded()
         problems.assertFailureHasProblems(failure) {
-            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with instant execution.")
-            withProblem("field 'prop' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
-            withProblem("input property 'brokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
-            withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
+            withProblem("field 'anotherProp' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with the configuration cache.")
+            withProblem("field 'prop' from type 'BrokenTaskType': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("input property 'brokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
         }
     }
 
@@ -302,54 +302,136 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
     }
 
     def "problems are reported and fail the build when failOnProblems is false but maxProblems is reached"() {
-
         given:
-        def stateSerializationProblems = withStateSerializationProblems().store
-        def taskExecutionProblems = withTaskExecutionProblems()
+        def instantExecution = newInstantExecutionFixture()
 
-        when:
-        instantFailsLenient 'taskWithStateSerializationProblems', 'a', 'b', "${MAX_PROBLEMS_CLI_OPTION}=2"
-
-        then:
-        notExecuted(':taskWithStateSerializationProblems', ':a', ':b')
-        problems.assertFailureHasTooManyProblems(failure) {
-            withUniqueProblems(stateSerializationProblems)
-            withProblemsWithStackTraceCount(0)
-        }
-
-        when:
-        instantFailsLenient 'taskWithStateSerializationProblems', 'a', 'b', "${MAX_PROBLEMS_CLI_OPTION}=4"
-
-        then:
-        executed(':taskWithStateSerializationProblems', ':a', ':b')
-        problems.assertFailureHasTooManyProblems(failure) {
-            withRootCauseDescription("Execution failed for task ':b'.")
-            withUniqueProblems(taskExecutionProblems + stateSerializationProblems)
-            withProblemsWithStackTraceCount(2)
-        }
-    }
-
-    def "problems not causing build failure are reported"() {
-
-        given:
-        settingsFile << "rootProject.name = 'test'"
-        def expectedProblems = withStateSerializationProblems().store
         buildFile << """
-            taskWithStateSerializationProblems.doFirst { throw new Exception("BOOM") }
+            class BrokenTask extends DefaultTask {
+                @Internal
+                final broken = project
+
+                @TaskAction
+                def go() {
+                    try {
+                        println("project = " + project)
+                    } catch(Exception e) {
+                        // should not happen, problems are collected
+                        throw new RuntimeException("broken")
+                    }
+                }
+            }
+
+            task problems(type: BrokenTask)
+            task moreProblems(type: BrokenTask)
+
+            task all {
+                dependsOn('problems', 'moreProblems')
+            }
         """
 
         when:
-        instantFailsLenient 'taskWithStateSerializationProblems'
+        instantFailsLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
 
         then:
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(expectedProblems)
-            withProblemsWithStackTraceCount(0)
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateStored() // does not fail
+        problems.assertFailureHasTooManyProblems(failure) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
         }
 
-        and:
-        failure.assertHasDescription("Execution failed for task ':taskWithStateSerializationProblems'.")
-        failure.assertHasCause("java.lang.Exception: BOOM")
+        when:
+        instantFailsLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=3"
+
+        then:
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateLoaded()
+        problems.assertFailureHasTooManyProblems(failure) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
+        }
+        failure.assertHasFailures(1)
+
+        when:
+        instantRunLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=4"
+
+        then:
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateLoaded()
+        problems.assertResultHasProblems(result) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
+        }
+    }
+
+    def "fails regardless of maxProblems when failOnProblems is true"() {
+        given:
+        def instantExecution = newInstantExecutionFixture()
+
+        buildFile << """
+            class BrokenTask extends DefaultTask {
+                @Internal
+                final broken = project
+
+                @TaskAction
+                def go() {
+                    println("project = " + project)
+                }
+            }
+
+            task problems(type: BrokenTask)
+            task moreProblems(type: BrokenTask)
+
+            task all {
+                dependsOn('problems', 'moreProblems')
+            }
+        """
+
+        when:
+        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
+
+        then:
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateStored() // does not fail
+        problems.assertFailureHasProblems(failure) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
+        }
+
+        when:
+        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
+
+        then:
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateLoaded()
+        problems.assertFailureHasProblems(failure) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
+        }
+        failure.assertHasFailures(1)
+
+        when:
+        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2000"
+
+        then:
+        executed(':problems', ':moreProblems', ':all')
+        instantExecution.assertStateLoaded()
+        problems.assertFailureHasProblems(failure) {
+            withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
+            withProblem("task `:problems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
+            totalProblemsCount = 4
+        }
     }
 
     def "report does not include configuration and runtime problems from buildSrc"() {
@@ -380,45 +462,8 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
 
         then:
         problems.assertResultHasProblems(result) {
-            withProblem("input property 'p' of ':broken': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with instant execution.")
+            withProblem("input property 'p' of ':broken': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
         }
-    }
-
-    private Map<String, List<String>> withStateSerializationProblems() {
-        buildFile << """
-            task taskWithStateSerializationProblems {
-                inputs.property 'brokenProperty', project
-                inputs.property 'otherBrokenProperty', project
-            }
-        """
-        return [
-            store: [
-                "input property 'brokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with the configuration cache.",
-                "input property 'otherBrokenProperty' of ':taskWithStateSerializationProblems': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with the configuration cache.",
-            ],
-            load: [
-                "input property 'brokenProperty' of ':taskWithStateSerializationProblems': cannot deserialize object of type '${Project.name}' as these are not supported with the configuration cache.",
-                "input property 'otherBrokenProperty' of ':taskWithStateSerializationProblems': cannot deserialize object of type '${Project.name}' as these are not supported with the configuration cache."
-            ]
-        ]
-    }
-
-    private List<String> withTaskExecutionProblems() {
-        buildFile << """
-            abstract class MyTask extends DefaultTask {
-                @TaskAction
-                def action() {
-                    println("project:${'\$'}{project.name}")
-                }
-            }
-
-            tasks.register("a", MyTask)
-            tasks.register("b", MyTask)
-        """
-        return [
-            "task `:a` of type `MyTask`: invocation of 'Task.project' at execution time is unsupported.",
-            "task `:b` of type `MyTask`: invocation of 'Task.project' at execution time is unsupported."
-        ]
     }
 
     @Unroll
@@ -574,53 +619,6 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
             )
             withProblemsWithStackTraceCount(0)
         }
-    }
-
-    @Unroll
-    def "can limit the number of problems to #maxProblems"() {
-        given:
-        buildFile << """
-            class Bean {
-                Project p1
-                Project p2
-                Project p3
-            }
-
-            class FooTask extends DefaultTask {
-                private final bean = new Bean()
-
-                FooTask() {
-                    bean.with {
-                        p1 = project
-                        p2 = project
-                        p3 = project
-                    }
-                }
-
-                @TaskAction
-                void run() {
-                }
-            }
-
-            task foo(type: FooTask)
-        """
-
-        when:
-        instantFailsLenient "foo", "${MAX_PROBLEMS_CLI_OPTION}=$maxProblems"
-
-        then:
-        def expectedProblems = (1..expectedNumberOfProblems).collect {
-            "field 'p$it' from type 'Bean': cannot serialize object of type '${DefaultProject.name}', a subtype of '${Project.name}', as these are not supported with the configuration cache."
-        }
-        problems.assertFailureHasTooManyProblems(failure) {
-            withTotalProblemsCount(expectedNumberOfProblems)
-            withUniqueProblems(expectedProblems)
-            withProblemsWithStackTraceCount(0)
-        }
-
-        where:
-        maxProblems << [0, 1, 2]
-        expectedNumberOfProblems = Math.max(1, maxProblems)
     }
 
     def "can request to not fail on problems"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -28,27 +28,22 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         def fixture = newInstantExecutionFixture()
 
         when:
-        run("thing", "-DCI=$value")
-
-        then:
-        outputContains("apply = $value")
-        outputContains("task = $value")
-
-        when:
         instantFails("thing", "-DCI=$value")
 
         then:
+        fixture.assertStateStored()
         // TODO - use problems fixture, need to be able to tweak the problem matching as build script class name is included in the message and this is generated
         failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
+        outputContains("apply = $value")
+        outputContains("task = $value")
 
         when:
         instantRunLenient("thing", "-DCI=$value")
 
         then:
-        fixture.assertStateStored()
-        // TODO - use problems fixture, need to be able to tweak the problem matching as build script class name is included in the message and this is generated
-        outputContains("- unknown location: read system property 'CI' from class '")
-        outputContains("apply = $value")
+        fixture.assertStateLoaded()
+        problems.assertResultHasProblems(result)
+        outputDoesNotContain("apply =")
         outputContains("task = $value")
 
         when:
@@ -57,6 +52,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         then:
         fixture.assertStateLoaded() // undeclared properties are not considered build inputs, but probably should be
         problems.assertResultHasProblems(result)
+        outputDoesNotContain("apply =")
         outputContains("task = $newValue")
 
         where:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -146,13 +146,15 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         instantFails("-DCI=$defaultValue") // use the default value
 
         then:
+        fixture.assertStateStored()
         failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
 
         when:
-        instantFails("-DCI=$newValue")
+        instantRun("-DCI=$newValue") // undeclared inputs are not treated as inputs, but probably should be
 
         then:
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
+        fixture.assertStateLoaded()
+        noExceptionThrown()
 
         where:
         read                                                                        | defaultValue | newValue

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -153,15 +153,11 @@ class DefaultInstantExecution internal constructor(
             try {
                 writeInstantExecutionFiles()
             } catch (error: InstantExecutionError) {
-                // Invalidate unusable state on errors
-                invalidateInstantExecutionState()
-                problems.requestConsoleSummary()
+                problems.failingBuildDueToSerializationError()
                 throw error
             } finally {
-                if (startParameter.failOnProblems) {
-                    // Invalidate state on problems that fail the build
-                    problems.runIfProblems { invalidateInstantExecutionState() }
-                }
+                // Invalidate state on problems that fail the build
+                problems.runIfBuildWillFail { invalidateInstantExecutionState() }
             }
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -153,11 +153,10 @@ class DefaultInstantExecution internal constructor(
             try {
                 writeInstantExecutionFiles()
             } catch (error: InstantExecutionError) {
+                // Invalidate state on problems that fail the build
+                invalidateInstantExecutionState()
                 problems.failingBuildDueToSerializationError()
                 throw error
-            } finally {
-                // Invalidate state on problems that fail the build
-                problems.runIfBuildWillFail { invalidateInstantExecutionState() }
             }
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
@@ -74,10 +74,6 @@ class InstantExecutionProblems(
     private
     var isFailOnProblems = startParameter.failOnProblems
 
-    fun runIfBuildWillFail(action: () -> Unit) {
-        if (isFailOnProblems && problems.isNotEmpty()) action()
-    }
-
     fun failingBuildDueToSerializationError() {
         isFailOnProblems = false
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
@@ -83,13 +83,6 @@ class InstantExecutionProblems(
 
         override fun onProblem(problem: PropertyProblem) {
             problems.add(problem)
-            when {
-                problems.size >= startParameter.maxProblems -> {
-                    isConsoleSummaryRequested = false
-                    isFailOnProblems = false
-                    throw TooManyInstantExecutionProblemsException(problems, report.htmlReportFile)
-                }
-            }
         }
     }
 
@@ -102,12 +95,13 @@ class InstantExecutionProblems(
             }
             report.writeReportFiles(problems)
             if (isFailOnProblems) {
-                // TODO - always include this as a build failure
+                // TODO - always include this as a build failure, currently it is disabled when a serialization problem happens
                 throw InstantExecutionProblemsException(problems, report.htmlReportFile)
-            } else if (isConsoleSummaryRequested) {
+            } else if (problems.size > startParameter.maxProblems) {
+                throw TooManyInstantExecutionProblemsException(problems, report.htmlReportFile)
+            } else {
                 report.logConsoleSummary(problems)
             }
-            // Else, problems are already reported in an exception
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -61,7 +61,14 @@ class AbstractIntegrationSpec extends Specification {
     final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     GradleDistribution distribution = new UnderDevelopmentGradleDistribution(getBuildContext())
-    GradleExecuter executer = createExecuter()
+    private GradleExecuter executor
+
+    GradleExecuter getExecuter() {
+        if (executor == null) {
+            executor = createExecuter()
+        }
+        return executor
+    }
 
     BuildTestFixture buildTestFixture = new BuildTestFixture(temporaryFolder)
 
@@ -91,6 +98,13 @@ class AbstractIntegrationSpec extends Specification {
 
     def cleanup() {
         executer.cleanup()
+    }
+
+    private void recreateExecuter() {
+        if (executor != null) {
+            executor.cleanup()
+        }
+        executor = null
     }
 
     GradleExecuter createExecuter() {
@@ -231,7 +245,7 @@ class AbstractIntegrationSpec extends Specification {
         def isolatedGradleHomeDir = getTestDirectory().file("gradle-home")
         getBuildContext().gradleHomeDir.copyTo(isolatedGradleHomeDir)
         distribution = new UnderDevelopmentGradleDistribution(getBuildContext(), isolatedGradleHomeDir)
-        executer = createExecuter()
+        recreateExecuter()
         executer.requireGradleDistribution()
         executer.requireIsolatedDaemons() //otherwise we might connect to a running daemon from the original installation location
         executer

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
@@ -170,4 +170,9 @@ public class ErrorsOnStdoutScrapingExecutionResult implements ExecutionResult {
         delegate.assertTasksNotSkipped(taskPath);
         return this;
     }
+
+    @Override
+    public void assertResultVisited() {
+        delegate.assertResultVisited();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -182,4 +182,9 @@ public interface ExecutionResult {
      * Asserts that the given task has not been skipped.
      */
     ExecutionResult assertTaskNotSkipped(String taskPath);
+
+    /**
+     * Asserts that the important information from this result has been verified by the test.
+     */
+    void assertResultVisited();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
@@ -47,7 +47,7 @@ class ForkingGradleHandle extends OutputScrapingGradleHandle {
     private final boolean isDaemon;
 
     private final DurationMeasurement durationMeasurement;
-    private AtomicReference<ExecHandle> execHandleRef = new AtomicReference<ExecHandle>();
+    private final AtomicReference<ExecHandle> execHandleRef = new AtomicReference<ExecHandle>();
 
     public ForkingGradleHandle(PipedOutputStream stdinPipe, boolean isDaemon, Action<ExecutionResult> resultAssertion, String outputEncoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory, DurationMeasurement durationMeasurement) {
         this.resultAssertion = resultAssertion;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -654,6 +654,11 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             notSkipped.removeAll(skippedTasks);
             return notSkipped;
         }
+
+        @Override
+        public void assertResultVisited() {
+            outputResult.assertResultVisited();
+        }
     }
 
     private static class InProcessExecutionFailure extends InProcessExecutionResult implements ExecutionFailure {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -198,12 +198,12 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
 
     @Override
     protected ExecutionResult doRun() {
-        return startHandle().waitForFinish();
+        return createGradleHandle().waitForFinish();
     }
 
     @Override
     protected ExecutionFailure doRunWithFailure() {
-        return start().waitForFailure();
+        return createGradleHandle().waitForFailure();
     }
 
     private interface ExecHandlerConfigurer {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -353,6 +353,10 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         return this;
     }
 
+    @Override
+    public void assertResultVisited() {
+    }
+
     private void failOnDifferentSets(String message, Set<String> expected, Set<String> actual) {
         failureOnUnexpectedOutput(String.format("%s%nExpected: %s%nActual: %s", message, expected, actual));
     }

--- a/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/rhino/RhinoPluginIntegrationTest.groovy
+++ b/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/rhino/RhinoPluginIntegrationTest.groovy
@@ -74,6 +74,7 @@ class RhinoPluginIntegrationTest extends WellBehavedPluginTest {
         output.contains "rhino arg: foo"
     }
 
+    @ToBeFixedForInstantExecution
     def "compile failure fails task"() {
         given:
         file("some.js") << " ' "

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
@@ -22,6 +22,7 @@ import spock.lang.Unroll
 
 
 class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
+    @ToBeFixedForInstantExecution
     def "export fails when external dependency cannot be mapped to a git url"() {
         given:
         buildFile << """
@@ -41,6 +42,7 @@ class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftP
         failure.assertHasCause("Cannot determine the Git URL for dependency on dep:dep.")
     }
 
+    @ToBeFixedForInstantExecution
     def "export fails when file dependency is present"() {
         given:
         buildFile << """
@@ -60,6 +62,7 @@ class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftP
         failure.assertHasCause("Cannot map a dependency of type ")
     }
 
+    @ToBeFixedForInstantExecution
     def "export fails when external dependency defines both branch and version constraint"() {
         given:
         buildFile << """
@@ -402,6 +405,7 @@ let package = Package(
         '[1.0.0, 2.0.0)' | '"1.0.0"..<"2.0.0"'
     }
 
+    @ToBeFixedForInstantExecution
     @Unroll
     def "cannot map dependency #src"() {
         given:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -44,7 +44,7 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
     def "group header is printed red if task failed"() {
         given:
         buildFile << """
-            task failing { doFirst { 
+            task failing { doFirst {
                 logger.quiet 'hello'
                 throw new RuntimeException('Failure...')
             } }
@@ -61,7 +61,7 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
     def "group header is printed red if task failed and there is no output"() {
         given:
         buildFile << """
-            task failing { doFirst { 
+            task failing { doFirst {
                 throw new RuntimeException('Failure...')
             } }
         """
@@ -76,7 +76,7 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
     def "group header is printed white if task succeeds"() {
         given:
         buildFile << """
-            task succeeding { doFirst { 
+            task succeeding { doFirst {
                 logger.quiet 'hello'
             } }
         """
@@ -91,9 +91,9 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
     def "configure project group header is printed red if configuration fails with additional failures"() {
         given:
         buildFile << """
-            afterEvaluate { 
+            afterEvaluate {
                 println "executing after evaluate..."
-                throw new RuntimeException("After Evaluate Failure...") 
+                throw new RuntimeException("After Evaluate Failure...")
             }
             throw new RuntimeException('Config Failure...')
         """
@@ -104,6 +104,7 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
 
         then:
         result.formattedOutput.contains(configuringProject.output)
+        failure.assertHasFailures(2)
     }
 
     def "tasks that complete without output do not break up other task output"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.java
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.Unroll
@@ -87,6 +88,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
 
     }
 
+    @ToBeFixedForInstantExecution(because = ":dependencies")
     def "can fail resolution if producer doesn't have appropriate target version"() {
         buildFile << """
             configurations.compileClasspath.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 5)

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resource.s3.ivy
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.resolve.ivy.AbstractIvyRemoteRepoResolveIntegrationTest
 import org.gradle.integtests.resource.s3.fixtures.S3Server
@@ -38,6 +39,7 @@ class IvyS3RepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveIntegr
         result = executer.withTasks(*tasks).run()
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for s3 repo"() {
         given:
         def remoteIvyRepo = server.getRemoteIvyRepo()

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/maven/MavenSftpRepoResolveIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/maven/MavenSftpRepoResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.resource.sftp.maven
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.resource.sftp.AbstractSftpDependencyResolutionTest
 
 class MavenSftpRepoResolveIntegrationTest extends AbstractSftpDependencyResolutionTest {
@@ -57,6 +58,7 @@ class MavenSftpRepoResolveIntegrationTest extends AbstractSftpDependencyResoluti
         file('libs').assertHasDescendants 'projectA-1.2.jar'
     }
 
+    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for sftp repo"() {
         given:
         def mavenSftpRepo = getMavenSftpRepo()

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaBasePluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaBasePluginIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.scala
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.ZincScalaCompileFixture
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
@@ -87,6 +88,7 @@ task verify {
         succeeds("verify")
     }
 
+    @ToBeFixedForInstantExecution
     def "not specifying a scala runtime produces decent error message"() {
         given:
         buildFile << """

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -218,6 +218,7 @@ task someTask
         succeeds("install")
     }
 
+    @ToBeFixedForInstantExecution
     def "forcing an incompatible version of Scala fails with a clear error message"() {
         settingsFile << """
             rootProject.name = "scala"


### PR DESCRIPTION

### Context

- Do not delete the cache when storing and there are no problems that affect the cache contents, for example if there are only listener registration or system property read problems.
- Do not throw an exception when max problems threshold is reached, but instead fail at the end of the build.

Also add more content to the user manual chapter.

Add checks to `AbstractIntegrationSpec` so that a test must check the details of the build failures when there is more than one failure. This is to avoid additional problems silently appearing accidentally. This also makes the configuration cache test suite more accurate, as many configuration cache problems were being ignored in tests that asserted that the build failed, and these were accidentally passing even though there were configuration cache problems present.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
