### PR TITLE
Make build compatible with git worktrees

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
             }
         }
 
-        tasks.withType<ValidatePlugins> {
+        tasks.withType<ValidatePlugins>().configureEach {
             failOnWarning.set(true)
             enableStricterValidation.set(true)
         }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -97,7 +97,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
  * Distributed test requires all dependencies to be declared
  */
 fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
-    tasks.withType<IntegrationTest>() {
+    tasks.withType<IntegrationTest>().configureEach {
         systemProperty("declaredSampleInputs", sampleDirs.joinToString(";"))
         inputs.files(rootProject.files(sampleDirs))
             .withPropertyName("autoTestedSamples")

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -48,7 +48,7 @@ gradlePlugin {
     }
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     environment("BUILD_BRANCH", "myBranch")
     environment("BUILD_COMMIT_ID", "myCommitId")
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -291,8 +291,10 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
      */
     private
     fun Test.configureGitInfo() {
-        systemProperty("gradleBuildBranch", project.gitInfo.gradleBuildBranch.get())
-        systemProperty("gradleBuildCommitId", project.gitInfo.gradleBuildCommitId.get())
+        project.gitInfo.run {
+            systemProperty("gradleBuildBranch", gradleBuildBranch.get())
+            systemProperty("gradleBuildCommitId", gradleBuildCommitId.get())
+        }
     }
 
     private

--- a/subprojects/architecture-test/architecture-test.gradle.kts
+++ b/subprojects/architecture-test/architecture-test.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     testImplementation(library("guava"))
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     // Looks like loading all the classes requires more than the default 512M
     maxHeapSize = "700M"
 


### PR DESCRIPTION
A recent change to build logic made the build incompatible with git worktrees, more specifically, the build started failing with an elusive `Cannot query the value of this provider because it has no value available` when executed from a git worktree directory. 

After some investigation the culprit was determined to be jgit's incomplete support for git worktrees.

This PR changes the build logic to detect whether the build is running from a git worktree directory and to fall back on the git command-line utility when it is. 

In the course of the investigation, a few eager `withType<...> { }` patterns were spotted and replaced by the lazy counterpart `withType<...>().configureEach { }`.