### PR TITLE
Fix configuration caching for chained artifact transforms that take artifact dependencies as input

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -679,6 +679,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
 
         then:
         assertTransformationsExecuted()
+        failure.assertHasDescription("Execution failed for task ':app:resolveGreen'") // failure is reported for task that takes the files as input
         failure.assertResolutionFailure(":app:implementation")
         failure.assertHasFailures(1)
         failure.assertThatCause(CoreMatchers.containsString("Could not find unknown:not-found:4.3"))
@@ -704,6 +705,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         fails ":app:resolveGreen"
 
         then:
+        failure.assertHasDescription("Execution failed for task ':app:resolveGreen'") // failure is reported for task that takes the files as input
         failure.assertResolutionFailure(":app:implementation")
         failure.assertHasFailures(1)
         failure.assertThatCause(CoreMatchers.containsString("Could not download cant-be-downloaded-4.3.jar (test:cant-be-downloaded:4.3)"))
@@ -729,6 +731,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         fails ":app:resolveGreen", '-DfailTransformOf=slf4j-api-1.7.25.jar'
 
         then:
+        failure.assertHasDescription("Execution failed for task ':app:resolveGreen'") // failure is reported for task that takes the files as input
         failure.assertResolutionFailure(":app:implementation")
         failure.assertHasFailures(1)
         failure.assertThatCause(CoreMatchers.containsString("Failed to transform slf4j-api-1.7.25.jar (org.slf4j:slf4j-api:1.7.25)"))

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -316,6 +316,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
+    @VisibleForTesting
     public InternalState getResolvedState() {
         return resolvedState;
     }
@@ -559,6 +560,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         assertIsResolvable();
         warnIfConfigurationIsDeprecatedForResolving();
 
+        if (resolvedState.compareTo(requestedState) >= 0) {
+            return;
+        }
+
         if (!owner.getModel().hasMutableState()) {
             if (!GradleThread.isManaged()) {
                 // Error if we are executing in a user-managed thread.
@@ -702,7 +707,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver() {
-        return new DefaultExtraExecutionGraphDependenciesResolverFactory(this::getResultsForBuildDependencies, this::getResultsForArtifacts, new ResolveGraphAction(this), fileCollectionFactory);
+        return new DefaultExtraExecutionGraphDependenciesResolverFactory(this::getResultsForBuildDependencies, this::getResultsForArtifacts, new ResolveGraphAction(this),
+            (attributes, filter) -> new ConfigurationFileCollection(Specs.satisfyAll(), attributes, filter, false, false));
     }
 
     private ResolverResults getResultsForBuildDependencies() {
@@ -1791,7 +1797,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public void run(NodeExecutionContext context) {
-            configuration.resolveExclusively(GRAPH_RESOLVED);
+            configuration.resolveExclusively(ARTIFACTS_RESOLVED);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ResolverResults;
-import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.Factory;
 
@@ -26,17 +25,17 @@ public class DefaultExtraExecutionGraphDependenciesResolverFactory implements Ex
     private final Factory<ResolverResults> graphResults;
     private final Factory<ResolverResults> artifactResults;
     private final WorkNodeAction graphResolveAction;
-    private final FileCollectionFactory fileCollectionFactory;
+    private final FilteredResultFactory filteredResultFactory;
 
-    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, WorkNodeAction graphResolveAction, FileCollectionFactory fileCollectionFactory) {
+    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, WorkNodeAction graphResolveAction, FilteredResultFactory filteredResultFactory) {
         this.graphResults = graphResults;
         this.artifactResults = artifactResults;
         this.graphResolveAction = graphResolveAction;
-        this.fileCollectionFactory = fileCollectionFactory;
+        this.filteredResultFactory = filteredResultFactory;
     }
 
     @Override
     public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier) {
-        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction, fileCollectionFactory);
+        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction, filteredResultFactory);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolver.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.execution.plan.Node;
 import org.gradle.internal.Try;
@@ -36,7 +37,12 @@ public interface ExecutionGraphDependenciesResolver {
     TaskDependencyContainer computeDependencyNodes(TransformationStep transformationStep);
 
     /**
-     * Computes the dependency artifacts for the given transformation step.
+     * Returns a collection containing the future dependency artifacts for the given transformation step.
      */
-    Try<ArtifactTransformDependencies> forTransformer(Transformer transformer);
+    FileCollection selectedArtifacts(Transformer transformer);
+
+    /**
+     * Computes the finalized dependency artifacts for the given transformation step.
+     */
+    Try<ArtifactTransformDependencies> computeArtifacts(Transformer transformer);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/FilteredResultFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/FilteredResultFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.specs.Spec;
+
+public interface FilteredResultFactory {
+    FileCollectionInternal resultsMatching(ImmutableAttributes attributes, Spec<? super ComponentIdentifier> filter);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -109,7 +109,7 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         FileCollectionFingerprinterRegistry fingerprinterRegistry = context != null ? context.getService(FileCollectionFingerprinterRegistry.class) : globalFingerprinterRegistry;
         isolateTransformerParameters(fingerprinterRegistry);
 
-        Try<ArtifactTransformDependencies> resolvedDependencies = dependenciesResolver.forTransformer(transformer);
+        Try<ArtifactTransformDependencies> resolvedDependencies = dependenciesResolver.computeArtifacts(transformer);
         return resolvedDependencies
             .map(dependencies -> {
                 ImmutableList<File> inputArtifacts = subjectToTransform.getFiles();

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -524,11 +524,14 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         instantRun(":resolve")
 
         then:
-        output.count("processing") == 3
-        outputContains("processing c.jar using []")
-        outputContains("processing b.jar using []")
-        outputContains("processing a.jar using [b.jar, c.jar]")
-        outputContains("result = [a.jar.green, b.jar.green, c.jar.green]")
+        output.count("processing") == 6
+        outputContains("processing a.jar")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("processing b.jar.red using []")
+        outputContains("processing c.jar.red using []")
+        outputContains("processing a.jar.red using [b.jar.red, c.jar.red]")
+        outputContains("result = [a.jar.red.green, b.jar.red.green, c.jar.red.green]")
 
         when:
         instantRun(":resolve")
@@ -542,7 +545,7 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         result.assertTaskSkipped(":b:producer")
         result.assertTaskSkipped(":c:producer")
         output.count("processing") == 0
-        outputContains("result = [a.jar.green, b.jar.green, c.jar.green]")
+        outputContains("result = [a.jar.red.green, b.jar.red.green, c.jar.red.green]")
 
         when:
         instantRun(":resolve", "-PbContent=changed")
@@ -555,9 +558,10 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         result.assertTaskSkipped(":a:producer")
         result.assertTaskNotSkipped(":b:producer")
         result.assertTaskSkipped(":c:producer")
-        output.count("processing") == 2
-        outputContains("processing b.jar using []")
-        outputContains("processing a.jar using [b.jar, c.jar]")
-        outputContains("result = [a.jar.green, b.jar.green, c.jar.green]")
+        output.count("processing") == 3
+        outputContains("processing b.jar")
+        outputContains("processing b.jar.red using []")
+        outputContains("processing a.jar.red using [b.jar.red, c.jar.red]")
+        outputContains("result = [a.jar.red.green, b.jar.red.green, c.jar.red.green]")
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/AbstractTransformationNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/AbstractTransformationNodeCodec.kt
@@ -47,7 +47,7 @@ abstract class AbstractTransformationNodeCodec<T : TransformationNode> : Codec<T
     suspend fun WriteContext.writeDependenciesResolver(value: TransformationNode) {
         if (value.transformationStep.transformer.requiresDependencies()) {
             writeBoolean(true)
-            write(value.dependenciesResolver.forTransformer(value.transformationStep.transformer).get().files)
+            write(value.dependenciesResolver.selectedArtifacts(value.transformationStep.transformer))
         } else {
             writeBoolean(false)
         }
@@ -79,7 +79,11 @@ class FixedDependenciesResolver(private val dependencies: ArtifactTransformDepen
         throw IllegalStateException()
     }
 
-    override fun forTransformer(transformer: Transformer): Try<ArtifactTransformDependencies> {
+    override fun selectedArtifacts(transformer: Transformer): FileCollection {
+        return dependencies.files
+    }
+
+    override fun computeArtifacts(transformer: Transformer): Try<ArtifactTransformDependencies> {
         return Try.successful(dependencies)
     }
 }


### PR DESCRIPTION

### Context

Replace some ad hoc logic to calculate the input artifact dependencies for a transform, with the same logic used to calculate the files and producer tasks of other filtered views of a dependency resolution result. This allows the configuration caching to deal with these files in the same way as other file collections containing dependency resolution outputs.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
