### PR TITLE
Fix whitespace error in gradlew unix start script

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -130,7 +130,7 @@ fi
 if [ "\$cygwin" = "true" -o "\$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
-    <% if ( mainClassName.startsWith('--module ') ) { %>MODULE_PATH=`cygpath --path --mixed "\$MODULE_PATH"`<% } %>
+<% if ( mainClassName.startsWith('--module ') ) { %>    MODULE_PATH=`cygpath --path --mixed "\$MODULE_PATH"`<% } %>
     JAVACMD=`cygpath --unix "\$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath


### PR DESCRIPTION
Gradle `6.4` and later has a whitespace error (4 trailing spaces) on line 133 of the `gradlew` shell script. This error was not present in any previous version of Gradle.

It is caused by an added template conditional in 60fe99060bc0b912d5a076e94b02423bcaf69750.

The problem is that the template `<% if %>` statement is _not_ part of the regular script flow, therefore, it should _not_ be indented as if it was. This is a very common mistake with templated files for statements that operate on line level.

To fix it, I moved `<%` to column 1, and the 4 leading spaces _inside of_ the template, so they only end up in the resulting file if the statement evaluates to true.

The result is:

- No more whitespace errors when the template conditional evaluates to false
- Zero changes to the existing behavior if the template conditional evaluates to true
