### PR TITLE
Move some of performance scenarios to later stage

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/Scenario.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/Scenario.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance
+
+import org.gradle.performance.generator.JavaTestProject
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface Scenario {
+    String[] value() default []
+
+    JavaTestProject[] testProjects() default []
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -236,7 +236,7 @@ class ReadyForMergeTaskOutputCachingJavaPerformanceTest extends AbstractTaskOutp
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testScenario << [[LARGE_JAVA_MULTI_PROJECT, true], [LARGE_JAVA_MULTI_PROJECT, false], [LARGE_MONOLITHIC_JAVA_PROJECT, false]]
+        testScenario << [[[LARGE_JAVA_MULTI_PROJECT, 'assemble'], true], [[LARGE_JAVA_MULTI_PROJECT, 'assemble'], false], [[LARGE_MONOLITHIC_JAVA_PROJECT, 'assemble'], false]]
         projectInfo = testScenario[0]
         parallel = testScenario[1]
         testProject = projectInfo[0]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -236,7 +236,7 @@ class ReadyForMergeTaskOutputCachingJavaPerformanceTest extends AbstractTaskOutp
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testScenario << [[LARGE_JAVA_MULTI_PROJECT], [true, false]].combinations() + [[LARGE_MONOLITHIC_JAVA_PROJECT, false]]
+        testScenario << [[LARGE_JAVA_MULTI_PROJECT, true], [LARGE_JAVA_MULTI_PROJECT, false], [LARGE_MONOLITHIC_JAVA_PROJECT, false]]
         projectInfo = testScenario[0]
         parallel = testScenario[1]
         testProject = projectInfo[0]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -18,7 +18,11 @@ package org.gradle.performance.regression.java
 
 
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
+import org.gradle.performance.Scenario
+import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.mutator.ApplyAbiChangeToJavaSourceFileMutator
+import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_GROOVY_MULTI_PROJECT
@@ -26,8 +30,7 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_GROOVY_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
-class JavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
-
+abstract class AbstractJavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
     @Unroll
     def "assemble for abi change on #testProject"() {
         given:
@@ -47,6 +50,16 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPer
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject << [LARGE_MONOLITHIC_JAVA_PROJECT, LARGE_JAVA_MULTI_PROJECT, LARGE_MONOLITHIC_GROOVY_PROJECT, LARGE_GROOVY_MULTI_PROJECT]
+        testProject << getClass().getAnnotation(Scenario).testProjects()
     }
+}
+
+@Scenario(testProjects = [LARGE_MONOLITHIC_GROOVY_PROJECT, LARGE_JAVA_MULTI_PROJECT])
+@Category(PerformanceExperiment)
+class ReadyForReleaseJavaABIChangePerformanceTest extends AbstractJavaABIChangePerformanceTest {
+}
+
+@Scenario(testProjects = [LARGE_MONOLITHIC_JAVA_PROJECT, LARGE_GROOVY_MULTI_PROJECT])
+@Category(PerformanceRegressionTest)
+class ReadyForMergeJavaABIChangePerformanceTest extends AbstractJavaABIChangePerformanceTest {
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -49,7 +49,7 @@ abstract class AbstractJavaNonABIChangePerformanceTest extends AbstractCrossVers
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject << getClass().getAnnotation(Scenario).value()
+        testProject << getClass().getAnnotation(Scenario).testProjects()
     }
 }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,11 @@
 package org.gradle.performance.regression.java
 
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
+import org.gradle.performance.Scenario
+import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
+import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_GROOVY_MULTI_PROJECT
@@ -25,8 +29,7 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_GROOVY_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
-class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
-
+abstract class AbstractJavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
     @Unroll
     def "assemble for non-abi change on #testProject"() {
         given:
@@ -39,7 +42,6 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternal
             runner.minimumBaseVersion = '5.0'
         }
 
-
         when:
         def result = runner.run()
 
@@ -47,6 +49,17 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternal
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject << [LARGE_MONOLITHIC_JAVA_PROJECT, LARGE_JAVA_MULTI_PROJECT, LARGE_MONOLITHIC_GROOVY_PROJECT, LARGE_GROOVY_MULTI_PROJECT]
+        testProject << getClass().getAnnotation(Scenario).value()
     }
+}
+
+
+@Scenario(testProjects = [LARGE_MONOLITHIC_GROOVY_PROJECT, LARGE_JAVA_MULTI_PROJECT])
+@Category(PerformanceExperiment)
+class ReadyForReleaseJavaNonABIChangePerformanceTest extends AbstractJavaNonABIChangePerformanceTest {
+}
+
+@Scenario(testProjects = [LARGE_GROOVY_MULTI_PROJECT, LARGE_MONOLITHIC_JAVA_PROJECT])
+@Category(PerformanceRegressionTest)
+class ReadyForMergeJavaNonABIChangePerformanceTest extends AbstractJavaNonABIChangePerformanceTest {
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
@@ -17,13 +17,16 @@
 package org.gradle.performance.regression.java
 
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
+import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
+import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.MEDIUM_JAVA_MULTI_PROJECT_WITH_TEST_NG
 
+@Category(PerformanceExperiment)
 class JavaTestChangePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -120,7 +120,7 @@ abstract class AbstractRealWorldNativePluginPerformanceTest extends AbstractCros
         runner.warmUpRuns = 5
         runner.runs = 10
 
-        def parallelWorkers = testProjectAndParallelWorkers.split('\\-')[1]
+        def parallelWorkers = testProjectAndParallelWorkers.split('\\-')[1].toInteger()
 
         if (parallelWorkers) {
             runner.args += ["--parallel", "--max-workers=$parallelWorkers".toString()]


### PR DESCRIPTION
### Context

Closes https://github.com/gradle/gradle-private/issues/2401

We want to move performance tests to later stage to improve feedback time. For `Unroll` scenarios, some of them are moved to later stage. 