### PR TITLE
Refine TAPI model

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -21,8 +21,10 @@ import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
@@ -33,6 +35,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.DaemonTracker
 import org.gradle.kotlin.dsl.*
 import org.gradle.process.CommandLineArgumentProvider
+import java.io.File
 import java.util.concurrent.Callable
 
 
@@ -94,6 +97,24 @@ class LibsRepositoryEnvironmentProvider(objects: ObjectFactory) : CommandLineArg
     @Input
     var required = false
 
+    @get:Classpath
+    @get:Optional
+    val jars: Set<File>
+        get() = if (required) emptySet()
+        else dir.get().asFileTree.matching {
+            include("**/*.jar")
+        }.files.toSortedSet()
+
+    @get:Classpath
+    @get:InputFiles
+    val metadatas: Set<File>
+        get() = if (required) emptySet()
+        else dir.get().asFileTree.matching {
+            include("**/*.pom")
+            include("**/*.xml")
+            include("**/*.metadata")
+        }.files.toSortedSet()
+
     override fun asArguments() =
         if (required) mapOf("integTest.libsRepo" to absolutePathOf(dir)).asSystemPropertyJvmArguments()
         else emptyList()
@@ -116,9 +137,6 @@ class GradleInstallationForTestEnvironmentProvider(project: Project) : CommandLi
     val gradleGeneratedApiJarCacheDir = project.objects.directoryProperty()
 
     @Internal
-    val toolingApiShadedJarDir = project.objects.directoryProperty()
-
-    @Internal
     val gradleSnippetsDir = project.objects.directoryProperty()
 
     /**
@@ -137,8 +155,7 @@ class GradleInstallationForTestEnvironmentProvider(project: Project) : CommandLi
             "integTest.samplesdir" to absolutePathOf(gradleSnippetsDir),
             "integTest.gradleUserHomeDir" to absolutePathOf(gradleUserHomeDir),
             "integTest.gradleGeneratedApiJarCacheDir" to absolutePathOf(gradleGeneratedApiJarCacheDir),
-            "org.gradle.integtest.daemon.registry" to absolutePathOf(daemonRegistry),
-            "integTest.toolingApiShadedJarDir" to absolutePathOf(toolingApiShadedJarDir)
+            "org.gradle.integtest.daemon.registry" to absolutePathOf(daemonRegistry)
         ).asSystemPropertyJvmArguments()
 
     @Internal

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -26,7 +26,6 @@ import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Sync
-import org.gradle.gradlebuild.packaging.ShadedJar
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.CleanupExtension
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.DefaultClassPath
@@ -54,15 +53,6 @@ class DistributionTestingPlugin : Plugin<Project> {
                 rootProject.objects
             )
             addSetUpAndTearDownActions(project)
-        }
-
-        tasks.withType<DistributionTest>().configureEach {
-            gradleInstallationForTest.toolingApiShadedJarDir.set(dirWorkaround(providers, layout, objects) {
-                // TODO Refactor to not reach into tasks of another project
-                val toolingApi = rootProject.project(":toolingApi")
-                val toolingApiShadedJar: ShadedJar by toolingApi.tasks
-                toolingApiShadedJar.jarFile.get().asFile.parentFile
-            })
         }
     }
 

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -11,7 +11,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.gradlebuild.versioning.buildVersion
-import java.util.concurrent.Executors.callable
+import java.util.concurrent.Callable
 
 
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
@@ -112,7 +112,7 @@ fun Project.integrationTestUsesSampleDir(vararg sampleDirs: String) {
  */
 fun Project.integrationTestUsesKotlinDslPlugins() {
     tasks.withType<IntegrationTest>().configureEach {
-        inputs.files(callable {
+        inputs.files(Callable {
             project(":kotlinDslPlugins")
                 .fileTree("build/repository")
                 .matching { include("**/*.jar") }
@@ -122,7 +122,7 @@ fun Project.integrationTestUsesKotlinDslPlugins() {
             .withPathSensitivity(PathSensitivity.RELATIVE)
             .withNormalizer(ClasspathNormalizer::class)
 
-        inputs.files(callable {
+        inputs.files(Callable {
             project(":kotlinDslPlugins")
                 .fileTree("build/repository")
                 .matching {

--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
@@ -65,7 +65,25 @@ fun Project.configurePublishingTasks() {
         doLast {
             val mavenMetadataXml = rootProject.file("build/repo/org/gradle/${base.archivesBaseName}/maven-metadata.xml")
             val content = mavenMetadataXml.readText()
+//            "size": 4523517,
+//            "sha512": "4748d3d1ad52021b14b41f308dab461684d5e281a28f393f1dd171e8ea4678ac71e87ada205d552630e8ac59185d2a68848f2b279ad0acd8d08941efd0171b63",
+//            "sha256": "bef23d15246d347f45857ccb5cb258510f33065433b42b46c6705ef957c7c576",
+//            "sha1": "7615d66924c610d4fa49bb31973489118308f1a0",
+//            "md5": "966c70fc54674d6c1043c534b3889622"
             mavenMetadataXml.writeText(content.replace("\\Q<lastUpdated>\\E\\d+\\Q</lastUpdated>\\E".toRegex(), "<lastUpdated>${Year.now().value}0101000000</lastUpdated>"))
+
+            rootProject.fileTree("build/repo/org/gradle/${base.archivesBaseName}").matching {
+                include("**/*.module")
+            }.forEach {
+                var content = it.readText()
+                content = content
+                    .replace("\"size\":\\s+\\d+".toRegex(), "\"size\": 0")
+                    .replace("\"sha512\":\\s+\"\\w+\"".toRegex(), "\"sha512\": \"\"")
+                    .replace("\"sha1\":\\s+\"\\w+\"".toRegex(), "\"sha1\": \"\"")
+                    .replace("\"sha256\":\\s+\"\\w+\"".toRegex(), "\"sha256\": \"\"")
+                    .replace("\"md5\":\\s+\"\\w+\"".toRegex(), "\"md5\": \"\"")
+                it.writeText(content)
+            }
         }
     }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
@@ -17,6 +17,7 @@ package gradlebuild
 
 import accessors.base
 import org.gradle.gradlebuild.versioning.buildVersion
+import java.time.Year
 
 plugins {
     `maven-publish`
@@ -59,6 +60,12 @@ fun Project.configurePublishingTasks() {
                 // Make sure artifacts do not pile up locally
                 moduleBaseDir.deleteRecursively()
             }
+        }
+
+        doLast {
+            val mavenMetadataXml = rootProject.file("build/repo/org/gradle/${base.archivesBaseName}/maven-metadata.xml")
+            val content = mavenMetadataXml.readText()
+            mavenMetadataXml.writeText(content.replace("\\Q<lastUpdated>\\E\\d+\\Q</lastUpdated>\\E".toRegex(), "<lastUpdated>${Year.now().value}0101000000</lastUpdated>"))
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
@@ -86,17 +86,6 @@ public class IntegrationTestBuildContext {
         return GradleVersion.version(System.getProperty("integTest.distZipVersion", GradleVersion.current().getVersion()));
     }
 
-    public TestFile getFatToolingApiJar() {
-        TestFile toolingApiShadedJarDir = file("integTest.toolingApiShadedJarDir", "subprojects/tooling-api/build/shaded-jar");
-        TestFile fatToolingApiJar = new TestFile(toolingApiShadedJarDir, String.format("gradle-tooling-api-shaded-%s.jar", getVersion().getBaseVersion().getVersion()));
-
-        if (!fatToolingApiJar.exists()) {
-            throw new IllegalStateException(String.format("The fat Tooling API JAR file does not exist: %s", fatToolingApiJar.getAbsolutePath()));
-        }
-
-        return fatToolingApiJar;
-    }
-
     public GradleDistribution distribution(String version) {
         if (version.equals(getVersion().getVersion())) {
             return new UnderDevelopmentGradleDistribution();

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -16,8 +16,7 @@
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
-import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesToolingApiFatJar
-import org.gradle.gradlebuild.versioning.buildVersion
+import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 
 plugins {
     gradlebuild.distribution.`plugins-api-java`
@@ -78,6 +77,8 @@ dependencies {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+tasks.withType<IntegrationTest>().configureEach {
+    libsRepository.required = true
+}
 
-integrationTestUsesToolingApiFatJar()
 integrationTestUsesSampleDir("subprojects/plugin-development/src/main")

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
@@ -20,12 +20,11 @@ import groovy.transform.TupleConstructor
 import org.gradle.api.Action
 import org.gradle.internal.ErroringAction
 import org.gradle.internal.IoActions
+import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
-
-import static org.gradle.util.TextUtil.normaliseFileSeparators
 
 class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsIntegrationTest {
 
@@ -107,6 +106,11 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
         buildFile << applyGroovyPlugin()
         buildFile << jcenterRepository()
         buildFile << spockDependency()
+        buildFile << """
+            repositories {
+                maven { url '${buildContext.libsRepo.toURI().toURL()}' }
+            }
+        """
 
         dependencyPermutations.each {
             buildFile << """
@@ -158,7 +162,7 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
         where:
         dependencyPermutations << [new GradleDependency('Gradle API', 'implementation', 'dependencies.gradleApi()'),
                                    new GradleDependency('TestKit', 'testImplementation', 'dependencies.gradleTestKit()'),
-                                   new GradleDependency('Tooling API', 'implementation', "project.files('${normaliseFileSeparators(buildContext.fatToolingApiJar.absolutePath)}')")].permutations()
+                                   new GradleDependency('Tooling API', 'implementation', "'org.gradle:gradle-tooling-api:${GradleVersion.current().version}'")].permutations()
     }
 
     static void writeClassesInZipFileToTextFile(File zipFile, File txtFile) {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -18,7 +18,6 @@ import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesSampleDir
-import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesToolingApiJar
 import org.gradle.gradlebuild.test.integrationtests.integrationTestUsesDistribution
 
 plugins {
@@ -112,5 +111,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 integrationTestUsesSampleDir("subprojects/tooling-api/src/main")
-integrationTestUsesToolingApiJar()
 integrationTestUsesDistribution()


### PR DESCRIPTION
This PR does the following improvements:

- Make TAPI/`kotlinDslPlugin` jars in local repository inputs of integration tests with class normalization.
- Remove fat TAPI jar and tasks and use simple TAPI jar in the test.