### PR TITLE
Remove gradle-user-home flag from preocmpiled plugin samples

### DIFF
--- a/subprojects/docs/src/samples/build-organization/multi-project-with-precompiled-script-plugins/tests/check.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-precompiled-script-plugins/tests/check.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: check
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-precompiled-script-plugins/tests/sanityCheck.conf
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-precompiled-script-plugins/tests/sanityCheck.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/build-organization/precompiled-script-plugin/tests/build.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/precompiled-script-plugin/tests/build.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: build
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/build-organization/precompiled-script-plugin/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/precompiled-script-plugin/tests/sanityCheck.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]


### PR DESCRIPTION
This greatly reduces the time needed to execute those tests.

Before:
<img width="623" alt="Screenshot 2020-05-27 at 08 48 21" src="https://user-images.githubusercontent.com/5560673/82996159-3efcdf00-a00d-11ea-9691-3bd64e7e328c.png">

After:
<img width="623" alt="Screenshot 2020-05-27 at 09 01 42" src="https://user-images.githubusercontent.com/5560673/82996176-44f2c000-a00d-11ea-8949-d7516080f662.png">
