### PR TITLE
Use RegularFileProperty instead of Property<File>

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -17,9 +17,8 @@
 package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-
-import java.io.File;
 
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
@@ -68,6 +67,6 @@ public interface DependencyLockingHandler {
      * @since 6.4
      */
     @Incubating
-    Property<File> getLockFile();
+    RegularFileProperty getLockFile();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -102,6 +102,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -558,8 +559,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer, dependencyLockingProvider);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager, PropertyFactory propertyFactory) {
-            DefaultDependencyLockingProvider dependencyLockingProvider = instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews, propertyFactory);
+        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager, PropertyFactory propertyFactory, FilePropertyFactory filePropertyFactory) {
+            DefaultDependencyLockingProvider dependencyLockingProvider = instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews, propertyFactory, filePropertyFactory);
             if (startParameter.isWriteDependencyLocks() && featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)) {
                 listenerManager.addListener(new InternalBuildFinishedListener() {
                     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 
-import java.io.File;
 import java.util.Set;
 
 public interface DependencyLockingProvider {
@@ -33,5 +33,5 @@ public interface DependencyLockingProvider {
 
     void buildFinished();
 
-    Property<File> getLockFile();
+    RegularFileProperty getLockFile();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
@@ -21,10 +21,9 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.provider.Property;
-
-import java.io.File;
 
 public class DefaultDependencyLockingHandler implements DependencyLockingHandler {
 
@@ -58,7 +57,7 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
     }
 
     @Override
-    public Property<File> getLockFile() {
+    public RegularFileProperty getLockFile() {
         return dependencyLockingProvider.getLockFile();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.FeaturePreviews;
@@ -34,6 +35,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.logging.Logger;
@@ -42,7 +44,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -72,11 +73,11 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private final DependencySubstitutionRules dependencySubstitutionRules;
     private final boolean uniqueLockStateEnabled;
     private final Property<LockMode> lockMode;
-    private final Property<File> lockFile;
+    private final RegularFileProperty lockFile;
     private boolean uniqueLockStateLoaded;
     private Map<String, List<String>> allLockState;
 
-    public DefaultDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, DependencySubstitutionRules dependencySubstitutionRules, FeaturePreviews featurePreviews, PropertyFactory propertyFactory) {
+    public DefaultDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, DependencySubstitutionRules dependencySubstitutionRules, FeaturePreviews featurePreviews, PropertyFactory propertyFactory, FilePropertyFactory filePropertyFactory) {
         this.context = context;
         this.dependencySubstitutionRules = dependencySubstitutionRules;
         this.writeLocks = startParameter.isWriteDependencyLocks();
@@ -89,7 +90,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         uniqueLockStateEnabled = featurePreviews.isFeatureEnabled(ONE_LOCKFILE_PER_PROJECT);
         lockMode = propertyFactory.property(LockMode.class);
         lockMode.convention(LockMode.DEFAULT);
-        lockFile = propertyFactory.property(File.class);
+        lockFile = filePropertyFactory.newFileProperty();
         this.lockFileReaderWriter = new LockFileReaderWriter(fileResolver, context, lockFile);
     }
 
@@ -219,7 +220,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     }
 
     @Override
-    public Property<File> getLockFile() {
+    public RegularFileProperty getLockFile() {
         return lockFile;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -17,15 +17,14 @@
 package org.gradle.internal.locking;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.provider.Property;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -56,15 +55,16 @@ public class LockFileReaderWriter {
 
     private final Path lockFilesRoot;
     private final DomainObjectContext context;
-    private final Property<File> lockFile;
+    private final RegularFileProperty lockFile;
 
-    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context, Property<File> lockFile) {
+    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context, RegularFileProperty lockFile) {
         this.context = context;
         this.lockFile = lockFile;
         Path resolve = null;
         if (fileResolver.canResolveRelativePath()) {
             resolve = fileResolver.resolve(DEPENDENCY_LOCKING_FOLDER).toPath();
-            lockFile.convention(fileResolver.resolve(decorate(UNIQUE_LOCKFILE_NAME)));
+            // TODO: Can I find a way to use a convention here instead?
+            lockFile.set(fileResolver.resolve(decorate(UNIQUE_LOCKFILE_NAME)));
         }
         this.lockFilesRoot = resolve;
         LOGGER.debug("Lockfiles root: {}", lockFilesRoot);
@@ -185,7 +185,7 @@ public class LockFileReaderWriter {
     }
 
     private Path getUniqueLockfilePath() {
-        return lockFile.map(File::toPath).get();
+        return lockFile.get().getAsFile().toPath();
     }
 
     private void parseLine(String line, Map<String, List<String>> result) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -18,11 +18,11 @@ package org.gradle.internal.locking;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.provider.Property;
 
-import java.io.File;
 import java.util.Set;
 
 public class NoOpDependencyLockingProvider implements DependencyLockingProvider {
@@ -53,7 +53,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public Property<File> getLockFile() {
+    public RegularFileProperty getLockFile() {
         throw new IllegalStateException("Should not be invoked on the no-op instance");
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -25,7 +25,9 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
+import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.provider.DefaultPropertyFactory
 import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.provider.PropertyHost
@@ -53,6 +55,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
     DependencySubstitutionRules dependencySubstitutionRules = Mock()
     FeaturePreviews featurePreviews = new FeaturePreviews()
     PropertyFactory propertyFactory = new DefaultPropertyFactory(Stub(PropertyHost))
+    FilePropertyFactory filePropertyFactory = TestFiles.filePropertyFactory()
 
     @Subject
     DefaultDependencyLockingProvider provider
@@ -269,7 +272,7 @@ empty=
     }
 
     private DefaultDependencyLockingProvider newProvider() {
-        new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews, propertyFactory)
+        new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews, propertyFactory, filePropertyFactory)
     }
 
     def writeLockFile(List<String> modules, boolean unique = true, String configuration = 'conf') {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.locking
 
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
-import org.gradle.api.provider.Property
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
@@ -38,7 +37,7 @@ class LockFileReaderWriterTest extends Specification {
     LockFileReaderWriter lockFileReaderWriter
     FileResolver resolver = Mock()
     DomainObjectContext context = Mock()
-    Property<File> lockFile = new DefaultProperty<>(Stub(PropertyHost), File)
+    RegularFileProperty lockFile = TestFiles.filePropertyFactory().newFileProperty()
 
     def setup() {
         context.identityPath(_) >> { String value -> Path.path(value) }


### PR DESCRIPTION
This replacement is done on a field only useful when combined with a
feature flag and introduced in 6.4.