### PR TITLE
Rework configuration cache build options

### DIFF
--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -131,7 +131,7 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("EVENT: finish :b:thing")
     }
 
-    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "off")
+    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "false")
     @UnsupportedWithInstantExecution
     def "listener receives task completion events from included builds"() {
         settingsFile << """

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnumBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnumBuildOption.java
@@ -19,7 +19,6 @@ package org.gradle.internal.buildoption;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -32,11 +31,15 @@ import java.util.Map;
  */
 public abstract class EnumBuildOption<E extends Enum<E>, T> extends AbstractBuildOption<T, CommandLineOptionConfiguration> {
 
-    private final EnumParser<E> enumParser;
+    private final String displayName;
+    private final Class<E> enumClass;
+    private final List<E> possibleValues;
 
     public EnumBuildOption(String displayName, Class<E> enumClass, E[] possibleValues, String gradleProperty, CommandLineOptionConfiguration... commandLineOptionConfigurations) {
         super(gradleProperty, commandLineOptionConfigurations);
-        this.enumParser = new EnumParser<E>(displayName, enumClass, possibleValues);
+        this.displayName = displayName;
+        this.enumClass = enumClass;
+        this.possibleValues = Collections.unmodifiableList(Arrays.asList(possibleValues));
     }
 
     @Override
@@ -66,51 +69,33 @@ public abstract class EnumBuildOption<E extends Enum<E>, T> extends AbstractBuil
     }
 
     private void applyTo(String value, T settings, Origin origin) {
-        applyTo(enumParser.getValue(value), settings, origin);
+        applyTo(getValue(value), settings, origin);
+    }
+
+    private E getValue(String value) {
+        E enumValue = null;
+        if (value != null) {
+            enumValue = tryGetValue(value);
+            if (enumValue == null) {
+                enumValue = tryGetValue(value.toLowerCase());
+            }
+            if (enumValue == null) {
+                enumValue = tryGetValue(value.toUpperCase());
+            }
+        }
+        if (enumValue == null) {
+            throw new RuntimeException("Option " + displayName + " doesn't accept value '" + value + "'. Possible values are " + possibleValues);
+        }
+        return enumValue;
+    }
+
+    private E tryGetValue(String value) {
+        try {
+            return Enum.valueOf(enumClass, value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     public abstract void applyTo(E value, T settings, Origin origin);
-
-    public static class EnumParser<E extends Enum<E>> {
-        private final String displayName;
-        private final Class<E> enumClass;
-        private final List<E> possibleValues;
-
-        public EnumParser(String displayName, Class<E> enumClass, E[] possibleValues) {
-            this.displayName = displayName;
-            this.enumClass = enumClass;
-            this.possibleValues = Collections.unmodifiableList(Arrays.asList(possibleValues));
-        }
-
-        public E getValue(String value) {
-            E enumValue = getValueOrNull(value);
-            if (enumValue == null) {
-                throw new RuntimeException("Option " + displayName + " doesn't accept value '" + value + "'. Possible values are " + possibleValues);
-            }
-            return enumValue;
-        }
-
-        @Nullable
-        public E getValueOrNull(String value) {
-            E enumValue = null;
-            if (value != null) {
-                enumValue = tryGetValue(value);
-                if (enumValue == null) {
-                    enumValue = tryGetValue(value.toLowerCase());
-                }
-                if (enumValue == null) {
-                    enumValue = tryGetValue(value.toUpperCase());
-                }
-            }
-            return enumValue;
-        }
-
-        private E tryGetValue(String value) {
-            try {
-                return Enum.valueOf(enumClass, value);
-            } catch (IllegalArgumentException e) {
-                return null;
-            }
-        }
-    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -190,7 +190,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 12")
     }
 
-    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "off")
+    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "false")
     @UnsupportedWithInstantExecution
     def "service can be used at configuration and execution time"() {
         serviceImplementation()
@@ -238,7 +238,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 11")
     }
 
-    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "on")
+    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "true")
     def "service used at configuration and execution time can be used with instant execution"() {
         serviceImplementation()
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption;
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
 import org.gradle.internal.deprecation.Deprecatable;
 import org.gradle.internal.deprecation.LoggingDeprecatable;
 
@@ -30,7 +30,8 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
 
     private boolean watchFileSystem;
 
-    private ConfigurationCacheOption.Value configurationCache = ConfigurationCacheOption.Value.OFF;
+    private boolean configurationCache;
+    private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
     private int configurationCacheMaxProblems = 512;
     private boolean configurationCacheRecreateCache;
     private boolean configurationCacheQuiet;
@@ -50,6 +51,7 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
         StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
         p.watchFileSystem = watchFileSystem;
         p.configurationCache = configurationCache;
+        p.configurationCacheProblems = configurationCacheProblems;
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
         p.configurationCacheRecreateCache = configurationCacheRecreateCache;
         p.configurationCacheQuiet = configurationCacheQuiet;
@@ -103,12 +105,20 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
         this.watchFileSystem = watchFileSystem;
     }
 
-    public ConfigurationCacheOption.Value getConfigurationCache() {
+    public boolean isConfigurationCache() {
         return configurationCache;
     }
 
-    public void setConfigurationCache(ConfigurationCacheOption.Value configurationCache) {
+    public void setConfigurationCache(boolean configurationCache) {
         this.configurationCache = configurationCache;
+    }
+
+    public ConfigurationCacheProblemsOption.Value getConfigurationCacheProblems() {
+        return configurationCacheProblems;
+    }
+
+    public void setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value configurationCacheProblems) {
+        this.configurationCacheProblems = configurationCacheProblems;
     }
 
     public int getConfigurationCacheMaxProblems() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -38,7 +38,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class StartParameterBuildOptions {
@@ -437,15 +436,8 @@ public class StartParameterBuildOptions {
 
     public static class ConfigurationCacheOption extends BooleanBuildOption<StartParameterInternal> {
 
-        @Deprecated
-        public enum Value {
-            OFF, ON, WARN
-        }
-
         public static final String PROPERTY_NAME = "org.gradle.unsafe.configuration-cache";
         public static final String LONG_OPTION = "configuration-cache";
-
-        private final EnumBuildOption.EnumParser<ConfigurationCacheOption.Value> enumParser;
 
         public ConfigurationCacheOption() {
             super(
@@ -456,44 +448,11 @@ public class StartParameterBuildOptions {
                     "Disables the configuration cache."
                 ).incubating()
             );
-            this.enumParser = new EnumBuildOption.EnumParser<>(
-                LONG_OPTION,
-                ConfigurationCacheOption.Value.class,
-                ConfigurationCacheOption.Value.values()
-            );
-        }
-
-        @Override
-        public void applyFromProperty(Map<String, String> properties, StartParameterInternal settings) {
-            ConfigurationCacheOption.Value enumValue = enumParser.getValueOrNull(properties.get(gradleProperty));
-            if (enumValue != null) {
-                applyTo(enumValue, settings);
-            } else {
-                super.applyFromProperty(properties, settings);
-            }
         }
 
         @Override
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
             settings.setConfigurationCache(value);
-        }
-
-        private void applyTo(ConfigurationCacheOption.Value value, StartParameterInternal settings) {
-            settings.addDeprecation("Property '" + PROPERTY_NAME + "' with value '" + value.name().toLowerCase() + "'");
-            switch (value) {
-                case OFF:
-                    settings.setConfigurationCache(false);
-                    settings.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.FAIL);
-                    break;
-                case ON:
-                    settings.setConfigurationCache(true);
-                    settings.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.FAIL);
-                    break;
-                case WARN:
-                    settings.setConfigurationCache(true);
-                    settings.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.WARN);
-                    break;
-            }
         }
     }
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -66,21 +66,21 @@ It can be enabled from the command line:
 
 [source,bash]
 ----
-$ gradle --configuration-cache=on
+$ gradle --configuration-cache
 ----
 
 It can also be enabled persistently in a `gradle.properties` file:
 
 [source,properties]
 ----
-org.gradle.unsafe.configuration-cache=on
+org.gradle.unsafe.configuration-cache=true
 ----
 
 If it is enabled in a `gradle.properties` file, it can be disabled on the command line for one build invocation:
 
 [source,bash]
 ----
-$ gradle --configuration-cache=off
+$ gradle --no-configuration-cache
 ----
 
 [[ignore_problems]]
@@ -91,14 +91,14 @@ Configuration cache problems can be turned into warnings on the command line:
 
 [source,bash]
 ----
-$ gradle --configuration-cache=warn
+$ gradle --configuration-cache-problems=warn
 ----
 
 or in a `gradle.properties` file:
 
 [source,properties]
 ----
-org.gradle.unsafe.configuration-cache=warn
+org.gradle.unsafe.configuration-cache-problems=warn
 ----
 
 [[max_problems]]
@@ -402,7 +402,7 @@ This includes:
 The Gradle TestKit (a.k.a. just TestKit) is a library that aids in testing Gradle plugins and build logic generally.
 For general guidance on how to use TestKit see the <<test_kit.adoc#test_kit,dedicated chapter>>.
 
-To enable configuration caching in your tests, you can pass the `--configuration-cache=on` argument to link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html[GradleRunner] or use one of the other methods described in <<configuration_cache.adoc#enable,Enabling the configuration cache>>.
+To enable configuration caching in your tests, you can pass the `--configuration-cache` argument to link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html[GradleRunner] or use one of the other methods described in <<configuration_cache.adoc#enable,Enabling the configuration cache>>.
 
 You need to run your tasks twice.
 Once to prime the configuration cache.

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
@@ -28,12 +28,12 @@ class BuildLogicFunctionalTest extends Specification {
 
         when:
         runner()
-            .withArguments('--configuration-cache=on', 'myTask')    // <1>
+            .withArguments('--configuration-cache', 'myTask')    // <1>
             .build()
 
         and:
         def result = runner()
-            .withArguments('--configuration-cache=on', 'myTask')    // <2>
+            .withArguments('--configuration-cache', 'myTask')    // <2>
             .build()
 
         then:

--- a/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/test/kotlin/org/example/BuildLogicFunctionalTest.kt
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/kotlin/src/test/kotlin/org/example/BuildLogicFunctionalTest.kt
@@ -33,11 +33,11 @@ class BuildLogicFunctionalTest {
         """)
 
         runner()
-            .withArguments("--configuration-cache=on", "myTask")        // <1>
+            .withArguments("--configuration-cache", "myTask")        // <1>
             .build()
 
         val result = runner()
-            .withArguments("--configuration-cache=on", "myTask")        // <2>
+            .withArguments("--configuration-cache", "myTask")        // <2>
             .build()
 
         require(result.output.contains("Reusing configuration cache.")) // <3>

--- a/subprojects/instant-execution/src/crossVersionTest/groovy/org/gradle/instantexecution/InstantExecutionCacheCrossVersionTest.groovy
+++ b/subprojects/instant-execution/src/crossVersionTest/groovy/org/gradle/instantexecution/InstantExecutionCacheCrossVersionTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.instantexecution.InstantExecutionBuildOperationsFixture
+import org.gradle.util.GradleVersion
 
 import static org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption.LONG_OPTION
 
@@ -34,11 +35,17 @@ class InstantExecutionCacheCrossVersionTest extends CrossVersionIntegrationSpec 
     def currentFixture = new InstantExecutionBuildOperationsFixture(new BuildOperationsFixture(currentExecuter, temporaryFolder))
 
     void runPrevious() {
-        previousExecuter.withArguments("--${LONG_OPTION}=on", 'help').run()
+        previousExecuter.withArguments(argFor(previous.version), 'help').run()
     }
 
     void runCurrent() {
-        currentExecuter.withArguments("--${LONG_OPTION}=on", 'help').run()
+        currentExecuter.withArguments(argFor(current.version), 'help').run()
+    }
+
+    private static String argFor(GradleVersion version) {
+        version.baseVersion == GradleVersion.version("6.5")
+            ? "--${LONG_OPTION}=on"
+            : "--$LONG_OPTION"
     }
 
     def "does not reuse cached state from previous version"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
@@ -29,9 +31,18 @@ import org.intellij.lang.annotations.Language
 
 class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
 
-    static final String STRICT_CLI_OPTION = InstantExecutionProblemsFixture.STRICT_CLI_OPTION
-    static final String LENIENT_CLI_OPTION = InstantExecutionProblemsFixture.LENIENT_CLI_OPTION
-    static final String MAX_PROBLEMS_CLI_OPTION = InstantExecutionProblemsFixture.MAX_PROBLEMS_CLI_OPTION
+    static final String ENABLE_CLI_OPT = "--${ConfigurationCacheOption.LONG_OPTION}"
+    static final String ENABLE_GRADLE_PROP = "${ConfigurationCacheOption.PROPERTY_NAME}=true"
+    static final String ENABLE_SYS_PROP = "-D$ENABLE_GRADLE_PROP"
+
+    static final String DISABLE_CLI_OPT = "--no-${ConfigurationCacheOption.LONG_OPTION}"
+    static final String DISABLE_GRADLE_PROP = "${ConfigurationCacheOption.PROPERTY_NAME}=false"
+    static final String DISABLE_SYS_PROP = "-D$DISABLE_GRADLE_PROP"
+
+    static final String WARN_PROBLEMS_CLI_OPT = "--${ConfigurationCacheProblemsOption.LONG_OPTION}=warn"
+
+    static final String MAX_PROBLEMS_GRADLE_PROP = "${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}"
+    static final String MAX_PROBLEMS_SYS_PROP = "-D$MAX_PROBLEMS_GRADLE_PROP"
 
     protected InstantExecutionProblemsFixture problems
 
@@ -52,19 +63,15 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     void instantRun(String... tasks) {
-        run(STRICT_CLI_OPTION, *tasks)
+        run(ENABLE_CLI_OPT, *tasks)
     }
 
     void instantRunLenient(String... tasks) {
-        run(LENIENT_CLI_OPTION, *tasks)
+        run(ENABLE_CLI_OPT, WARN_PROBLEMS_CLI_OPT, *tasks)
     }
 
     void instantFails(String... tasks) {
-        fails(STRICT_CLI_OPTION, *tasks)
-    }
-
-    void instantFailsLenient(String... tasks) {
-        fails(LENIENT_CLI_OPTION, *tasks)
+        fails(ENABLE_CLI_OPT, *tasks)
     }
 
     String relativePath(String path) {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionClassLoaderCachingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionClassLoaderCachingIntegrationTest.groovy
@@ -93,6 +93,6 @@ class InstantExecutionClassLoaderCachingIntegrationTest extends PersistentBuildP
     }
 
     private void instantRun(String... args) {
-        run(AbstractInstantExecutionIntegrationTest.STRICT_CLI_OPTION, *args)
+        run(AbstractInstantExecutionIntegrationTest.ENABLE_CLI_OPT, *args)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionEnablingIntegrationTest.groovy
@@ -27,9 +27,6 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
 
         given:
         def fixture = newInstantExecutionFixture()
-        if (deprecation) {
-            expectDeprecatedProperty(ConfigurationCacheOption.PROPERTY_NAME, 'on')
-        }
 
         when:
         run 'help', argument
@@ -46,24 +43,19 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         fixture.assertStateLoaded()
 
         where:
-        origin                       | deprecation | argument
-        "long option"                | false       | ENABLE_CLI_OPT
-        "system property"            | false       | ENABLE_SYS_PROP
-        "deprecated system property" | true        | "-D${ConfigurationCacheOption.PROPERTY_NAME}=on"
+        origin            | argument
+        "long option"     | ENABLE_CLI_OPT
+        "system property" | ENABLE_SYS_PROP
     }
 
-    @Unroll
-    def "can enable with a #origin in root directory gradle.properties"() {
+    def "can enable with a property in root directory gradle.properties"() {
 
         given:
         def fixture = newInstantExecutionFixture()
-        if (deprecation) {
-            expectDeprecatedProperty(ConfigurationCacheOption.PROPERTY_NAME, 'on')
-        }
 
         and:
         file('gradle.properties') << """
-            $propertyLine
+            $ENABLE_GRADLE_PROP
         """
 
         when:
@@ -79,26 +71,17 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         then:
         outputContainsIncubatingFeatureUsage()
         fixture.assertStateLoaded()
-
-        where:
-        origin                | deprecation | propertyLine
-        "property"            | false       | ENABLE_GRADLE_PROP
-        "deprecated property" | true        | "${ConfigurationCacheOption.PROPERTY_NAME}=on"
     }
 
-    @Unroll
-    def "can enable with a #origin in gradle user home gradle.properties"() {
+    def "can enable with a property in gradle user home gradle.properties"() {
 
         given:
         def fixture = newInstantExecutionFixture()
-        if (deprecation) {
-            expectDeprecatedProperty(ConfigurationCacheOption.PROPERTY_NAME, 'on')
-        }
 
         and:
         executer.requireOwnGradleUserHomeDir()
         executer.gradleUserHomeDir.file('gradle.properties') << """
-            $propertyLine
+            $ENABLE_GRADLE_PROP
         """
 
         when:
@@ -114,11 +97,6 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         then:
         outputContainsIncubatingFeatureUsage()
         fixture.assertStateLoaded()
-
-        where:
-        origin                | deprecation | propertyLine
-        "property"            | false       | ENABLE_GRADLE_PROP
-        "deprecated property" | true        | "${ConfigurationCacheOption.PROPERTY_NAME}=on"
     }
 
     @Unroll
@@ -126,9 +104,6 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
 
         given:
         def fixture = newInstantExecutionFixture()
-        if (deprecation) {
-            expectDeprecatedProperty(ConfigurationCacheOption.PROPERTY_NAME, 'off')
-        }
 
         and:
         file('gradle.properties') << """
@@ -142,10 +117,9 @@ class InstantExecutionEnablingIntegrationTest extends AbstractInstantExecutionIn
         fixture.assertNoInstantExecution()
 
         where:
-        cliOrigin                    | deprecation | cliArgument
-        "long option"                | false       | DISABLE_CLI_OPT
-        "system property"            | false       | DISABLE_SYS_PROP
-        "deprecated system property" | true        | "-D${ConfigurationCacheOption.PROPERTY_NAME}=off"
+        cliOrigin         | cliArgument
+        "long option"     | DISABLE_CLI_OPT
+        "system property" | DISABLE_SYS_PROP
     }
 
     private void outputContainsIncubatingFeatureUsage() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -132,7 +132,7 @@ class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionInte
         """
 
         when:
-        instantFailsLenient "assemble"
+        instantFails WARN_PROBLEMS_CLI_OPT, "assemble"
 
         then:
         instantExecution.assertStateStored()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -686,7 +686,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         """
 
         when:
-        instantFailsLenient "broken"
+        instantFails  WARN_PROBLEMS_CLI_OPT,"broken"
 
         then:
         problems.assertResultHasProblems(result) {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
@@ -61,7 +61,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         }
 
         when:
-        instantFailsLenient 'broken'
+        instantFails WARN_PROBLEMS_CLI_OPT, 'broken'
 
         then:
         failure.assertTasksExecuted()
@@ -120,7 +120,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         }
 
         when:
-        instantFailsLenient 'problems', 'broken'
+        instantFails WARN_PROBLEMS_CLI_OPT, 'problems', 'broken'
 
         then:
         failure.assertTasksExecuted()
@@ -338,7 +338,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(2)
 
         when:
-        instantFailsLenient 'all'
+        instantFails WARN_PROBLEMS_CLI_OPT, 'all'
 
         then:
         instantExecution.assertStateLoaded()
@@ -391,7 +391,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         """
 
         when:
-        instantFailsLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
+        instantFails WARN_PROBLEMS_CLI_OPT, "$MAX_PROBLEMS_SYS_PROP=2", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -405,7 +405,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         }
 
         when:
-        instantFailsLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=3"
+        instantFails WARN_PROBLEMS_CLI_OPT, "$MAX_PROBLEMS_SYS_PROP=3", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -420,7 +420,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
 
         when:
-        instantRunLenient 'all', "${MAX_PROBLEMS_CLI_OPTION}=4"
+        instantRun WARN_PROBLEMS_CLI_OPT, "$MAX_PROBLEMS_SYS_PROP=4", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -458,7 +458,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         """
 
         when:
-        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
+        instantFails "$MAX_PROBLEMS_SYS_PROP=2", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -472,7 +472,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         }
 
         when:
-        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2"
+        instantFails "$MAX_PROBLEMS_SYS_PROP=2", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -487,7 +487,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         failure.assertHasFailures(1)
 
         when:
-        instantFails 'all', "${MAX_PROBLEMS_CLI_OPTION}=2000"
+        instantFails "$MAX_PROBLEMS_SYS_PROP=2000", 'all'
 
         then:
         executed(':problems', ':moreProblems', ':all')
@@ -722,7 +722,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         """
 
         when:
-        run "foo", LENIENT_CLI_OPTION
+        run ENABLE_CLI_OPT, WARN_PROBLEMS_CLI_OPT, "foo"
 
         then:
         problems.assertResultHasProblems(result) {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -57,7 +57,7 @@ class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstan
         try {
             connection.newBuild()
                 .forTasks(tasks)
-                .withArguments(STRICT_CLI_OPTION)
+                .withArguments(ENABLE_CLI_OPT)
                 .setStandardOutput(output)
                 .setStandardError(error)
                 .run()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -40,7 +40,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         outputContains("task = $value")
 
         when:
-        instantRunLenient("thing", "-DCI=$value")
+        instantRun WARN_PROBLEMS_CLI_OPT, "thing", "-DCI=$value"
 
         then:
         fixture.assertStateLoaded()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -18,7 +18,7 @@ package org.gradle.instantexecution.initialization
 
 import org.gradle.StartParameter
 import org.gradle.api.internal.StartParameterInternal
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
 import org.gradle.instantexecution.extensions.unsafeLazy
 import org.gradle.internal.classpath.BuildLogicTransformStrategy
@@ -41,7 +41,7 @@ class InstantExecutionStartParameter(
     val startParameter = startParameter as StartParameterInternal
 
     val isEnabled: Boolean
-        get() = startParameter.configurationCache != ConfigurationCacheOption.Value.OFF
+        get() = startParameter.isConfigurationCache
 
     val isQuiet: Boolean
         get() = startParameter.isConfigurationCacheQuiet
@@ -50,7 +50,7 @@ class InstantExecutionStartParameter(
         get() = startParameter.configurationCacheMaxProblems
 
     val failOnProblems: Boolean
-        get() = startParameter.configurationCache == ConfigurationCacheOption.Value.ON
+        get() = startParameter.configurationCacheProblems == ConfigurationCacheProblemsOption.Value.FAIL
 
     val recreateCache: Boolean
         get() = startParameter.isConfigurationCacheRecreateCache

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/InstantExecutionRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/InstantExecutionRunner.java
@@ -24,9 +24,6 @@ import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOp
  */
 public class InstantExecutionRunner extends BehindFlagFeatureRunner {
     public InstantExecutionRunner(Class<?> target) {
-        super(target, ImmutableMap.of(ConfigurationCacheOption.PROPERTY_NAME, new Feature(ImmutableMap.of(
-            "off", "without configuration cache",
-            "on", "with configuration cache"
-        ))));
+        super(target, ImmutableMap.of(ConfigurationCacheOption.PROPERTY_NAME, booleanFeature("configuration cache")));
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.GradleVersion
 class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
 
     static final List<String> INSTANT_EXECUTION_ARGS = [
-        "--${ConfigurationCacheOption.LONG_OPTION}=on",
+        "--${ConfigurationCacheOption.LONG_OPTION}",
         "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0"
     ].collect { it.toString() }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
@@ -20,8 +20,6 @@ import groovy.transform.PackageScope
 import junit.framework.AssertionFailedError
 import org.gradle.api.Action
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleExecuter
@@ -49,10 +47,6 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.Assert.assertTrue
 
 final class InstantExecutionProblemsFixture {
-
-    static final String STRICT_CLI_OPTION = "--${ConfigurationCacheOption.LONG_OPTION}=on"
-    static final String LENIENT_CLI_OPTION = "--${ConfigurationCacheOption.LONG_OPTION}=warn"
-    static final String MAX_PROBLEMS_CLI_OPTION = "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}"
 
     protected static final String PROBLEMS_REPORT_HTML_FILE_NAME = "configuration-cache-report.html"
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -23,7 +23,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.logging.configuration.WarningMode;
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption;
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.serialize.BaseSerializerFactory;
@@ -116,7 +116,8 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildCacheEnabled());
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystem());
-            encoder.writeString(startParameter.getConfigurationCache().name());
+            encoder.writeBoolean(startParameter.isConfigurationCache());
+            encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeSmallInt(startParameter.getConfigurationCacheMaxProblems());
             encoder.writeBoolean(startParameter.isConfigurationCacheRecreateCache());
             encoder.writeBoolean(startParameter.isConfigurationCacheQuiet());
@@ -195,7 +196,8 @@ public class BuildActionSerializer {
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
             startParameter.setWatchFileSystem(decoder.readBoolean());
-            startParameter.setConfigurationCache(ConfigurationCacheOption.Value.valueOf(decoder.readString()));
+            startParameter.setConfigurationCache(decoder.readBoolean());
+            startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheMaxProblems(decoder.readSmallInt());
             startParameter.setConfigurationCacheRecreateCache(decoder.readBoolean());
             startParameter.setConfigurationCacheQuiet(decoder.readBoolean());

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.regression.android
 
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
 import org.gradle.internal.scan.config.fixtures.GradleEnterprisePluginSettingsFixture
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
@@ -79,7 +80,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     private void buildSpecForSupportedOptimizations(IncrementalAndroidTestProject testProject, @DelegatesTo(GradleBuildExperimentSpec.GradleBuilder) Closure scenarioConfiguration) {
         supportedOptimizations(testProject).each { name, Set<Optimization> enabledOptimizations ->
             runner.buildSpec {
-                invocation.args(*enabledOptimizations*.argument)
+                invocation.args(*enabledOptimizations*.arguments.flatten())
                 testProject.configureForLatestAgpVersionOfMinor(delegate, AGP_TARGET_VERSION)
                 displayName(name)
 
@@ -129,14 +130,17 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     enum Optimization {
-        CONFIGURATION_CACHING("--${ConfigurationCacheOption.LONG_OPTION}=warn"), // TODO on
+        CONFIGURATION_CACHING(
+            "--${ConfigurationCacheOption.LONG_OPTION}",
+            "--${ConfigurationCacheProblemsOption.LONG_OPTION}=warn" // TODO remove
+        ),
         WATCH_FS("--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}")
 
-        Optimization(String argument) {
-            this.argument = argument
+        Optimization(String... arguments) {
+            this.arguments = arguments
         }
 
-        final String argument
+        final List<String> arguments
     }
 
     void applyEnterprisePlugin(GradleBuildExperimentSpec.GradleBuilder builder) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -17,17 +17,15 @@
 package org.gradle.performance.regression.java
 
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
-import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
 import org.gradle.performance.categories.PerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListener
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
-import org.gradle.performance.fixture.GradleInvocationSpec
 import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.GradleVersion
 import org.junit.experimental.categories.Category
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import java.nio.file.Files
@@ -36,6 +34,7 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_
 import static org.gradle.performance.generator.JavaTestProject.SMALL_JAVA_MULTI_PROJECT_NO_BUILD_SRC
 import static org.junit.Assert.assertTrue
 
+@Ignore("temporarily because of the build options breaking change")
 @Category(PerformanceRegressionTest)
 class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
@@ -50,24 +49,12 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
 
         given:
         runner.targetVersions = ["6.5-20200512182414+0000"]
-        runner.minimumBaseVersion = "5.6"
+        runner.minimumBaseVersion = "5.6" // TODO make 6.6 after rebaseline
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
 
         and:
-        // runner.args = ["-D${ConfigurationCacheOption.PROPERTY_NAME}=true"] // TODO simplify on rebaseline
-        runner.addInvocationCustomizer({ BuildExperimentInvocationInfo invocationInfo, GradleInvocationSpec invocationSpec ->
-            def dist = invocationSpec.gradleDistribution as GradleDistribution
-            def builder = invocationSpec.withBuilder()
-            if (dist.version < GradleVersion.version("6.5-rc-1")) {
-                builder.args('-Dorg.gradle.unsafe.instant-execution=true').build()
-            } else if (dist.version < GradleVersion.version("6.6-20200527184619+0000")) {
-                builder.args("--${ConfigurationCacheOption.LONG_OPTION}=on")
-            } else {
-                builder.args("--${ConfigurationCacheOption.LONG_OPTION}")
-            }
-            return builder.build()
-        })
+        runner.args = ["-D${ConfigurationCacheOption.PROPERTY_NAME}=true"]
 
         and:
         runner.useDaemon = daemon == hot

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -51,7 +51,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
         runner.args = [
-            "-D${ConfigurationCacheOption.PROPERTY_NAME}=on" // TODO remove property argument on rebaseline
+            "-D${ConfigurationCacheOption.PROPERTY_NAME}=true"
         ]
 
         and:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -46,13 +46,12 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
     def "assemble on #testProject #action instant execution state with #daemon daemon"() {
 
         given:
-        runner.targetVersions = ["6.5-20200512182414+0000"]
+        runner.targetVersions = ["6.6-branch-eskatos_cc_rework_build_options-20200527184619+0000"]
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
         runner.args = [
-            "-Dorg.gradle.unsafe.instant-execution=true", // TODO remove on rebaseline
-            "-D${ConfigurationCacheOption.PROPERTY_NAME}=on"
+            "-D${ConfigurationCacheOption.PROPERTY_NAME}=on" // TODO remove property argument on rebaseline
         ]
 
         and:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -20,6 +20,7 @@ import org.apache.commons.io.FileUtils
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheQuietOption
 import org.gradle.integtests.fixtures.instantexecution.InstantExecutionBuildOperationsFixture
 import org.gradle.integtests.fixtures.BuildOperationTreeFixture
@@ -202,16 +203,15 @@ abstract class AbstractSmokeTest extends Specification {
         List<String> parameters = []
         if (GradleContextualExecuter.isInstant()) {
             def maxProblems = maxInstantExecutionProblems()
-            if (maxProblems == 0) {
-                parameters += ["--${ConfigurationCacheOption.LONG_OPTION}=on".toString()]
-            } else {
-                parameters += ["--${ConfigurationCacheOption.LONG_OPTION}=warn".toString(),]
-            }
             parameters += [
+                "--${ConfigurationCacheOption.LONG_OPTION}".toString(),
                 "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=$maxProblems".toString(),
                 "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true".toString(),
                 "-D${BuildOperationTrace.SYSPROP}=${buildOperationTracePath()}".toString()
             ]
+            if (maxProblems > 0) {
+                parameters += ["--${ConfigurationCacheProblemsOption.LONG_OPTION}=warn".toString(),]
+            }
         }
         return parameters
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import org.gradle.api.JavaVersion
 import org.gradle.api.specs.Spec
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -100,7 +101,8 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
 
     private void instantRun(String... tasks) {
         result = run(
-            "--${ConfigurationCacheOption.LONG_OPTION}=warn", // TODO on
+            "--${ConfigurationCacheOption.LONG_OPTION}",
+            "--${ConfigurationCacheProblemsOption.LONG_OPTION}=warn", // TODO remove
             *tasks
         )
     }


### PR DESCRIPTION
This PR changes the build options to configure the configuration cache for uniformity with other Gradle options.

On the command line:
```
gradle --configuration-cache
gradle --no-configuration-cache
gradle --configuration-cache-problems=[fail|warn]
```

In a `gradle.properties` file:
```
org.gradle.unsafe.configuration-cache=[true|false]
org.gradle.unsafe.configuration-cache-problems=[fail|warn]
```
