### PR TITLE
Fix location of `module-info.java`

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -449,7 +449,7 @@ Sample: link:../samples/sample_java_modules_multi_project_with_integration_tests
 
 The simplest setup to write unit tests for functions or classes in modules is to _not_ use module specifics during test execution.
 For this, you just need to write tests the same way you would write them for normal libraries.
-If you don't have a `module-info.java` file in your test source set (`src/main/test`) this source set will be considered as traditional Java library during compilation and test runtime.
+If you don't have a `module-info.java` file in your test source set (`src/test/java`) this source set will be considered as traditional Java library during compilation and test runtime.
 This means, all dependencies, including Jars with module information, are put on the classpath.
 The advantage is that all internal classes of your (or other) modules are then accessible directly in tests.
 This may be a totally valid setup for unit testing, where we do not care about the larger module structure, but only about testing single functions.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes (no issue)

### Context
Minor issue in user guide.
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
