### PR TITLE
Update project-reports plugin to lazily register tasks

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
@@ -17,7 +17,6 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.internal.DefaultProjectReportsPluginConvention;
 import org.gradle.api.reporting.dependencies.HtmlDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
@@ -42,31 +41,34 @@ public class ProjectReportsPlugin implements Plugin<Project> {
         final ProjectReportsPluginConvention convention = new DefaultProjectReportsPluginConvention(project);
         project.getConvention().getPlugins().put("projectReports", convention);
 
-        TaskReportTask taskReportTask = project.getTasks().create(TASK_REPORT, TaskReportTask.class);
-        taskReportTask.setDescription("Generates a report about your tasks.");
-        taskReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "tasks.txt"));
-        taskReportTask.conventionMapping("projects", convention::getProjects);
+        project.getTasks().register(TASK_REPORT, TaskReportTask.class, taskReportTask -> {
+            taskReportTask.setDescription("Generates a report about your tasks.");
+            taskReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "tasks.txt"));
+            taskReportTask.conventionMapping("projects", convention::getProjects);
+        });
 
-        PropertyReportTask propertyReportTask = project.getTasks().create(PROPERTY_REPORT, PropertyReportTask.class);
-        propertyReportTask.setDescription("Generates a report about your properties.");
-        propertyReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "properties.txt"));
-        propertyReportTask.conventionMapping("projects", convention::getProjects);
+        project.getTasks().register(PROPERTY_REPORT, PropertyReportTask.class, propertyReportTask -> {
+            propertyReportTask.setDescription("Generates a report about your properties.");
+            propertyReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "properties.txt"));
+            propertyReportTask.conventionMapping("projects", convention::getProjects);
+        });
 
-        DependencyReportTask dependencyReportTask = project.getTasks().create(DEPENDENCY_REPORT,
-                DependencyReportTask.class);
-        dependencyReportTask.setDescription("Generates a report about your library dependencies.");
-        dependencyReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "dependencies.txt"));
-        dependencyReportTask.conventionMapping("projects", convention::getProjects);
+        project.getTasks().register(DEPENDENCY_REPORT, DependencyReportTask.class, dependencyReportTask -> {
+            dependencyReportTask.setDescription("Generates a report about your library dependencies.");
+            dependencyReportTask.conventionMapping("outputFile", () -> new File(convention.getProjectReportDir(), "dependencies.txt"));
+            dependencyReportTask.conventionMapping("projects", convention::getProjects);
+        });
 
-        HtmlDependencyReportTask htmlDependencyReportTask = project.getTasks().create(HTML_DEPENDENCY_REPORT,
-                HtmlDependencyReportTask.class);
-        htmlDependencyReportTask.setDescription("Generates an HTML report about your library dependencies.");
-        htmlDependencyReportTask.getReports().getHtml().getOutputLocation().convention(project.getLayout().getProjectDirectory().dir(project.provider(() -> new File(convention.getProjectReportDir(), "dependencies").getAbsolutePath())));
-        htmlDependencyReportTask.conventionMapping("projects", convention::getProjects);
+        project.getTasks().create(HTML_DEPENDENCY_REPORT, HtmlDependencyReportTask.class, htmlDependencyReportTask -> {
+            htmlDependencyReportTask.setDescription("Generates an HTML report about your library dependencies.");
+            htmlDependencyReportTask.getReports().getHtml().getOutputLocation().convention(project.getLayout().getProjectDirectory().dir(project.provider(() -> new File(convention.getProjectReportDir(), "dependencies").getAbsolutePath())));
+            htmlDependencyReportTask.conventionMapping("projects", convention::getProjects);
+        });
 
-        Task projectReportTask = project.getTasks().create(PROJECT_REPORT);
-        projectReportTask.dependsOn(TASK_REPORT, PROPERTY_REPORT, DEPENDENCY_REPORT, HTML_DEPENDENCY_REPORT);
-        projectReportTask.setDescription("Generates a report about your project.");
-        projectReportTask.setGroup("reporting");
+        project.getTasks().register(PROJECT_REPORT, projectReportTask -> {
+            projectReportTask.dependsOn(TASK_REPORT, PROPERTY_REPORT, DEPENDENCY_REPORT, HTML_DEPENDENCY_REPORT);
+            projectReportTask.setDescription("Generates a report about your project.");
+            projectReportTask.setGroup("reporting");
+        });
     }
 }


### PR DESCRIPTION
### Context
Refactor the project-reporst to lazily register tasks (using `TaskCollection.register()` instead of `TaskCollection.create()`). This follows the official [Gradle task configuration avoidance guidelines](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html)

This will be beneficial to anyone who uses the project-reports plugin, especially on a large Gradle project.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
