### PR TITLE
Add task to run embedded Gradle

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/GradleDistributionPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/GradleDistributionPlugin.kt
@@ -142,6 +142,11 @@ open class GradleDistributionPlugin : Plugin<Project> {
                     }
                 }
             }
+            tasks.register<RunEmbeddedGradle>("runDevGradle") {
+                group = "verification"
+                description = "Runs an embedded Gradle using the partial distribution for ${project.path}."
+                gradleClasspath.from(coreRuntimeClasspath, partialDistributionPluginsClasspath)
+            }
         }
     }
 

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/RunEmbeddedGradle.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/RunEmbeddedGradle.kt
@@ -32,8 +32,13 @@ abstract class RunEmbeddedGradle : DefaultTask() {
     @get:Classpath
     abstract val gradleClasspath: ConfigurableFileCollection
 
+    @Option(option = "args", description = "Arguments for invoking Gradle, separated by spaces.")
+    fun setAllArgs(args: String) {
+        this.args = args.split(' ').filter { it.isNotEmpty() }
+    }
+
     @get:Input
-    @set:Option(option = "arg", description = "Arguments for invoking Gradle")
+    @set:Option(option = "arg", description = "Argument for invoking Gradle, can be specified multiple times.")
     var args: List<String> = listOf()
 
     @get:Input

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/RunEmbeddedGradle.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/RunEmbeddedGradle.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.test.fixtures
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.internal.ProcessOperations
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+
+
+abstract class RunEmbeddedGradle : DefaultTask() {
+
+    @get:Classpath
+    abstract val gradleClasspath: ConfigurableFileCollection
+
+    @get:Input
+    @set:Option(option = "arg", description = "Arguments for invoking Gradle")
+    var args: List<String> = listOf()
+
+    @get:Input
+    @get:Option(option = "working-dir", description = "Working dir for invoking Gradle")
+    abstract val workingDir: Property<String>
+
+    @get:javax.inject.Inject
+    abstract val processOperations: ProcessOperations
+
+    @TaskAction
+    fun runGradle() {
+        processOperations.javaexec {
+            classpath(gradleClasspath)
+            mainClass.set("org.gradle.launcher.Main")
+            workingDir = File(this@RunEmbeddedGradle.workingDir.get())
+            jvmArgs?.add("-Dorg.gradle.daemon=false")
+            args = this@RunEmbeddedGradle.args
+        }
+    }
+}


### PR DESCRIPTION
Adds a task to all projects which build an
integration test image to also run a Gradle
distribution from the classpath.

The task is called `runDevGradle` and takes
the working directory and the command line
arguments as arguments.

Example invocation:
```
./gradlew fileWatching:runDevGradle --working-dir "/home/user/multiproject" --arg tasks --arg help
```
or
```
./gradlew fileWatching:runDevGradle --working-dir "/home/user/multiproject" --args "tasks help"
```

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/3097.