### PR TITLE
More fixes for configuration cache and artifact transforms of file dependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -22,12 +22,14 @@ import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
-import org.gradle.api.internal.artifacts.transform.ConsumerProvidedResolvedVariant;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.Transformation;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeRegistry;
+import org.gradle.api.internal.artifacts.transform.TransformedExternalArtifactSet;
+import org.gradle.api.internal.artifacts.transform.TransformedProjectArtifactSet;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -132,7 +134,11 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
     @Override
     public ResolvedArtifactSet asTransformed(ResolvedArtifactSet artifacts, AttributeContainerInternal targetAttributes, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver, TransformationNodeRegistry transformationNodeRegistry) {
-        return new ConsumerProvidedResolvedVariant(componentIdentifier, artifacts, targetAttributes, transformation, dependenciesResolver, transformationNodeRegistry);
+        if (componentIdentifier instanceof ProjectComponentIdentifier) {
+            return new TransformedProjectArtifactSet(componentIdentifier, artifacts, targetAttributes, transformation, dependenciesResolver, transformationNodeRegistry);
+        } else {
+            return new TransformedExternalArtifactSet(componentIdentifier, artifacts, targetAttributes, transformation, dependenciesResolver, transformationNodeRegistry);
+        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+import java.util.Map;
+
+/**
+ * Transformed artifact set that performs the transformation itself when visited.
+ */
+public abstract class AbstractTransformedArtifactSet implements ResolvedArtifactSet {
+    private final ResolvedArtifactSet delegate;
+    private final AttributeContainerInternal attributes;
+    private final Transformation transformation;
+    private final TransformationNodeRegistry transformationNodeRegistry;
+    private final ExecutionGraphDependenciesResolver dependenciesResolver;
+
+    public AbstractTransformedArtifactSet(
+        ComponentIdentifier componentIdentifier,
+        ResolvedArtifactSet delegate,
+        AttributeContainerInternal target,
+        Transformation transformation,
+        ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory,
+        TransformationNodeRegistry transformationNodeRegistry
+    ) {
+        this.delegate = delegate;
+        this.attributes = target;
+        this.transformation = transformation;
+        this.transformationNodeRegistry = transformationNodeRegistry;
+        this.dependenciesResolver = dependenciesResolverFactory.create(componentIdentifier);
+    }
+
+    protected abstract FileCollectionInternal.Source getVisitSource();
+
+    protected ExecutionGraphDependenciesResolver getDependenciesResolver() {
+        return dependenciesResolver;
+    }
+
+    @Override
+    public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
+        FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(getVisitSource());
+        if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
+            return visitor -> visitor.endVisitCollection(getVisitSource());
+        }
+        Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
+        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, actions, artifactResults, dependenciesResolver, transformationNodeRegistry));
+        return new TransformCompletion(result, attributes, artifactResults);
+    }
+
+    @Override
+    public void visitLocalArtifacts(LocalArtifactVisitor listener) {
+        // Should never be called
+        throw new IllegalStateException();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -35,7 +35,8 @@ public class DefaultExtraExecutionGraphDependenciesResolverFactory implements Ex
     }
 
     @Override
-    public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier) {
+    public ExecutionGraphDependenciesResolver
+    create(ComponentIdentifier componentIdentifier) {
         return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction, filteredResultFactory);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+
+/**
+ * An artifact set containing transformed external artifacts.
+ */
+public class TransformedExternalArtifactSet extends AbstractTransformedArtifactSet {
+    public TransformedExternalArtifactSet(
+        ComponentIdentifier componentIdentifier,
+        ResolvedArtifactSet delegate,
+        AttributeContainerInternal target,
+        Transformation transformation,
+        ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory,
+        TransformationNodeRegistry transformationNodeRegistry
+    ) {
+        super(componentIdentifier, delegate, target, transformation, dependenciesResolverFactory, transformationNodeRegistry);
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+    }
+
+    @Override
+    protected FileCollectionInternal.Source getVisitSource() {
+        return FileCollectionInternal.OTHER;
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -136,15 +136,28 @@ class Codecs(
         bind(AttributeContainerCodec(attributesFactory, managedFactoryRegistry))
         bind(TransformationNodeReferenceCodec)
         bind(TransformationStepCodec(projectStateRegistry, fingerprinterRegistry))
-        bind(DefaultTransformerCodec(BindingsBackedCodec {
-            bind(BeanCodec())
-        }, buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
+        bind(DefaultTransformerCodec(buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
         bind(LegacyTransformerCodec(actionScheme))
+        bind(ResolvableArtifactCodec)
 
         bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))
 
         bind(TaskReferenceCodec)
+
+        bind(IsolatedManagedValueCodec(managedFactoryRegistry))
+        bind(IsolatedImmutableManagedValueCodec(managedFactoryRegistry))
+        bind(IsolatedArrayCodec)
+        bind(IsolatedSetCodec)
+        bind(IsolatedListCodec)
+        bind(IsolatedMapCodec)
+        bind(MapEntrySnapshotCodec)
+        bind(IsolatedEnumValueSnapshotCodec)
+        bind(StringValueSnapshotCodec)
+        bind(IntegerValueSnapshotCodec)
+        bind(FileValueSnapshotCodec)
+        bind(BooleanValueSnapshotCodec)
+        bind(NullValueSnapshotCodec)
 
         bind(ownerServiceCodec<ProviderFactory>())
         bind(ownerServiceCodec<ObjectFactory>())
@@ -179,36 +192,17 @@ class Codecs(
     }
 
     val internalTypesCodec = BindingsBackedCodec {
-
         baseTypes()
 
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
         fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
 
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
-        bind(InitialTransformationNodeCodec(buildOperationExecutor, transformListener))
-        bind(ChainedTransformationNodeCodec(buildOperationExecutor, transformListener))
+        bind(InitialTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
+        bind(ChainedTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
         bind(ActionNodeCodec)
+
         bind(ResolvableArtifactCodec)
-        bind(TransformationStepCodec(projectStateRegistry, fingerprinterRegistry))
-        bind(DefaultTransformerCodec(userTypesCodec, buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
-        bind(LegacyTransformerCodec(actionScheme))
-
-        bind(ImmutableAttributesCodec(attributesFactory, managedFactoryRegistry))
-
-        bind(IsolatedManagedValueCodec(managedFactoryRegistry))
-        bind(IsolatedImmutableManagedValueCodec(managedFactoryRegistry))
-        bind(IsolatedArrayCodec)
-        bind(IsolatedSetCodec)
-        bind(IsolatedListCodec)
-        bind(IsolatedMapCodec)
-        bind(MapEntrySnapshotCodec)
-        bind(IsolatedEnumValueSnapshotCodec)
-        bind(StringValueSnapshotCodec)
-        bind(IntegerValueSnapshotCodec)
-        bind(FileValueSnapshotCodec)
-        bind(BooleanValueSnapshotCodec)
-        bind(NullValueSnapshotCodec)
 
         bind(NotImplementedCodec)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -132,7 +132,7 @@ class CollectingVisitor : FileCollectionStructureVisitor {
     }
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
-        if (source is ConsumerProvidedVariantFiles && source.scheduledNodes.isNotEmpty()) {
+        if (source is ConsumerProvidedVariantFiles) {
             // Some transforms are scheduled, so visit the source rather than the files
             return FileCollectionStructureVisitor.VisitType.NoContents
         } else if (source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet && source.isBuildable) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/DefaultTransformerCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/DefaultTransformerCodec.kt
@@ -30,7 +30,6 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.readClassOf
 import org.gradle.instantexecution.serialization.readNonNull
-import org.gradle.instantexecution.serialization.withCodec
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.isolation.Isolatable
@@ -42,7 +41,6 @@ import org.gradle.internal.snapshot.ValueSnapshotter
 
 internal
 class DefaultTransformerCodec(
-    private val userTypesCodec: Codec<Any?>,
     private val buildOperationExecutor: BuildOperationExecutor,
     private val classLoaderHierarchyHasher: ClassLoaderHierarchyHasher,
     private val isolatableFactory: IsolatableFactory,
@@ -68,7 +66,7 @@ class DefaultTransformerCodec(
             write(value.isolatedParameters.isolatedParameterObject)
         } else {
             writeBoolean(false)
-            withCodec(userTypesCodec) { write(value.parameterObject) }
+            write(value.parameterObject)
         }
     }
 
@@ -88,7 +86,7 @@ class DefaultTransformerCodec(
             val isolatedParameters = readNonNull<Isolatable<TransformParameters>>()
             isolatedParametersObject = DefaultTransformer.IsolatedParameters(isolatedParameters, secondaryInputsHash)
         } else {
-            parametersObject = withCodec(userTypesCodec) { read() as TransformParameters? }
+            parametersObject = read() as TransformParameters?
             isolatedParametersObject = null
         }
         return DefaultTransformer(


### PR DESCRIPTION

### Context

Follow on for #13314, to correctly serialize transform parameters to the configuration cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
