### PR TITLE
Limit the number of configuration cache problems that are reported on the console

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -26,15 +26,13 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         settingsFile << """includeBuild("included")"""
         file("included/settings.gradle") << ""
 
-        and:
-        def expectedProblem = "Gradle runtime: support for included builds is not yet implemented with the configuration cache."
-
         when:
         instantFails("help")
 
         then:
         problems.assertFailureHasProblems(failure) {
-            withUniqueProblems(expectedProblem)
+            withUniqueProblems("Gradle runtime: support for included builds is not yet implemented with the configuration cache.")
+            withProblemsWithStackTraceCount(0)
         }
 
         when:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -49,6 +49,7 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         problems.assertFailureHasProblems(failure) {
             withUniqueProblems(expectedStoreProblems)
             withTotalProblemsCount(expectedStoreProblemCount)
+            withProblemsWithStackTraceCount(0)
         }
 
         when:
@@ -59,6 +60,7 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         problems.assertResultHasProblems(result) {
             withTotalProblemsCount(expectedLoadProblemCount)
             withUniqueProblems(expectedLoadProblems)
+            withProblemsWithStackTraceCount(0)
         }
         htmlReportDir.assertIsDir()
 
@@ -74,6 +76,7 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         problems.assertFailureHasProblems(failure) {
             withTotalProblemsCount(expectedLoadProblemCount)
             withUniqueProblems(expectedLoadProblems)
+            withProblemsWithStackTraceCount(0)
         }
 
         when:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -215,6 +215,7 @@ class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstan
             withUniqueProblems(
                 "field 'this${'$'}0' from type 'Build_gradle${'$'}1': cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with the configuration cache."
             )
+            withProblemsWithStackTraceCount(0)
         }
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionUnsupportedTypesIntegrationTest.groovy
@@ -145,6 +145,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
                 "field 'badReference' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with the configuration cache.",
                 "field 'badReference' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with the configuration cache."
             )
+            withProblemsWithStackTraceCount(0)
         }
 
         when:
@@ -157,6 +158,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
                 "field 'badReference' from type 'SomeTask': cannot deserialize object of type '${baseType.name}' as these are not supported with the configuration cache.",
                 "field 'badReference' from type 'SomeBean': cannot deserialize object of type '${baseType.name}' as these are not supported with the configuration cache."
             )
+            withProblemsWithStackTraceCount(0)
         }
 
         and:
@@ -261,6 +263,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
                 "field 'badField' from type 'SomeTask': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with the configuration cache.",
                 "field 'badField' from type 'SomeBean': cannot serialize object of type '${concreteType.name}', a subtype of '${baseType.name}', as these are not supported with the configuration cache."
             )
+            withProblemsWithStackTraceCount(0)
         }
 
         when:
@@ -275,6 +278,7 @@ class InstantExecutionUnsupportedTypesIntegrationTest extends AbstractInstantExe
                 "field 'badField' from type 'SomeBean': cannot deserialize object of type '${baseType.name}' as these are not supported with the configuration cache.",
                 "field 'badField' from type 'SomeBean': value '$deserializedValue' is not assignable to '${baseType.name}'"
             )
+            withProblemsWithStackTraceCount(0)
         }
 
         and:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -32,7 +32,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
 
         then:
         fixture.assertStateStored()
-        // TODO - use problems fixture, need to be able to tweak the problem matching as build script class name is included in the message and this is generated
+        // TODO - use problems fixture, need to be able to ignore problems from the Kotlin plugin
         failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class '"))
         outputContains("apply = $value")
         outputContains("task = $value")
@@ -62,7 +62,6 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         SystemPropertyRead.systemGetPropertiesGet("CI")                               | "true" | "false"
         SystemPropertyRead.systemGetPropertiesGetProperty("CI")                       | "true" | "false"
         SystemPropertyRead.systemGetPropertiesGetPropertyWithDefault("CI", "default") | "true" | "false"
-        SystemPropertyRead.systemGetPropertiesFilterEntries("CI")                     | "true" | "false"
         SystemPropertyRead.integerGetInteger("CI")                                    | "12"   | "45"
         SystemPropertyRead.integerGetIntegerWithPrimitiveDefault("CI", 123)           | "12"   | "45"
         SystemPropertyRead.integerGetIntegerWithIntegerDefault("CI", 123)             | "12"   | "45"
@@ -70,5 +69,25 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         SystemPropertyRead.longGetLongWithPrimitiveDefault("CI", 123)                 | "12"   | "45"
         SystemPropertyRead.longGetLongWithLongDefault("CI", 123)                      | "12"   | "45"
         SystemPropertyRead.booleanGetBoolean("CI")                                    | "true" | "false"
+    }
+
+    @Unroll
+    def "reports undeclared system property read using when iterating over system properties"() {
+        buildLogicApplication(propertyRead)
+        def fixture = newInstantExecutionFixture()
+
+        when:
+        instantFails("thing", "-DCI=$value")
+
+        then:
+        fixture.assertStateStored()
+        // TODO - use the fixture, need to be able to ignore other problems
+        failure.assertHasDescription("Configuration cache problems found in this build.")
+        outputContains("apply = $value")
+        outputContains("task = $value")
+
+        where:
+        propertyRead                                              | value  | newValue
+        SystemPropertyRead.systemGetPropertiesFilterEntries("CI") | "true" | "false"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -36,8 +36,9 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         instantFails(*mechanism.gradleArgs)
 
         then:
-        // TODO - use problems fixture, however build script class is generated
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class 'build_"))
+        problems.assertFailureHasProblems(failure) {
+            withProblem("unknown location: read system property 'CI' from class 'build_")
+        }
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(3)
         failure.assertThatCause(containsNormalizedString("Read system property 'CI' from class 'build_"))
@@ -60,8 +61,10 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         instantFails(*mechanism.gradleArgs, "-DCI2=true")
 
         then:
-        // TODO - use problems fixture, however build script class is generated
-        failure.assertThatDescription(containsNormalizedString("- unknown location: read system property 'CI' from class 'build_"))
+        problems.assertFailureHasProblems(failure) {
+            withProblem("unknown location: read system property 'CI' from class 'build_")
+            withProblem("unknown location: read system property 'CI2' from class 'build_")
+        }
         failure.assertHasFileName("Build file '${file("buildSrc/build.gradle").absolutePath}'")
         failure.assertHasLineNumber(2)
         failure.assertThatCause(containsNormalizedString("Read system property 'CI' from class 'build_"))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
@@ -69,20 +69,23 @@ open class InstantExecutionProblemsException : InstantExecutionException {
     protected
     constructor(
         message: String,
+        causes: List<Throwable>,
         problems: List<PropertyProblem>,
         htmlReportFile: File
     ) : super(
         { "$message\n${buildConsoleSummary(problems, htmlReportFile)}" },
-        problems.mapNotNull(PropertyProblem::exception)
+        causes
     )
 
     internal
     constructor(
+        causes: List<Throwable>,
         problems: List<PropertyProblem>,
         htmlReportFile: File
     ) : this(
         "Configuration cache problems found in this build.\n" +
             "Gradle can be made to ignore these problems, see ${Documentation.ignoreProblems}.",
+        causes,
         problems,
         htmlReportFile
     )
@@ -90,11 +93,13 @@ open class InstantExecutionProblemsException : InstantExecutionException {
 
 
 class TooManyInstantExecutionProblemsException internal constructor(
+    causes: List<Throwable>,
     problems: List<PropertyProblem>,
     htmlReportFile: File
 ) : InstantExecutionProblemsException(
     "Maximum number of configuration cache problems has been reached.\n" +
         "This behavior can be adjusted, see ${Documentation.maxProblems}.",
+    causes,
     problems,
     htmlReportFile
 )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
@@ -25,6 +25,10 @@ private
 data class UniquePropertyProblem(val property: String, val message: StructuredMessage, val documentationSection: String?)
 
 
+private
+const val maxConsoleProblems = 15
+
+
 internal
 fun buildConsoleSummary(problems: List<PropertyProblem>, reportFile: File): String {
     val documentationRegistry = DocumentationRegistry()
@@ -32,7 +36,7 @@ fun buildConsoleSummary(problems: List<PropertyProblem>, reportFile: File): Stri
     return StringBuilder().apply {
         appendln()
         appendln(buildSummaryHeader(problems.size, uniquePropertyProblems))
-        uniquePropertyProblems.forEach { problem ->
+        uniquePropertyProblems.take(maxConsoleProblems).forEach { problem ->
             append("- ")
             append(problem.property)
             append(": ")
@@ -40,6 +44,9 @@ fun buildConsoleSummary(problems: List<PropertyProblem>, reportFile: File): Stri
             if (problem.documentationSection != null) {
                 appendln("  See ${documentationRegistry.getDocumentationFor("configuration_cache", problem.documentationSection)}")
             }
+        }
+        if (uniquePropertyProblems.size > maxConsoleProblems) {
+            appendln("plus ${uniquePropertyProblems.size - maxConsoleProblems} more problems. Please see the report for details.")
         }
         appendln()
         append(buildSummaryReportLink(reportFile))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
@@ -18,6 +18,8 @@ package org.gradle.integtests.fixtures.executer;
 
 import org.hamcrest.Matcher;
 
+import java.util.function.Consumer;
+
 public class ErrorsOnStdoutScrapingExecutionFailure extends ErrorsOnStdoutScrapingExecutionResult implements ExecutionFailure {
     private final ExecutionFailure delegate;
 
@@ -70,6 +72,12 @@ public class ErrorsOnStdoutScrapingExecutionFailure extends ErrorsOnStdoutScrapi
     @Override
     public ExecutionFailure assertThatDescription(Matcher<? super String> matcher) {
         delegate.assertThatDescription(matcher);
+        return this;
+    }
+
+    @Override
+    public ExecutionFailure assertHasFailure(String description, Consumer<? super Failure> action) {
+        delegate.assertHasFailure(description, action);
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
@@ -17,6 +17,8 @@ package org.gradle.integtests.fixtures.executer;
 
 import org.hamcrest.Matcher;
 
+import java.util.function.Consumer;
+
 public interface ExecutionFailure extends ExecutionResult {
     /**
      * {@inheritDoc}
@@ -34,28 +36,37 @@ public interface ExecutionFailure extends ExecutionResult {
     ExecutionFailure assertHasFailures(int count);
 
     /**
-     * Asserts that the reported failure has the given cause (ie the bit after the description).
+     * Assert that there is a failure present with the given description and invokes the given action on the failure.
+     *
+     * <p>Error messages are normalized to use new-line char as line separator.
+     *
+     * @return this
+     */
+    ExecutionFailure assertHasFailure(String description, Consumer<? super Failure> action);
+
+    /**
+     * Asserts that there is a failure present with the given cause (ie the bit after the description).
      *
      * <p>Error messages are normalized to use new-line char as line separator.
      */
     ExecutionFailure assertHasCause(String description);
 
     /**
-     * Asserts that the reported failure has the given cause (ie the bit after the description).
+     * Asserts that there is a failure present with the given cause (ie the bit after the description).
      *
      * <p>Error messages are normalized to use new-line char as line separator.
      */
     ExecutionFailure assertThatCause(Matcher<? super String> matcher);
 
     /**
-     * Asserts that the reported failure has the given description (ie the bit after '* What went wrong').
+     * Asserts that there is a failure present with the given description (ie the bit after '* What went wrong').
      *
      * <p>Error messages are normalized to use new-line char as line separator.
      */
     ExecutionFailure assertHasDescription(String context);
 
     /**
-     * Asserts that the reported failure has the given description (ie the bit after '* What went wrong').
+     * Asserts that there is a failure present with the given description (ie the bit after '* What went wrong').
      *
      * <p>Error messages are normalized to use new-line char as line separator.
      */
@@ -79,4 +90,11 @@ public interface ExecutionFailure extends ExecutionResult {
      * @param configurationPath, for example ':compile'
      */
     DependencyResolutionFailure assertResolutionFailure(String configurationPath);
+
+    interface Failure {
+        /**
+         * Asserts that this failure has the given number of direct causes.
+         */
+        void assertHasCauses(int count);
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
@@ -39,12 +39,12 @@ import javax.script.ScriptEngineManager
 import java.nio.file.Paths
 import java.util.regex.Pattern
 
-import static org.gradle.util.Matchers.normalizedLineSeparators
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.CoreMatchers.nullValue
+import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.Assert.assertTrue
 
@@ -86,7 +86,7 @@ final class InstantExecutionProblemsFixture {
     ) {
         spec.validateSpec()
 
-        assertFailureDescription(failure, spec.rootCauseDescription, failureDescriptionMatcherForError(spec))
+        assertFailureDescription(failure, failureDescriptionMatcherForError(spec))
 
         if (spec.hasProblems()) {
             assertHasConsoleSummary(failure.output, spec)
@@ -131,7 +131,7 @@ final class InstantExecutionProblemsFixture {
         HasInstantExecutionProblemsSpec spec
     ) {
         assertNoProblemsSummary(failure.output)
-        assertFailureDescription(failure, spec.rootCauseDescription, failureDescriptionMatcherForProblems(spec))
+        assertFailureDescription(failure, failureDescriptionMatcherForProblems(spec))
         assertProblemsHtmlReport(failure.error, rootDir, spec)
     }
 
@@ -154,7 +154,7 @@ final class InstantExecutionProblemsFixture {
         HasInstantExecutionProblemsSpec spec
     ) {
         assertNoProblemsSummary(failure.output)
-        assertFailureDescription(failure, spec.rootCauseDescription, failureDescriptionMatcherForTooManyProblems(spec))
+        assertFailureDescription(failure, failureDescriptionMatcherForTooManyProblems(spec))
         assertProblemsHtmlReport(failure.error, rootDir, spec)
     }
 
@@ -228,7 +228,9 @@ final class InstantExecutionProblemsFixture {
         return new BaseMatcher<String>() {
             @Override
             boolean matches(Object item) {
-                assert item.toString().contains(message)
+                if (!item.toString().contains(message)) {
+                    return false
+                }
                 assertHasConsoleSummary(item.toString(), spec)
                 return true
             }
@@ -246,15 +248,9 @@ final class InstantExecutionProblemsFixture {
 
     private static void assertFailureDescription(
         ExecutionFailure failure,
-        @Nullable String rootCauseDescription = null,
         Matcher<String> failureMatcher
     ) {
-        if (rootCauseDescription) {
-            failure.assertHasDescription(rootCauseDescription)
-            failure.assertThatCause(failureMatcher)
-        } else {
-            failure.assertThatDescription(failureMatcher)
-        }
+        failure.assertThatDescription(failureMatcher)
     }
 
     private static void assertHasConsoleSummary(String text, HasInstantExecutionProblemsSpec spec) {
@@ -264,7 +260,10 @@ final class InstantExecutionProblemsFixture {
         def summary = extractSummary(text)
         assert summary.totalProblems == totalCount
         assert summary.uniqueProblems == uniqueCount
-        assert summary.messages == spec.uniqueProblems
+        assert summary.messages.size() == spec.uniqueProblems.size()
+        for (int i in spec.uniqueProblems.indices) {
+            assert spec.uniqueProblems[i].matches(summary.messages[i])
+        }
     }
 
     protected static void assertProblemsHtmlReport(
@@ -272,12 +271,13 @@ final class InstantExecutionProblemsFixture {
         File rootDir,
         HasInstantExecutionProblemsSpec spec
     ) {
+        def totalProblemCount = spec.totalProblemsCount ? spec.totalProblemsCount : spec.uniqueProblems.size()
         assertProblemsHtmlReport(
             rootDir,
             output,
-            spec.totalProblemsCount ? spec.totalProblemsCount : spec.uniqueProblems.size(),
+            totalProblemCount,
             spec.uniqueProblems.size(),
-            spec.problemsWithStackTraceCount
+            spec.problemsWithStackTraceCount == null ? totalProblemCount : spec.problemsWithStackTraceCount
         )
     }
 
@@ -286,7 +286,7 @@ final class InstantExecutionProblemsFixture {
         String output,
         int totalProblemCount,
         int uniqueProblemCount,
-        @Nullable Integer problemsWithStackTraceCount
+        int problemsWithStackTraceCount
     ) {
         def expectReport = totalProblemCount > 0 || uniqueProblemCount > 0
         def reportDir = resolveInstantExecutionReportDirectory(rootDir, output)
@@ -302,13 +302,11 @@ final class InstantExecutionProblemsFixture {
                 numberOfProblemsIn(jsFile),
                 equalTo(totalProblemCount)
             )
-            if (problemsWithStackTraceCount != null) {
-                assertThat(
-                    "HTML report JS model has wrong number of problem(s) with stacktrace",
-                    numberOfProblemsWithStacktraceIn(jsFile),
-                    equalTo(problemsWithStackTraceCount)
-                )
-            }
+            assertThat(
+                "HTML report JS model has wrong number of problem(s) with stacktrace",
+                numberOfProblemsWithStacktraceIn(jsFile),
+                equalTo(problemsWithStackTraceCount)
+            )
         } else {
             assertThat("Unexpected HTML report URI found", reportDir, nullValue())
         }
@@ -347,14 +345,11 @@ final class InstantExecutionProblemsFixture {
         new ScriptEngineManager().getEngineByName("JavaScript")
     }
 
-    protected static Matcher<String> containsNormalizedString(String string) {
-        return normalizedLineSeparators(containsString(string))
-    }
-
     private static ProblemsSummary extractSummary(String text) {
         def headerPattern = Pattern.compile("(\\d+) configuration cache (problems were|problem was) found(, (\\d+) of which seem(s)? unique)?.*")
         def problemPattern = Pattern.compile("- (.*)")
         def docPattern = Pattern.compile(" {2}\\QSee https://docs.gradle.org\\E.*")
+        def tooManyProblemsPattern = Pattern.compile("plus (\\d+) more problems. Please see the report for details.")
 
         def output = LogContent.of(text)
 
@@ -369,14 +364,21 @@ ${text}
         def matcher = headerPattern.matcher(summary.first)
         assert matcher.matches()
         def totalProblems = matcher.group(1).toInteger()
-        def uniqueProblems = matcher.group(4)?.toInteger() ?: totalProblems
+        def expectedUniqueProblems = matcher.group(4)?.toInteger() ?: totalProblems
         summary = summary.drop(1)
 
         def problems = []
-        for (int i = 0; i < uniqueProblems; i++) {
+        for (int i = 0; i < expectedUniqueProblems; i++) {
             matcher = problemPattern.matcher(summary.first)
             if (!matcher.matches()) {
-                throw new AssertionFailedError("""Expected a problem description, found: ${summary.first}""")
+                matcher = tooManyProblemsPattern.matcher(summary.first)
+                if (matcher.matches()) {
+                    def remainder = matcher.group(1).toInteger()
+                    if (i + remainder == expectedUniqueProblems) {
+                        break
+                    }
+                }
+                throw new AssertionFailedError("""Expected ${expectedUniqueProblems - i} more problem descriptions, found: ${summary.first}""")
             }
             def problem = matcher.group(1)
             problems.add(problem)
@@ -388,7 +390,7 @@ ${text}
             }
         }
 
-        return new ProblemsSummary(totalProblems, uniqueProblems, problems)
+        return new ProblemsSummary(totalProblems, problems.size(), problems)
     }
 
     private static class ProblemsSummary {
@@ -418,13 +420,8 @@ final class HasInstantExecutionErrorSpec extends HasInstantExecutionProblemsSpec
 
 
 class HasInstantExecutionProblemsSpec {
-
-    @Nullable
     @PackageScope
-    String rootCauseDescription
-
-    @PackageScope
-    final List<String> uniqueProblems = []
+    final List<Matcher<String>> uniqueProblems = []
 
     @Nullable
     @PackageScope
@@ -455,22 +452,24 @@ class HasInstantExecutionProblemsSpec {
         return !uniqueProblems.isEmpty()
     }
 
-    HasInstantExecutionProblemsSpec withRootCauseDescription(String rootCauseDescription) {
-        this.rootCauseDescription = rootCauseDescription
-        return this
-    }
-
     HasInstantExecutionProblemsSpec withUniqueProblems(String... uniqueProblems) {
         return withUniqueProblems(uniqueProblems as List)
     }
 
     HasInstantExecutionProblemsSpec withUniqueProblems(Iterable<String> uniqueProblems) {
         this.uniqueProblems.clear()
-        this.uniqueProblems.addAll(uniqueProblems)
+        uniqueProblems.each {
+            withProblem(it)
+        }
         return this
     }
 
     HasInstantExecutionProblemsSpec withProblem(String problem) {
+        uniqueProblems.add(startsWith(problem))
+        return this
+    }
+
+    HasInstantExecutionProblemsSpec withProblem(Matcher<String> problem) {
         uniqueProblems.add(problem)
         return this
     }


### PR DESCRIPTION

### Context

Avoid flooding the console build summary when there are many similar configuration cache problems, by limiting the number of problems that are reported on the console and configuration cache exceptions that are included in the build failure.

All problems are still included in the report along with their stack traces.

Add methods to the fixtures to allow a build failure and its causes to be verified, rather than grouping the causes of all failures together.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
