### PR TITLE
Move archive operations to their own service

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ArchiveOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ArchiveOperations.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.file;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Project;
+
+
+/**
+ * Operations on archives such as ZIP or TAR files.
+ *
+ * <p>An instance of this type can be injected into a task, plugin or other object by annotating a public constructor or property getter method with {@code javax.inject.Inject}.
+ *
+ * @since 6.6
+ */
+@Incubating
+public interface ArchiveOperations {
+
+    /**
+     * <p>Creates a read-only {@code FileTree} which contains the contents of the given ZIP file, as defined by {@link Project#zipTree(Object)}.</p>
+     *
+     * @param zipPath The ZIP file. Evaluated as per {@link Project#file(Object)}.
+     * @return the file tree. Never returns null.
+     */
+    FileTree zipTree(Object zipPath);
+
+    /**
+     * <p>Creates a read-only {@code FileTree} which contains the contents of the given TAR file, as defined by {@link Project#tarTree(Object)}.</p>
+     *
+     * @param tarPath The TAR file. Evaluated as per {@link Project#file(Object)}.
+     * @return the file tree. Never returns null.
+     */
+    FileTree tarTree(Object tarPath);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.file;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
@@ -63,26 +62,6 @@ public interface ProjectLayout {
      * @since 4.8
      */
     FileCollection files(Object... paths);
-
-    /**
-     * <p>Creates a read-only {@code FileTree} which contains the contents of the given ZIP file, as defined by {@link Project#zipTree(Object)}.</p>
-     *
-     * @param zipPath The ZIP file. Evaluated as per {@link Project#file(Object)}.
-     * @return the file tree. Never returns null.
-     * @since 6.6
-     */
-    @Incubating
-    FileTree zipTree(Object zipPath);
-
-    /**
-     * <p>Creates a read-only {@code FileTree} which contains the contents of the given TAR file, as defined by {@link Project#tarTree(Object)}.</p>
-     *
-     * @param tarPath The TAR file. Evaluated as per {@link Project#file(Object)}.
-     * @return the file tree. Never returns null.
-     * @since 6.6
-     */
-    @Incubating
-    FileTree tarTree(Object tarPath);
 
     /**
      * <p>Returns a mutable {@link ConfigurableFileCollection} containing the given files, as defined by {@link Project#files(Object...)}.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ArchiveOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ArchiveOperationsIntegrationTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+
+class ArchiveOperationsIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "can create readonly FileTree for #archiveType archive in task action"() {
+
+        given:
+        file("inputs/file.txt") << "some text"
+        buildFile << """
+            import javax.inject.Inject
+
+            def createArchive = tasks.register("createArchive", ${archiveType.capitalize()}) {
+                destinationDirectory.set(layout.buildDirectory.dir("archives"))
+                archiveFileName.set("archive.$archiveType")
+                from("inputs")
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @InputFile abstract RegularFileProperty getArchiveFile()
+                @OutputDirectory abstract DirectoryProperty getUnpackDir()
+                @Inject abstract FileSystemOperations getFs()
+                @Inject abstract ArchiveOperations getArchives()
+                @TaskAction void action() {
+                    fs.copy {
+                        from(archives.${archiveType}Tree(archiveFile))
+                        into(unpackDir)
+                    }
+                }
+            }
+
+            tasks.register("myTask", MyTask) {
+                archiveFile = createArchive.flatMap { it.archiveFile }
+                unpackDir = layout.buildDirectory.dir("unpacked")
+            }
+        """
+
+        when:
+        run "myTask"
+
+        then:
+        file("build/unpacked/file.txt").isFile()
+
+        where:
+        archiveType << ['zip', 'tar']
+    }
+
+    @Unroll
+    def "can create readonly FileTree for #archiveType archive in #isolation isolation worker action"() {
+
+        given:
+        file("inputs/file.txt") << "some text"
+        buildFile << """
+            import javax.inject.Inject
+
+            def createArchive = tasks.register("createArchive", ${archiveType.capitalize()}) {
+                destinationDirectory.set(layout.buildDirectory.dir("archives"))
+                archiveFileName.set("archive.$archiveType")
+                from("inputs")
+            }
+
+            interface MyParameters extends WorkParameters {
+                RegularFileProperty getArchive()
+                DirectoryProperty getUnpackDir()
+            }
+
+            abstract class MyWork implements WorkAction<MyParameters> {
+                @Inject abstract FileSystemOperations getFs()
+                @Inject abstract ArchiveOperations getArchives()
+                @Override void execute() {
+                    fs.copy {
+                        from(archives.${archiveType}Tree(parameters.archive))
+                        into(parameters.unpackDir)
+                    }
+                }
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @InputFile abstract RegularFileProperty getArchiveFile()
+                @OutputDirectory abstract DirectoryProperty getUnpackDirectory()
+                @Inject abstract WorkerExecutor getWorkerExecutor()
+                @TaskAction void action() {
+                    workerExecutor.${isolation}Isolation().submit(MyWork) { parameters ->
+                        parameters.archive.set(archiveFile)
+                        parameters.unpackDir.set(unpackDirectory)
+                    }
+                }
+            }
+
+            tasks.register("myTask", MyTask) {
+                archiveFile = createArchive.flatMap { it.archiveFile }
+                unpackDirectory = layout.buildDirectory.dir("unpacked")
+            }
+        """
+
+        when:
+        run "myTask"
+
+        then:
+        file("build/unpacked/file.txt").isFile()
+
+        where:
+        archiveType | isolation
+        'zip'       | 'no'
+        'tar'       | 'no'
+        'zip'       | 'classLoader'
+        'tar'       | 'classLoader'
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultArchiveOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultArchiveOperations.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.ArchiveOperations;
+import org.gradle.api.file.FileTree;
+
+
+public class DefaultArchiveOperations implements ArchiveOperations {
+
+    private final FileOperations fileOperations;
+
+    public DefaultArchiveOperations(FileOperations fileOperations) {
+        this.fileOperations = fileOperations;
+    }
+
+    @Override
+    public FileTree zipTree(Object zipPath) {
+        return fileOperations.zipTree(zipPath);
+    }
+
+    @Override
+    public FileTree tarTree(Object tarPath) {
+        return fileOperations.tarTree(tarPath);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -23,7 +23,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -47,26 +46,14 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     private final PropertyHost propertyHost;
     private final FileCollectionFactory fileCollectionFactory;
     private final FileFactory fileFactory;
-    private final FileOperations fileOperations;
 
-    public DefaultProjectLayout(
-        File projectDir,
-        FileResolver fileResolver,
-        TaskDependencyFactory taskDependencyFactory,
-        Factory<PatternSet> patternSetFactory,
-        PropertyHost propertyHost,
-        FileCollectionFactory fileCollectionFactory,
-        FilePropertyFactory filePropertyFactory,
-        FileFactory fileFactory,
-        FileOperations fileOperations
-    ) {
+    public DefaultProjectLayout(File projectDir, FileResolver fileResolver, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, PropertyHost propertyHost, FileCollectionFactory fileCollectionFactory, FilePropertyFactory filePropertyFactory, FileFactory fileFactory) {
         this.fileResolver = fileResolver;
         this.taskDependencyFactory = taskDependencyFactory;
         this.patternSetFactory = patternSetFactory;
         this.propertyHost = propertyHost;
         this.fileCollectionFactory = fileCollectionFactory;
         this.fileFactory = fileFactory;
-        this.fileOperations = fileOperations;
         this.projectDir = fileFactory.dir(projectDir);
         this.buildDir = filePropertyFactory.newDirectoryProperty().fileValue(fileResolver.resolve(Project.DEFAULT_BUILD_DIR_NAME));
     }
@@ -114,16 +101,6 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     @Override
     public FileCollection files(Object... paths) {
         return fileCollectionFactory.resolving(paths);
-    }
-
-    @Override
-    public FileTree zipTree(Object zipPath) {
-        return fileOperations.zipTree(zipPath);
-    }
-
-    @Override
-    public FileTree tarTree(Object tarPath) {
-        return fileOperations.tarTree(tarPath);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.classpath.PluginModuleRegistry;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.component.DefaultComponentTypeRegistry;
+import org.gradle.api.internal.file.DefaultArchiveOperations;
 import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.DefaultFileSystemOperations;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -207,6 +208,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             registration.add(DefaultExecOperations.class);
             registration.add(DefaultFileOperations.class);
             registration.add(DefaultFileSystemOperations.class);
+            registration.add(DefaultArchiveOperations.class);
             for (PluginServiceRegistry pluginServiceRegistry : parent.getAll(PluginServiceRegistry.class)) {
                 pluginServiceRegistry.registerBuildServices(registration);
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.service.scopes;
 
+import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
+import org.gradle.api.internal.file.DefaultArchiveOperations;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
 import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
@@ -105,6 +107,10 @@ public class WorkerSharedProjectScopeServices {
 
     protected FileSystemOperations createFileSystemOperations(Instantiator instantiator, FileOperations fileOperations) {
         return instantiator.newInstance(DefaultFileSystemOperations.class, fileOperations);
+    }
+
+    protected ArchiveOperations createArchiveOperations(Instantiator instantiator, FileOperations fileOperations) {
+        return instantiator.newInstance(DefaultArchiveOperations.class, fileOperations);
     }
 
     protected ExecOperations createExecOperations(Instantiator instantiator, ExecFactory execFactory) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -125,26 +125,8 @@ public class WorkerSharedProjectScopeServices {
                 domainObjectCollectionFactory);
     }
 
-    DefaultProjectLayout createProjectLayout(
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
-        TaskDependencyFactory taskDependencyFactory,
-        FilePropertyFactory filePropertyFactory,
-        Factory<PatternSet> patternSetFactory,
-        PropertyHost propertyHost,
-        FileFactory fileFactory,
-        FileOperations fileOperations
-    ) {
-        return new DefaultProjectLayout(
-            projectDir,
-            fileResolver,
-            taskDependencyFactory,
-            patternSetFactory,
-            propertyHost,
-            fileCollectionFactory,
-            filePropertyFactory,
-            fileFactory,
-            fileOperations
-        );
+    DefaultProjectLayout createProjectLayout(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory,
+                                             FilePropertyFactory filePropertyFactory, Factory<PatternSet> patternSetFactory, PropertyHost propertyHost, FileFactory fileFactory) {
+        return new DefaultProjectLayout(projectDir, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost, fileCollectionFactory, filePropertyFactory, fileFactory);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -36,7 +36,7 @@ class DefaultProjectLayoutTest extends Specification {
 
     def setup() {
         projectDir = tmpDir.createDir("project")
-        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), TestFiles.fileCollectionFactory(projectDir), TestFiles.filePropertyFactory(projectDir), TestFiles.fileFactory(), TestFiles.fileOperations(projectDir))
+        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), TestFiles.fileCollectionFactory(projectDir), TestFiles.filePropertyFactory(projectDir), TestFiles.fileFactory())
     }
 
     def "can query the project directory"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -227,7 +227,7 @@ class DefaultProjectTest extends Specification {
         ModelSchemaStore modelSchemaStore = Stub(ModelSchemaStore)
         serviceRegistryMock.get((Type) ModelSchemaStore) >> modelSchemaStore
         serviceRegistryMock.get(ModelSchemaStore) >> modelSchemaStore
-        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory(), TestFiles.fileOperations(rootDir))
+        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(Factory), Stub(PropertyHost), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory())
 
         build.getProjectEvaluationBroadcaster() >> Stub(ProjectEvaluationListener)
         build.getParent() >> null

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -132,8 +132,7 @@ class TestUtil {
 
                 ProjectLayout createProjectLayout() {
                     def filePropertyFactory = new DefaultFilePropertyFactory(PropertyHost.NO_OP, fileResolver, fileCollectionFactory)
-                    def baseDir = fileResolver.resolve(".")
-                    return new DefaultProjectLayout(baseDir, fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), PatternSets.getNonCachingPatternSetFactory(), PropertyHost.NO_OP, fileCollectionFactory, filePropertyFactory, filePropertyFactory, TestFiles.fileOperations(baseDir))
+                    return new DefaultProjectLayout(fileResolver.resolve("."), fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), PatternSets.getNonCachingPatternSetFactory(), PropertyHost.NO_OP, fileCollectionFactory, filePropertyFactory, filePropertyFactory)
                 }
 
                 ChecksumService createChecksumService() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -58,6 +58,18 @@ This improves the likelihood of [build cache hits](userguide/build_cache.html) w
 See the [userguide](userguide/more_about_tasks.html#sec:meta_inf_normalization) for further information.  Note that this API is incubating and will likely change in future releases as support 
 is expanded for normalizing properties files outside of `META-INF`.
 
+## Improvements for plugin authors
+
+### Injectable `ArchiveOperations` service
+
+Previously, it was only possible to create a `FileTree` for a ZIP or TAR archive by using the APIs provided by a `Project`.
+However, a `Project` object is not always available.
+
+The new `ArchiveOperations` service has [zipTree()](javadoc/org/gradle/api/file/ArchiveOperations.html#zipTree-java.lang.Object-) and [tarTree()](javadoc/org/gradle/api/file/ArchiveOperations.html#tarTree-java.lang.Object-) methods for creating read-only `FileTree` instances respectively for ZIP and TAR archives.
+
+See the [user manual](userguide/custom_gradle_types.html#service_injection) for how to inject services and the [`ArchiveOperations`](javadoc/org/gradle/api/file/ArchiveOperations.html) api documentation for more details and examples. 
+
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -58,17 +58,6 @@ This improves the likelihood of [build cache hits](userguide/build_cache.html) w
 See the [userguide](userguide/more_about_tasks.html#sec:meta_inf_normalization) for further information.  Note that this API is incubating and will likely change in future releases as support 
 is expanded for normalizing properties files outside of `META-INF`.
 
-## Improvements for plugin authors
-
-### New ZIP and TAR `FileTree` factory methods
-
-Previously, it was only possible to create a `FileTree` for a ZIP or TAR archive by using the APIs provided by a `Project`.
-However, a `Project` object is not always available.
-
-The `ProjectLayout` service now has [zipTree()](javadoc/org/gradle/api/file/ProjectLayout.html#zipTree-java.lang.Object-) and [tarTree()](javadoc/org/gradle/api/file/ProjectLayout.html#tarTree-java.lang.Object-) methods for creating read-only `FileTree` instances respectively for ZIP and TAR archives.
-
-See the [user manual](userguide/custom_gradle_types.html#service_injection) for how to inject services and the [`ProjectLayout`](javadoc/org/gradle/api/file/ProjectLayout.html) api documentation for more details and examples. 
-
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -153,6 +153,7 @@ The following services are available for injection:
 - link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html[ProviderFactory] - Creates `Provider` instances. See <<lazy_configuration.adoc#lazy_configuration,lazy configuration>> for more details.
 - link:{javadocPath}/org/gradle/workers/WorkerExecutor.html[WorkerExecutor] - Allows a task to run work in parallel. See <<custom_tasks.adoc#worker_api,the worker API>> for more details.
 - link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html[FileSystemOperations] - Allows a task to run operations on the filesystem such as deleting files, copying files or syncing directories.
+- link:{javadocPath}/org/gradle/api/file/ArchiveOperations.html[FileSystemOperations] - Allows a task to run operations on archive files such as ZIP or TAR files.
 - link:{javadocPath}/org/gradle/process/ExecOperations.html[ExecOperations] - Allows a task to run external processes with dedicated support for running external `java` programs.
 
 Out of the above, `ProjectLayout` and `WorkerExecutor` services are only available for injection in project plugins.

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.instantexecution
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
 import org.gradle.initialization.LoadProjectsBuildOperationType
@@ -92,7 +93,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         def fixture = newInstantExecutionFixture()
 
         when:
-        instantRun "help" , "-D${ConfigurationCacheRecreateOption.PROPERTY_NAME}=true"
+        instantRun "help", "-D${ConfigurationCacheRecreateOption.PROPERTY_NAME}=true"
 
         then:
         fixture.assertStateStored()
@@ -580,6 +581,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         ToolingModelBuilderRegistry.name | "project.services.get(${ToolingModelBuilderRegistry.name})" | "toString()"
         WorkerExecutor.name              | "project.services.get(${WorkerExecutor.name})"              | "noIsolation()"
         FileSystemOperations.name        | "project.services.get(${FileSystemOperations.name})"        | "toString()"
+        ArchiveOperations.name           | "project.services.get(${ArchiveOperations.name})"           | "toString()"
         ExecOperations.name              | "project.services.get(${ExecOperations.name})"              | "toString()"
         ListenerManager.name             | "project.services.get(${ListenerManager.name})"             | "toString()"
         JavaInstallationRegistry.name    | "project.services.get(${JavaInstallationRegistry.name})"    | "installationForCurrentVirtualMachine"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme
@@ -150,6 +151,7 @@ class Codecs(
         bind(ownerServiceCodec<FileCollectionFactory>())
         bind(ownerServiceCodec<FileSystemOperations>())
         bind(ownerServiceCodec<FileOperations>())
+        bind(ownerServiceCodec<ArchiveOperations>())
         bind(ownerServiceCodec<BuildOperationExecutor>())
         bind(ownerServiceCodec<ToolingModelBuilderRegistry>())
         bind(ownerServiceCodec<ExecOperations>())

--- a/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.isolated;
 
 import com.google.common.reflect.TypeToken;
+import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
@@ -157,6 +158,9 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
                 }
                 if (serviceClass.isAssignableFrom(FileSystemOperations.class)) {
                     return allServices.find(FileSystemOperations.class);
+                }
+                if (serviceClass.isAssignableFrom(ArchiveOperations.class)) {
+                    return allServices.find(ArchiveOperations.class);
                 }
                 if (serviceClass.isAssignableFrom(ObjectFactory.class)) {
                     return allServices.find(ObjectFactory.class);


### PR DESCRIPTION
Follow up to https://github.com/gradle/gradle/pull/13280

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
