### PR TITLE
Update list of install tasks

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
@@ -350,7 +350,7 @@ abstract class BuildTimestampFromBuildReceipt : ValueSource<String, BuildTimesta
 private
 fun Project.isRunningInstallTask() =
     listOf("install", "installAll")
-        .flatMap { listOf(":$it", it) }
+        .flatMap { listOf(":distributions:$it", "distributions:$it", it) }
         .any(gradle.startParameter.taskNames::contains)
 
 


### PR DESCRIPTION
in `BuildVersionPlugin` so all built distributions
have a unique version number.

When the `install` task moved to the `distributions` project, the task list which causes local build to use unique versions has not been updated. I suppose that was an oversight.