### PR TITLE
Add license check to contributor checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Fixes #?
 ### Contributor Checklist
 - [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
 - [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
+- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
 - [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
 - [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
 - [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic


### PR DESCRIPTION
### Context

We need to make sure all code introduced in the Gradle code base can be licensed under terms of Apache License 2.0. This can two ways:
- eitherthe contributor wrote the code themselves and granted us the permit distribute it under terms of AL v2.0 by creating the PR
- if they copied the code from another project the original code needs to be licensed under a license that allows us include it. Furthermore we need to make sure we follow all requirements defined by that license, e.g. adding attribution in NOTICE.txt.
