### PR TITLE
Fix a race condition in build logic instrumentation

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -81,14 +81,6 @@ public class DefaultClassPath implements ClassPath, Serializable {
         this(ImmutableUniqueList.<File>empty());
     }
 
-    /**
-     * @deprecated Only here for the Kotlin DSL, use {@link #of(File...)} instead.
-     */
-    @Deprecated
-    public DefaultClassPath(File... files) {
-        this(new ImmutableUniqueList<File>(Arrays.asList(files)));
-    }
-
     protected DefaultClassPath(ImmutableUniqueList<File> files) {
         this.files = files;
     }


### PR DESCRIPTION

### Context

Do not attempt to instrument multiple entries in a build logic classpath that have the same content hash, as these all end up using the same cache entry. Instead, just instrument one entry and reuse the result for the other entries with the same content. Previously, each of these entries would be instrumented in parallel by separate threads and these threads would trample over each other.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
