### PR TITLE
Prefer watching roots of nested builds

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -74,7 +74,7 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
         this.owner = owner;
         this.parentLease = parentLease;
         // Use a defensive copy of the build definition, as it may be mutated during build execution
-        gradleLauncher = owner.getNestedBuildFactory().nestedInstance(buildDefinition.newInstance(), this);
+        this.gradleLauncher = owner.getNestedBuildFactory().nestedInstance(buildDefinition.newInstance(), this);
     }
 
     @Override
@@ -129,6 +129,11 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
             // Not yet supported for implicit included builds
             super.assertCanAdd(includedBuildSpec);
         }
+    }
+
+    @Override
+    public File getBuildRootDir() {
+        return buildDefinition.getBuildRootDir();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -30,6 +30,8 @@ import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.util.Path;
 
+import java.io.File;
+
 class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild, Stoppable {
     private final Path identityPath;
     private final BuildState owner;
@@ -42,7 +44,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         this.identityPath = identityPath;
         this.buildDefinition = buildDefinition;
         this.owner = owner;
-        gradleLauncher = owner.getNestedBuildFactory().nestedInstance(buildDefinition, this);
+        this.gradleLauncher = owner.getNestedBuildFactory().nestedInstance(buildDefinition, this);
     }
 
     @Override
@@ -93,5 +95,10 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
         return gradleLauncher.getGradle().getIdentityPath().append(projectPath);
+    }
+
+    @Override
+    public File getBuildRootDir() {
+        return gradleLauncher.getBuildRootDir();
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -37,13 +37,15 @@ import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.internal.service.scopes.BuildTreeScopeServices;
 import org.gradle.util.Path;
 
+import java.io.File;
+
 class DefaultRootBuildState extends AbstractBuildState implements RootBuildState, Stoppable {
     private final ListenerManager listenerManager;
     private final GradleLauncher gradleLauncher;
 
     DefaultRootBuildState(BuildDefinition buildDefinition, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, BuildTreeScopeServices parentServices) {
         this.listenerManager = listenerManager;
-        gradleLauncher = gradleLauncherFactory.newInstance(buildDefinition, this, parentServices);
+        this.gradleLauncher = gradleLauncherFactory.newInstance(buildDefinition, this, parentServices);
     }
 
     @Override
@@ -63,6 +65,11 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
 
     @Override
     public void assertCanAdd(IncludedBuildSpec includedBuildSpec) {
+    }
+
+    @Override
+    public File getBuildRootDir() {
+        return gradleLauncher.getBuildRootDir();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -29,6 +29,7 @@ import org.gradle.initialization.RunNestedBuildBuildOperationType;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.NestedRootBuild;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.invocation.GradleBuildController;
@@ -37,6 +38,8 @@ import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.util.Path;
+
+import java.io.File;
 
 public class RootOfNestedBuildTree extends AbstractBuildState implements NestedRootBuild {
     private final BuildIdentifier buildIdentifier;
@@ -51,6 +54,10 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
         this.owner = owner;
         this.buildName = buildDefinition.getName() == null ? buildIdentifier.getName() : buildDefinition.getName();
         this.gradleLauncher = owner.getNestedBuildFactory().nestedBuildTree(buildDefinition, this);
+    }
+
+    public void attach() {
+        gradleLauncher.getGradle().getServices().get(BuildStateRegistry.class).attachRootBuild(this);
     }
 
     @Override
@@ -91,6 +98,11 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
         return gradleLauncher.getGradle().getIdentityPath().append(projectPath);
+    }
+
+    @Override
+    public File getBuildRootDir() {
+        return gradleLauncher.getBuildRootDir();
     }
 
     @Override

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.initialization.GradleLauncher
 import org.gradle.initialization.GradleLauncherFactory
 import org.gradle.initialization.NestedBuildFactory
 import org.gradle.internal.Actions
+import org.gradle.internal.build.BuildAddedListener
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.IncludedBuildState
 import org.gradle.internal.build.RootBuildState
@@ -43,7 +44,17 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def includedBuildFactory = Stub(IncludedBuildFactory)
-    def registry = new DefaultIncludedBuildRegistry(includedBuildFactory, Stub(IncludedBuildDependencySubstitutionsBuilder), Stub(GradleLauncherFactory), Stub(ListenerManager), Stub(BuildTreeScopeServices))
+    def buildAddedListener = Mock(BuildAddedListener)
+    def listenerManager = Stub(ListenerManager) {
+        getBroadcaster(BuildAddedListener) >> buildAddedListener
+    }
+    def registry = new DefaultIncludedBuildRegistry(
+        includedBuildFactory,
+        Stub(IncludedBuildDependencySubstitutionsBuilder),
+        Stub(GradleLauncherFactory),
+        listenerManager,
+        Stub(BuildTreeScopeServices)
+    )
 
     def "is empty by default"() {
         expect:
@@ -52,11 +63,19 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     }
 
     def "can add a root build"() {
-        expect:
+        def notifiedBuild
+        when:
         def rootBuild = registry.createRootBuild(Stub(BuildDefinition))
+        then:
+        1 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
+            notifiedBuild = addedBuild
+        }
+        0 * _
+
         !rootBuild.implicitBuild
         rootBuild.buildIdentifier == DefaultBuildIdentifier.ROOT
         rootBuild.identityPath == Path.ROOT
+        notifiedBuild.is(rootBuild)
 
         registry.getBuild(rootBuild.buildIdentifier).is(rootBuild)
     }
@@ -71,11 +90,15 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(buildIdentifier, idPath, buildDefinition, false, _) >> includedBuild
+        includedBuildFactory.createBuild(buildIdentifier, idPath, buildDefinition, false, _ as BuildState) >> includedBuild
 
-        expect:
+        when:
         def result = registry.addIncludedBuild(buildDefinition)
-        result == includedBuild
+        then:
+        1 * buildAddedListener.buildAdded(includedBuild)
+        0 * _
+
+        result.is includedBuild
 
         registry.hasIncludedBuilds()
         registry.includedBuilds as List == [includedBuild]
@@ -162,11 +185,15 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(new DefaultBuildIdentifier("b1"), Path.path(":b1"), buildDefinition, true, _) >> includedBuild
+        includedBuildFactory.createBuild(new DefaultBuildIdentifier("b1"), Path.path(":b1"), buildDefinition, true, _ as BuildState) >> includedBuild
 
-        expect:
+        when:
         def result = registry.addImplicitIncludedBuild(buildDefinition)
-        result == includedBuild
+        then:
+        1 * buildAddedListener.buildAdded(includedBuild)
+        0 * _
+
+        result.is(includedBuild)
 
         registry.hasIncludedBuilds()
         registry.includedBuilds as List == [includedBuild]
@@ -178,12 +205,20 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         buildDefinition.name >> "buildSrc"
         registry.attachRootBuild(rootBuild())
         def owner = Stub(BuildState) { getIdentityPath() >> Path.ROOT }
+        def notifiedBuild
 
-        expect:
+        when:
         def nestedBuild = registry.addBuildSrcNestedBuild(buildDefinition, owner)
+        then:
+        1 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
+            notifiedBuild = addedBuild
+        }
+        0 * _
+
         nestedBuild.implicitBuild
         nestedBuild.buildIdentifier == new DefaultBuildIdentifier("buildSrc")
         nestedBuild.identityPath == Path.path(":buildSrc")
+        notifiedBuild.is(nestedBuild)
 
         registry.getBuild(nestedBuild.buildIdentifier).is(nestedBuild)
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -29,10 +29,12 @@ import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -113,6 +115,11 @@ public class DefaultGradleLauncher implements GradleLauncher {
     public GradleInternal getConfiguredBuild() {
         doBuildStages(Stage.Configure);
         return gradle;
+    }
+
+    @Override
+    public File getBuildRootDir() {
+        return buildServices.get(BuildLayout.class).getRootDirectory();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -179,7 +179,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
         RuntimeException reportableFailure = stageFailure == null ? null : exceptionAnalyser.transform(stageFailure);
         BuildResult buildResult = new BuildResult(action, gradle, reportableFailure);
-        List<Throwable> failures = new ArrayList<Throwable>();
+        List<Throwable> failures = new ArrayList<>();
         includedBuildControllers.finishBuild(failures);
         try {
             buildListener.buildFinished(buildResult);
@@ -253,7 +253,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
             throw new IllegalStateException("Cannot execute tasks: current stage = " + stage);
         }
 
-        List<Throwable> taskFailures = new ArrayList<Throwable>();
+        List<Throwable> taskFailures = new ArrayList<>();
         buildExecuter.execute(gradle, taskFailures);
         if (!taskFailures.isEmpty()) {
             throw new MultipleBuildFailures(taskFailures);

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -31,12 +31,12 @@ import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.build.BuildState;
-import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.build.NestedRootBuild;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.featurelifecycle.DeprecatedUsageBuildOperationProgressBroadcaster;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
@@ -52,7 +52,6 @@ import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.time.Time;
 import org.gradle.invocation.DefaultGradle;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -179,7 +178,6 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             BuildRequestMetaData buildRequestMetaData = new DefaultBuildRequestMetaData(Time.currentTimeMillis());
             BuildSessionScopeServices sessionScopeServices = new BuildSessionScopeServices(userHomeServices, crossBuildSessionScopeServices, startParameter, buildRequestMetaData, ClassPath.EMPTY, buildCancellationToken, buildRequestMetaData.getClient(), new NoOpBuildEventConsumer());
             BuildTreeScopeServices buildTreeScopeServices = new BuildTreeScopeServices(sessionScopeServices);
-            buildTreeScopeServices.get(BuildStateRegistry.class).attachRootBuild(build);
             return doNewInstance(buildDefinition, build, parent, buildTreeScopeServices, ImmutableList.of(buildTreeScopeServices, sessionScopeServices, new Stoppable() {
                 @Override
                 public void stop() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -19,6 +19,8 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.internal.concurrent.Stoppable;
 
+import java.io.File;
+
 /**
  * This was the old Gradle embedding API (it used to be in the public `org.gradle` package). It is now internal and is due to be merged into {@link org.gradle.internal.invocation.BuildController} and {@link org.gradle.internal.build.BuildState}.
  */
@@ -39,6 +41,8 @@ public interface GradleLauncher extends Stoppable {
      * @return The configured Gradle build instance.
      */
     GradleInternal getConfiguredBuild();
+
+    File getBuildRootDir();
 
     /**
      * Schedules the specified tasks for this build.

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -17,6 +17,7 @@ package org.gradle.initialization;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.concurrent.Stoppable;
 
 import java.io.File;
@@ -42,6 +43,11 @@ public interface GradleLauncher extends Stoppable {
      */
     GradleInternal getConfiguredBuild();
 
+    /**
+     * The root directory of the build, never null.
+     *
+     * @see BuildLayout#getRootDirectory()
+     */
     File getBuildRootDir();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildAddedListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildAddedListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.internal.service.scopes.EventScope;
+import org.gradle.internal.service.scopes.Scopes;
+
+/**
+ * Listener for changes to the {@link BuildStateRegistry}.
+ */
+@EventScope(Scopes.BuildTree)
+public interface BuildAddedListener {
+    /**
+     * Called every time a build is added to the {@link BuildStateRegistry}.
+     *
+     * The first call is always for the root build.
+     */
+    void buildAdded(BuildState buildState);
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -23,6 +23,8 @@ import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.util.Path;
 
+import java.io.File;
+
 /**
  * Encapsulates the identity and state of a particular build in a build tree.
  *
@@ -77,4 +79,9 @@ public interface BuildState {
      * Asserts that the given build can be included by this build.
      */
     void assertCanAdd(IncludedBuildSpec includedBuildSpec);
+
+    /**
+     * The root directory of the build.
+     */
+    File getBuildRootDir();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.service.scopes;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.RootBuildLifecycleListener;
@@ -52,7 +53,7 @@ class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListe
             }
         }
         virtualFileSystem.afterBuildStarted(watchFileSystem);
-        gradle.settingsEvaluated(settings -> virtualFileSystem.updateProjectRootDirectory(settings.getRootDir()));
+        gradle.settingsEvaluated(settings -> virtualFileSystem.updateProjectRootDirectories(ImmutableList.of(settings.getRootDir())));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemBuildLifecycleListener.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.service.scopes;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.RootBuildLifecycleListener;
@@ -53,7 +52,6 @@ class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListe
             }
         }
         virtualFileSystem.afterBuildStarted(watchFileSystem);
-        gradle.settingsEvaluated(settings -> virtualFileSystem.updateProjectRootDirectories(ImmutableList.of(settings.getRootDir())));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -40,6 +40,7 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.initialization.layout.ProjectCacheDir;
+import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.classloader.ClasspathHasher;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.OutputChangeListener;
@@ -189,6 +190,9 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             listenerManager.addListener(new VirtualFileSystemBuildLifecycleListener(
                 watchingAwareVirtualFileSystem
             ));
+            listenerManager.addListener((BuildAddedListener) buildState ->
+                watchingAwareVirtualFileSystem.buildRootDirectoryAdded(buildState.getBuildRootDir())
+            );
             return watchingAwareVirtualFileSystem;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -21,7 +21,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
@@ -114,7 +113,7 @@ public class ProjectBuilderImpl {
         buildServices.get(BuildStateRegistry.class).attachRootBuild(build);
 
         GradleInternal gradle = buildServices.get(InstantiatorFactory.class).decorateLenient().newInstance(DefaultGradle.class, null, startParameter, buildServices.get(ServiceRegistryFactory.class));
-        gradle.setIncludedBuilds(Collections.<IncludedBuild>emptyList());
+        gradle.setIncludedBuilds(Collections.emptyList());
 
         ProjectDescriptorRegistry projectDescriptorRegistry = buildServices.get(ProjectDescriptorRegistry.class);
         DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null, name, projectDir, projectDescriptorRegistry, buildServices.get(FileResolver.class));

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -107,7 +107,7 @@ public class ProjectBuilderImpl {
         BuildSessionScopeServices buildSessionScopeServices = new BuildSessionScopeServices(userHomeServices, crossBuildSessionScopeServices, startParameter, buildRequestMetaData, ClassPath.EMPTY, new DefaultBuildCancellationToken(), buildRequestMetaData.getClient(), new NoOpBuildEventConsumer());
         BuildTreeScopeServices buildTreeScopeServices = new BuildTreeScopeServices(buildSessionScopeServices);
         TestBuildScopeServices buildServices = new TestBuildScopeServices(buildTreeScopeServices, homeDir);
-        TestRootBuild build = new TestRootBuild();
+        TestRootBuild build = new TestRootBuild(projectDir);
         buildServices.add(BuildState.class, build);
 
         buildServices.get(BuildStateRegistry.class).attachRootBuild(build);
@@ -175,6 +175,12 @@ public class ProjectBuilderImpl {
     }
 
     private static class TestRootBuild extends AbstractBuildState implements RootBuildState {
+        private final File rootProjectDir;
+
+        public TestRootBuild(File rootProjectDir) {
+            this.rootProjectDir = rootProjectDir;
+        }
+
         @Override
         public BuildIdentifier getBuildIdentifier() {
             return DefaultBuildIdentifier.ROOT;
@@ -227,6 +233,11 @@ public class ProjectBuilderImpl {
                 name = "root";
             }
             return new DefaultProjectComponentIdentifier(getBuildIdentifier(), projectPath, projectPath, name);
+        }
+
+        @Override
+        public File getBuildRootDir() {
+            return rootProjectDir;
         }
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -25,14 +25,14 @@ import java.util.Collection;
 
 public interface FileWatcherUpdater extends SnapshotHierarchy.SnapshotDiffListener {
     /**
-     * Changes the project root directory, e.g. when the same daemon is used on a different project.
+     * Changes the project root directories, e.g. when the same daemon is used on a different project.
      *
-     * Hierarchical watchers use project root directory to minimize the number of watched roots
-     * by watching the project root instead of watching directories inside.
+     * The project root directories are used by hierarchical watchers to minimize the number of watched roots
+     * by watching the project roots instead of watching directories inside.
      *
      * @throws WatchingNotSupportedException when the native watchers can't be updated.
      */
-    void updateProjectRootDirectory(File projectRoot);
+    void updateProjectRootDirectories(Collection<File> updatedProjectRootDirectories);
 
     /**
      * {@inheritDoc}.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -79,10 +79,11 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private void updateWatchedDirectories() {
         Set<Path> directoriesToWatch = new HashSet<>();
         shouldWatchDirectories.elementSet().forEach(shouldWatchDirectory -> {
+            String shouldWatchDirectoryPathString = shouldWatchDirectory.toString();
             for (Map.Entry<Path, String> entry : projectRootDirectories.entrySet()) {
                 Path projectRootDirectory = entry.getKey();
                 String projectRootDirectoryPrefix = entry.getValue();
-                if (shouldWatchDirectory.toString().startsWith(projectRootDirectoryPrefix)) {
+                if (shouldWatchDirectoryPathString.startsWith(projectRootDirectoryPrefix)) {
                     directoriesToWatch.add(projectRootDirectory);
                     return;
                 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -80,8 +80,10 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         Set<Path> directoriesToWatch = new HashSet<>();
         shouldWatchDirectories.elementSet().forEach(shouldWatchDirectory -> {
             for (Map.Entry<Path, String> entry : projectRootDirectories.entrySet()) {
-                if (shouldWatchDirectory.toString().startsWith(entry.getValue())) {
-                    directoriesToWatch.add(entry.getKey());
+                Path projectRootDirectory = entry.getKey();
+                String projectRootDirectoryPrefix = entry.getValue();
+                if (shouldWatchDirectory.toString().startsWith(projectRootDirectoryPrefix)) {
+                    directoriesToWatch.add(projectRootDirectory);
                     return;
                 }
             }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -28,9 +28,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,9 +43,9 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private final Map<String, ImmutableList<Path>> watchedRootsForSnapshot = new HashMap<>();
     private final Multiset<Path> shouldWatchDirectories = HashMultiset.create();
     private final Set<Path> watchedRoots = new HashSet<>();
+    private final List<Path> projectRootDirectories = new ArrayList<>();
+    private final List<String> projectRootDirectoryPrefixes = new ArrayList<>();
     private final FileWatcher watcher;
-    private Path projectRootDirectory;
-    private String projectRootDirectoryPrefix;
 
     public HierarchicalFileWatcherUpdater(FileWatcher watcher) {
         this.watcher = watcher;
@@ -64,19 +66,32 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public void updateProjectRootDirectory(File projectRoot) {
-        projectRootDirectory = projectRoot.toPath().toAbsolutePath();
-        projectRootDirectoryPrefix = projectRootDirectory.toString() + File.separator;
+    public void updateProjectRootDirectories(Collection<File> updatedProjectRootDirectories) {
+        Set<Path> rootPaths = updatedProjectRootDirectories.stream()
+            .map(File::toPath)
+            .map(Path::toAbsolutePath)
+            .collect(Collectors.toSet());
+        projectRootDirectories.clear();
+        projectRootDirectories.addAll(WatchRootUtil.resolveRootsToWatch(rootPaths));
+        projectRootDirectoryPrefixes.clear();
+        projectRootDirectories.stream()
+            .map(path -> path.toString() + File.separator)
+            .forEach(projectRootDirectoryPrefixes::add);
 
         updateWatchedDirectories();
     }
 
     private void updateWatchedDirectories() {
-        Set<Path> directoriesToWatch = shouldWatchDirectories.elementSet().stream()
-            .map(shouldWatchDirectory -> projectRootDirectoryPrefix != null && shouldWatchDirectory.toString().startsWith(projectRootDirectoryPrefix)
-                ? projectRootDirectory
-                : shouldWatchDirectory)
-            .collect(Collectors.toSet());
+        Set<Path> directoriesToWatch = new HashSet<>();
+        shouldWatchDirectories.elementSet().forEach(shouldWatchDirectory -> {
+            for (int i = 0; i < projectRootDirectoryPrefixes.size(); i++) {
+                String prefix = projectRootDirectoryPrefixes.get(i);
+                if (shouldWatchDirectory.toString().startsWith(prefix)) {
+                    directoriesToWatch.add(projectRootDirectories.get(i));
+                }
+            }
+            directoriesToWatch.add(shouldWatchDirectory);
+        });
 
         updateWatchedDirectories(WatchRootUtil.resolveRootsToWatch(directoriesToWatch));
     }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -28,11 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,8 +41,7 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private final Map<String, ImmutableList<Path>> watchedRootsForSnapshot = new HashMap<>();
     private final Multiset<Path> shouldWatchDirectories = HashMultiset.create();
     private final Set<Path> watchedRoots = new HashSet<>();
-    private final List<Path> projectRootDirectories = new ArrayList<>();
-    private final List<String> projectRootDirectoryPrefixes = new ArrayList<>();
+    private final Map<Path, String> projectRootDirectories = new HashMap<>();
     private final FileWatcher watcher;
 
     public HierarchicalFileWatcherUpdater(FileWatcher watcher) {
@@ -72,22 +69,20 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
             .map(Path::toAbsolutePath)
             .collect(Collectors.toSet());
         projectRootDirectories.clear();
-        projectRootDirectories.addAll(WatchRootUtil.resolveRootsToWatch(rootPaths));
-        projectRootDirectoryPrefixes.clear();
-        projectRootDirectories.stream()
-            .map(path -> path.toString() + File.separator)
-            .forEach(projectRootDirectoryPrefixes::add);
-
+        for (Path rootPathToWatch : WatchRootUtil.resolveRootsToWatch(rootPaths)) {
+            projectRootDirectories.put(rootPathToWatch, rootPathToWatch.toString() + File.separator);
+        }
+        LOGGER.info("Now considering {} as root directories to watch", projectRootDirectories.keySet());
         updateWatchedDirectories();
     }
 
     private void updateWatchedDirectories() {
         Set<Path> directoriesToWatch = new HashSet<>();
         shouldWatchDirectories.elementSet().forEach(shouldWatchDirectory -> {
-            for (int i = 0; i < projectRootDirectoryPrefixes.size(); i++) {
-                String prefix = projectRootDirectoryPrefixes.get(i);
-                if (shouldWatchDirectory.toString().startsWith(prefix)) {
-                    directoriesToWatch.add(projectRootDirectories.get(i));
+            for (Map.Entry<Path, String> entry : projectRootDirectories.entrySet()) {
+                if (shouldWatchDirectory.toString().startsWith(entry.getValue())) {
+                    directoriesToWatch.add(entry.getKey());
+                    return;
                 }
             }
             directoriesToWatch.add(shouldWatchDirectory);
@@ -106,7 +101,6 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         if (newWatchRoots.isEmpty() && watchRootsToRemove.isEmpty()) {
             return;
         }
-        LOGGER.info("Watching {} directory hierarchies to track changes", newWatchRoots.size());
         if (!watchRootsToRemove.isEmpty()) {
             watcher.stopWatching(watchRootsToRemove.stream()
                 .map(Path::toFile)
@@ -121,5 +115,6 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
             );
             watchedRoots.addAll(newWatchRoots);
         }
+        LOGGER.info("Watching {} directory hierarchies to track changes", watchedRoots.size());
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -71,7 +71,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public void updateProjectRootDirectory(File projectRoot) {
+    public void updateProjectRootDirectories(Collection<File> updatedProjectRootDirectories) {
     }
 
     private void updateWatchedDirectories(Map<String, Integer> changedWatchDirectories) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchingAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchingAwareVirtualFileSystem.java
@@ -19,6 +19,7 @@ package org.gradle.internal.watch.vfs;
 import org.gradle.internal.vfs.VirtualFileSystem;
 
 import java.io.File;
+import java.util.Collection;
 
 /**
  * A {@link VirtualFileSystem} that can be instructed to try to maintain its
@@ -32,10 +33,10 @@ public interface WatchingAwareVirtualFileSystem extends VirtualFileSystem {
     void afterBuildStarted(boolean watchingEnabled);
 
     /**
-     * Called when there is a change to project root directory,
+     * Called when there is a change to project root directories,
      * normally when settings have been evaluated.
      */
-    void updateProjectRootDirectory(File projectRootDirectory);
+    void updateProjectRootDirectories(Collection<File> projectRootDirectories);
 
     /**
      * Called when the build is finished.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchingAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchingAwareVirtualFileSystem.java
@@ -19,7 +19,6 @@ package org.gradle.internal.watch.vfs;
 import org.gradle.internal.vfs.VirtualFileSystem;
 
 import java.io.File;
-import java.util.Collection;
 
 /**
  * A {@link VirtualFileSystem} that can be instructed to try to maintain its
@@ -33,10 +32,12 @@ public interface WatchingAwareVirtualFileSystem extends VirtualFileSystem {
     void afterBuildStarted(boolean watchingEnabled);
 
     /**
-     * Called when there is a change to project root directories,
-     * normally when settings have been evaluated.
+     * Called when a new build (aka project) root directory has been added.
+     *
+     * This method is first called for the root directory of the root project.
+     * It is also called for the root directories of included builds, and all other nested builds.
      */
-    void updateProjectRootDirectories(Collection<File> projectRootDirectories);
+    void buildRootDirectoryAdded(File buildRootDirectory);
 
     /**
      * Called when the build is finished.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/NonWatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/NonWatchingVirtualFileSystem.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Collection;
 
 /**
  * A {@link org.gradle.internal.vfs.VirtualFileSystem} which is not able to register any watches.
@@ -43,7 +44,7 @@ public class NonWatchingVirtualFileSystem extends AbstractDelegatingVirtualFileS
     }
 
     @Override
-    public void updateProjectRootDirectory(File projectRootDirectory) {
+    public void updateProjectRootDirectories(Collection<File> projectRootDirectories) {
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/NonWatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/NonWatchingVirtualFileSystem.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Collection;
 
 /**
  * A {@link org.gradle.internal.vfs.VirtualFileSystem} which is not able to register any watches.
@@ -44,7 +43,7 @@ public class NonWatchingVirtualFileSystem extends AbstractDelegatingVirtualFileS
     }
 
     @Override
-    public void updateProjectRootDirectories(Collection<File> projectRootDirectories) {
+    public void buildRootDirectoryAdded(File buildRootDirectory) {
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -39,6 +39,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -108,8 +109,8 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     }
 
     @Override
-    public void updateProjectRootDirectory(File projectRootDirectory) {
-        updateWatchRegistry(watchRegistry -> watchRegistry.getFileWatcherUpdater().updateProjectRootDirectory(projectRootDirectory));
+    public void updateProjectRootDirectories(Collection<File> projectRootDirectories) {
+        updateWatchRegistry(watchRegistry -> watchRegistry.getFileWatcherUpdater().updateProjectRootDirectories(projectRootDirectories));
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -56,7 +56,7 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
     private final DelegatingDiffCapturingUpdateFunctionDecorator delegatingUpdateFunctionDecorator;
     private final AtomicReference<FileHierarchySet> producedByCurrentBuild = new AtomicReference<>(DefaultFileHierarchySet.of());
     private final Predicate<String> watchFilter;
-    private final Set<File> buildRootDirectories = new HashSet<>();
+    private final Set<File> buildRootDirectoriesForWatching = new HashSet<>();
 
     private FileWatcherRegistry watchRegistry;
 
@@ -112,16 +112,16 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
 
     @Override
     public void buildRootDirectoryAdded(File buildRootDirectory) {
-        synchronized (buildRootDirectories) {
-            buildRootDirectories.add(buildRootDirectory);
-            updateWatchRegistry(watchRegistry -> watchRegistry.getFileWatcherUpdater().updateProjectRootDirectories(buildRootDirectories));
+        synchronized (buildRootDirectoriesForWatching) {
+            buildRootDirectoriesForWatching.add(buildRootDirectory);
+            updateWatchRegistry(watchRegistry -> watchRegistry.getFileWatcherUpdater().updateProjectRootDirectories(buildRootDirectoriesForWatching));
         }
     }
 
     @Override
     public void beforeBuildFinished(boolean watchingEnabled) {
-        synchronized (buildRootDirectories) {
-            buildRootDirectories.clear();
+        synchronized (buildRootDirectoriesForWatching) {
+            buildRootDirectoriesForWatching.clear();
         }
         if (watchingEnabled) {
             getRoot().update(currentRoot -> {
@@ -188,7 +188,7 @@ public class WatchingVirtualFileSystem extends AbstractDelegatingVirtualFileSyst
                     stopWatchingAndInvalidateHierarchy();
                 }
             });
-            watchRegistry.getFileWatcherUpdater().updateProjectRootDirectories(buildRootDirectories);
+            watchRegistry.getFileWatcherUpdater().updateProjectRootDirectories(buildRootDirectoriesForWatching);
             delegatingUpdateFunctionDecorator.setSnapshotDiffListener(snapshotDiffListener, this::handleWatcherChangeErrors);
             long endTime = System.currentTimeMillis() - startTime;
             LOGGER.warn("Spent {} ms registering watches for file system events", endTime);

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -50,7 +50,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     def decorator = new DelegatingDiffCapturingUpdateFunctionDecorator({ String path -> true})
     def root = DefaultSnapshotHierarchy.empty(CaseSensitivity.CASE_SENSITIVE)
 
-    def updater
+    FileWatcherUpdater updater
 
     def setup() {
         updater = createUpdater(watcher)

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -26,13 +26,12 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         new NonHierarchicalFileWatcherUpdater(watcher)
     }
 
-    def "ignores project root directory"() {
-        def projectRootDirectory = file("first").createDir()
-        def secondProjectRootDirectory = file("second").createDir()
-        def fileInProjectRootDirectory = projectRootDirectory.file("inside/root/dir/file.txt")
+    def "ignores project root directories"() {
+        def projectRootDirectories = ["first", "second", "third"].collect { file(it).createDir() }
+        def fileInProjectRootDirectory = file("first/inside/root/dir/file.txt")
 
         when:
-        updater.updateProjectRootDirectory(projectRootDirectory)
+        updater.updateProjectRootDirectories(projectRootDirectories)
         then:
         0 * _
 
@@ -44,7 +43,7 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         0 * _
 
         when:
-        updater.updateProjectRootDirectory(secondProjectRootDirectory)
+        updater.updateProjectRootDirectories([])
         then:
         0 * _
     }


### PR DESCRIPTION
For nested builds, like included builds, the hierarchical watcher would watch the respective root directories as well.

To this end, we introduce a listener when builds are added in the `BuildStateRegistry`. This listener works as well when instant execution is enabled.