### PR TITLE
Add file-system watching troubleshooting to user manual

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -241,19 +241,19 @@ Limitations::
 - On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
 
 Gradle does not pick up some of my changes.::
-_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. If it does, it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know on the Gradle community Slack] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. So it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
 
 Why am I always getting “Received 8 file system events since last build” even though I only changed one file?::
 These are harmless notifications about changes to Gradle's own caches that happen after file watching has started.
 
 `Dropped VFS state due to lost state`::
-_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ That means that either
-- The daemon received some unknown file-system event.
-- Too many changes happened, and the watching API couldn’t handle it.
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ This message means that either
+- the daemon received some unknown file-system event,
+- too many changes happened, and the watching API couldn’t handle it.
 In both cases the build cannot benefit from file-system watching.
 
 `Caught exception: Couldn't add watch, error = 28`::
-If you receive this error on Linux, you need to raise inotify limits, see https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit[here].
+If you receive this error on Linux then you ran out of inotify handles. To raise the limit https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit[see here].
 
 `java.io.IOException: Too many open files`::
 If you receive this error on macOS, you need to raise your open files limit, see https://superuser.com/a/443168/8117[here].

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -234,26 +234,33 @@ This enables watching the file-system for all builds, unless explicitly disabled
 === Troubleshooting file-system watching
 
 Limitations::
-- If your build doesn’t declare inputs and outputs properly, there is a chance Gradle does not detect changes to undeclared stuff.
+We are working on removing the following limitations to make file-system watching production ready.
 - If you have symlinks in your build, you won’t get the performance benefits for those locations (we plan to change this in the future).
 - Default excludes (ignoring files and directories like “CVS/”, “.DS_Store” etc.) cannot be configured when VFS retention is enabled.
 - When multiple daemons are running, the idle ones can pick up the changes produced by the others and create large log files with lots of debug info about the changes.
 - On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
 
 Gradle does not pick up some of my changes.::
-_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know on the Gradle community Slack] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. So it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know on the Gradle community Slack] if that happens to you._
+If your build declares its inputs and outputs correctly, this should not happen.
+So it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
 
 Why am I always getting “Received 8 file system events since last build” even though I only changed one file?::
 These are harmless notifications about changes to Gradle's own caches that happen after file watching has started.
 
 `Dropped VFS state due to lost state`::
-_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ This message means that either
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know on the Gradle community Slack] if that happens to you._
+This message means that either
++
+--
 - the daemon received some unknown file-system event,
 - too many changes happened, and the watching API couldn’t handle it.
+--
 In both cases the build cannot benefit from file-system watching.
 
 `Caught exception: Couldn't add watch, error = 28`::
-If you receive this error on Linux then you ran out of inotify handles. To raise the limit https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit[see here].
+If you receive this error on Linux then you ran out of inotify handles.
+To raise the limit see https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit[here].
 
 `java.io.IOException: Too many open files`::
 If you receive this error on macOS, you need to raise your open files limit, see https://superuser.com/a/443168/8117[here].

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -229,3 +229,31 @@ Run with `--watch-fs` on the command line::
 This enables watching the file-system for this build only.
 Put `org.gradle.unsafe.watch-fs=true` in your `gradle.properties`::
 This enables watching the file-system for all builds, unless explicitly disabled with `--no-watch-fs`.
+
+[[sec:daemon_watch_fs_troubleshooting]]
+=== Troubleshooting file-system watching
+
+Limitations::
+- If your build doesn’t declare inputs and outputs properly, there is a chance Gradle does not detect changes to undeclared stuff.
+- If you have symlinks in your build, you won’t get the performance benefits for those locations (we plan to change this in the future).
+- Default excludes (ignoring files and directories like “CVS/”, “.DS_Store” etc.) cannot be configured when VFS retention is enabled.
+- When multiple daemons are running, the idle ones can pick up the changes produced by the others and create large log files with lots of debug info about the changes.
+- On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
+
+Gradle does not pick up some of my changes.::
+_Please https://gradle-community.slack.com/[let us know] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. If it does, it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
+
+Why am I always getting “Received 8 file system events since last build” even though I only changed one file?::
+These are harmless notifications about changes to Gradle's own caches that happen after file watching has started.
+
+`Dropped VFS state due to lost state`::
+_Please https://gradle-community.slack.com/[let us know] if that happens to you._ That means that either
+- The daemon received some unknown file-system event.
+- Too many changes happened, and the watching API couldn’t handle it.
+In both cases the build cannot benefit from file-system watching.
+
+`Caught exception: Couldn't add watch, error = 28`::
+If you receive this error on Linux, you need to raise inotify limits, see https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit[here].
+
+`java.io.IOException: Too many open files`::
+If you receive this error on macOS, you need to raise your open files limit, see https://superuser.com/a/443168/8117[here].

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -241,13 +241,13 @@ Limitations::
 - On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
 
 Gradle does not pick up some of my changes.::
-_Please https://gradle-community.slack.com/[let us know] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. If it does, it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ If your build declares its inputs and outputs correctly, this should not happen. If it does, it’s either a bug we need to fix, or your build is lacking the declaration of some inputs or outputs.
 
 Why am I always getting “Received 8 file system events since last build” even though I only changed one file?::
 These are harmless notifications about changes to Gradle's own caches that happen after file watching has started.
 
 `Dropped VFS state due to lost state`::
-_Please https://gradle-community.slack.com/[let us know] if that happens to you._ That means that either
+_Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know] if that happens to you._ That means that either
 - The daemon received some unknown file-system event.
 - Too many changes happened, and the watching API couldn’t handle it.
 In both cases the build cannot benefit from file-system watching.


### PR DESCRIPTION
So we have one place where the current shortcomings are documented.