### PR TITLE
Fix typo in --all option of outgoingVariants task.

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -74,7 +74,7 @@ It is conceptually similar to the `dependencyInsight` <<viewing_debugging_depend
 
 By default, `outgoingVariants` prints information about all variants.
 It offers the optional parameter `--variant <variantName>` to select a single variant to display.
-It also accepts the `-all` flag to include information about legacy and deprecated configurations.
+It also accepts the `--all` flag to include information about legacy and deprecated configurations.
 
 Here is the output of the `outgoingVariants` task on a freshly generated `java-library` project:
 


### PR DESCRIPTION
Fix documentation typo.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
