### PR TITLE
Add dedicated placeholder assertion error type

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderAssertionError.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderAssertionError.java
@@ -17,24 +17,24 @@
 package org.gradle.internal.serialize;
 
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 
 /**
- * A {@code PlaceholderException} is used when an exception cannot be serialized or deserialized.
+ * A {@code PlaceholderException} is used when an assertion error cannot be serialized or deserialized.
  */
-@UsedByScanPlugin
-public class PlaceholderException extends RuntimeException implements PlaceholderExceptionSupport {
+public class PlaceholderAssertionError extends AssertionError implements PlaceholderExceptionSupport {
     private final String exceptionClassName;
     private final Throwable getMessageException;
     private final String toString;
     private final Throwable toStringRuntimeEx;
 
-    @UsedByScanPlugin("test-distribution")
-    public PlaceholderException(String exceptionClassName, @Nullable String message, @Nullable Throwable getMessageException, @Nullable String toString,
-                                @Nullable Throwable toStringException, @Nullable Throwable cause) {
-        super(message, cause);
+    public PlaceholderAssertionError(String exceptionClassName,
+                                     @Nullable String message,
+                                     @Nullable Throwable getMessageException,
+                                     @Nullable String toString,
+                                     @Nullable Throwable toStringException) {
+        super(message);
         this.exceptionClassName = exceptionClassName;
         this.getMessageException = getMessageException;
         this.toString = toString;

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderExceptionSupport.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderExceptionSupport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.serialize;
+
+import java.io.Serializable;
+
+public interface PlaceholderExceptionSupport extends Serializable {
+
+    StackTraceElement[] getStackTrace();
+
+    String getExceptionClassName();
+
+    String getMessage();
+}

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.serialize
 
+import groovy.transform.CompileStatic
 import org.gradle.internal.exceptions.Contextual
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import spock.lang.Issue
@@ -325,8 +326,19 @@ class MessageTest extends Specification {
         looksLike(notOk, transported)
     }
 
+    def "preserves assertion errors"() {
+        def assertionError = new CustomAssertionError("true == false")
+
+        when:
+        def transported = transport(assertionError)
+
+        then:
+        transported instanceof PlaceholderAssertionError
+        looksLike(assertionError, transported)
+    }
+
     void looksLike(Throwable original, Throwable transported) {
-        assert transported instanceof PlaceholderException
+        assert transported instanceof PlaceholderExceptionSupport
         assert transported.exceptionClassName == original.class.name
         assert transported.message == original.message
         assert transported.toString() == original.toString()
@@ -465,6 +477,17 @@ class MessageTest extends Specification {
 
         private Object readResolve() {
             return singleton
+        }
+    }
+
+    @CompileStatic
+    static class CustomAssertionError extends AssertionError {
+        CustomAssertionError(Object message) {
+            super(message)
+        }
+
+        private void readObject(ObjectInputStream outstr) {
+            throw new RuntimeException("broken readObject()")
         }
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.testing.TestListener;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestOutputListener;
 import org.gradle.api.tasks.testing.TestResult;
-import org.gradle.internal.serialize.PlaceholderException;
+import org.gradle.internal.serialize.PlaceholderExceptionSupport;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -110,7 +110,7 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
     }
 
     private String exceptionClassName(Throwable throwable) {
-        return throwable instanceof PlaceholderException ? ((PlaceholderException) throwable).getExceptionClassName() : throwable.getClass().getName();
+        return throwable instanceof PlaceholderExceptionSupport ? ((PlaceholderExceptionSupport) throwable).getExceptionClassName() : throwable.getClass().getName();
     }
 
     private String stackTrace(Throwable throwable) {


### PR DESCRIPTION
This commit introduces a dedicated placeholder assertion error
type which is used whenever a subtype of `AssertionError` cannot
be deserialized. Before, we would use the regular `PlaceholderException`,
which happens to discard the fact that it's an `AssertionError`.
The consequence is that IntelliJ IDEA in combination with Spock can't
infer the correct failure kind, and displays a wrong icon (see #12302).

It does not, however, fix the problem that the "Click here to see diff"
link doesn't show up. The reason is that this feature builds on top
of a dedicated subtype of `AssertionError` that the messaging bus
isn't aware of (org.opentest4j.AssertionFailedError and its legacy JUnit
equivalent).

Fixes #12302

