### PR TITLE
Fix configuration caching when artifact transforms are applied to file dependencies that include a task output

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1018,7 +1018,6 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*scheduled: true\\)")
     def "failure in resolution propagates to chain (scheduled: #scheduled)"() {
         given:
         def module = mavenHttpRepo.module("test", "test", "1.3").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -105,8 +105,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         succeeds ":util:resolve"
 
-        def transformationPosition1 = output.indexOf("> Transform artifact lib1.jar (project :lib) with FileSizer")
-        def transformationPosition2 = output.indexOf("> Transform artifact lib2.jar (project :lib) with FileSizer")
+        def transformationPosition1 = output.indexOf("> Transform lib1.jar (project :lib) with FileSizer")
+        def transformationPosition2 = output.indexOf("> Transform lib2.jar (project :lib) with FileSizer")
         def taskPosition = output.indexOf("> Task :util:resolve")
 
         then:
@@ -135,8 +135,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         succeeds ":util:resolve", ":util2:resolve"
 
         then:
-        output.count("> Transform artifact lib1.jar (project :lib) with FileSizer") == 1
-        output.count("> Transform artifact lib2.jar (project :lib) with FileSizer") == 1
+        output.count("> Transform lib1.jar (project :lib) with FileSizer") == 1
+        output.count("> Transform lib2.jar (project :lib) with FileSizer") == 1
     }
 
     def "scheduled chained transformation is only invoked once per subject"() {
@@ -234,12 +234,12 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         run ":app1:resolveRed", ":app2:resolveYellow"
 
         then:
-        output.count("> Transform artifact lib1.jar (project :lib) with MakeBlueToGreenThings") == 1
-        output.count("> Transform artifact lib2.jar (project :lib) with MakeBlueToGreenThings") == 1
-        output.count("> Transform artifact lib1.jar (project :lib) with MakeGreenToYellowThings") == 1
-        output.count("> Transform artifact lib2.jar (project :lib) with MakeGreenToYellowThings") == 1
-        output.count("> Transform artifact lib1.jar (project :lib) with MakeGreenToRedThings") == 1
-        output.count("> Transform artifact lib2.jar (project :lib) with MakeGreenToRedThings") == 1
+        output.count("> Transform lib1.jar (project :lib) with MakeBlueToGreenThings") == 1
+        output.count("> Transform lib2.jar (project :lib) with MakeBlueToGreenThings") == 1
+        output.count("> Transform lib1.jar (project :lib) with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib2.jar (project :lib) with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib1.jar (project :lib) with MakeGreenToRedThings") == 1
+        output.count("> Transform lib2.jar (project :lib) with MakeGreenToRedThings") == 1
     }
 
     def "executes transform immediately when required during task graph building"() {
@@ -307,8 +307,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         run(":app:toBeFinalized", "withDependency", "--info")
         then:
-        output.count("Transforming artifact lib1.jar (project :lib) with MakeGreen") == 2
-        output.count("Transforming artifact lib2.jar (project :lib) with MakeGreen") == 2
+        output.count("Transforming lib1.jar (project :lib) with MakeGreen") == 2
+        output.count("Transforming lib2.jar (project :lib) with MakeGreen") == 2
     }
 
     def "each file is transformed once per set of configuration parameters"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -169,7 +169,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         expect:
         succeeds("help", "--info")
         output.count("Creating FileSizer") == 1
-        output.count("Transforming commons-math3") == 1
+        output.count("Transforming commons-math3-3.6.1.jar to commons-math3-3.6.1.jar.txt") == 1
     }
 
     def "applies transforms to files from file dependencies matching on implicit format attribute"() {
@@ -2231,15 +2231,15 @@ Found the following transforms:
         run "app:resolve"
 
         then:
-        outputContains("Before transformer FileSizer on artifact lib.jar (project :lib)")
-        outputContains("After transformer FileSizer on artifact lib.jar (project :lib)")
+        outputContains("Before transformer FileSizer on lib.jar (project :lib)")
+        outputContains("After transformer FileSizer on lib.jar (project :lib)")
 
         and:
         with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
             it.failure == null
-            displayName == "Transform artifact lib.jar (project :lib) with FileSizer"
+            displayName == "Transform lib.jar (project :lib) with FileSizer"
             details.transformerName == "FileSizer"
-            details.subjectName == "artifact lib.jar (project :lib)"
+            details.subjectName == "lib.jar (project :lib)"
         }
     }
 
@@ -2291,14 +2291,14 @@ Found the following transforms:
         fails "app:resolve"
 
         then:
-        outputContains("Before transformer BrokenTransform on artifact lib.jar (project :lib)")
-        outputContains("After transformer BrokenTransform on artifact lib.jar (project :lib)")
+        outputContains("Before transformer BrokenTransform on lib.jar (project :lib)")
+        outputContains("After transformer BrokenTransform on lib.jar (project :lib)")
 
         and:
         with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
-            displayName == "Transform artifact lib.jar (project :lib) with BrokenTransform"
+            displayName == "Transform lib.jar (project :lib) with BrokenTransform"
             details.transformerName == "BrokenTransform"
-            details.subjectName == "artifact lib.jar (project :lib)"
+            details.subjectName == "lib.jar (project :lib)"
         }
     }
 
@@ -2345,7 +2345,7 @@ Found the following transforms:
         then:
         output.count("> Dependency:") == 1
         output.contains("> Dependency: task ':app:dependent' -> task ':app:resolve'")
-        output.contains("> Transform artifact lib1.jar (project :lib) with FileSizer")
+        output.contains("> Transform lib1.jar (project :lib) with FileSizer")
         output.contains("> Task :app:resolve")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -223,8 +223,8 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
         then:
         block.waitForAllPendingCalls()
         poll {
-            assertHasWorkInProgress(build, "> Transforming artifact lib1.jar (project :lib) with Red > Red lib1.jar")
-            assertHasWorkInProgress(build, "> Transforming artifact lib2.jar (project :lib) with Red > Red lib2.jar")
+            assertHasWorkInProgress(build, "> Transforming lib1.jar (project :lib) with Red > Red lib1.jar")
+            assertHasWorkInProgress(build, "> Transforming lib2.jar (project :lib) with Red > Red lib2.jar")
         }
 
         block.releaseAll()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -16,11 +16,14 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.AsyncArtifactListener;
+import org.gradle.api.internal.artifacts.transform.TransformationSubject;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -28,13 +31,14 @@ import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.EMPTY;
 
-class ArtifactBackedResolvedVariant implements ResolvedVariant {
+public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final ResolvedArtifactSet artifacts;
@@ -117,7 +121,9 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
         @Override
         public void visitLocalArtifacts(LocalArtifactVisitor listener) {
-            listener.visitArtifact(artifact);
+            if (artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
+                listener.visitArtifact(new SingleLocalArtifactSet(artifact));
+            }
         }
 
         @Override
@@ -128,6 +134,43 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
         @Override
         public String toString() {
             return artifact.getId().getDisplayName();
+        }
+    }
+
+    public static class SingleLocalArtifactSet implements ResolvedArtifactSet.LocalArtifactSet {
+        private final ResolvableArtifact artifact;
+
+        public SingleLocalArtifactSet(ResolvableArtifact artifact) {
+            this.artifact = artifact;
+        }
+
+        public ResolvableArtifact getArtifact() {
+            return artifact;
+        }
+
+        @Override
+        public Object getId() {
+            return artifact.getId();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return artifact.getId().getDisplayName();
+        }
+
+        @Override
+        public TaskDependencyContainer getTaskDependencies() {
+            return artifact;
+        }
+
+        @Override
+        public TransformationSubject calculateSubject() {
+            return TransformationSubject.initial(artifact.getId(), artifact.getFile());
+        }
+
+        @Override
+        public ResolvableArtifact transformedTo(File output) {
+            return artifact.transformedTo(output);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/FileDependencyArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/FileDependencyArtifactSet.java
@@ -33,6 +33,7 @@ public class FileDependencyArtifactSet implements ArtifactSet {
 
     @Override
     public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector) {
+        // Select the artifacts later, as this is a function of the file names and these may not be known yet because the producing tasks have not yet executed
         return new LocalFileDependencyBackedArtifactSet(fileDependency, componentFilter, selector, artifactTypeRegistry);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 
 public interface LocalDependencyFiles extends FileCollectionInternal.Source {
-    void visitSpec(FileCollectionStructureVisitor visitor);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -98,7 +98,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
                 artifactIdentifier = new ComponentFileArtifactIdentifier(componentIdentifier, file.getName());
             }
 
-            AttributeContainerInternal variantAttributes = artifactTypeRegistry.mapAttributesFor(file);
+            ImmutableAttributes variantAttributes = artifactTypeRegistry.mapAttributesFor(file);
             SingletonFileResolvedVariant variant = new SingletonFileResolvedVariant(file, artifactIdentifier, LOCAL_FILE, variantAttributes, dependencyMetadata);
             selectedArtifacts.add(selector.select(variant, this));
         }
@@ -130,11 +130,11 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     private static class SingletonFileResolvedVariant implements ResolvedVariant, ResolvedArtifactSet, Completion, ResolvedVariantSet {
         private final ComponentArtifactIdentifier artifactIdentifier;
         private final DisplayName variantName;
-        private final AttributeContainerInternal variantAttributes;
+        private final ImmutableAttributes variantAttributes;
         private final LocalFileDependencyMetadata dependencyMetadata;
         private final ResolvableArtifact artifact;
 
-        SingletonFileResolvedVariant(File file, ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainerInternal variantAttributes, LocalFileDependencyMetadata dependencyMetadata) {
+        SingletonFileResolvedVariant(File file, ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, ImmutableAttributes variantAttributes, LocalFileDependencyMetadata dependencyMetadata) {
             this.artifactIdentifier = artifactIdentifier;
             this.variantName = variantName;
             this.variantAttributes = variantAttributes;
@@ -226,6 +226,10 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
             this.transformationNodeRegistry = transformationNodeRegistry;
         }
 
+        public ComponentIdentifier getOwnerId() {
+            return delegate.getComponentId();
+        }
+
         public File getFile() {
             return delegate.getFile();
         }
@@ -236,6 +240,14 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
         public boolean isBuildable() {
             return delegate.isBuildable();
+        }
+
+        public DisplayName getTargetVariantName() {
+            return delegate.variantName;
+        }
+
+        public ImmutableAttributes getTargetVariantAttributes() {
+            return delegate.variantAttributes;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -59,11 +59,6 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     }
 
     @Override
-    public void visitSpec(FileCollectionStructureVisitor visitor) {
-        dependencyMetadata.getFiles().visitStructure(visitor);
-    }
-
-    @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
         FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(this);
         if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
@@ -119,7 +114,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         context.add(dependencyMetadata.getFiles().getBuildDependencies());
     }
 
-    private static class SingletonFileResolvedVariant implements ResolvedVariant, ResolvedArtifactSet, Completion, ResolvedVariantSet {
+    public static class SingletonFileResolvedVariant implements ResolvedVariant, ResolvedArtifactSet, Completion, ResolvedVariantSet {
         private final ComponentArtifactIdentifier artifactIdentifier;
         private final DisplayName variantName;
         private final AttributeContainerInternal variantAttributes;
@@ -137,6 +132,14 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public String toString() {
             return asDescribable().getDisplayName();
+        }
+
+        public File getFile() {
+            return artifact.getFile();
+        }
+
+        public boolean isBuildable() {
+            return !dependencyMetadata.getFiles().getBuildDependencies().getDependencies(null).isEmpty();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -16,12 +16,15 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import org.gradle.api.internal.artifacts.transform.TransformationSubject;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
+
+import java.io.File;
 
 /**
  * A container for a set of files or artifacts. May or may not be immutable, and may require building and further resolution.
@@ -87,7 +90,19 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
         boolean requireArtifactFiles();
     }
 
+    interface LocalArtifactSet {
+        Object getId();
+
+        String getDisplayName();
+
+        TaskDependencyContainer getTaskDependencies();
+
+        TransformationSubject calculateSubject();
+
+        ResolvableArtifact transformedTo(File output);
+    }
+
     interface LocalArtifactVisitor {
-        void visitArtifact(ResolvableArtifact artifact);
+        void visitArtifact(LocalArtifactSet artifactSet);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Describable;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
@@ -27,11 +26,6 @@ import java.util.Set;
  * Represents some provider of {@link ResolvedVariant} instances to select from.
  */
 public interface ResolvedVariantSet {
-    /**
-     * The id of the component that owns this set of variants.
-     */
-    ComponentIdentifier getComponentId();
-
     Describable asDescribable();
 
     AttributesSchemaInternal getSchema();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/SelectedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/SelectedArtifactSet.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 
 /**
- * A container of artifacts that match some criteria. Not every query method is available, depending on which details are available.
+ * A container of artifacts that match some criteria.
  */
 public interface SelectedArtifactSet extends TaskDependencyContainer {
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -104,13 +103,11 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
     @Override
     public Collection<TransformationNode> getScheduledNodes() {
         // Only care about transformed project outputs. For everything else, calculate the value eagerly
-        AtomicReference<Boolean> hasProjectArtifacts = new AtomicReference<>(false);
+        AtomicReference<Boolean> hasLocalArtifacts = new AtomicReference<>(false);
         delegate.visitLocalArtifacts(artifact -> {
-            if (artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
-                hasProjectArtifacts.set(true);
-            }
+            hasLocalArtifacts.set(true);
         });
-        if (hasProjectArtifacts.get()) {
+        if (hasLocalArtifacts.get()) {
             return transformationNodeRegistry.getOrCreate(delegate, transformation, getDependenciesResolver());
         } else {
             return Collections.emptySet();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -88,6 +88,16 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
     }
 
     @Override
+    public Transformation getTransformation() {
+        return transformation;
+    }
+
+    @Override
+    public Object getSource() {
+        return delegate;
+    }
+
+    @Override
     public void visitLocalArtifacts(LocalArtifactVisitor listener) {
         // Cannot visit local artifacts until transform has been executed
     }
@@ -102,7 +112,6 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
 
     @Override
     public Collection<TransformationNode> getScheduledNodes() {
-        // Only care about transformed project outputs. For everything else, calculate the value eagerly
         AtomicReference<Boolean> hasLocalArtifacts = new AtomicReference<>(false);
         delegate.visitLocalArtifacts(artifact -> {
             hasLocalArtifacts.set(true);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFiles.java
@@ -28,6 +28,10 @@ public interface ConsumerProvidedVariantFiles extends FileCollectionInternal.Sou
      */
     Collection<TransformationNode> getScheduledNodes();
 
+    Transformation getTransformation();
+
+    Object getSource();
+
     DisplayName getTargetVariantName();
 
     ImmutableAttributes getTargetVariantAttributes();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -20,6 +20,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 
+import javax.annotation.Nullable;
+
 /**
  * The internal API equivalent of {@link org.gradle.api.artifacts.transform.TransformAction}, which is also aware of our cache infrastructure.
  *
@@ -37,7 +39,7 @@ public interface Transformation extends Describable {
      * Creating the invocation is not for free, since the workspace identity needs to be determined.
      * This requires snapshotting the input artifact and its dependencies.
      */
-    CacheableInvocation<TransformationSubject> createInvocation(TransformationSubject subjectToTransform, ExecutionGraphDependenciesResolver dependenciesResolver, NodeExecutionContext context);
+    CacheableInvocation<TransformationSubject> createInvocation(TransformationSubject subjectToTransform, ExecutionGraphDependenciesResolver dependenciesResolver, @Nullable NodeExecutionContext context);
 
     /**
      * Whether the transformation requires dependencies of the transformed artifact to be injected.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -21,7 +21,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.SelfExecutingNode;
@@ -36,7 +36,6 @@ import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -56,8 +55,8 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
         return new ChainedTransformationNode(current, previous, executionGraphDependenciesResolver, buildOperationExecutor, transformListener);
     }
 
-    public static InitialTransformationNode initial(TransformationStep initial, ResolvableArtifact artifact, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
-        return new InitialTransformationNode(initial, artifact, executionGraphDependenciesResolver, buildOperationExecutor, transformListener);
+    public static InitialTransformationNode initial(TransformationStep initial, ResolvedArtifactSet.LocalArtifactSet localArtifacts, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
+        return new InitialTransformationNode(initial, localArtifacts, executionGraphDependenciesResolver, buildOperationExecutor, transformListener);
     }
 
     protected TransformationNode(TransformationStep transformationStep, ExecutionGraphDependenciesResolver dependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
@@ -67,7 +66,7 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
         this.transformListener = transformListener;
     }
 
-    public abstract ResolvableArtifact getInputArtifact();
+    public abstract ResolvedArtifactSet.LocalArtifactSet getInputArtifacts();
 
     @Nullable
     @Override
@@ -163,16 +162,16 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     }
 
     public static class InitialTransformationNode extends TransformationNode {
-        private final ResolvableArtifact artifact;
+        private final ResolvedArtifactSet.LocalArtifactSet artifacts;
 
-        public InitialTransformationNode(TransformationStep transformationStep, ResolvableArtifact artifact, ExecutionGraphDependenciesResolver dependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
+        public InitialTransformationNode(TransformationStep transformationStep, ResolvedArtifactSet.LocalArtifactSet localArtifacts, ExecutionGraphDependenciesResolver dependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
             super(transformationStep, dependenciesResolver, buildOperationExecutor, transformListener);
-            this.artifact = artifact;
+            this.artifacts = localArtifacts;
         }
 
         @Override
-        public ResolvableArtifact getInputArtifact() {
-            return artifact;
+        public ResolvedArtifactSet.LocalArtifactSet getInputArtifacts() {
+            return artifacts;
         }
 
         @Override
@@ -180,9 +179,9 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
             this.transformedSubject = buildOperationExecutor.call(new ArtifactTransformationStepBuildOperation() {
                 @Override
                 protected Try<TransformationSubject> transform() {
-                    File file;
+                    TransformationSubject initialArtifactTransformationSubject;
                     try {
-                        file = artifact.getFile();
+                        initialArtifactTransformationSubject = artifacts.calculateSubject();
                     } catch (ResolveException e) {
                         return Try.failure(e);
                     } catch (RuntimeException e) {
@@ -190,13 +189,12 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
                             new DefaultLenientConfiguration.ArtifactResolveException("artifacts", transformationStep.getDisplayName(), "artifact transform", Collections.singleton(e)));
                     }
 
-                    TransformationSubject initialArtifactTransformationSubject = TransformationSubject.initial(artifact.getId(), file);
                     return transformationStep.createInvocation(initialArtifactTransformationSubject, dependenciesResolver, context).invoke();
                 }
 
                 @Override
                 protected String describeSubject() {
-                    return "artifact " + artifact.getId().getDisplayName();
+                    return artifacts.getDisplayName();
                 }
             });
         }
@@ -204,7 +202,7 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
         @Override
         public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
             super.resolveDependencies(dependencyResolver, processHardSuccessor);
-            processDependencies(processHardSuccessor, dependencyResolver.resolveDependenciesFor(null, artifact));
+            processDependencies(processHardSuccessor, dependencyResolver.resolveDependenciesFor(null, artifacts.getTaskDependencies()));
         }
     }
 
@@ -217,8 +215,8 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
         }
 
         @Override
-        public ResolvableArtifact getInputArtifact() {
-            return previousTransformationNode.getInputArtifact();
+        public ResolvedArtifactSet.LocalArtifactSet getInputArtifacts() {
+            return previousTransformationNode.getInputArtifacts();
         }
 
         public TransformationNode getPreviousTransformationNode() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
@@ -106,7 +106,7 @@ public abstract class TransformationSubject implements Describable {
 
         @Override
         public String getDisplayName() {
-            return "artifact " + artifactId.getDisplayName();
+            return artifactId.getDisplayName();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -28,14 +28,14 @@ import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 
-class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArtifactListener {
+public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArtifactListener {
     private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
     private final ExecutionGraphDependenciesResolver dependenciesResolver;
     private final TransformationNodeRegistry transformationNodeRegistry;
     private final BuildOperationQueue<RunnableBuildOperation> actions;
     private final Transformation transformation;
 
-    TransformingAsyncArtifactListener(
+    public TransformingAsyncArtifactListener(
         Transformation transformation,
         BuildOperationQueue<RunnableBuildOperation> actions,
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/VariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/VariantSelector.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 
 public interface VariantSelector {
     /**
@@ -25,5 +26,9 @@ public interface VariantSelector {
      *
      * On failure, returns a set that forwards the failure to the {@link org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor}.
      */
-    ResolvedArtifactSet select(ResolvedVariantSet candidates);
+    ResolvedArtifactSet select(ResolvedVariantSet candidates, Factory factory);
+
+    interface Factory {
+        ResolvedArtifactSet asTransformed(ResolvedArtifactSet artifacts, AttributeContainerInternal targetAttributes, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver, TransformationNodeRegistry transformationNodeRegistry);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifacts.java
@@ -27,7 +27,7 @@ import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import java.util.Map;
 
 /**
- * Represents the variants associated with each configuration of a particular component. Implementations must be immutable.
+ * Resolves the variants associated with each configuration of a particular component. Implementations must be immutable.
  */
 public interface ComponentArtifacts {
     /**

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -18,10 +18,13 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.Buildable
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.Describables
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Specification
 
@@ -148,15 +151,17 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         set1.artifacts.visitLocalArtifacts(visitor)
 
         then:
-        1 * visitor.visitArtifact(artifact1)
-        1 * visitor.visitArtifact(artifact2)
+        1 * artifact1.id >> new ComponentFileArtifactIdentifier(Stub(ProjectComponentIdentifier), "some-file")
+        1 * artifact2.id >> new ComponentFileArtifactIdentifier(Stub(ModuleComponentIdentifier), "some-file")
+        1 * visitor.visitArtifact({it.artifact == artifact1})
         0 * _
 
         when:
         set2.artifacts.visitLocalArtifacts(visitor)
 
         then:
-        1 * visitor.visitArtifact(artifact1)
+        1 * artifact1.id >> new ComponentFileArtifactIdentifier(Stub(ProjectComponentIdentifier), "some-file")
+        1 * visitor.visitArtifact({it.artifact == artifact1})
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
@@ -28,10 +27,8 @@ import spock.lang.Specification
 
 class DefaultArtifactSetTest extends Specification {
     def componentId = Stub(ComponentIdentifier)
-    def exclusions = Stub(ModuleExclusions)
     def schema = Stub(AttributesSchemaInternal)
     def artifactTypeRegistry = Stub(ArtifactTypeRegistry)
-
 
     def setup() {
         artifactTypeRegistry.mapAttributesFor(_) >> ImmutableAttributes.EMPTY
@@ -47,9 +44,9 @@ class DefaultArtifactSetTest extends Specification {
         def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         expect:
-        artifacts1.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
-        artifacts2.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
-        artifacts3.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
+        artifacts1.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
+        artifacts2.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
+        artifacts3.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
     }
 
     def "selects artifacts when component id matches spec"() {
@@ -63,11 +60,11 @@ class DefaultArtifactSetTest extends Specification {
         def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
         def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
-        selector.select(_) >> resolvedVariant1
+        selector.select(_, _) >> resolvedVariant1
 
         expect:
-        artifacts1.select({true}, selector) == resolvedVariant1
-        artifacts2.select({true}, selector) == resolvedVariant1
-        artifacts3.select({true}, selector) == resolvedVariant1
+        artifacts1.select({ true }, selector) == resolvedVariant1
+        artifacts2.select({ true }, selector) == resolvedVariant1
+        artifacts3.select({ true }, selector) == resolvedVariant1
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -131,7 +131,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         _ * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.Visit
         _ * filter.isSatisfiedBy(_) >> true
         1 * files.files >> ([f1, f2] as Set)
-        2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
+        2 * selector.select(_, _) >> { ResolvedVariantSet variants, f -> variants.variants.first() }
         1 * listener.artifactAvailable({ it.file == f1 })
         1 * listener.artifactAvailable({ it.file == f2 })
         1 * artifactTypeRegistry.mapAttributesFor(f1) >> attrs1
@@ -189,7 +189,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         1 * artifactTypeRegistry.mapAttributesFor(f1) >> attrs1
         1 * artifactTypeRegistry.mapAttributesFor(f2) >> attrs2
         1 * files.files >> ([f1, f2] as Set)
-        2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
+        2 * selector.select(_, _) >> { ResolvedVariantSet variants, f -> variants.variants.first() }
         1 * visitor.visitArtifact(_, attrs1, {it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'
             assert artifact.id == new OpaqueComponentArtifactIdentifier(f1)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -16,11 +16,8 @@
 
 package org.gradle.api.internal.artifacts.transform
 
-import com.google.common.collect.ImmutableList
-import org.gradle.api.Buildable
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet
@@ -28,15 +25,11 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.internal.Describables
-import org.gradle.internal.Try
 import org.gradle.internal.component.AmbiguousVariantSelectionException
 import org.gradle.internal.component.NoMatchingVariantSelectionException
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
-import org.gradle.internal.operations.BuildOperationQueue
 import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.util.AttributeTestUtil
@@ -52,6 +45,7 @@ class DefaultArtifactTransformsTest extends Specification {
         getConsumerDescribers() >> []
     }
     def attributeMatcher = Mock(AttributeMatcher)
+    def factory = Mock(VariantSelector.Factory)
     def dependenciesResolver = Stub(ExtraExecutionGraphDependenciesResolverFactory)
     def transformationNodeRegistry = Mock(TransformationNodeRegistry)
     def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformationNodeRegistry)
@@ -74,7 +68,7 @@ class DefaultArtifactTransformsTest extends Specification {
         attributeMatcher.matches(variants, typeAttributes("classes"), _ as AttributeMatchingExplanationBuilder) >> [variant1]
 
         expect:
-        def result = transforms.variantSelector(typeAttributes("classes"), true, dependenciesResolver).select(set)
+        def result = transforms.variantSelector(typeAttributes("classes"), true, dependenciesResolver).select(set, factory)
         result == variant1Artifacts
     }
 
@@ -98,7 +92,7 @@ class DefaultArtifactTransformsTest extends Specification {
         attributeMatcher.isMatching(_, _, _) >> true
 
         when:
-        def result = transforms.variantSelector(typeAttributes("classes"), true, dependenciesResolver).select(set)
+        def result = transforms.variantSelector(typeAttributes("classes"), true, dependenciesResolver).select(set, factory)
         visit(result)
 
         then:
@@ -116,71 +110,6 @@ class DefaultArtifactTransformsTest extends Specification {
         Stub(ResolvedVariantSet) {
             getOverriddenAttributes() >> ImmutableAttributes.EMPTY
         }
-    }
-
-    def "selects variant with attributes that can be transformed to requested format"() {
-        def variant1 = resolvedVariant()
-        def variant2 = resolvedVariant()
-        def variant1Artifacts = Stub(ResolvedArtifactSet)
-        def sourceArtifactId = Stub(ComponentArtifactIdentifier)
-        def sourceArtifact = Stub(TestArtifact)
-        def sourceArtifactFile = new File("thing-1.0.jar")
-        def outFile1 = new File("out1.classes")
-        def outFile2 = new File("out2.classes")
-        def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
-        def transformation = Mock(Transformation)
-        CacheableInvocation<TransformationSubject> invocation1 = Mock(CacheableInvocation)
-        def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
-        def visitor = Mock(ArtifactVisitor)
-        def targetAttributes = typeAttributes("classes")
-        def variant1DisplayName = Describables.of('variant1')
-
-        given:
-        sourceArtifact.id >> sourceArtifactId
-        set.schema >> producerSchema
-        set.variants >> variants
-        variant1.attributes >> typeAttributes("jar")
-        variant1.artifacts >> variant1Artifacts
-        variant2.attributes >> typeAttributes("dll")
-
-        consumerSchema.withProducer(producerSchema) >> attributeMatcher
-        attributeMatcher.matches(_, _, _) >> []
-
-        matchingCache.collectConsumerVariants(typeAttributes("jar"), targetAttributes) >> { AttributeContainerInternal from, AttributeContainerInternal to ->
-            match(to, transformation, 1)
-        }
-        matchingCache.collectConsumerVariants(typeAttributes("dll"), targetAttributes) >> { new ConsumerVariantMatchResult(0) }
-        def result = transforms.variantSelector(targetAttributes, true, dependenciesResolver).select(set)
-
-        when:
-        result.startVisit(new TestBuildOperationExecutor.TestBuildOperationQueue<RunnableBuildOperation>(), listener).visit(visitor)
-
-        then:
-
-        _ * variant1Artifacts.startVisit(_, _) >> { BuildOperationQueue q, ResolvedArtifactSet.AsyncArtifactListener l ->
-            l.artifactAvailable(sourceArtifact)
-            return new ResolvedArtifactSet.Completion() {
-                @Override
-                void visit(ArtifactVisitor v) {
-                    v.visitArtifact(variant1DisplayName, targetAttributes, sourceArtifact)
-                }
-            }
-        }
-        _ * transformation.getDisplayName() >> "transform"
-        _ * transformation.requiresDependencies() >> false
-        _ * transformationNodeRegistry.getIfExecuted(_, _) >> Optional.empty()
-
-        1 * transformation.createInvocation({ it.files == [sourceArtifactFile]}, _ as ExecutionGraphDependenciesResolver, _) >> invocation1
-        1 * invocation1.getCachedResult() >> Optional.empty()
-        1 * invocation1.invoke() >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2))) >> invocation1
-
-        1 * listener.prepareForVisit({it instanceof ConsumerProvidedVariantFiles}) >> FileCollectionStructureVisitor.VisitType.Visit
-        1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
-        1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
-        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
-        0 * visitor._
-        0 * transformation._
     }
 
     def "fails when multiple transforms match"() {
@@ -202,13 +131,13 @@ class DefaultArtifactTransformsTest extends Specification {
         attributeMatcher.matches(_, _, _) >> []
 
         matchingCache.collectConsumerVariants(_, _) >> { AttributeContainerInternal from, AttributeContainerInternal to ->
-                match(to, Stub(Transformation), 1)
+            match(to, Stub(Transformation), 1)
         }
 
         def selector = transforms.variantSelector(typeAttributes("dll"), true, dependenciesResolver)
 
         when:
-        def result = selector.select(set)
+        def result = selector.select(set, factory)
         visit(result)
 
         then:
@@ -244,7 +173,7 @@ Found the following transforms:
         matchingCache.collectConsumerVariants(_, _) >> new ConsumerVariantMatchResult(0)
 
         expect:
-        def result = transforms.variantSelector(typeAttributes("dll"), true, dependenciesResolver).select(set)
+        def result = transforms.variantSelector(typeAttributes("dll"), true, dependenciesResolver).select(set, factory)
         result == ResolvedArtifactSet.EMPTY
     }
 
@@ -269,7 +198,7 @@ Found the following transforms:
         matchingCache.collectConsumerVariants(_, _) >> new ConsumerVariantMatchResult(0)
 
         when:
-        def result = transforms.variantSelector(typeAttributes("dll"), false, dependenciesResolver).select(set)
+        def result = transforms.variantSelector(typeAttributes("dll"), false, dependenciesResolver).select(set, factory)
         visit(result)
 
         then:
@@ -298,6 +227,4 @@ Found the following transforms:
         result.matched(output, trn, depth)
         result
     }
-
-    interface TestArtifact extends ResolvableArtifact, Buildable {}
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.transform
 
 import org.gradle.api.Action
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.TaskDependencyResolver
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class TransformationNodeSpec extends Specification {
 
-    def artifact = Mock(ResolvableArtifact)
+    def artifact = Mock(ResolvedArtifactSet.LocalArtifactSet)
     def dependencyResolver = Mock(TaskDependencyResolver)
     def transformerDependencies = Mock(TaskDependencyContainer)
     def hardSuccessor = Mock(Action)
@@ -36,7 +36,8 @@ class TransformationNodeSpec extends Specification {
     def transformListener = Mock(ArtifactTransformListener)
 
     def "initial node adds dependency on artifact node and dependencies"() {
-        def container = Stub(TaskDependencyContainer)
+        def artifactDependencies = Stub(TaskDependencyContainer)
+        def artifactDependencyDependencies = Stub(TaskDependencyContainer)
         def artifactNode = node()
         def additionalNode = node()
         def isolationNode = node()
@@ -48,10 +49,11 @@ class TransformationNodeSpec extends Specification {
         node.resolveDependencies(dependencyResolver, hardSuccessor)
 
         then:
-        1 * dependencyResolver.resolveDependenciesFor(null, artifact) >> [artifactNode]
+        1 * artifact.taskDependencies >> artifactDependencies
+        1 * dependencyResolver.resolveDependenciesFor(null, artifactDependencies) >> [artifactNode]
         1 * hardSuccessor.execute(artifactNode)
-        1 * graphDependenciesResolver.computeDependencyNodes(transformationStep) >> container
-        1 * dependencyResolver.resolveDependenciesFor(null, container) >> [additionalNode]
+        1 * graphDependenciesResolver.computeDependencyNodes(transformationStep) >> artifactDependencyDependencies
+        1 * dependencyResolver.resolveDependenciesFor(null, artifactDependencyDependencies) >> [additionalNode]
         1 * hardSuccessor.execute(additionalNode)
         1 * transformationStep.dependencies >> transformerDependencies
         1 * dependencyResolver.resolveDependenciesFor(null, transformerDependencies) >> [isolationNode]

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/tests/artifactTransformMinify.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/tests/artifactTransformMinify.out
@@ -3,7 +3,7 @@
 > Task :producer:classes
 > Task :producer:jar
 
-> Transform artifact producer.jar (project :producer) with Minify
+> Transform producer.jar (project :producer) with Minify
 Nothing to minify - using producer.jar unchanged
 
 > Task :resolveRuntimeClasspath

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -377,7 +377,7 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         instantRun(":resolve")
 
         then:
-        assertTransformed("root.blue", "root.additional.blue", "a.blue", "a.jar")
+        assertTransformed("root.blue", "root.additional.blue", "a.additional.blue", "a.jar")
         outputContains("result = [root.additional.blue.green, root.blue.green, a.jar.green, a.additional.blue.green]")
 
         when:

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -54,6 +54,7 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
 
     override suspend fun ReadContext.decode(): ArtifactCollectionInternal {
         val elements = readList().uncheckedCast<List<Any>>()
+
         @Suppress("implicit_cast_to_any")
         val files = fileCollectionFactory.resolving(elements.map {
             when (it) {
@@ -146,7 +147,7 @@ class FixedArtifactCollection(
                 is ResolvedArtifactResultSpec -> result.add(DefaultResolvedArtifactResult(element.id, element.variantAttributes, element.variantDisplayName, Artifact::class.java, element.file))
                 is ConsumerProvidedVariantSpec -> {
                     for (output in element.node.transformedSubject.get().files) {
-                        val resolvedArtifact: ResolvableArtifact = element.node.inputArtifact.transformedTo(output)
+                        val resolvedArtifact: ResolvableArtifact = element.node.inputArtifacts.transformedTo(output)
                         result.add(DefaultResolvedArtifactResult(resolvedArtifact.id, element.variantDisplayName, element.variantAttributes, Artifact::class.java, output))
                     }
                     // Ignore

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -17,16 +17,21 @@
 package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.component.Artifact
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFiles
+import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformDependencies
+import org.gradle.api.internal.artifacts.transform.Transformation
 import org.gradle.api.internal.artifacts.transform.TransformationNode
+import org.gradle.api.internal.artifacts.transform.TransformationSubject
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
@@ -35,9 +40,11 @@ import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.codecs.transform.FixedDependenciesResolver
 import org.gradle.instantexecution.serialization.readList
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.internal.DisplayName
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import java.io.File
 import java.util.concurrent.Callable
 
@@ -59,12 +66,17 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
         val files = fileCollectionFactory.resolving(elements.map {
             when (it) {
                 is ResolvedArtifactResultSpec -> it.file
-                is ConsumerProvidedVariantSpec -> Callable { it.node.transformedSubject.get().files }
+                is ConsumerProvidedVariantSpec -> Callable {
+                    it.node.transformedSubject.get().files
+                }
+                is TransformedLocalArtifactSpec -> Callable {
+                    it.transformation.createInvocation(TransformationSubject.initial(it.origin), FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty())), null).invoke().get().files
+                }
                 else -> throw IllegalArgumentException("Unexpected element $it in artifact collection")
             }
         })
         val failures = readList().uncheckedCast<List<Throwable>>()
-        return FixedArtifactCollection(files, elements, failures)
+        return FixedArtifactCollection(files, elements, failures, fileCollectionFactory)
     }
 }
 
@@ -87,16 +99,30 @@ class ConsumerProvidedVariantSpec(
 
 
 private
+class
+TransformedLocalArtifactSpec(
+    val ownerId: ComponentIdentifier,
+    val origin: File,
+    val transformation: Transformation,
+    val variantDisplayName: DisplayName,
+    val variantAttributes: ImmutableAttributes
+)
+
+
+private
 class CollectingArtifactVisitor : ArtifactVisitor {
     val elements = mutableListOf<Any>()
     val failures = mutableListOf<Throwable>()
 
-    override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType =
-        if (source is ConsumerProvidedVariantFiles && source.scheduledNodes.isNotEmpty()) {
+    override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
+        return if (source is ConsumerProvidedVariantFiles && source.scheduledNodes.isNotEmpty()) {
+            FileCollectionStructureVisitor.VisitType.NoContents
+        } else if (source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet && source.isBuildable) {
             FileCollectionStructureVisitor.VisitType.NoContents
         } else {
             FileCollectionStructureVisitor.VisitType.Visit
         }
+    }
 
     override fun requireArtifactFiles(): Boolean {
         return true
@@ -111,7 +137,7 @@ class CollectingArtifactVisitor : ArtifactVisitor {
     }
 
     override fun endVisitCollection(source: FileCollectionInternal.Source) {
-        if (source is ConsumerProvidedVariantFiles && source.scheduledNodes.isNotEmpty()) {
+        if (source is ConsumerProvidedVariantFiles) {
             for (node in source.scheduledNodes) {
                 elements.add(
                     ConsumerProvidedVariantSpec(
@@ -121,6 +147,8 @@ class CollectingArtifactVisitor : ArtifactVisitor {
                     )
                 )
             }
+        } else if (source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet) {
+            elements.add(TransformedLocalArtifactSpec(source.ownerId, source.file, source.transformation, source.targetVariantName, source.targetVariantAttributes))
         }
     }
 }
@@ -130,7 +158,8 @@ private
 class FixedArtifactCollection(
     private val artifactFiles: FileCollection,
     private val elements: List<Any>,
-    private val failures: List<Throwable>
+    private val failures: List<Throwable>,
+    private val fileCollectionFactory: FileCollectionFactory
 ) : ArtifactCollectionInternal {
 
     override fun getFailures() = failures
@@ -150,7 +179,12 @@ class FixedArtifactCollection(
                         val resolvedArtifact: ResolvableArtifact = element.node.inputArtifacts.transformedTo(output)
                         result.add(DefaultResolvedArtifactResult(resolvedArtifact.id, element.variantDisplayName, element.variantAttributes, Artifact::class.java, output))
                     }
-                    // Ignore
+                }
+                is TransformedLocalArtifactSpec -> {
+                    for (output in element.transformation.createInvocation(TransformationSubject.initial(element.origin), FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty())), null).invoke().get().files) {
+                        val artifactId = ComponentFileArtifactIdentifier(element.ownerId, output.name)
+                        result.add(DefaultResolvedArtifactResult(artifactId, element.variantDisplayName, element.variantAttributes, Artifact::class.java, output))
+                    }
                 }
                 else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -134,6 +134,11 @@ class Codecs(
         bind(ImmutableAttributesCodec(attributesFactory, managedFactoryRegistry))
         bind(AttributeContainerCodec(attributesFactory, managedFactoryRegistry))
         bind(TransformationNodeReferenceCodec)
+        bind(TransformationStepCodec(projectStateRegistry, fingerprinterRegistry))
+        bind(DefaultTransformerCodec(BindingsBackedCodec {
+            bind(BeanCodec())
+        }, buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
+        bind(LegacyTransformerCodec(actionScheme))
 
         bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/AbstractTransformationNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/AbstractTransformationNodeCodec.kt
@@ -74,7 +74,6 @@ abstract class AbstractTransformationNodeCodec<T : TransformationNode> : Codec<T
 }
 
 
-private
 class FixedDependenciesResolver(private val dependencies: ArtifactTransformDependencies) : ExecutionGraphDependenciesResolver {
     override fun computeDependencyNodes(transformationStep: TransformationStep): TaskDependencyContainer {
         throw IllegalStateException()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/InitialTransformationNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/InitialTransformationNodeCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs.transform
 
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedResolvedVariant
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
 import org.gradle.api.internal.artifacts.transform.TransformationNode
@@ -35,13 +36,13 @@ class InitialTransformationNodeCodec(
     override suspend fun WriteContext.doEncode(value: TransformationNode.InitialTransformationNode) {
         write(value.transformationStep)
         writeDependenciesResolver(value)
-        write(value.inputArtifact)
+        write((value.inputArtifacts as ArtifactBackedResolvedVariant.SingleLocalArtifactSet).artifact)
     }
 
     override suspend fun ReadContext.doDecode(): TransformationNode.InitialTransformationNode {
         val transformationStep = readNonNull<TransformationStep>()
         val resolver = readDependenciesResolver()
-        val artifact = readNonNull<ResolvableArtifact>()
-        return TransformationNode.initial(transformationStep, artifact, resolver, buildOperationExecutor, transformListener)
+        val artifacts = ArtifactBackedResolvedVariant.SingleLocalArtifactSet(readNonNull())
+        return TransformationNode.initial(transformationStep, artifacts, resolver, buildOperationExecutor, transformListener)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/InitialTransformationNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/InitialTransformationNodeCodec.kt
@@ -17,7 +17,6 @@
 package org.gradle.instantexecution.serialization.codecs.transform
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedResolvedVariant
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
 import org.gradle.api.internal.artifacts.transform.TransformationNode
 import org.gradle.api.internal.artifacts.transform.TransformationStep

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -35,7 +35,7 @@ public class GroupedOutputFixture {
      * All tasks will start with > Task, captures everything starting with : and going until end of line
      */
     private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n";
-    private final static String TRANSFORMATION_HEADER = "> Transform (artifact|file) ([^\\n]+) with ([^\\n]+)\\n";
+    private final static String TRANSFORMATION_HEADER = "> Transform (file )?([^\\n]+) with ([^\\n]+)\\n";
 
     private final static String EMBEDDED_BUILD_START = "> :\\w* > [:\\w]+";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";
@@ -76,8 +76,8 @@ public class GroupedOutputFixture {
     }
 
     private String parse(LogContent output) {
-        tasks = new HashMap<String, GroupedTaskFixture>();
-        transformations = new HashMap<String, GroupedTransformationFixture>();
+        tasks = new HashMap<>();
+        transformations = new HashMap<>();
 
         String strippedOutput = output.ansiCharsToPlainText().withNormalizedEol();
         findOutputs(strippedOutput, TASK_OUTPUT_PATTERN, this::consumeTaskOutput);

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -19,7 +19,6 @@ package org.gradle.jvm.internal;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
@@ -31,8 +30,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Defau
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ParallelResolveArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
@@ -40,7 +37,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
-import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -219,12 +215,9 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
 
         @Override
         public void finishArtifacts() {
-            artifactsResults = artifactsBuilder.complete().select(Specs.<ComponentIdentifier>satisfyAll(), new VariantSelector() {
-                @Override
-                public ResolvedArtifactSet select(ResolvedVariantSet variants) {
-                    // Select the first variant
-                    return variants.getVariants().iterator().next().getArtifacts();
-                }
+            artifactsResults = artifactsBuilder.complete().select(Specs.satisfyAll(), (candidates, factory) -> {
+                // Select the first variant
+                return candidates.getVariants().iterator().next().getArtifacts();
             });
         }
     }


### PR DESCRIPTION
### Context

Some initial fixes for configuration caching when artifact transforms are applied to file dependencies (for example `dependencies { thing files(xyz) }`) and those file dependencies include a task output.

There are more more fixes to be applied in a follow-up PR.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
