### PR TITLE
Add remote projects as inputs to smoke test

### DIFF
--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
@@ -172,13 +172,17 @@ class CommonFileSystemTest extends Specification {
     }
 
     def lastModified(File file) {
-        return Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis()
+        return normalize(Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis())
     }
 
     def lastModified(FileMetadata fileMetadata) {
+        return normalize(fileMetadata.lastModified)
+    }
+
+    def normalize(long time) {
         // Java 8 on Unix only captures the seconds in lastModified, so we cut it off the value returned from the filesystem as well
         return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
-            ? fileMetadata.lastModified
-            : fileMetadata.lastModified.intdiv(1000) * 1000
+            ? time
+            : time.intdiv(1000) * 1000
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
@@ -172,17 +172,13 @@ class CommonFileSystemTest extends Specification {
     }
 
     def lastModified(File file) {
-        return normalize(Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis())
+        return Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis()
     }
 
     def lastModified(FileMetadata fileMetadata) {
-        return normalize(fileMetadata.lastModified)
-    }
-
-    def normalize(long time) {
         // Java 8 on Unix only captures the seconds in lastModified, so we cut it off the value returned from the filesystem as well
         return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
-            ? time
-            : time.intdiv(1000) * 1000
+            ? fileMetadata.lastModified
+            : fileMetadata.lastModified.intdiv(1000) * 1000
     }
 }

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -131,6 +131,8 @@ tasks {
     withType<SmokeTest>().configureEach {
         dependsOn(remoteProjects)
         inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
-        inputs.files(Callable { remoteProjects.map { it.outputDirectory } }).withPropertyName("remoteProjectsSource")
+        inputs.files(Callable { remoteProjects.map { it.outputDirectory } })
+            .withPropertyName("remoteProjectsSource")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
     }
 }

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -131,5 +131,6 @@ tasks {
     withType<SmokeTest>().configureEach {
         dependsOn(remoteProjects)
         inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
+        inputs.files(Callable { remoteProjects.map { it.outputDirectory } }).withPropertyName("remoteProjectsSource")
     }
 }


### PR DESCRIPTION
### Context

Previously, the remote projects are not declared as inputs of smoke test, which breaks distributed test.