### PR TITLE
Give ability to opt-out of the build id in GMM

### DIFF
--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -53,7 +53,7 @@ This value must contain an object with the following values:
 This value, nested in `createdBy`, must contain an object with the following values:
 
 - `version`: The version of Gradle. A string
-- `buildId`: The buildId for the Gradle instance. A string
+- `buildId`: optional. The buildId for the Gradle instance. A string
 
 ### `variants` value
 
@@ -63,6 +63,7 @@ This value must contain an array with zero or more elements. Each element must b
 - `attributes`: optional. When missing the variant is assumed to have no attributes.
 - `available-at`: optional. Information about where the metadata and files of this variant are available.
 - `dependencies`: optional. When missing the variant is assumed to have no dependencies. Must not be present when `available-at` is present.
+- `dependencyConstraints`: optional. When missing the variant is assumed to have no dependency constraints. Must not be present when `available-at` is present.
 - `files`: optional. When missing the variant is assumed to have no files. Must not be present when `available-at` is present.
 - `capabilities`: optional. When missing the variant is assumed to declared no specific capability.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -58,6 +58,22 @@ This improves the likelihood of [build cache hits](userguide/build_cache.html) w
 See the [userguide](userguide/more_about_tasks.html#sec:meta_inf_normalization) for further information.  Note that this API is incubating and will likely change in future releases as support 
 is expanded for normalizing properties files outside of `META-INF`.
 
+## Gradle module metadata can be made reproducible
+
+The Gradle Module Metadata file contains a build identifier field which defaults to a unique ID generated during build execution.
+This results in the generated file being different at each build execution.
+
+This value can now be disabled at the publication level, allowing users to opt-in for a reproducible Gradle Module Metadata file.
+
+```groovy
+main(MavenPublication) {
+    from components.java
+    withoutBuildIdentifier()
+}
+```
+
+See the documentation for more information on [Gradle Module Metadata generation](userguide/publishing_gradle_module_metadata.html#sub:gmm-reproducible).
+
 ## Improvements for plugin authors
 
 ### New ZIP and TAR `FileTree` factory methods

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
@@ -123,6 +123,28 @@ The following rules are enforced:
 
 These rules ensure the quality of the metadata produced, and help confirm that consumption will not be problematic.
 
+[[sub:gmm-reproducible]]
+== Making Gradle Module Metadata reproducible
+
+By default, the Gradle Module Metadata file contains a unique id from the build that generated it.
+This means that the file will always be different.
+
+Users can choose to disable this unique identifier in their `publication`:
+
+.Configure the build identifier of a publication
+====
+include::sample[dir="snippets/publishing/javaLibrary/groovy",files="build.gradle[tags=disable-build-id]"]
+include::sample[dir="snippets/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=disable-build-id]"]
+====
+
+With the changes above, the generated Gradle Module Metadata file will always be the same, allowing downstream tasks to consider it up-to-date.
+
+[NOTE]
+====
+The task generating the module metadata files is currently never marked `UP-TO-DATE` by Gradle due to the way it is implemented.
+However, if the build identifier is skipped, and no build inputs nor build scripts changed, the task is effectively up-to-date (it always produces the same output).
+====
+
 [[sub:disabling-gmm-publication]]
 == Disabling Gradle Module Metadata publication
 

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
@@ -41,3 +41,14 @@ tasks.withType(GenerateMavenPom).all {
     destination = "$buildDir/poms/${publicationName}-pom.xml"
 }
 // end::configure-generate-task[]
+
+// tag::disable-build-id[]
+publishing {
+    publications {
+        main(MavenPublication) {
+            from components.java
+            withoutBuildIdentifier()
+        }
+    }
+}
+// end::disable-build-id[]

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
@@ -41,3 +41,14 @@ tasks.withType<GenerateMavenPom>().configureEach {
     destination = file("$buildDir/poms/$publicationName-pom.xml")
 }
 // end::configure-generate-task[]
+
+// tag::disable-build-id[]
+publishing {
+    publications {
+        create<MavenPublication>("main") {
+            from(components["java"])
+            withoutBuildIdentifier()
+        }
+    }
+}
+// end::disable-build-id[]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -38,8 +38,16 @@ class GradleModuleMetadata {
         }
         assert values.formatVersion == '1.1'
         assert values.createdBy.gradle.version == GradleVersion.current().version
-        assert values.createdBy.gradle.buildId
         variants = (values.variants ?: []).collect { new Variant(it.name, it) }
+    }
+
+    @Nullable
+    CreatedBy getCreatedBy() {
+        def createdBy = values.createdBy
+        if (createdBy == null) {
+            return null
+        }
+        return new CreatedBy(createdBy.gradle.version, createdBy.gradle.buildId)
     }
 
     @Nullable
@@ -431,6 +439,17 @@ class GradleModuleMetadata {
                 assert actualAttributes == expectedAttributes
                 this
             }
+        }
+    }
+
+    @EqualsAndHashCode
+    static class CreatedBy {
+        final String gradleVersion
+        final String buildId
+
+        CreatedBy(String gradleVersion, String buildId) {
+            this.gradleVersion = gradleVersion
+            this.buildId = buildId
         }
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -137,6 +137,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
     private boolean silenceAllPublicationWarnings;
+    private boolean withBuildIdentifier = true;
 
     @Inject
     public DefaultIvyPublication(
@@ -162,6 +163,21 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public void withoutBuildIdentifier() {
+        withBuildIdentifier = false;
+    }
+
+    @Override
+    public void withBuildIdentifier() {
+        withBuildIdentifier = true;
+    }
+
+    @Override
+    public boolean isPublishBuildId() {
+        return withBuildIdentifier;
     }
 
     @Override

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -888,4 +888,41 @@ class TestCapability implements Capability {
         variant.dependencyConstraints[0].strictly == '1.1'
         variant.dependencyConstraints[0].rejectsVersion == []
     }
+
+    @ToBeFixedForInstantExecution
+    def 'can skip the build identifier'() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'),
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                        withoutBuildIdentifier()
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.createdBy.buildId == null
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -163,6 +163,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
     private boolean silenceAllPublicationWarnings;
+    private boolean withBuildIdentifier = true;
 
     @Inject
     public DefaultMavenPublication(
@@ -187,6 +188,21 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public void withoutBuildIdentifier() {
+        withBuildIdentifier = false;
+    }
+
+    @Override
+    public void withBuildIdentifier() {
+        withBuildIdentifier = true;
+    }
+
+    @Override
+    public boolean isPublishBuildId() {
+        return withBuildIdentifier;
     }
 
     @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.publish;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -24,4 +25,24 @@ import org.gradle.api.Named;
  * @since 1.3
  */
 public interface Publication extends Named {
+
+    /**
+     * Disables publication of a unique build identifier in Gradle Module Metadata.
+     * <p>
+     * The build identifier is published by default.
+     *
+     * @since 6.6
+     */
+    @Incubating
+    void withoutBuildIdentifier();
+
+    /**
+     * Enables publication of a unique build identifier in Gradle Module Metadata.
+     * <p>
+     * The build identifier is published by default.
+     *
+     * @since 6.6
+     */
+    @Incubating
+    void withBuildIdentifier();
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -141,7 +141,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(publication.getCoordinates(), publication.getAttributes(), component, componentCoordinates, owners, jsonWriter);
-        writeCreator(jsonWriter);
+        writeCreator(publication, jsonWriter);
         writeVariants(publication, component, componentCoordinates, jsonWriter, checker);
         jsonWriter.endObject();
     }
@@ -259,15 +259,17 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeCreator(JsonWriter jsonWriter) throws IOException {
+    private void writeCreator(PublicationInternal<?> publication, JsonWriter jsonWriter) throws IOException {
         jsonWriter.name("createdBy");
         jsonWriter.beginObject();
         jsonWriter.name("gradle");
         jsonWriter.beginObject();
         jsonWriter.name("version");
         jsonWriter.value(GradleVersion.current().getVersion());
-        jsonWriter.name("buildId");
-        jsonWriter.value(buildInvocationScopeId.getId().asString());
+        if (publication.isPublishBuildId()) {
+            jsonWriter.name("buildId");
+            jsonWriter.value(buildInvocationScopeId.getId().asString());
+        }
         jsonWriter.endObject();
         jsonWriter.endObject();
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -72,6 +72,8 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
     @Nullable
     VersionMappingStrategyInternal getVersionMappingStrategy();
 
+    boolean isPublishBuildId();
+
     interface PublishedFile {
         String getName();
 

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
@@ -97,5 +97,15 @@ class DefaultPublicationContainerTest extends Specification {
         TestPublication(name) {
             this.name = name
         }
+
+        @Override
+        void withoutBuildIdentifier() {
+            // No-op
+        }
+
+        @Override
+        void withBuildIdentifier() {
+            // No-op
+        }
     }
 }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -1128,6 +1128,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         publication.component >> component
         publication.coordinates >> coords
         publication.versionMappingStrategy >> mappingStrategyInternal
+        publication.isPublishBuildId() >> true
         return publication
     }
 


### PR DESCRIPTION
Gradle Module Metadata by default contains a unique build identifier,
making the production of the file not reproducible.
With this commit, it is now possible to opt-out of the inclusion of this
build identifier in the produced metadata file.