### PR TITLE
Use command line flag for file-system watching build comparison

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -96,11 +96,11 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
         return testProject == SANTA_TRACKER_KOTLIN
             ? [
             "no optimizations": EnumSet.noneOf(Optimization),
-            "fs watching": EnumSet.of(Optimization.WATCH_FS)
+            "FS watching": EnumSet.of(Optimization.WATCH_FS)
         ]
             : [
             "no optimizations": EnumSet.noneOf(Optimization),
-            "fs watching": EnumSet.of(Optimization.WATCH_FS),
+            "FS watching": EnumSet.of(Optimization.WATCH_FS),
             "configuration caching": EnumSet.of(Optimization.CONFIGURATION_CACHING),
             "all optimizations": EnumSet.allOf(Optimization)
         ]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -130,7 +130,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
 
     enum Optimization {
         INSTANT_EXECUTION("--${ConfigurationCacheOption.LONG_OPTION}=warn"), // TODO on
-        VFS_RETENTION("-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true")
+        VFS_RETENTION("--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}")
 
         Optimization(String argument) {
             this.argument = argument

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -92,16 +92,16 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     private static Map<String, Set<Optimization>> supportedOptimizations(IncrementalAndroidTestProject testProject) {
-        // Kotlin is not supported for instant execution
+        // Kotlin is not supported for configuration caching
         return testProject == SANTA_TRACKER_KOTLIN
             ? [
             "no optimizations": EnumSet.noneOf(Optimization),
-            "VFS retention": EnumSet.of(Optimization.VFS_RETENTION)
+            "fs watching": EnumSet.of(Optimization.WATCH_FS)
         ]
             : [
             "no optimizations": EnumSet.noneOf(Optimization),
-            "VFS retention": EnumSet.of(Optimization.VFS_RETENTION),
-            "instant execution": EnumSet.of(Optimization.INSTANT_EXECUTION),
+            "fs watching": EnumSet.of(Optimization.WATCH_FS),
+            "configuration caching": EnumSet.of(Optimization.CONFIGURATION_CACHING),
             "all optimizations": EnumSet.allOf(Optimization)
         ]
     }
@@ -129,8 +129,8 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     enum Optimization {
-        INSTANT_EXECUTION("--${ConfigurationCacheOption.LONG_OPTION}=warn"), // TODO on
-        VFS_RETENTION("--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}")
+        CONFIGURATION_CACHING("--${ConfigurationCacheOption.LONG_OPTION}=warn"), // TODO on
+        WATCH_FS("--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}")
 
         Optimization(String argument) {
             this.argument = argument


### PR DESCRIPTION
For some reason the `-Dorg.gradle.unsafe.watch-fs=true` build option is not picked up.

See https://builds.gradle.org/repository/download/Gradle_Util_Performance_AdHocPerformanceScenarioLinux/35222250:id/results/performance/build/test-results-performanceAdhocTest.zip!/benchmark.html for the results of an ad-hoc performance run.