### PR TITLE
Do not instrument build logic required by build scripts when configuration cache is disabled

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -93,6 +93,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         loopNumber << (1..6).toList()
     }
 
+    @ToBeFixedForInstantExecution(because = "classpath locations are different when caching enabled or disabled")
     def "build script classloader copies jar files to cache"() {
         given:
         createBuildFileThatPrintsClasspathURLs("""
@@ -114,7 +115,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         then:
         succeeds("showBuildscript")
         inJarCache("test-1.3-BUILD-SNAPSHOT.jar")
-        inJarCache("commons-io-1.4.jar")
+        notInJarCache("commons-io-1.4.jar")
     }
 
     private void createBuildFileThatPrintsClasspathURLs(String dependencies = '') {

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -36,6 +36,8 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.plugin.management.internal.PluginRequests;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +46,7 @@ import java.io.File;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
+@ServiceScope(Scopes.Build)
 public class BuildSourceBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildSourceBuilder.class);
     private static final BuildBuildSrcBuildOperationType.Result BUILD_BUILDSRC_RESULT = new BuildBuildSrcBuildOperationType.Result() {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/BuildLogicTransformStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/BuildLogicTransformStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scopes.BuildTree)
+public interface BuildLogicTransformStrategy {
+    /**
+     * Calculates the transform to apply to build logic.
+     */
+    CachedClasspathTransformer.StandardTransform transformToApplyToBuildLogic();
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -24,7 +24,9 @@ import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -33,6 +35,8 @@ import java.util.Set;
 
 @ServiceScope(Scopes.UserHome)
 public class ClasspathBuilder {
+    private static final int BUFFER_SIZE = 8192;
+
     /**
      * Creates a Jar file using the given action to add entries to the file.
      */
@@ -49,7 +53,7 @@ public class ClasspathBuilder {
         File tmpFile = File.createTempFile(jarFile.getName(), ".tmp");
         try {
             Files.createDirectories(parentDir.toPath());
-            try (ZipOutputStream outputStream = new ZipOutputStream(tmpFile)) {
+            try (ZipOutputStream outputStream = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tmpFile), BUFFER_SIZE))) {
                 outputStream.setLevel(0);
                 action.execute(new ZipEntryBuilder(outputStream));
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -46,14 +46,14 @@ public class ClasspathBuilder {
 
     private void buildJar(File jarFile, Action action) throws IOException {
         File parentDir = jarFile.getParentFile();
-        File tmpFile = new File(parentDir, jarFile.getName() + ".tmp");
+        File tmpFile = File.createTempFile(jarFile.getName(), ".tmp");
         try {
             Files.createDirectories(parentDir.toPath());
             try (ZipOutputStream outputStream = new ZipOutputStream(tmpFile)) {
                 outputStream.setLevel(0);
                 action.execute(new ZipEntryBuilder(outputStream));
             }
-            Files.move(tmpFile.toPath(), jarFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(tmpFile.toPath(), jarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } finally {
             Files.deleteIfExists(tmpFile.toPath());
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -153,7 +153,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         VirtualFileSystem virtualFileSystem,
         ClasspathWalker classpathWalker,
         ClasspathBuilder classpathBuilder,
-        ExecutorFactory executorFactory
+        ExecutorFactory executorFactory,
+        List<AdditiveCache> additiveCaches
     ) {
         return new DefaultCachedClasspathTransformer(
             cacheRepository,
@@ -162,7 +163,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
             classpathWalker,
             classpathBuilder,
             virtualFileSystem,
-            executorFactory);
+            executorFactory,
+            additiveCaches);
     }
 
     WorkerProcessFactory createWorkerProcessFactory(LoggingManagerInternal loggingManagerInternal, MessagingServer messagingServer, ClassPathRegistry classPathRegistry,

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
@@ -19,11 +19,13 @@ package org.gradle.plugin.use.internal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.plugin.management.internal.PluginRequests;
 
 import javax.annotation.Nullable;
 
-// Implementation is provided by 'plugin-use' module
+@ServiceScope(Scopes.Build)
 public interface PluginRequestApplicator {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -25,6 +25,8 @@ import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.build.NestedRootBuild;
+import org.gradle.internal.classpath.BuildLogicTransformStrategy;
+import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
 import org.gradle.internal.service.ServiceRegistry;
@@ -54,6 +56,15 @@ public class TestBuildScopeServices extends BuildScopeServices {
 
     protected CurrentGradleInstallation createCurrentGradleInstallation() {
         return new CurrentGradleInstallation(new GradleInstallation(homeDir));
+    }
+
+    protected BuildLogicTransformStrategy createBuildLogicTransformStrategy() {
+        return new BuildLogicTransformStrategy() {
+            @Override
+            public CachedClasspathTransformer.StandardTransform transformToApplyToBuildLogic() {
+                return CachedClasspathTransformer.StandardTransform.BuildLogic;
+            }
+        };
     }
 
     protected NestedBuildFactory createNestedBuildFactory() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -136,7 +136,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
+        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, None)
@@ -154,7 +154,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
+        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
         transformer.transform(classpath, None)
 
         when:
@@ -191,7 +191,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
+        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
         transformer.transform(classpath, None)
         modifiedJar(file)
 
@@ -227,7 +227,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/396146b843a8f87e95864ef58964482f/thing.jar")
+        def cachedFile = testDir.file("cached/530c6bbffbdcca1d28d8e9445ae3d710/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -286,7 +286,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
         def cachedDir = testDir.file("cached/242050944f8d64367cc4fb4427e7968a/thing.dir.jar")
-        def cachedFile = testDir.file("cached/396146b843a8f87e95864ef58964482f/thing.jar")
+        def cachedFile = testDir.file("cached/530c6bbffbdcca1d28d8e9445ae3d710/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -306,7 +306,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/504af72ac0b2238332034919ee747fc2/thing.jar")
+        def cachedFile = testDir.file("cached/6b9668d41759de943201082f7963d427/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)
@@ -340,7 +340,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def remote = new URL("https://somewhere")
-        def cachedFile = testDir.file("cached/o_659c65796b577f3b8d3ac61e3196d918/thing.jar")
+        def cachedFile = testDir.file("cached/o_e161f24809571a55f09d3f820c8e5942/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform([file.toURI().toURL(), remote], None)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -165,7 +165,7 @@ org.gradle.api.internal.tasks.CompileServices
                 'META-INF/services/org.gradle.internal.other.Service',
                 'META-INF/.gradle-runtime-shaded']
         }
-        outputJar.md5Hash == "18aea65849b2aebd52d160f59823d635"
+        outputJar.md5Hash == "dee78866d881612695b2875ef948d5d5"
     }
 
     def "excludes module-info.class from jar"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -236,7 +236,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         """
 
         when:
-        run()
+        instantRun()
 
         then:
         // The JVM only exposes one of the resources

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.plugins.PluginInspector;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.internal.Factory;
+import org.gradle.internal.classpath.BuildLogicTransformStrategy;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.reflect.Instantiator;
@@ -94,10 +95,11 @@ public class PluginUsePluginServiceRegistry extends AbstractPluginServiceRegistr
 
         PluginRequestApplicator createPluginRequestApplicator(PluginRegistry pluginRegistry, PluginDependencyResolutionServices dependencyResolutionServices,
                                                               PluginResolverFactory pluginResolverFactory, PluginResolutionStrategyInternal internalPluginResolutionStrategy,
-                                                              PluginInspector pluginInspector, CachedClasspathTransformer cachedClasspathTransformer) {
+                                                              PluginInspector pluginInspector, CachedClasspathTransformer cachedClasspathTransformer,
+                                                              BuildLogicTransformStrategy transformStrategy) {
             return new DefaultPluginRequestApplicator(
                 pluginRegistry, pluginResolverFactory, dependencyResolutionServices.getPluginRepositoriesProvider(),
-                internalPluginResolutionStrategy, pluginInspector, cachedClasspathTransformer);
+                internalPluginResolutionStrategy, pluginInspector, cachedClasspathTransformer, transformStrategy);
         }
 
         InjectedClasspathPluginResolver createInjectedClassPathPluginResolver(ClassLoaderScopeRegistry classLoaderScopeRegistry, PluginInspector pluginInspector,

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.plugins.InvalidPluginException;
 import org.gradle.api.plugins.UnknownPluginException;
+import org.gradle.internal.classpath.BuildLogicTransformStrategy;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.exceptions.LocationAwareException;
@@ -50,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newLinkedHashMap;
-import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic;
 import static org.gradle.util.CollectionUtils.collect;
 
 public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
@@ -60,14 +60,16 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     private final PluginResolutionStrategyInternal pluginResolutionStrategy;
     private final PluginInspector pluginInspector;
     private final CachedClasspathTransformer cachedClasspathTransformer;
+    private final BuildLogicTransformStrategy transformStrategy;
 
-    public DefaultPluginRequestApplicator(PluginRegistry pluginRegistry, PluginResolverFactory pluginResolver, PluginRepositoriesProvider pluginRepositoriesProvider, PluginResolutionStrategyInternal pluginResolutionStrategy, PluginInspector pluginInspector, CachedClasspathTransformer cachedClasspathTransformer) {
+    public DefaultPluginRequestApplicator(PluginRegistry pluginRegistry, PluginResolverFactory pluginResolver, PluginRepositoriesProvider pluginRepositoriesProvider, PluginResolutionStrategyInternal pluginResolutionStrategy, PluginInspector pluginInspector, CachedClasspathTransformer cachedClasspathTransformer, BuildLogicTransformStrategy transformStrategy) {
         this.pluginRegistry = pluginRegistry;
         this.pluginResolverFactory = pluginResolver;
         this.pluginRepositoriesProvider = pluginRepositoriesProvider;
         this.pluginResolutionStrategy = pluginResolutionStrategy;
         this.pluginInspector = pluginInspector;
         this.cachedClasspathTransformer = cachedClasspathTransformer;
+        this.transformStrategy = transformStrategy;
     }
 
     @Override
@@ -153,7 +155,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
 
     private void defineScriptHandlerClassScope(ScriptHandlerInternal scriptHandler, ClassLoaderScope classLoaderScope, Iterable<PluginImplementation<?>> pluginsFromOtherLoaders) {
         ClassPath classPath = scriptHandler.getScriptClassPath();
-        ClassPath cachedClassPath = cachedClasspathTransformer.transform(classPath, BuildLogic);
+        ClassPath cachedClassPath = cachedClasspathTransformer.transform(classPath, transformStrategy.transformToApplyToBuildLogic());
         classLoaderScope.export(cachedClassPath);
 
         for (PluginImplementation<?> pluginImplementation : pluginsFromOtherLoaders) {


### PR DESCRIPTION

### Context

Temporarily disable build logic instrumentation when the configuration cache is not enabled. This is intended to give us some time to fix issues without those issues impacting people who are currently not using the configuration cache. This will be reverted at some point so that the instrumentation is always applied regardless of whether the configuration cache is enable or not.

The instrumentation is always applied to `buildSrc` plugins, build scripts and also anything injected via `TestKit`, so that we keep some coverage of the instrumentation.

Also fix a performance regression generating the instrumented Jars.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
