### PR TITLE
Use org.gradle.api.credentials.PasswordCredentials internally

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.test.fixtures.server.http
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.test.fixtures.file.TestFile
 
 abstract class HttpResource extends AbstractHttpResource {
-    public HttpResource(HttpServer server) {
+    HttpResource(HttpServer server) {
         super(server)
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -19,7 +19,7 @@ import com.google.common.net.UrlEscapers
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import groovy.xml.MarkupBuilder
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.internal.BiAction
 import org.gradle.internal.credentials.DefaultPasswordCredentials
 import org.gradle.internal.hash.HashUtil

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.internal.credentials.DefaultPasswordCredentials

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/authentication/DefaultBasicAuthentication.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/authentication/DefaultBasicAuthentication.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.authentication;
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.authentication.http.BasicAuthentication;
 
 public class DefaultBasicAuthentication extends AbstractAuthentication implements BasicAuthentication {

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/authentication/DefaultDigestAuthentication.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/authentication/DefaultDigestAuthentication.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.authentication;
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.authentication.http.DigestAuthentication;
 
 public class DefaultDigestAuthentication extends AbstractAuthentication implements DigestAuthentication {

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpProxySettings.java
@@ -16,7 +16,7 @@
 package org.gradle.internal.resource.transport.http;
 
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.internal.credentials.DefaultPasswordCredentials;
 
 public interface HttpProxySettings {
@@ -25,7 +25,7 @@ public interface HttpProxySettings {
 
     HttpProxy getProxy(String host);
 
-    public class HttpProxy {
+    class HttpProxy {
         public final String host;
         public final int port;
         public final PasswordCredentials credentials;

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.transport.http
 import org.apache.http.auth.AuthScope
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.ssl.SSLContexts
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.internal.authentication.AllSchemesAuthentication
 import org.gradle.internal.credentials.DefaultHttpHeaderCredentials
 import org.gradle.internal.resource.UriTextResource

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ntlm/NTLMCredentialsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ntlm/NTLMCredentialsTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.resource.transport.http.ntlm
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -34,7 +34,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.credentials.AwsCredentials;
 import org.gradle.internal.resource.ResourceExceptions;
 import org.gradle.internal.resource.transport.http.HttpProxySettings;

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
@@ -19,15 +19,22 @@ package org.gradle.internal.resource.transport.sftp;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-import com.jcraft.jsch.*;
-import javax.annotation.concurrent.ThreadSafe;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.HostKey;
+import com.jcraft.jsch.HostKeyRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UserInfo;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.net.URI;
 import java.util.List;
 

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpConnectorFactory.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpConnectorFactory.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.sftp;
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.authentication.Authentication;
 import org.gradle.internal.authentication.AllSchemesAuthentication;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpHost.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpHost.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.sftp;
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 
 import java.net.URI;
 

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResource.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResource.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.sftp;
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.internal.resource.ResourceExceptions;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.resource.transfer.ExternalResourceReadResponse;

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceAccessor.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceAccessor.java
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.transport.sftp;
 
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.SftpATTRS;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.internal.resource.ResourceExceptions;
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceLister.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceLister.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.resource.transport.sftp;
 
 import com.jcraft.jsch.ChannelSftp;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.resource.transfer.ExternalResourceLister;
 

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceUploader.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceUploader.java
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.transport.sftp;
 
 import com.jcraft.jsch.ChannelSftp;
 import org.apache.commons.io.FilenameUtils;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
+import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.resource.ResourceExceptions;
 import org.gradle.internal.resource.ReadableContent;

--- a/subprojects/resources-sftp/src/test/groovy/org/gradle/internal/resource/transport/sftp/SftpClientFactoryTest.groovy
+++ b/subprojects/resources-sftp/src/test/groovy/org/gradle/internal/resource/transport/sftp/SftpClientFactoryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.sftp
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.internal.credentials.DefaultPasswordCredentials
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 


### PR DESCRIPTION
`org.gradle.api.artifacts.repositories.PasswordCredentials` was where PasswordCredentials originated before being moved to `org.gradle.api.credentials` package together with other Credentials interfaces.
After this change `org.gradle.api.artifacts.repositories.PasswordCredentials` will remain to be used only in the public APIs around repositories.
Once its surface area is reduced, we might be able to deprecate it in favor of `org.gradle.api.credentials.PasswordCredentials` in a subsequent change.
