### PR TITLE
Let zipTree() and tarTree() be available on injected service

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.file;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
@@ -62,6 +63,26 @@ public interface ProjectLayout {
      * @since 4.8
      */
     FileCollection files(Object... paths);
+
+    /**
+     * <p>Creates a read-only {@code FileTree} which contains the contents of the given ZIP file, as defined by {@link Project#zipTree(Object)}.</p>
+     *
+     * @param zipPath The ZIP file. Evaluated as per {@link Project#file(Object)}.
+     * @return the file tree. Never returns null.
+     * @since 6.6
+     */
+    @Incubating
+    FileTree zipTree(Object zipPath);
+
+    /**
+     * <p>Creates a read-only {@code FileTree} which contains the contents of the given TAR file, as defined by {@link Project#tarTree(Object)}.</p>
+     *
+     * @param tarPath The TAR file. Evaluated as per {@link Project#file(Object)}.
+     * @return the file tree. Never returns null.
+     * @since 6.6
+     */
+    @Incubating
+    FileTree tarTree(Object tarPath);
 
     /**
      * <p>Returns a mutable {@link ConfigurableFileCollection} containing the given files, as defined by {@link Project#files(Object...)}.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -22,6 +22,7 @@ import spock.lang.Unroll
 
 class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
     private static final String STRING_CALLABLE = 'new java.util.concurrent.Callable<String>() { String call() { return "src/resource/file.txt" } }'
+    private static final String STRING_ZIP_CALLABLE = 'new java.util.concurrent.Callable<String>() { String call() { return "src/resource/archive.zip" } }'
 
     def "can access the project dir and build dir"() {
         buildFile << """
@@ -194,6 +195,9 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
     def 'can create #collectionType containing #content'() {
         given:
         file('src/resource/file.txt') << "some text"
+        createZip("src/resource/archive.zip") {
+            file("file.txt") << "some text"
+        }
 
         buildFile << """
             def fileCollection = $expression
@@ -238,6 +242,16 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'ConfigurableFileCollection' | 'Callable'       | "project.layout.configurableFiles($STRING_CALLABLE)"
         'ConfigurableFileCollection' | 'Provider'       | "project.layout.configurableFiles(provider($STRING_CALLABLE))"
         'ConfigurableFileCollection' | 'nested objects' | "project.layout.configurableFiles({[{$STRING_CALLABLE}]})"
+
+        'archive FileTree'           | 'String'         | 'project.layout.zipTree("src/resource/archive.zip")'
+        'archive FileTree'           | 'File'           | 'project.layout.zipTree(new File("src/resource/archive.zip"))'
+        'archive FileTree'           | 'Path'           | 'project.layout.zipTree(java.nio.file.Paths.get("src/resource/archive.zip"))'
+        'archive FileTree'           | 'URI'            | 'project.layout.zipTree(new File(projectDir, "/src/resource/archive.zip").toURI())'
+        'archive FileTree'           | 'URL'            | 'project.layout.zipTree(new File(projectDir, "/src/resource/archive.zip").toURI().toURL())'
+        'archive FileTree'           | 'RegularFile'    | 'project.layout.zipTree(project.layout.projectDirectory.file("src/resource/archive.zip"))'
+        'archive FileTree'           | 'Closure'        | 'project.layout.zipTree({ "src/resource/archive.zip" })'
+        'archive FileTree'           | 'Callable'       | "project.layout.zipTree($STRING_ZIP_CALLABLE)"
+        'archive FileTree'           | 'Provider'       | "project.layout.zipTree(provider($STRING_ZIP_CALLABLE))"
     }
 
     @Unroll
@@ -268,6 +282,51 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'FileCollection'             | 'TaskOutputs'  | 'project.layout.files(project.tasks.myTask.outputs)'
         'ConfigurableFileCollection' | 'Task'         | 'project.layout.configurableFiles(project.tasks.myTask)'
         'ConfigurableFileCollection' | 'TaskOutputs'  | 'project.layout.configurableFiles(project.tasks.myTask.outputs)'
+    }
+
+    @Unroll
+    def 'can create #archiveType FileTree in task action'() {
+
+        given:
+        file("src/resources/file.txt") << "some text"
+
+        and:
+        buildFile << """
+            import javax.inject.Inject
+
+            def producer = tasks.register("producer", ${archiveType.capitalize()}) {
+                archiveFileName.set("archive.$archiveType")
+                destinationDirectory.set(layout.buildDirectory.dir("resources"))
+                from("src/resources")
+            }
+
+            abstract class ConsumerTask extends DefaultTask {
+                @InputFile abstract RegularFileProperty getArchiveFile()
+                @OutputDirectory abstract DirectoryProperty getUnpackDir()
+                @Inject abstract ProjectLayout getLayout()
+                @Inject abstract FileSystemOperations getFs()
+                @TaskAction void action() {
+                    fs.copy {
+                        from(layout.${archiveType}Tree(archiveFile))
+                        into(unpackDir)
+                    }
+                }
+            }
+
+            tasks.register("consumer", ConsumerTask) {
+                archiveFile = producer.flatMap { it.archiveFile }
+                unpackDir = layout.buildDirectory.dir("unpacked")
+            }
+        """
+
+        when:
+        run('consumer')
+
+        then:
+        file("build/unpacked/file.txt").isFile()
+
+        where:
+        archiveType << ['zip', 'tar']
     }
 
     @Unroll

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -23,6 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -46,14 +47,26 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     private final PropertyHost propertyHost;
     private final FileCollectionFactory fileCollectionFactory;
     private final FileFactory fileFactory;
+    private final FileOperations fileOperations;
 
-    public DefaultProjectLayout(File projectDir, FileResolver fileResolver, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, PropertyHost propertyHost, FileCollectionFactory fileCollectionFactory, FilePropertyFactory filePropertyFactory, FileFactory fileFactory) {
+    public DefaultProjectLayout(
+        File projectDir,
+        FileResolver fileResolver,
+        TaskDependencyFactory taskDependencyFactory,
+        Factory<PatternSet> patternSetFactory,
+        PropertyHost propertyHost,
+        FileCollectionFactory fileCollectionFactory,
+        FilePropertyFactory filePropertyFactory,
+        FileFactory fileFactory,
+        FileOperations fileOperations
+    ) {
         this.fileResolver = fileResolver;
         this.taskDependencyFactory = taskDependencyFactory;
         this.patternSetFactory = patternSetFactory;
         this.propertyHost = propertyHost;
         this.fileCollectionFactory = fileCollectionFactory;
         this.fileFactory = fileFactory;
+        this.fileOperations = fileOperations;
         this.projectDir = fileFactory.dir(projectDir);
         this.buildDir = filePropertyFactory.newDirectoryProperty().fileValue(fileResolver.resolve(Project.DEFAULT_BUILD_DIR_NAME));
     }
@@ -101,6 +114,16 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     @Override
     public FileCollection files(Object... paths) {
         return fileCollectionFactory.resolving(paths);
+    }
+
+    @Override
+    public FileTree zipTree(Object zipPath) {
+        return fileOperations.zipTree(zipPath);
+    }
+
+    @Override
+    public FileTree tarTree(Object tarPath) {
+        return fileOperations.tarTree(tarPath);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -125,8 +125,26 @@ public class WorkerSharedProjectScopeServices {
                 domainObjectCollectionFactory);
     }
 
-    DefaultProjectLayout createProjectLayout(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory,
-                                             FilePropertyFactory filePropertyFactory, Factory<PatternSet> patternSetFactory, PropertyHost propertyHost, FileFactory fileFactory) {
-        return new DefaultProjectLayout(projectDir, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost, fileCollectionFactory, filePropertyFactory, fileFactory);
+    DefaultProjectLayout createProjectLayout(
+        FileResolver fileResolver,
+        FileCollectionFactory fileCollectionFactory,
+        TaskDependencyFactory taskDependencyFactory,
+        FilePropertyFactory filePropertyFactory,
+        Factory<PatternSet> patternSetFactory,
+        PropertyHost propertyHost,
+        FileFactory fileFactory,
+        FileOperations fileOperations
+    ) {
+        return new DefaultProjectLayout(
+            projectDir,
+            fileResolver,
+            taskDependencyFactory,
+            patternSetFactory,
+            propertyHost,
+            fileCollectionFactory,
+            filePropertyFactory,
+            fileFactory,
+            fileOperations
+        );
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -36,7 +36,7 @@ class DefaultProjectLayoutTest extends Specification {
 
     def setup() {
         projectDir = tmpDir.createDir("project")
-        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), TestFiles.fileCollectionFactory(projectDir), TestFiles.filePropertyFactory(projectDir), TestFiles.fileFactory())
+        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), TestFiles.fileCollectionFactory(projectDir), TestFiles.filePropertyFactory(projectDir), TestFiles.fileFactory(), TestFiles.fileOperations(projectDir))
     }
 
     def "can query the project directory"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -227,7 +227,7 @@ class DefaultProjectTest extends Specification {
         ModelSchemaStore modelSchemaStore = Stub(ModelSchemaStore)
         serviceRegistryMock.get((Type) ModelSchemaStore) >> modelSchemaStore
         serviceRegistryMock.get(ModelSchemaStore) >> modelSchemaStore
-        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory())
+        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory(), TestFiles.fileOperations(rootDir))
 
         build.getProjectEvaluationBroadcaster() >> Stub(ProjectEvaluationListener)
         build.getParent() >> null

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -132,7 +132,8 @@ class TestUtil {
 
                 ProjectLayout createProjectLayout() {
                     def filePropertyFactory = new DefaultFilePropertyFactory(PropertyHost.NO_OP, fileResolver, fileCollectionFactory)
-                    return new DefaultProjectLayout(fileResolver.resolve("."), fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), PatternSets.getNonCachingPatternSetFactory(), PropertyHost.NO_OP, fileCollectionFactory, filePropertyFactory, filePropertyFactory)
+                    def baseDir = fileResolver.resolve(".")
+                    return new DefaultProjectLayout(baseDir, fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), PatternSets.getNonCachingPatternSetFactory(), PropertyHost.NO_OP, fileCollectionFactory, filePropertyFactory, filePropertyFactory, TestFiles.fileOperations(baseDir))
                 }
 
                 ChecksumService createChecksumService() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -58,6 +58,17 @@ This improves the likelihood of [build cache hits](userguide/build_cache.html) w
 See the [userguide](userguide/more_about_tasks.html#sec:meta_inf_normalization) for further information.  Note that this API is incubating and will likely change in future releases as support 
 is expanded for normalizing properties files outside of `META-INF`.
 
+## Improvements for plugin authors
+
+### New ZIP and TAR `FileTree` factory methods
+
+Previously, it was only possible to create a `FileTree` for a ZIP or TAR archive by using the APIs provided by a `Project`.
+However, a `Project` object is not always available.
+
+The `ProjectLayout` service now has [zipTree()](javadoc/org/gradle/api/file/ProjectLayout.html#zipTree-java.lang.Object-) and [tarTree()](javadoc/org/gradle/api/file/ProjectLayout.html#tarTree-java.lang.Object-) methods for creating read-only `FileTree` instances respectively for ZIP and TAR archives.
+
+See the [user manual](userguide/custom_gradle_types.html#service_injection) for how to inject services and the [`ProjectLayout`](javadoc/org/gradle/api/file/ProjectLayout.html) api documentation for more details and examples. 
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.


### PR DESCRIPTION
to create read-only archive FileTree instances where the Project isn't available.

See https://github.com/gradle/gradle/issues/13277
