### PR TITLE
Introduce an API for variant dependency substitution

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -53,6 +53,14 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
 """
     }
 
+    def platformDependency(BuildTestFile sourceBuild = buildA, String notation) {
+        sourceBuild.buildFile << """
+            dependencies {
+                implementation platform('${notation}')
+            }
+"""
+    }
+
     def includeBuildAs(File build, String name) {
         buildA.settingsFile << """
                 includeBuild('${build.toURI()}') {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
+import spock.lang.Unroll
 
 /**
  * Tests for resolving dependency graph with substitution within a composite build.
@@ -271,6 +272,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def "preserves the requested attributes when performing a composite substitution using mapping"() {
         platformDependency 'org.test:platform:1.0'
 
@@ -287,7 +289,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
 
         when:
         includeBuild(platform, """
-            substitute platform(module("org.test:platform")) with platform(project(":"))
+            substitute $source with $dest
         """)
 
         then:
@@ -299,6 +301,13 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
             }
         }
 
+        where:
+        source                                  | dest
+        'platform(module("org.test:platform"))' | 'platform(project(":"))'
+        'module("org.test:platform")'           | 'platform(project(":"))'
+        'platform(module("org.test:platform"))' | 'project(":")'
+        'module("org.test:platform")'           | 'project(":")'
+        'module("org.test:platform")'           | 'project(":")'
     }
 
     void resolvedGraph(@DelegatesTo(ResolveTestFixture.NodeBuilder) Closure closure) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -18,9 +18,11 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentProvider;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.composite.internal.plugins.CompositeBuildPluginResolverContributor;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.internal.build.BuildState;
@@ -48,9 +50,17 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
     }
 
     private static class CompositeBuildTreeScopeServices {
-        public BuildStateRegistry createIncludedBuildRegistry(CompositeBuildContext context, Instantiator instantiator, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, ServiceRegistry rootServices) {
+        public BuildStateRegistry createIncludedBuildRegistry(CompositeBuildContext context,
+                                                              Instantiator instantiator,
+                                                              WorkerLeaseService workerLeaseService,
+                                                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                                              GradleLauncherFactory gradleLauncherFactory,
+                                                              ListenerManager listenerManager,
+                                                              ServiceRegistry rootServices,
+                                                              ObjectFactory objectFactory,
+                                                              ImmutableAttributesFactory attributesFactory) {
             IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, workerLeaseService);
-            IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory, instantiator);
+            IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory);
             return new DefaultIncludedBuildRegistry(includedBuildFactory, dependencySubstitutionsBuilder, gradleLauncherFactory, listenerManager, (BuildTreeScopeServices) rootServices);
         }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -19,7 +19,9 @@ package org.gradle.composite.internal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.reflect.Instantiator;
 import org.slf4j.Logger;
@@ -31,13 +33,19 @@ public class IncludedBuildDependencySubstitutionsBuilder {
     private final CompositeBuildContext context;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final Instantiator instantiator;
+    private final ObjectFactory objectFactory;
+    private final ImmutableAttributesFactory attributesFactory;
 
     public IncludedBuildDependencySubstitutionsBuilder(CompositeBuildContext context,
                                                        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                                       Instantiator instantiator) {
+                                                       Instantiator instantiator,
+                                                       ObjectFactory objectFactory,
+                                                       ImmutableAttributesFactory attributesFactory) {
         this.context = context;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.instantiator = instantiator;
+        this.objectFactory = objectFactory;
+        this.attributesFactory = attributesFactory;
     }
 
     public void build(IncludedBuildState build) {
@@ -53,7 +61,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
     }
 
     private DependencySubstitutionsInternal resolveDependencySubstitutions(IncludedBuildState build) {
-        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, moduleIdentifierFactory, instantiator);
+        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory);
         build.getRegisteredDependencySubstitutions().execute(dependencySubstitutions);
         return dependencySubstitutions;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
@@ -23,6 +23,7 @@ import org.gradle.internal.HasInternalProtocol;
 
 /**
  * Allows replacing dependencies with other dependencies.
+ *
  * @since 2.5
  */
 @HasInternalProtocol
@@ -72,6 +73,25 @@ public interface DependencySubstitutions {
     ComponentSelector project(String path);
 
     /**
+     * Transforms the supplied selector into a specific variant selector.
+     * @param selector the origin selector
+     * @param detailsAction the variant selection details configuration
+     *
+     * @since 6.6
+     */
+    @Incubating
+    ComponentSelector variant(ComponentSelector selector, Action<? super VariantSelectionDetails> detailsAction);
+
+    /**
+     * Transforms the provided selector into a platform selector.
+     *
+     * @param selector the original selector
+     * @since 6.6
+     */
+    @Incubating
+    ComponentSelector platform(ComponentSelector selector);
+
+    /**
      * DSL-friendly mechanism to construct a dependency substitution for dependencies matching the provided selector.
      * <p>
      * Examples:
@@ -95,11 +115,10 @@ public interface DependencySubstitutions {
     interface Substitution {
         /**
          * Specify a reason for the substitution. This is optional
+         *
          * @param reason the reason for the selection
-         *
-         * @since 4.5
-         *
          * @return the substitution
+         * @since 4.5
          */
         Substitution because(String reason);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantSelectionDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantSelectionDetails.java
@@ -47,7 +47,7 @@ public interface VariantSelectionDetails {
     /**
      * Replaces the provided selector attributes with the attributes configured
      * in the configuration action.
-     * @param configurationAction the configurationa action
+     * @param configurationAction the configuration action
      */
     void attributes(Action<? super AttributeContainer> configurationAction);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantSelectionDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantSelectionDetails.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
+
+/**
+ * Allows configuring the variant-aware selection aspects of a specific
+ * dependency. This includes the ability to substitute a dependency on
+ * a platform with another platform, or substitute a dependency without
+ * attributes with a dependency with attributes.
+ *
+ * @since 6.6
+ */
+@Incubating
+public interface VariantSelectionDetails {
+    /**
+     * Selects the platform variant of a component
+     */
+    void platform();
+
+    /**
+     * Selects the enforced platform variant of a component
+     */
+    void enforcedPlatform();
+
+    /**
+     * Selects the library variant of a component
+     */
+    void library();
+
+    /**
+     * Replaces the provided selector attributes with the attributes configured
+     * in the configuration action.
+     * @param configurationAction the configurationa action
+     */
+    void attributes(Action<? super AttributeContainer> configurationAction);
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -46,7 +46,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
             ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-            ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, TestUtil.domainObjectCollectionFactory())],
+            ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, TestUtil.domainObjectCollectionFactory(), TestUtil.objectFactory())],
             ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
             ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Issue
+import spock.lang.Unroll
+
+class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec {
+    def resolve = new ResolveTestFixture(buildFile, "conf").expectDefaultConfiguration("runtime")
+
+    def setup() {
+        settingsFile << "rootProject.name='depsub'\n"
+        resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
+    }
+
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/13204")
+    def "can substitute a normal dependency with a platform dependency"() {
+
+        buildFile << """
+
+            configurations {
+                conf {
+                    resolutionStrategy.dependencySubstitution {
+                        substitute module('org:lib') with $notation
+                    }
+                }
+            }
+
+            dependencies {
+                conf 'org:lib:1.0'
+            }
+        """
+
+        settingsFile << """
+            include 'platform'
+        """
+
+        file("platform/build.gradle") << """
+            plugins {
+                id 'java-platform'
+            }
+
+        """
+
+        when:
+        succeeds ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                edge('org:lib:1.0', 'project :platform', 'depsub:platform:') {
+                    variant(expectedVariant, [
+                        'org.gradle.category': expectedCategory,
+                        'org.gradle.usage': 'java-runtime'
+                    ])
+                    selectedByRule()
+                    noArtifacts()
+                }
+            }
+        }
+
+        where:
+        notation                                                                                                                                       | expectedCategory    | expectedVariant
+        'platform(project(":platform"))'                                                                                                               | 'platform'          | 'runtimeElements'
+        'variant(project(":platform")) { platform() }'                                                                                                 | 'platform'          | 'runtimeElements'
+        'variant(project(":platform")) { attributes { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.REGULAR_PLATFORM)) } }'  | 'platform'          | 'runtimeElements'
+
+        'variant(project(":platform")) { enforcedPlatform() }'                                                                                         | 'enforced-platform' | 'enforcedRuntimeElements'
+        'variant(project(":platform")) { attributes { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.ENFORCED_PLATFORM)) } }' | 'enforced-platform' | 'enforcedRuntimeElements'
+
+    }
+
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/13204")
+    def "can substitute a platform dependency with a regular dependency"() {
+        mavenRepo.module("org", "lib", "1.0").publish()
+
+        buildFile << """
+
+            repositories {
+               maven { url "${mavenRepo.uri}" }
+            }
+
+            configurations {
+                conf {
+                    resolutionStrategy.dependencySubstitution {
+                        substitute $notation with module('org:lib:1.0')
+                    }
+                }
+            }
+
+            dependencies {
+                conf platform('org:lib:1.0')
+            }
+        """
+
+        when:
+        succeeds ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                edge('org:lib:1.0', 'org:lib:1.0') {
+                    variant('runtime', [
+                        'org.gradle.category': 'library',
+                        'org.gradle.libraryelements': 'jar',
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-runtime'
+                    ])
+                    selectedByRule()
+                }
+            }
+        }
+
+        where:
+        notation << [
+            'platform(module("org:lib:1.0"))',
+            'variant(platform(module("org:lib:1.0"))) { }',
+            'variant(module("org:lib:1.0")) { platform() }',
+            'variant(module("org:lib:1.0")) { attributes { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.REGULAR_PLATFORM)) } }',
+        ]
+
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -484,7 +484,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultRepositoryHandler.class, baseRepositoryFactory, instantiator, callbackDecorator);
         }
 
-        ConfigurationContainerInternal createConfigurationContainer(Instantiator instantiator, ConfigurationResolver configurationResolver, DomainObjectContext domainObjectContext,
+        ConfigurationContainerInternal createConfigurationContainer(Instantiator instantiator,
+                                                                    ConfigurationResolver configurationResolver, DomainObjectContext domainObjectContext,
                                                                     ListenerManager listenerManager, DependencyMetaDataProvider metaDataProvider, ProjectAccessListener projectAccessListener,
                                                                     ProjectFinder projectFinder, LocalComponentMetadataBuilder metaDataBuilder, FileCollectionFactory fileCollectionFactory,
                                                                     GlobalDependencyResolutionRules globalDependencyResolutionRules, VcsMappingsStore vcsMappingsStore, ComponentIdentifierFactory componentIdentifierFactory,
@@ -495,7 +496,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                     DocumentationRegistry documentationRegistry,
                                                                     CollectionCallbackActionDecorator callbackDecorator,
                                                                     UserCodeApplicationContext userCodeApplicationContext,
-                                                                    DomainObjectCollectionFactory domainObjectCollectionFactory) {
+                                                                    DomainObjectCollectionFactory domainObjectCollectionFactory,
+                                                                    ObjectFactory objectFactory) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 configurationResolver,
                 instantiator,
@@ -519,7 +521,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 documentationRegistry,
                 callbackDecorator,
                 userCodeApplicationContext,
-                domainObjectCollectionFactory
+                domainObjectCollectionFactory,
+                objectFactory
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -46,6 +46,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskResolver;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.Factory;
@@ -85,24 +86,29 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
     public DefaultConfigurationContainer(ConfigurationResolver resolver,
-                                         final Instantiator instantiator, DomainObjectContext context, ListenerManager listenerManager,
-                                         DependencyMetaDataProvider dependencyMetaDataProvider, ProjectAccessListener projectAccessListener,
-                                         ProjectFinder projectFinder, LocalComponentMetadataBuilder localComponentMetadataBuilder,
+                                         Instantiator instantiator,
+                                         DomainObjectContext context,
+                                         ListenerManager listenerManager,
+                                         DependencyMetaDataProvider dependencyMetaDataProvider,
+                                         ProjectAccessListener projectAccessListener,
+                                         ProjectFinder projectFinder,
+                                         LocalComponentMetadataBuilder localComponentMetadataBuilder,
                                          FileCollectionFactory fileCollectionFactory,
-                                         final DependencySubstitutionRules globalDependencySubstitutionRules,
-                                         final VcsMappingsStore vcsMappingsStore,
-                                         final ComponentIdentifierFactory componentIdentifierFactory,
+                                         DependencySubstitutionRules globalDependencySubstitutionRules,
+                                         VcsMappingsStore vcsMappingsStore,
+                                         ComponentIdentifierFactory componentIdentifierFactory,
                                          BuildOperationExecutor buildOperationExecutor,
                                          TaskResolver taskResolver,
                                          ImmutableAttributesFactory attributesFactory,
-                                         final ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                         final ComponentSelectorConverter componentSelectorConverter,
-                                         final DependencyLockingProvider dependencyLockingProvider,
+                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                         ComponentSelectorConverter componentSelectorConverter,
+                                         DependencyLockingProvider dependencyLockingProvider,
                                          ProjectStateRegistry projectStateRegistry,
                                          DocumentationRegistry documentationRegistry,
                                          CollectionCallbackActionDecorator callbackDecorator,
                                          UserCodeApplicationContext userCodeApplicationContext,
-                                         DomainObjectCollectionFactory domainObjectCollectionFactory) {
+                                         DomainObjectCollectionFactory domainObjectCollectionFactory,
+                                         ObjectFactory objectFactory) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
         this.resolver = resolver;
         this.instantiator = instantiator;
@@ -122,7 +128,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         this.documentationRegistry = documentationRegistry;
         resolutionStrategyFactory = () -> {
             CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class, new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create());
-            return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator);
+            return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory);
         };
         this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, localComponentMetadataBuilder, this, projectStateRegistry, dependencyLockingProvider);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -37,6 +37,8 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.locking.NoOpDependencyLockingProvider;
@@ -85,8 +87,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
                                      ComponentSelectorConverter componentSelectorConverter,
                                      DependencyLockingProvider dependencyLockingProvider,
                                      CapabilitiesResolutionInternal capabilitiesResolution,
-                                     Instantiator instantiator) {
-        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, instantiator), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
+                                     Instantiator instantiator,
+                                     ObjectFactory objectFactory,
+                                     ImmutableAttributesFactory attributesFactory) {
+        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
     }
 
     DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider, CapabilitiesResolutionInternal capabilitiesResolution) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -196,7 +196,7 @@ class EdgeState implements DependencyGraphEdge {
 
     private ImmutableAttributes safeGetAttributes() throws AttributeMergingException {
         ModuleResolveState module = selector.getTargetModule();
-        cachedAttributes = module.mergedConstraintsAttributes(dependencyState.getRequested().getAttributes());
+        cachedAttributes = module.mergedConstraintsAttributes(dependencyState.getDependency().getSelector().getAttributes());
         return cachedAttributes;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -190,4 +190,14 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     public static ModuleComponentSelector newSelector(ModuleVersionSelector selector) {
         return new DefaultModuleComponentSelector(selector.getModule(), DefaultImmutableVersionConstraint.of(selector.getVersion()), ImmutableAttributes.EMPTY, ImmutableList.of());
     }
+
+    public static ModuleComponentSelector withAttributes(ModuleComponentSelector selector, ImmutableAttributes attributes) {
+        DefaultModuleComponentSelector cs = (DefaultModuleComponentSelector) selector;
+        return new DefaultModuleComponentSelector(
+            cs.moduleIdentifier,
+            cs.versionConstraint,
+            attributes,
+            cs.requestedCapabilities
+        );
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -154,6 +154,23 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
         return new DefaultProjectComponentSelector(projectComponentIdentifier.getBuild(), projectComponentIdentifier.getIdentityPath(), projectComponentIdentifier.projectPath(), projectComponentIdentifier.getProjectName(), ImmutableAttributes.EMPTY, Collections.emptyList());
     }
 
+    public static ProjectComponentSelector newSelector(ProjectComponentIdentifier identifier, ImmutableAttributes attributes, List<Capability> requestedCapabilities) {
+        DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) identifier;
+        return new DefaultProjectComponentSelector(projectComponentIdentifier.getBuild(), projectComponentIdentifier.getIdentityPath(), projectComponentIdentifier.projectPath(), projectComponentIdentifier.getProjectName(), attributes, requestedCapabilities);
+    }
+
+    public static ProjectComponentSelector withAttributes(ProjectComponentSelector selector, ImmutableAttributes attributes) {
+        DefaultProjectComponentSelector current = (DefaultProjectComponentSelector) selector;
+        return new DefaultProjectComponentSelector(
+            current.buildIdentifier,
+            current.identityPath,
+            current.projectPath,
+            current.projectName,
+            attributes,
+            current.requestedCapabilities
+        );
+    }
+
     public ProjectComponentIdentifier toIdentifier() {
         return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, projectName);
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -76,7 +76,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider,
             projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
             immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry, documentationRegistry,
-            domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory())
+            domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory(), TestUtil.objectFactory())
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -72,11 +72,31 @@ class DefaultConfigurationContainerTest extends Specification {
     }
     private ComponentSelectorConverter componentSelectorConverter = Mock()
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
-            resolver, instantiator, new RootScriptDomainObjectContext(),
-            listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(),
-            globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
-            immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, lockingProvider, projectStateRegistry,
-            documentationRegistry, callbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory())
+        resolver,
+        instantiator,
+        new RootScriptDomainObjectContext(),
+        listenerManager,
+        metaDataProvider,
+        projectAccessListener,
+        projectFinder,
+        metaDataBuilder,
+        TestFiles.fileCollectionFactory(),
+        globalSubstitutionRules,
+        vcsMappingsInternal,
+        componentIdentifierFactory,
+        buildOperationExecutor,
+        taskResolver,
+        immutableAttributesFactory,
+        moduleIdentifierFactory,
+        componentSelectorConverter,
+        lockingProvider,
+        projectStateRegistry,
+        documentationRegistry,
+        callbackActionDecorator,
+        userCodeApplicationContext,
+        TestUtil.domainObjectCollectionFactory(),
+        TestUtil.objectFactory()
+    )
 
     def addsNewConfigurationWhenConfiguringSelf() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConst
 import org.gradle.internal.Actions
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.TestComponentIdentifiers
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -45,7 +46,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
     DependencySubstitutionsInternal substitutions;
 
     def setup() {
-        substitutions = DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, TestUtil.instantiatorFactory().decorateScheme().instantiator())
+        substitutions = DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, TestUtil.instantiatorFactory().decorateScheme().instantiator(), TestUtil.objectFactory(), AttributeTestUtil.attributesFactory())
     }
 
     def "provides no op resolve rule when no rules or forced modules configured"() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
@@ -31,14 +31,14 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultRe
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
-import org.gradle.internal.locking.NoOpDependencyLockingProvider;
-import org.gradle.internal.reflect.DirectInstantiator;
-import org.gradle.vcs.internal.VcsMappingsStore;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.locking.NoOpDependencyLockingProvider;
+import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.language.base.internal.model.DefaultLibraryLocalComponentMetadata;
 import org.gradle.platform.base.DependencySpec;
+import org.gradle.vcs.internal.VcsMappingsStore;
 
 import java.util.Set;
 
@@ -64,7 +64,7 @@ public class JvmLibraryResolveContext implements ResolveContext {
         this.displayName = displayName;
         this.variants = variants;
         this.dependencies = dependencies;
-        this.resolutionStrategy = new DefaultResolutionStrategy(DependencySubstitutionRules.NO_OP, VcsMappingsStore.NO_OP, null, moduleIdentifierFactory, null, NoOpDependencyLockingProvider.getInstance(), new DefaultCapabilitiesResolution(new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create()), DirectInstantiator.INSTANCE);
+        this.resolutionStrategy = new DefaultResolutionStrategy(DependencySubstitutionRules.NO_OP, VcsMappingsStore.NO_OP, null, moduleIdentifierFactory, null, NoOpDependencyLockingProvider.getInstance(), new DefaultCapabilitiesResolution(new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create()), DirectInstantiator.INSTANCE, null, null);
     }
 
     @Override


### PR DESCRIPTION
This commit introduces a new API to deal with _variant-aware_ dependency
substitution. Before this change, it wasn't possible to substitute a
dependency on a platform, for example. This change allows configuring
the attributes of a dependency, both on the "source" side (what dependency
we need to substitute) and the "target" side (what dependency is going to
be used instead).

Some DSL short-hand notations are added for common use cases.

Fixes #13204
