### PR TITLE
Extract state write/read from DefaultInstantExecution

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -16,16 +16,9 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
-import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
-import org.gradle.api.provider.Provider
-import org.gradle.caching.configuration.BuildCache
-import org.gradle.execution.plan.Node
 import org.gradle.initialization.GradlePropertiesController
 import org.gradle.initialization.InstantExecution
 import org.gradle.instantexecution.coroutines.runToCompletion
@@ -40,32 +33,20 @@ import org.gradle.instantexecution.serialization.IsolateOwner
 import org.gradle.instantexecution.serialization.MutableIsolateContext
 import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.instantexecution.serialization.codecs.Codecs
-import org.gradle.instantexecution.serialization.codecs.WorkNodeCodec
-import org.gradle.instantexecution.serialization.logNotImplemented
-import org.gradle.instantexecution.serialization.readCollection
-import org.gradle.instantexecution.serialization.readFile
-import org.gradle.instantexecution.serialization.readNonNull
 import org.gradle.instantexecution.serialization.runWriteOperation
 import org.gradle.instantexecution.serialization.withIsolate
-import org.gradle.instantexecution.serialization.writeCollection
-import org.gradle.instantexecution.serialization.writeFile
 import org.gradle.internal.Factory
-import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.classpath.Instrumented
-import org.gradle.internal.cleanup.BuildOutputCleanupRegistry
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
 import org.gradle.kotlin.dsl.support.useToRun
-import org.gradle.tooling.events.OperationCompletionListener
 import org.gradle.util.GradleVersion
 import org.gradle.util.IncubationLogger
 import java.io.File
 import java.io.OutputStream
 import java.nio.file.Files
-import java.util.ArrayList
 
 
 class DefaultInstantExecution internal constructor(
@@ -78,6 +59,7 @@ class DefaultInstantExecution internal constructor(
     private val beanConstructors: BeanConstructors,
     private val gradlePropertiesController: GradlePropertiesController
 ) : InstantExecution {
+
     interface Host {
 
         val currentBuild: VintageGradleBuild
@@ -185,8 +167,9 @@ class DefaultInstantExecution internal constructor(
     fun writeInstantExecutionState() {
         service<ProjectStateRegistry>().withLenientState {
             withWriteContextFor(instantExecutionStateFile) {
-                encodeScheduledWork()
-                writeInt(0x1ecac8e)
+                InstantExecutionState(codecs, host).run {
+                    writeState()
+                }
             }
         }
     }
@@ -194,45 +177,10 @@ class DefaultInstantExecution internal constructor(
     private
     fun readInstantExecutionState() {
         withReadContextFor(instantExecutionStateFile) {
-            decodeScheduledWork()
-            require(readInt() == 0x1ecac8e) {
-                "corrupt state file"
+            InstantExecutionState(codecs, host).run {
+                readState()
             }
         }
-    }
-
-    private
-    suspend fun DefaultWriteContext.encodeScheduledWork() {
-        val build = host.currentBuild
-        writeString(build.rootProject.name)
-
-        writeGradleState(build.gradle)
-
-        val scheduledNodes = build.scheduledWork
-        writeRelevantProjectsFor(scheduledNodes)
-
-        WorkNodeCodec(build.gradle, codecs.internalTypesCodec).run {
-            writeWork(scheduledNodes)
-        }
-    }
-
-    private
-    suspend fun DefaultReadContext.decodeScheduledWork() {
-        val rootProjectName = readString()
-        val build = host.createBuild(rootProjectName)
-
-        readGradleState(build.gradle)
-
-        readRelevantProjects(build)
-
-        build.registerProjects()
-
-        initProjectProvider(build::getProject)
-
-        val scheduledNodes = WorkNodeCodec(build.gradle, codecs.internalTypesCodec).run {
-            readWork()
-        }
-        build.scheduleNodes(scheduledNodes)
     }
 
     private
@@ -365,76 +313,9 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    suspend fun DefaultWriteContext.writeGradleState(gradle: GradleInternal) {
-        withGradleIsolate(gradle) {
-            if (gradle.includedBuilds.isNotEmpty()) {
-                logNotImplemented("included builds")
-            }
-            gradle.settings.buildCache.let { buildCache ->
-                write(buildCache.local)
-                write(buildCache.remote)
-            }
-            val eventListenerRegistry = service<BuildEventListenerRegistryInternal>()
-            writeCollection(eventListenerRegistry.subscriptions)
-            val buildOutputCleanupRegistry = service<BuildOutputCleanupRegistry>()
-            writeCollection(buildOutputCleanupRegistry.registeredOutputs)
-        }
-    }
-
-    private
-    suspend fun DefaultReadContext.readGradleState(gradle: GradleInternal) {
-        withGradleIsolate(gradle) {
-            gradle.settings.buildCache.let { buildCache ->
-                buildCache.local = readNonNull()
-                buildCache.remote = read() as BuildCache?
-            }
-            val eventListenerRegistry = service<BuildEventListenerRegistryInternal>()
-            readCollection {
-                val provider = readNonNull<Provider<OperationCompletionListener>>()
-                eventListenerRegistry.subscribe(provider)
-            }
-            val buildOutputCleanupRegistry = service<BuildOutputCleanupRegistry>()
-            readCollection {
-                val files = readNonNull<FileCollection>()
-                buildOutputCleanupRegistry.registerOutputs(files)
-            }
-        }
-    }
-
-    private
-    inline fun <T : MutableIsolateContext, R> T.withGradleIsolate(gradle: Gradle, block: T.() -> R): R =
-        withIsolate(IsolateOwner.OwnerGradle(gradle), codecs.userTypesCodec) {
-            block()
-        }
-
-    private
     inline fun <T : MutableIsolateContext, R> T.withHostIsolate(block: T.() -> R): R =
         withIsolate(IsolateOwner.OwnerHost(host), codecs.userTypesCodec) {
             block()
-        }
-
-    private
-    fun Encoder.writeRelevantProjectsFor(nodes: List<Node>) {
-        writeCollection(fillTheGapsOf(relevantProjectPathsFor(nodes))) { project ->
-            writeString(project.path)
-            writeFile(project.projectDir)
-        }
-    }
-
-    private
-    fun Decoder.readRelevantProjects(build: InstantExecutionBuild) {
-        readCollection {
-            val projectPath = readString()
-            val projectDir = readFile()
-            build.createProject(projectPath, projectDir)
-        }
-    }
-
-    private
-    fun relevantProjectPathsFor(nodes: List<Node>): List<Project> =
-        nodes.mapNotNullTo(mutableListOf()) { node ->
-            node.owningProject
-                ?.takeIf { it.parent != null }
         }
 
     private
@@ -509,28 +390,9 @@ class DefaultInstantExecution internal constructor(
 }
 
 
+internal
 inline fun <reified T> DefaultInstantExecution.Host.service(): T =
     service(T::class.java)
-
-
-internal
-fun fillTheGapsOf(projects: Collection<Project>): List<Project> {
-    val projectsWithoutGaps = ArrayList<Project>(projects.size)
-    var index = 0
-    projects.forEach { project ->
-        var parent = project.parent
-        var added = 0
-        while (parent !== null && parent !in projectsWithoutGaps) {
-            projectsWithoutGaps.add(index, parent)
-            added += 1
-            parent = parent.parent
-        }
-        projectsWithoutGaps.add(project)
-        added += 1
-        index += added
-    }
-    return projectsWithoutGaps
-}
 
 
 private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.provider.Provider
+import org.gradle.caching.configuration.BuildCache
+import org.gradle.execution.plan.Node
+import org.gradle.instantexecution.serialization.DefaultReadContext
+import org.gradle.instantexecution.serialization.DefaultWriteContext
+import org.gradle.instantexecution.serialization.IsolateOwner
+import org.gradle.instantexecution.serialization.MutableIsolateContext
+import org.gradle.instantexecution.serialization.codecs.Codecs
+import org.gradle.instantexecution.serialization.codecs.WorkNodeCodec
+import org.gradle.instantexecution.serialization.logNotImplemented
+import org.gradle.instantexecution.serialization.readCollection
+import org.gradle.instantexecution.serialization.readFile
+import org.gradle.instantexecution.serialization.readNonNull
+import org.gradle.instantexecution.serialization.withIsolate
+import org.gradle.instantexecution.serialization.writeCollection
+import org.gradle.instantexecution.serialization.writeFile
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
+import org.gradle.internal.cleanup.BuildOutputCleanupRegistry
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+import org.gradle.tooling.events.OperationCompletionListener
+import java.util.ArrayList
+
+
+internal
+class InstantExecutionState(
+    private val codecs: Codecs,
+    private val host: DefaultInstantExecution.Host
+) {
+
+    suspend fun DefaultWriteContext.writeState() {
+        encodeScheduledWork()
+        writeInt(0x1ecac8e)
+    }
+
+    suspend fun DefaultReadContext.readState() {
+        decodeScheduledWork()
+        require(readInt() == 0x1ecac8e) {
+            "corrupt state file"
+        }
+    }
+
+    private
+    suspend fun DefaultWriteContext.encodeScheduledWork() {
+        val build = host.currentBuild
+        writeString(build.rootProject.name)
+
+        writeGradleState(build.gradle)
+
+        val scheduledNodes = build.scheduledWork
+        writeRelevantProjectsFor(scheduledNodes)
+
+        WorkNodeCodec(build.gradle, codecs.internalTypesCodec).run {
+            writeWork(scheduledNodes)
+        }
+    }
+
+    private
+    suspend fun DefaultReadContext.decodeScheduledWork() {
+
+        val rootProjectName = readString()
+        val build = host.createBuild(rootProjectName)
+
+        readGradleState(build.gradle)
+
+        readRelevantProjects(build)
+
+        build.registerProjects()
+
+        initProjectProvider(build::getProject)
+
+        val scheduledNodes = WorkNodeCodec(build.gradle, codecs.internalTypesCodec).run {
+            readWork()
+        }
+        build.scheduleNodes(scheduledNodes)
+    }
+
+    private
+    suspend fun DefaultWriteContext.writeGradleState(gradle: GradleInternal) {
+        withGradleIsolate(gradle) {
+            writeIncludedBuilds(gradle)
+            writeBuildCacheConfiguration(gradle)
+            val eventListenerRegistry = service<BuildEventListenerRegistryInternal>()
+            writeCollection(eventListenerRegistry.subscriptions)
+            val buildOutputCleanupRegistry = service<BuildOutputCleanupRegistry>()
+            writeCollection(buildOutputCleanupRegistry.registeredOutputs)
+        }
+    }
+
+    private
+    suspend fun DefaultReadContext.readGradleState(gradle: GradleInternal) {
+        withGradleIsolate(gradle) {
+            readIncludedBuilds()
+            readBuildCacheConfiguration(gradle)
+            val eventListenerRegistry = service<BuildEventListenerRegistryInternal>()
+            readCollection {
+                val provider = readNonNull<Provider<OperationCompletionListener>>()
+                eventListenerRegistry.subscribe(provider)
+            }
+            val buildOutputCleanupRegistry = service<BuildOutputCleanupRegistry>()
+            readCollection {
+                val files = readNonNull<FileCollection>()
+                buildOutputCleanupRegistry.registerOutputs(files)
+            }
+        }
+    }
+
+    private
+    inline fun <T : MutableIsolateContext, R> T.withGradleIsolate(gradle: Gradle, block: T.() -> R): R =
+        withIsolate(IsolateOwner.OwnerGradle(gradle), codecs.userTypesCodec) {
+            block()
+        }
+
+    private
+    suspend fun DefaultWriteContext.writeIncludedBuilds(gradle: GradleInternal) {
+        if (gradle.includedBuilds.isNotEmpty()) {
+            logNotImplemented("included builds")
+        }
+        // TODO write if there were any included build so we can report when reading
+    }
+
+    private
+    suspend fun DefaultReadContext.readIncludedBuilds() {
+        // TODO report problems if there were included builds
+    }
+
+    private
+    suspend fun DefaultWriteContext.writeBuildCacheConfiguration(gradle: GradleInternal) {
+        gradle.settings.buildCache.let { buildCache ->
+            write(buildCache.local)
+            write(buildCache.remote)
+        }
+    }
+
+    private
+    suspend fun DefaultReadContext.readBuildCacheConfiguration(gradle: GradleInternal) {
+        gradle.settings.buildCache.let { buildCache ->
+            buildCache.local = readNonNull()
+            buildCache.remote = read() as BuildCache?
+        }
+    }
+
+    private
+    fun Encoder.writeRelevantProjectsFor(nodes: List<Node>) {
+        writeCollection(fillTheGapsOf(relevantProjectPathsFor(nodes))) { project ->
+            writeString(project.path)
+            writeFile(project.projectDir)
+        }
+    }
+
+    private
+    fun relevantProjectPathsFor(nodes: List<Node>): List<Project> =
+        nodes.mapNotNullTo(mutableListOf()) { node ->
+            node.owningProject
+                ?.takeIf { it.parent != null }
+        }
+
+    private
+    fun Decoder.readRelevantProjects(build: InstantExecutionBuild) {
+        readCollection {
+            val projectPath = readString()
+            val projectDir = readFile()
+            build.createProject(projectPath, projectDir)
+        }
+    }
+
+    private
+    inline fun <reified T> service() =
+        host.service<T>()
+}
+
+
+internal
+fun fillTheGapsOf(projects: Collection<Project>): List<Project> {
+    val projectsWithoutGaps = ArrayList<Project>(projects.size)
+    var index = 0
+    projects.forEach { project ->
+        var parent = project.parent
+        var added = 0
+        while (parent !== null && parent !in projectsWithoutGaps) {
+            projectsWithoutGaps.add(index, parent)
+            added += 1
+            parent = parent.parent
+        }
+        projectsWithoutGaps.add(project)
+        added += 1
+        index += added
+    }
+    return projectsWithoutGaps
+}


### PR DESCRIPTION
This is a cleanup refactoring PR, it doesn't change any behaviour.

Because DefaultInstantExecution was getting large and had too many responsibilities.

Leaving the orchestration and cache layout handling responsibility to `DefaultInstantExecution` and moving the knowledge of how to write/read the state to the new `InstantExecutionState`.
