### PR TITLE
Introduce stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,84 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+pulls:
+  # XXX: We'll only match very few issues to ensure the bot works as expected
+  # daysUntilStale: 365
+  daysUntilStale: 1200
+
+  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 21
+
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had recent activity.
+    Given the limited bandwidth of the team, it will be closed if no further activity occurs.
+    If you intend to work on this pull request, please reopen the PR.
+    Thank you for your contributions.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    This pull request has been automatically closed due to inactivity.
+    If you are still interested in contributing this, please ensure that
+    it is rebased against the latest branch (usually `master`), all review
+    comments have been adressed and the build is passing.
+
+issues:
+  # XXX: We'll only match very few issues to ensure the bot works as expected
+  # daysUntilStale: 365
+  daysUntilStale: 1200
+
+  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 21
+
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had recent activity.
+    Given the limited bandwidth of the team, it will be automatically closed if no further
+    activity occurs. If you're interested how we try to keep the backlog in a healty state, 
+    please read our [blog post on working with a large community](XXXX).
+    If you feel this is something you could contribute, please have a look
+    at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
+    Thank you for your contribution.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    This issue has been automatically closed due to inactivity. If you can reproduce this on a
+    recent version of Gradle or if you have a good use case for this feature, please feel free
+    to reopen the issue with steps to reproduce, a quick explanation of your use case or a
+    high-quality pull request.
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+#onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+# exemptLabels:
+#   - pinned
+#   - security
+#   - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+#exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+#exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: closed:stale
+
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -69,7 +69,7 @@ exemptMilestones: true
 #exemptAssignees: false
 
 # Label to use when marking as stale
-staleLabel: closed:stale
+staleLabel: stale
 
 
 # Comment to post when removing the stale label.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,23 +1,25 @@
 # Configuration for probot-stale - https://github.com/probot/stale
+# Configuration options apply to both Issues and Pull Requests.
+# We configure those individually to match our workflow (see `pulls:` and `issues:`)
 
-# Number of days of inactivity before an Issue or Pull Request becomes stale
 pulls:
-  # XXX: We'll only match very few issues to ensure the bot works as expected
-  # XXX: Once working, we're going to reduce the stale window incrementally
+  # Number of days of inactivity before a Pull Request becomes stale
+  # TODO: We'll only match very few Pull Requests to ensure the bot works as expected
+  # Once working, we're going to reduce the stale window incrementally
   daysUntilStale: 1250
 
-  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  # Number of days of inactivity before a Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, Pull Request still need to be closed manually, but will remain marked as stale.
   daysUntilClose: 21
 
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
-    This issue has been automatically marked as stale because it has not had recent activity.
+    This pull request has been automatically marked as stale because it has not had recent activity.
     Given the limited bandwidth of the team, it will be closed if no further activity occurs.
     If you intend to work on this pull request, please reopen the PR.
     Thank you for your contributions.
 
-  # Comment to post when closing a stale Issue or Pull Request.
+  # Comment to post when closing a stale Pull Request.
   closeComment: >
     This pull request has been automatically closed due to inactivity.
     If you are still interested in contributing this, please ensure that
@@ -25,11 +27,11 @@ pulls:
     comments have been addressed and the build is passing.
 
 issues:
-  # XXX: We'll only match very few issues to ensure the bot works as expected
-  # XXX: Once working, we're going to reduce the stale window incrementally
+  # TODO: We'll only match very few issues to ensure the bot works as expected
+  # Once working, we're going to reduce the stale window incrementally
   daysUntilStale: 1250
 
-  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Number of days of inactivity before an Issue with the stale label is closed.
   # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
   daysUntilClose: 21
 
@@ -43,7 +45,7 @@ issues:
     at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
     Thank you for your contribution.
 
-  # Comment to post when closing a stale Issue or Pull Request.
+  # Comment to post when closing a stale Issue.
   closeComment: >
     This issue has been automatically closed due to inactivity. If you can reproduce this on a
     recent version of Gradle or if you have a good use case for this feature, please feel free

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,18 +3,18 @@
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 pulls:
   # XXX: We'll only match very few issues to ensure the bot works as expected
-  # daysUntilStale: 365
-  daysUntilStale: 1200
+    # XXX: Once working, we're going to reduce the stale window incrementally
+    daysUntilStale: 1250
 
-  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-  daysUntilClose: 21
+    # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+    # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+    daysUntilClose: 21
 
-  # Comment to post when marking as stale. Set to `false` to disable
-  markComment: >
-    This issue has been automatically marked as stale because it has not had recent activity.
-    Given the limited bandwidth of the team, it will be closed if no further activity occurs.
-    If you intend to work on this pull request, please reopen the PR.
+    # Comment to post when marking as stale. Set to `false` to disable
+    markComment: >
+        This issue has been automatically marked as stale because it has not had recent activity.
+        Given the limited bandwidth of the team, it will be closed if no further activity occurs.
+        If you intend to work on this pull request, please reopen the PR.
     Thank you for your contributions.
 
   # Comment to post when closing a stale Issue or Pull Request.
@@ -22,22 +22,22 @@ pulls:
     This pull request has been automatically closed due to inactivity.
     If you are still interested in contributing this, please ensure that
     it is rebased against the latest branch (usually `master`), all review
-    comments have been adressed and the build is passing.
+      comments have been addressed and the build is passing.
 
 issues:
-  # XXX: We'll only match very few issues to ensure the bot works as expected
-  # daysUntilStale: 365
-  daysUntilStale: 1200
+    # XXX: We'll only match very few issues to ensure the bot works as expected
+    # XXX: Once working, we're going to reduce the stale window incrementally
+    daysUntilStale: 1250
 
-  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-  daysUntilClose: 21
+    # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+    # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+    daysUntilClose: 21
 
-  # Comment to post when marking as stale. Set to `false` to disable
-  markComment: >
-    This issue has been automatically marked as stale because it has not had recent activity.
-    Given the limited bandwidth of the team, it will be automatically closed if no further
-    activity occurs. If you're interested how we try to keep the backlog in a healty state, 
+    # Comment to post when marking as stale. Set to `false` to disable
+    markComment: >
+        This issue has been automatically marked as stale because it has not had recent activity.
+        Given the limited bandwidth of the team, it will be automatically closed if no further
+        activity occurs. If you're interested how we try to keep the backlog in a healty state,
     please read our [blog post on working with a large community](XXXX).
     If you feel this is something you could contribute, please have a look
     at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
@@ -70,7 +70,6 @@ exemptMilestones: true
 
 # Label to use when marking as stale
 staleLabel: stale
-
 
 # Comment to post when removing the stale label.
 # unmarkComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,14 +15,14 @@ pulls:
         This issue has been automatically marked as stale because it has not had recent activity.
         Given the limited bandwidth of the team, it will be closed if no further activity occurs.
         If you intend to work on this pull request, please reopen the PR.
-    Thank you for your contributions.
+        Thank you for your contributions.
 
-  # Comment to post when closing a stale Issue or Pull Request.
-  closeComment: >
-    This pull request has been automatically closed due to inactivity.
-    If you are still interested in contributing this, please ensure that
-    it is rebased against the latest branch (usually `master`), all review
-      comments have been addressed and the build is passing.
+    # Comment to post when closing a stale Issue or Pull Request.
+    closeComment: >
+        This pull request has been automatically closed due to inactivity.
+        If you are still interested in contributing this, please ensure that
+        it is rebased against the latest branch (usually `master`), all review
+          comments have been addressed and the build is passing.
 
 issues:
     # XXX: We'll only match very few issues to ensure the bot works as expected
@@ -37,18 +37,18 @@ issues:
     markComment: >
         This issue has been automatically marked as stale because it has not had recent activity.
         Given the limited bandwidth of the team, it will be automatically closed if no further
-        activity occurs. If you're interested how we try to keep the backlog in a healty state,
-    please read our [blog post on working with a large community](XXXX).
-    If you feel this is something you could contribute, please have a look
-    at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
-    Thank you for your contribution.
+        activity occurs. If you're interested how we try to keep the backlog in a healthy state,
+        please read our [blog post on how we groom our backlog](https://blog.gradle.org/stale-issue-backlog).
+        If you feel this is something you could contribute, please have a look
+        at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
+        Thank you for your contribution.
 
-  # Comment to post when closing a stale Issue or Pull Request.
-  closeComment: >
-    This issue has been automatically closed due to inactivity. If you can reproduce this on a
-    recent version of Gradle or if you have a good use case for this feature, please feel free
-    to reopen the issue with steps to reproduce, a quick explanation of your use case or a
-    high-quality pull request.
+    # Comment to post when closing a stale Issue or Pull Request.
+    closeComment: >
+        This issue has been automatically closed due to inactivity. If you can reproduce this on a
+        recent version of Gradle or if you have a good use case for this feature, please feel free
+        to reopen the issue with steps to reproduce, a quick explanation of your use case or a
+        high-quality pull request.
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 #onlyLabels: []

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,52 +3,52 @@
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 pulls:
   # XXX: We'll only match very few issues to ensure the bot works as expected
-    # XXX: Once working, we're going to reduce the stale window incrementally
-    daysUntilStale: 1250
+  # XXX: Once working, we're going to reduce the stale window incrementally
+  daysUntilStale: 1250
 
-    # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-    # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-    daysUntilClose: 21
+  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 21
 
-    # Comment to post when marking as stale. Set to `false` to disable
-    markComment: >
-        This issue has been automatically marked as stale because it has not had recent activity.
-        Given the limited bandwidth of the team, it will be closed if no further activity occurs.
-        If you intend to work on this pull request, please reopen the PR.
-        Thank you for your contributions.
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had recent activity.
+    Given the limited bandwidth of the team, it will be closed if no further activity occurs.
+    If you intend to work on this pull request, please reopen the PR.
+    Thank you for your contributions.
 
-    # Comment to post when closing a stale Issue or Pull Request.
-    closeComment: >
-        This pull request has been automatically closed due to inactivity.
-        If you are still interested in contributing this, please ensure that
-        it is rebased against the latest branch (usually `master`), all review
-          comments have been addressed and the build is passing.
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    This pull request has been automatically closed due to inactivity.
+    If you are still interested in contributing this, please ensure that
+    it is rebased against the latest branch (usually `master`), all review
+    comments have been addressed and the build is passing.
 
 issues:
-    # XXX: We'll only match very few issues to ensure the bot works as expected
-    # XXX: Once working, we're going to reduce the stale window incrementally
-    daysUntilStale: 1250
+  # XXX: We'll only match very few issues to ensure the bot works as expected
+  # XXX: Once working, we're going to reduce the stale window incrementally
+  daysUntilStale: 1250
 
-    # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-    # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-    daysUntilClose: 21
+  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 21
 
-    # Comment to post when marking as stale. Set to `false` to disable
-    markComment: >
-        This issue has been automatically marked as stale because it has not had recent activity.
-        Given the limited bandwidth of the team, it will be automatically closed if no further
-        activity occurs. If you're interested how we try to keep the backlog in a healthy state,
-        please read our [blog post on how we groom our backlog](https://blog.gradle.org/stale-issue-backlog).
-        If you feel this is something you could contribute, please have a look
-        at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
-        Thank you for your contribution.
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had recent activity.
+    Given the limited bandwidth of the team, it will be automatically closed if no further
+    activity occurs. If you're interested how we try to keep the backlog in a healthy state,
+    please read our [blog post on how we groom our backlog](https://blog.gradle.org/stale-issue-backlog).
+    If you feel this is something you could contribute, please have a look
+    at our [Contributor Guide](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
+    Thank you for your contribution.
 
-    # Comment to post when closing a stale Issue or Pull Request.
-    closeComment: >
-        This issue has been automatically closed due to inactivity. If you can reproduce this on a
-        recent version of Gradle or if you have a good use case for this feature, please feel free
-        to reopen the issue with steps to reproduce, a quick explanation of your use case or a
-        high-quality pull request.
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    This issue has been automatically closed due to inactivity. If you can reproduce this on a
+    recent version of Gradle or if you have a good use case for this feature, please feel free
+    to reopen the issue with steps to reproduce, a quick explanation of your use case or a
+    high-quality pull request.
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 #onlyLabels: []


### PR DESCRIPTION
This adds a configuration for [stale bot](https://github.com/probot/stale).
Initially, the window is set to 1250 days (~3.5y) of inactivity (matching ~20 issues) to try it out.
If everything is successful, we'll reduce the window incrementally over the coming months.
This configuration will only be used once we install the app on our repository.