### PR TITLE
Don't require a JS engine to verify the configuration cache problems report

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -17,7 +17,11 @@
 package org.gradle.instantexecution
 
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import org.gradle.util.Requires
 
+import static org.gradle.util.TestPrecondition.JDK14_OR_EARLIER
+
+@Requires(JDK14_OR_EARLIER)
 class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
     def "can use jacoco"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -123,7 +123,7 @@ class InstantExecutionReport(
         appendln("\"documentationLink\": \"${documentationRegistry.getDocumentationFor("configuration_cache")}\",")
         appendln("\"problems\": [") // begin problems
         problems.forEachIndexed { index, problem ->
-            if (index > 0) appendln(",")
+            if (index > 0) append(',')
             append(
                 JsonOutput.toJson(
                     mapOf(

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -118,6 +118,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK13_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_13
     }),
+    JDK14_OR_EARLIER({
+        JavaVersion.current() <= JavaVersion.VERSION_14
+    }),
     JDK14_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_14
     }),


### PR DESCRIPTION
By making sure the data can be read as pure json.