### PR TITLE
Expose provided credentials in authenticated repositories

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.credentials.Credentials;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -95,6 +96,33 @@ public interface AuthenticationSupported {
      * @throws IllegalArgumentException if {@code credentialsType} is of a different type to the credentials previously specified for this repository
      */
     <T extends Credentials> void credentials(Class<T> credentialsType, Action<? super T> action);
+
+    /**
+     * Configures the credentials for this repository that will be provided by the build.
+     * <p>
+     * Credentials will be provided from Gradle properties based on the repository name.
+     * If credentials for this repository can not be resolved and the repository will be used in the current build, then the build will fail to start and point to the missing configuration.
+     * <pre class='autoTested'>
+     * repositories {
+     *     maven {
+     *         url "${url}"
+     *         credentials(PasswordCredentials)
+     *     }
+     * }
+     * </pre>
+     * <p>
+     * The following credential types are currently supported for the {@code credentialsType} argument:
+     * <ul>
+     * <li>{@link org.gradle.api.credentials.PasswordCredentials}</li>
+     * <li>{@link org.gradle.api.credentials.AwsCredentials}</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if {@code credentialsType} is not of a supported type
+     *
+     * @since 6.6
+     */
+    @Incubating
+    void credentials(Class<? extends Credentials> credentialsType);
 
     /**
      * <p>Configures the authentication schemes for this repository.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
@@ -77,6 +77,7 @@ public abstract class AbstractAuthenticationSupportedRepository extends Abstract
         delegate.credentials(credentialsType, action);
     }
 
+    @Override
     public void credentials(Class<? extends Credentials> credentialsType) {
         invalidateDescriptor();
         delegate.credentials(credentialsType, this::getName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
@@ -89,6 +89,11 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         action.execute(getCredentials(credentialsType));
     }
 
+    @Override
+    public void credentials(Class<? extends Credentials> credentialsType) {
+        throw new UnsupportedOperationException();
+    }
+
     public void credentials(Class<? extends Credentials> credentialsType, Supplier<String> identity) {
         this.usesCredentials = true;
         this.credentials.set(credentialsProviderFactory.provideCredentials(credentialsType, identity));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
@@ -27,7 +27,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.authentication.Authentication;
 import org.gradle.internal.Cast;
-import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
 import org.gradle.internal.authentication.AllSchemesAuthentication;
 import org.gradle.internal.authentication.AuthenticationInternal;
 import org.gradle.internal.credentials.DefaultAwsCredentials;
@@ -39,7 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Supplier;
 
-public class AuthenticationSupporter implements AuthenticationSupportedInternal {
+public class AuthenticationSupporter {
     private final Instantiator instantiator;
     private final AuthenticationContainer authenticationContainer;
     private final CredentialsProviderFactory credentialsProviderFactory;
@@ -54,7 +53,6 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         this.credentialsProviderFactory = credentialsProviderFactory;
     }
 
-    @Override
     public PasswordCredentials getCredentials() {
         if (!usesCredentials()) {
             return setCredentials(PasswordCredentials.class);
@@ -65,7 +63,6 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         }
     }
 
-    @Override
     public <T extends Credentials> T getCredentials(Class<T> credentialsType) {
         if (!usesCredentials()) {
             return setCredentials(credentialsType);
@@ -76,7 +73,6 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         }
     }
 
-    @Override
     public void credentials(Action<? super PasswordCredentials> action) {
         if (usesCredentials() && !(credentials.get() instanceof PasswordCredentials)) {
             throw new IllegalStateException("Can not use credentials(Action) method when not using PasswordCredentials; please use credentials(Class, Action)");
@@ -84,14 +80,8 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         credentials(PasswordCredentials.class, action);
     }
 
-    @Override
     public <T extends Credentials> void credentials(Class<T> credentialsType, Action<? super T> action) throws IllegalStateException {
         action.execute(getCredentials(credentialsType));
-    }
-
-    @Override
-    public void credentials(Class<? extends Credentials> credentialsType) {
-        throw new UnsupportedOperationException();
     }
 
     public void credentials(Class<? extends Credentials> credentialsType, Supplier<String> identity) {
@@ -99,7 +89,6 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         this.credentials.set(credentialsProviderFactory.provideCredentials(credentialsType, identity));
     }
 
-    @Override
     public void setConfiguredCredentials(Credentials credentials) {
         this.usesCredentials = true;
         this.credentials.set(credentials);
@@ -116,22 +105,18 @@ public class AuthenticationSupporter implements AuthenticationSupportedInternal 
         return instantiator.newInstance(getCredentialsImplType(clazz));
     }
 
-    @Override
     public Property<Credentials> getConfiguredCredentials() {
         return credentials;
     }
 
-    @Override
     public void authentication(Action<? super AuthenticationContainer> action) {
         action.execute(getAuthentication());
     }
 
-    @Override
     public AuthenticationContainer getAuthentication() {
         return authenticationContainer;
     }
 
-    @Override
     public Collection<Authentication> getConfiguredAuthentication() {
         populateAuthenticationCredentials();
         if (usesCredentials() && authenticationContainer.size() == 0) {

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/README.adoc
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/README.adoc
@@ -17,31 +17,25 @@ include::sample[dir="groovy",files="build.gradle[tags=publication]"]
 include::sample[dir="kotlin",files="build.gradle.kts[tags=publication]"]
 ====
 
-Authentication credentials are only configured and validated if the publication task is going to be invoked in the current build:
-====
-include::sample[dir="groovy",files="build.gradle[tags=credentials]"]
-include::sample[dir="kotlin",files="build.gradle.kts[tags=credentials]"]
-====
-
 Credential values are declared to be Gradle properties and can be passed to the publish task in multiple ways:
 
 * via command-line properties:
 =====
 ----
-$ ./gradlew publish -PmavenUser=secret-user -PmavenPassword=secret-password
+$ ./gradlew publish -PmySecureRepositoryUsername=secret-user -PmySecureRepositoryPassword=secret-password
 ----
 =====
 * via environment variables:
 =====
 ----
-$ ORG_GRADLE_PROJECT_mavenUser=secret-user ORG_GRADLE_PROJECT_mavenPassword=secret-password ./gradlew publish
+$ ORG_GRADLE_PROJECT_mySecureRepositoryUsername=secret-user ORG_GRADLE_PROJECT_mySecureRepositoryPassword=secret-password ./gradlew publish
 ----
 =====
 * by setting the properties in `gradle.properties` file:
 =====
 ----
-mavenUser=secret-user
-mavenPassword=secret-password
+mySecureRepositoryUsername=secret-user
+mySecureRepositoryPassword=secret-password
 ----
 =====
 and running

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/README.adoc
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/README.adoc
@@ -11,13 +11,18 @@ include::sample[dir="groovy",files="maven-repository-stub/src/main/java/com/exam
 In a real project, your build would point to a private repository for your organization.
 
 The published project has some sample Java code to be compiled and distributed as a Java library.
-Gradle build file registers a publication to a Maven repository:
+Gradle build file registers a publication to a Maven repository using provided credentials:
 ====
 include::sample[dir="groovy",files="build.gradle[tags=publication]"]
 include::sample[dir="kotlin",files="build.gradle.kts[tags=publication]"]
 ====
 
-Credential values are declared to be Gradle properties and can be passed to the publish task in multiple ways:
+Credentials will be required by the build only if the task requiring them is to be executed - in this case the task publishing to the secure repository.
+This allows to build the project without worrying about the credentials.
+Try running `./gradlew jar` and it will succeed. Run `./gradlew publish` and it will tell you what is missing right away, without executing the build.
+Credentials can and should be kept externally from the project sources and be known only by those having to publish artifacts, perhaps injected by a CI server.
+
+Credential values are provided using Gradle properties and can be passed to the publish task in multiple ways:
 
 * via command-line properties:
 =====

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/build.gradle
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/build.gradle
@@ -18,30 +18,11 @@ publishing {
     }
     repositories {
         maven {
-            name = 'mySecure'
+            name = 'mySecureRepository'
+            credentials(PasswordCredentials)
             // url = uri(<<some repository url>>)
         }
     }
 }
 // end::publication[]
-
-// tag::credentials[]
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.allTasks.any { it.name == 'publishLibraryPublicationToMySecureRepository' }) {
-        def MAVEN_USERNAME_PROPERTY = 'mavenUser'
-        def MAVEN_PASSWORD_PROPERTY = 'mavenPassword'
-        def mavenUser = providers.gradleProperty(MAVEN_USERNAME_PROPERTY)
-        def mavenPassword = providers.gradleProperty(MAVEN_PASSWORD_PROPERTY)
-        if (!mavenUser.present || !mavenPassword.present) {
-            throw new GradleException("Publishing requires '$MAVEN_USERNAME_PROPERTY' and '$MAVEN_PASSWORD_PROPERTY' properties")
-        }
-        publishing.repositories.named('mySecure') {
-            credentials {
-                username = mavenUser.get()
-                password = mavenPassword.get()
-            }
-        }
-    }
-}
-// end::credentials[]
 

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/build.gradle.kts
@@ -18,29 +18,10 @@ publishing {
     }
     repositories {
         maven {
-            name = "mySecure"
+            name = "mySecureRepository"
+            credentials(PasswordCredentials::class)
             // url = uri(<<some repository url>>)
         }
     }
 }
 // end::publication[]
-
-// tag::credentials[]
-gradle.taskGraph.whenReady {
-    if (allTasks.any { it.name == "publishLibraryPublicationToMySecureRepository" }) {
-        val MAVEN_USERNAME_PROPERTY = "mavenUser"
-        val MAVEN_PASSWORD_PROPERTY = "mavenPassword"
-        val mavenUser = providers.gradleProperty(MAVEN_USERNAME_PROPERTY)
-        val mavenPassword = providers.gradleProperty(MAVEN_PASSWORD_PROPERTY)
-        if (!mavenUser.isPresent || !mavenPassword.isPresent) {
-            throw GradleException("Publishing requires '$MAVEN_USERNAME_PROPERTY' and '$MAVEN_PASSWORD_PROPERTY' properties")
-        }
-        publishing.repositories.named<MavenArtifactRepository>("mySecure") {
-            credentials {
-                username = mavenUser.get()
-                password = mavenPassword.get()
-            }
-        }
-    }
-}
-// end::credentials[]

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
@@ -1,4 +1,5 @@
 commands: [{
     executable: gradle
-    args: "publish -PmavenUser=secret-user -PmavenPassword=secret-password"
+    args: "publish -PmySecureRepositoryUsername=secret-user -PmySecureRepositoryPassword=secret-password"
+    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/sanityCheck.sample.conf
@@ -1,0 +1,5 @@
+commands: [{
+    executable: gradle
+    args: help -q
+    flags: "--gradle-user-home=local-gradle-user-home"
+}]


### PR DESCRIPTION
Exposes an API provided by https://github.com/gradle/gradle/pull/13107 for public use.

Credentials can be supplied by Gradle for repositories using:
```
publishing {
    repositories {
        maven {
            url "<...>
            credentials(PasswordCredentials)
        }
    }
    publications {
        <...>
    }
}
```

Updated the publishing credentials sample to use this API and removed the boilerplate.