### PR TITLE
Setup timeout monitor for all CI builds

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/lifecycle/LifecyclePlugin.kt
@@ -18,10 +18,8 @@ package org.gradle.plugins.lifecycle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.gradlebuild.BuildEnvironment
-import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.kotlin.dsl.*
 import java.util.Timer
 import java.util.concurrent.TimeUnit
@@ -113,7 +111,7 @@ class LifecyclePlugin : Plugin<Project> {
             val timer = Timer(true).apply {
                 schedule(timerTask {
                     javaexec {
-                        classpath = findOutIntegrationTestClasspath()
+                        classpath = project(":internalIntegTesting").configurations["runtimeClasspath"]
                         main = "org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor"
                     }
                 }, determineTimeoutMillis())
@@ -131,18 +129,6 @@ class LifecyclePlugin : Plugin<Project> {
         } else {
             TimeUnit.MINUTES.toMillis(165) // 2h45m
         }
-
-    private
-    fun Project.findOutIntegrationTestClasspath(): FileCollection {
-        subprojects.forEach {
-            tasks.withType(IntegrationTest::class).forEach {
-                if (it.didWork) {
-                    return it.classpath
-                }
-            }
-        }
-        throw IllegalStateException("Can't find integration test classpath!")
-    }
 
     private
     fun Project.setupGlobalState() {


### PR DESCRIPTION
Recently we have several timeouts in this build configuration: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Platform_14_bucket11&tab=buildTypeHistoryList&state=failed

Checking the timeout builds, all test tasks have been finished successfully. So there's something else in the build hanging. Previously we set up a timeout monitor for each `IntegrationTest`, now we set the monitor for the whole build. 

Also fixes https://github.com/gradle/gradle-private/issues/3051