### PR TITLE
Round both lastModified for CommonFileSystemTest

### DIFF
--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
@@ -172,13 +172,18 @@ class CommonFileSystemTest extends Specification {
     }
 
     def lastModified(File file) {
-        return Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis()
+        return maybeRoundLastModified(Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis())
     }
 
     def lastModified(FileMetadata fileMetadata) {
-        // Java 8 on Unix only captures the seconds in lastModified, so we cut it off the value returned from the filesystem as well
+        return maybeRoundLastModified(fileMetadata.lastModified)
+    }
+
+    private static maybeRoundLastModified(long lastModified) {
+        // Some Java 8 versions on Unix only capture the seconds in lastModified, so we cut off the milliseconds returned from the filesystem as well.
+        // For example, Oracle JDK 1.8.0_181-b13 does not capture milliseconds, while OpenJDK 1.8.0_242-b08 does.
         return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
-            ? fileMetadata.lastModified
-            : fileMetadata.lastModified.intdiv(1000) * 1000
+            ? lastModified
+            : lastModified.intdiv(1000) * 1000
     }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -41,7 +41,8 @@ class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataA
     }
 
     private static maybeRoundLastModified(long lastModified) {
-        // Java 8 on Unix only captures the seconds in lastModified, so we cut it off the value returned from the filesystem as well
+        // Some Java 8 versions on Unix only capture the seconds in lastModified, so we cut off the milliseconds returned from the filesystem as well.
+        // For example, Oracle JDK 1.8.0_181-b13 does not capture milliseconds, while OpenJDK 1.8.0_242-b08 does.
         return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
             ? lastModified
             : lastModified.intdiv(1000) * 1000


### PR DESCRIPTION
Some Java 8 versions on Unix only capture the seconds in lastModified.
For example, Oracle JDK 1.8.0_181-b13 does not capture milliseconds, while OpenJDK 1.8.0_242-b08 does.

Native platform always returns the milliseconds,
so we need to cut off the millisecond part for
comparison with the value returned by Java NIO.
