### PR TITLE
Rename `InstantExecutionCache{Invalidation => Key}`

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -52,7 +52,7 @@ class DefaultInstantExecution internal constructor(
     private val host: Host,
     private val startParameter: InstantExecutionStartParameter,
     private val cache: InstantExecutionCache,
-    private val cacheInvalidation: InstantExecutionCacheInvalidation,
+    private val cacheKey: InstantExecutionCacheKey,
     private val problems: InstantExecutionProblems,
     private val systemPropertyListener: SystemPropertyAccessListener,
     private val scopeRegistryListener: InstantExecutionClassLoaderScopeRegistryListener,
@@ -89,7 +89,7 @@ class DefaultInstantExecution internal constructor(
         }
         else -> {
             val checkedFingerprint = cache.useForFingerprintCheck(
-                cacheInvalidation.cacheKey,
+                cacheKey.string,
                 this::checkFingerprint
             )
             when (checkedFingerprint) {
@@ -136,7 +136,7 @@ class DefaultInstantExecution internal constructor(
         stopCollectingCacheFingerprint()
 
         buildOperationExecutor.withStoreOperation {
-            cache.useForStore(cacheInvalidation.cacheKey) { layout ->
+            cache.useForStore(cacheKey.string) { layout ->
                 try {
                     writeInstantExecutionFiles(layout)
                 } catch (error: InstantExecutionError) {
@@ -158,7 +158,7 @@ class DefaultInstantExecution internal constructor(
         scopeRegistryListener.dispose()
 
         buildOperationExecutor.withLoadOperation {
-            cache.useForStateLoad(cacheInvalidation.cacheKey) { stateFile ->
+            cache.useForStateLoad(cacheKey.string) { stateFile ->
                 readInstantExecutionState(stateFile)
             }
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -44,7 +44,7 @@ class InstantExecutionReport(
     val startParameter: InstantExecutionStartParameter,
 
     private
-    val cacheInvalidation: InstantExecutionCacheInvalidation
+    val cacheKey: InstantExecutionCacheKey
 
 ) {
 
@@ -60,7 +60,7 @@ class InstantExecutionReport(
     private
     val outputDirectory: File by lazy {
         startParameter.rootDirectory.resolve(
-            "build/reports/configuration-cache/${cacheInvalidation.cacheKey}"
+            "build/reports/configuration-cache/$cacheKey"
         ).let { base ->
             if (!base.exists()) base
             else generateSequence(1) { it + 1 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -42,7 +42,7 @@ class InstantExecutionServices : AbstractPluginServiceRegistry() {
         registration.run {
             add(BuildTreeListenerManager::class.java)
             add(InstantExecutionStartParameter::class.java)
-            add(InstantExecutionCacheInvalidation::class.java)
+            add(InstantExecutionCacheKey::class.java)
             add(InstantExecutionReport::class.java)
             add(InstantExecutionProblems::class.java)
         }


### PR DESCRIPTION
Plus:

- make it a little more convenient to use in string templates by overriding
  `toString`
- compose method