### PR TITLE
Fix snippet references in user guide

### DIFF
--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -110,12 +110,12 @@ include::sample[dir="snippets/initScripts/customLogger/kotlin",files="customLogg
 [.multi-language-text.lang-groovy]
 ----
 $ gradle -I init.gradle build
-include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out
+include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out[]
 ----
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle -I customLogger.init.gradle.kts build
-include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out
+include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out[]
 ----
 ```
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/ant.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/ant.adoc
@@ -42,7 +42,7 @@ include::sample[dir="snippets/ant/useAntTask/kotlin",files="build.gradle.kts"]
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/useAntTask/tests/useAntTask.out
+include::{snippetsPath}/ant/useAntTask/tests/useAntTask.out[]
 ----
 
 You pass nested text to an Ant task by passing it as a parameter of the task method call. In this example, we pass the message for the `echo` task as nested text:
@@ -56,7 +56,7 @@ include::sample[dir="snippets/ant/taskWithNestedText/kotlin",files="build.gradle
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/taskWithNestedText/tests/taskWithNestedText.out
+include::{snippetsPath}/ant/taskWithNestedText/tests/taskWithNestedText.out[]
 ----
 
 You pass nested elements to an Ant task inside a closure. Nested elements are defined in the same way as tasks, by calling a method with the same name as the element we want to define.
@@ -122,7 +122,7 @@ include::sample[dir="snippets/ant/hello/groovy",files="build.xml"]
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/hello/tests/antHello.out
+include::{snippetsPath}/ant/hello/tests/antHello.out[]
 ----
 
 You can add a task which depends on an Ant target:
@@ -136,7 +136,7 @@ include::sample[dir="snippets/ant/dependsOnAntTarget/kotlin",files="build.gradle
 .Output of `gradle intro`
 ----
 > gradle intro
-include::{snippetsPath}/ant/dependsOnAntTarget/tests/dependsOnAntTarget.out
+include::{snippetsPath}/ant/dependsOnAntTarget/tests/dependsOnAntTarget.out[]
 ----
 
 Or, you can add behaviour to an Ant target:
@@ -150,7 +150,7 @@ include::sample[dir="snippets/ant/addBehaviourToAntTarget/kotlin",files="build.g
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/addBehaviourToAntTarget/tests/addBehaviourToAntTarget.out
+include::{snippetsPath}/ant/addBehaviourToAntTarget/tests/addBehaviourToAntTarget.out[]
 ----
 
 It is also possible for an Ant target to depend on a Gradle task:
@@ -168,7 +168,7 @@ include::sample[dir="snippets/ant/dependsOnTask/groovy",files="build.xml"]
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/dependsOnTask/tests/dependsOnTask.out
+include::{snippetsPath}/ant/dependsOnTask/tests/dependsOnTask.out[]
 ----
 
 Sometimes it may be necessary to “rename” the task generated for an Ant target to avoid a naming collision with existing Gradle tasks. To do this, use the link:{javadocPath}/org/gradle/api/AntBuilder.html#importBuild-java.lang.Object-org.gradle.api.Transformer-[AntBuilder.importBuild(java.lang.Object, org.gradle.api.Transformer)] method.
@@ -186,7 +186,7 @@ include::sample[dir="snippets/ant/renameTask/groovy",files="build.xml"]
 .Output of `gradle a-hello`
 ----
 > gradle a-hello
-include::{snippetsPath}/ant/renameTask/tests/renameAntDelegate.out
+include::{snippetsPath}/ant/renameTask/tests/renameAntDelegate.out[]
 ----
 
 Note that while the second argument to this method should be a link:{javadocPath}/org/gradle/api/Transformer.html[Transformer], when programming in Groovy we can simply use a closure instead of an anonymous inner class (or similar) due to http://mrhaki.blogspot.ie/2013/11/groovy-goodness-implicit-closure.html[Groovy's support for automatically coercing closures to single-abstract-method types].
@@ -286,7 +286,7 @@ include::sample[dir="snippets/ant/antLogging/kotlin",files="build.gradle.kts"]
 .Output of `gradle hello`
 ----
 > gradle hello
-include::{snippetsPath}/ant/antLogging/tests/antLogging.out
+include::{snippetsPath}/ant/antLogging/tests/antLogging.out[]
 ----
 
 On the other hand, if the `lifecycleLogLevel` was set to _ERROR_, Ant messages logged at the _WARN_ priority would no longer be logged at the `WARN` log level. They would now be logged at the `INFO` level and would be suppressed by default.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
@@ -49,12 +49,12 @@ include::sample[dir="snippets/buildlifecycle/basic/kotlin",files="settings.gradl
 [source.multi-language-sample,groovy]
 ----
 > gradle test testBoth
-include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.groovy.out[]
+include::{snippetsPath}/buildlifecycle/basic/tests-groovy/buildlifecycle.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle test testBoth
-include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.kotlin.out[]
+include::{snippetsPath}/buildlifecycle/basic/tests-kotlin/buildlifecycle.kotlin.out[]
 ----
 
 For a build script, the property access and method calls are delegated to a project object. Similarly property access and method calls within the settings file is delegated to a settings object. Look at the link:{groovyDslPath}/org.gradle.api.initialization.Settings.html[Settings] class in the API documentation for more information.
@@ -185,12 +185,12 @@ include::sample[dir="snippets/buildlifecycle/buildProjectEvaluateEvents/kotlin",
 [source.multi-language-sample,groovy]
 ----
 > gradle -q test
-include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.groovy.out[]
+include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests-groovy/buildProjectEvaluateEvents.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle -q test
-include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.kotlin.out[]
+include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests-kotlin/buildProjectEvaluateEvents.kotlin.out[]
 ----
 
 You can also add a link:{javadocPath}/org/gradle/api/ProjectEvaluationListener.html[ProjectEvaluationListener] to the link:{groovyDslPath}/org.gradle.api.invocation.Gradle.html[Gradle] to receive these events.
@@ -240,12 +240,12 @@ include::sample[dir="snippets/buildlifecycle/taskExecutionEvents/kotlin",files="
 [source.multi-language-sample,groovy]
 ----
 > gradle -q broken
-include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.groovy.out[]
+include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle -q broken
-include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.kotlin.out[]
+include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out[]
 ----
 
 You can also use a link:{javadocPath}/org/gradle/api/execution/TaskExecutionListener.html[TaskExecutionListener] to the link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html[TaskExecutionGraph] to receive these events.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
@@ -49,12 +49,12 @@ include::sample[dir="snippets/buildlifecycle/basic/kotlin",files="settings.gradl
 [source.multi-language-sample,groovy]
 ----
 > gradle test testBoth
-include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.groovy.out
+include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle test testBoth
-include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.kotlin.out
+include::{snippetsPath}/buildlifecycle/basic/tests/buildlifecycle.kotlin.out[]
 ----
 
 For a build script, the property access and method calls are delegated to a project object. Similarly property access and method calls within the settings file is delegated to a settings object. Look at the link:{groovyDslPath}/org.gradle.api.initialization.Settings.html[Settings] class in the API documentation for more information.
@@ -168,7 +168,7 @@ include::sample[dir="snippets/buildlifecycle/projectEvaluateEvents/kotlin",files
 .Output of `gradle -q test`
 ----
 > gradle -q test
-include::{snippetsPath}/buildlifecycle/projectEvaluateEvents/tests/projectEvaluateEvents.out
+include::{snippetsPath}/buildlifecycle/projectEvaluateEvents/tests/projectEvaluateEvents.out[]
 ----
 
 This example uses method `Project.afterEvaluate()` to add a closure which is executed after the project is evaluated.
@@ -185,12 +185,12 @@ include::sample[dir="snippets/buildlifecycle/buildProjectEvaluateEvents/kotlin",
 [source.multi-language-sample,groovy]
 ----
 > gradle -q test
-include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.groovy.out
+include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle -q test
-include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.kotlin.out
+include::{snippetsPath}/buildlifecycle/buildProjectEvaluateEvents/tests/buildProjectEvaluateEvents.kotlin.out[]
 ----
 
 You can also add a link:{javadocPath}/org/gradle/api/ProjectEvaluationListener.html[ProjectEvaluationListener] to the link:{groovyDslPath}/org.gradle.api.invocation.Gradle.html[Gradle] to receive these events.
@@ -211,7 +211,7 @@ include::sample[dir="snippets/buildlifecycle/taskCreationEvents/kotlin",files="b
 .Output of **`gradle -q a`**
 ----
 > gradle -q a
-include::{snippetsPath}/buildlifecycle/taskCreationEvents/tests/taskCreationEvents.out
+include::{snippetsPath}/buildlifecycle/taskCreationEvents/tests/taskCreationEvents.out[]
 ----
 
 You can also add an link:{javadocPath}/org/gradle/api/Action.html[Action] to a link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html[TaskContainer] to receive these events.
@@ -240,12 +240,12 @@ include::sample[dir="snippets/buildlifecycle/taskExecutionEvents/kotlin",files="
 [source.multi-language-sample,groovy]
 ----
 > gradle -q broken
-include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.groovy.out
+include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.groovy.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle -q broken
-include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.kotlin.out
+include::{snippetsPath}/buildlifecycle/taskExecutionEvents/tests/taskExecutionEvents.kotlin.out[]
 ----
 
 You can also use a link:{javadocPath}/org/gradle/api/execution/TaskExecutionListener.html[TaskExecutionListener] to the link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html[TaskExecutionGraph] to receive these events.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -166,12 +166,12 @@ include::sample[dir="snippets/initScripts/customLogger/kotlin",files="customLogg
 [.multi-language-text.lang-groovy]
 ----
 $ gradle -I customLogger.init.gradle build
-include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out
+include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out[]
 ----
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle -I customLogger.init.gradle.kts build
-include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out
+include::{snippetsPath}/initScripts/customLogger/tests/customLogger.out[]
 ----
 
 Your logger can implement any of the listener interfaces listed below. When you register a logger, only the logging for the interfaces that it implements is replaced. Logging for the other interfaces is left untouched. You can find out more about the listener interfaces in <<build_lifecycle.adoc#build_lifecycle_events,Build lifecycle events>>.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -120,7 +120,7 @@ include::sample[dir="snippets/tasks/accessUsingPath/kotlin",files="build.gradle.
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/tasks/accessUsingPath/tests/accessUsingPath.out
+include::{snippetsPath}/tasks/accessUsingPath/tests/accessUsingPath.out[]
 ----
 ====
 
@@ -233,7 +233,7 @@ include::sample[dir="snippets/tasks/addDependencyUsingPath/kotlin",files="build.
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/addDependencyUsingPath/tests/addDependencyUsingPath.out
+include::{snippetsPath}/tasks/addDependencyUsingPath/tests/addDependencyUsingPath.out[]
 ----
 ====
 
@@ -247,7 +247,7 @@ include::sample[dir="snippets/tasks/addDependencyUsingTask/kotlin",files="build.
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/addDependencyUsingTask/tests/addDependencyUsingTask.out
+include::{snippetsPath}/tasks/addDependencyUsingTask/tests/addDependencyUsingTask.out[]
 ----
 ====
 
@@ -261,7 +261,7 @@ include::sample[dir="snippets/tasks/addDependencyUsingClosure/kotlin",files="bui
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/addDependencyUsingClosure/tests/addDependencyUsingClosure.out
+include::{snippetsPath}/tasks/addDependencyUsingClosure/tests/addDependencyUsingClosure.out[]
 ----
 ====
 
@@ -293,7 +293,7 @@ include::sample[dir="snippets/tasks/mustRunAfter/kotlin",files="build.gradle.kts
 .Output of **`gradle -q taskY taskX`**
 ----
 > gradle -q taskY taskX
-include::{snippetsPath}/tasks/mustRunAfter/tests/mustRunAfter.out
+include::{snippetsPath}/tasks/mustRunAfter/tests/mustRunAfter.out[]
 ----
 ====
 
@@ -305,7 +305,7 @@ include::sample[dir="snippets/tasks/shouldRunAfter/kotlin",files="build.gradle.k
 .Output of **`gradle -q taskY taskX`**
 ----
 > gradle -q taskY taskX
-include::{snippetsPath}/tasks/shouldRunAfter/tests/shouldRunAfter.out
+include::{snippetsPath}/tasks/shouldRunAfter/tests/shouldRunAfter.out[]
 ----
 ====
 
@@ -316,7 +316,7 @@ In the examples above, it is still possible to execute `taskY` without causing `
 .Output of **`gradle -q taskY`**
 ----
 > gradle -q taskY
-include::{snippetsPath}/tasks/mustRunAfter/tests/mustRunAfterSingleTask.out
+include::{snippetsPath}/tasks/mustRunAfter/tests/mustRunAfterSingleTask.out[]
 ----
 ====
 
@@ -338,7 +338,7 @@ include::sample[dir="snippets/tasks/shouldRunAfterWithCycle/kotlin",files="build
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/shouldRunAfterWithCycle/tests/shouldRunAfterWithCycle.out
+include::{snippetsPath}/tasks/shouldRunAfterWithCycle/tests/shouldRunAfterWithCycle.out[]
 ----
 ====
 
@@ -372,7 +372,7 @@ include::sample[dir="snippets/tutorial/taskOnlyIf/kotlin",files="build.gradle.kt
 .Output of **`gradle hello -PskipHello`**
 ----
 > gradle hello -PskipHello
-include::{snippetsPath}/tutorial/taskOnlyIf/tests/taskOnlyIf.out
+include::{snippetsPath}/tutorial/taskOnlyIf/tests/taskOnlyIf.out[]
 ----
 ====
 
@@ -390,7 +390,7 @@ include::sample[dir="snippets/tutorial/stopExecutionException/kotlin",files="bui
 .Output of **`gradle -q myTask`**
 ----
 > gradle -q myTask
-include::{snippetsPath}/tutorial/stopExecutionException/tests/stopExecutionException.out
+include::{snippetsPath}/tutorial/stopExecutionException/tests/stopExecutionException.out[]
 ----
 ====
 
@@ -409,7 +409,7 @@ include::sample[dir="snippets/tutorial/disableTask/kotlin",files="build.gradle.k
 .Output of **`gradle disableMe`**
 ----
 > gradle disableMe
-include::{snippetsPath}/tutorial/disableTask/tests/disableTask.out
+include::{snippetsPath}/tutorial/disableTask/tests/disableTask.out[]
 ----
 ====
 
@@ -510,13 +510,13 @@ include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/groovy/buildSrc/s
 .Output of `gradle processTemplates`
 ----
 > gradle processTemplates
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithInputOutputAnnotations.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithInputOutputAnnotations.out[]
 ----
 
 .Output of `gradle processTemplates` (run again)
 ----
 > gradle processTemplates
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithInputOutputAnnotationsUpToDate.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithInputOutputAnnotationsUpToDate.out[]
 ----
 ====
 
@@ -762,7 +762,7 @@ These problems are then turned into deprecation warnings when the task is execut
 .Example output with a task having undeclared inputs and outputs
 ----
 > gradle processTemplatesRuntime
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithoutInputOutputAnnotations.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/customTaskClassWithoutInputOutputAnnotations.out[]
 ----
 
 [[sec:task_input_output_runtime_api]]
@@ -796,7 +796,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-customTaskClass/kotlin",fil
 .Output of **`gradle processTemplatesAdHoc`**
 ----
 > gradle processTemplatesAdHoc
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/incrementalAdHocTask.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/incrementalAdHocTask.out[]
 ----
 ====
 
@@ -833,7 +833,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-customTaskClass/kotlin",fil
 .Output of **`gradle clean processTemplatesAdHocSkipWhenEmpty`**
 ----
 > gradle clean processTemplatesAdHocSkipWhenEmpty
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/incrementalAdHocTaskNoSource.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/incrementalAdHocTaskNoSource.out[]
 ----
 ====
 
@@ -883,7 +883,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-customTaskClass/kotlin",fil
 .Output of **`gradle clean packageFiles`**
 ----
 > gradle clean packageFiles
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/inferredTaskDep.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/inferredTaskDep.out[]
 ----
 ====
 
@@ -899,7 +899,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-customTaskClass/kotlin",fil
 .Output of **`gradle clean packageFiles2`**
 ----
 > gradle clean packageFiles2
-include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/inferredTaskDep2.out
+include::{snippetsPath}/tasks/incrementalBuild-customTaskClass/tests/inferredTaskDep2.out[]
 ----
 ====
 
@@ -1002,7 +1002,7 @@ include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/b
 .Output of `gradle processTemplates`
 ----
 > gradle processTemplates
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildCustomMethods.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildCustomMethods.out[]
 ----
 ====
 
@@ -1024,7 +1024,7 @@ include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/b
 .Output of `gradle processTemplates2`
 ----
 > gradle processTemplates2
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildCustomMethodsWithTaskArg.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildCustomMethodsWithTaskArg.out[]
 ----
 ====
 
@@ -1050,7 +1050,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-incrementalBuildAdvanced/ko
 .Output of **`gradle clean badInstrumentClasses`**
 ----
 > gradle clean badInstrumentClasses
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildBadInputFilesConfig.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildBadInputFilesConfig.out[]
 ----
 ====
 
@@ -1066,7 +1066,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-incrementalBuildAdvanced/ko
 .Output of **`gradle clean instrumentClasses`**
 ----
 > gradle clean instrumentClasses
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildInputFilesConfig.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildInputFilesConfig.out[]
 ----
 ====
 
@@ -1080,7 +1080,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-incrementalBuildAdvanced/ko
 .Output of **`gradle clean instrumentClasses2`**
 ----
 > gradle clean instrumentClasses2
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildInputFilesConfigUsingTask.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildInputFilesConfigUsingTask.out[]
 ----
 ====
 
@@ -1096,7 +1096,7 @@ include::sample[dir="snippets/tasks/incrementalBuild-incrementalBuildAdvanced/ko
 .Output of **`gradle clean instrumentClassesBuiltBy`**
 ----
 > gradle clean instrumentClassesBuiltBy
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/inferredTaskDependencyWithBuiltBy.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/inferredTaskDependencyWithBuiltBy.out[]
 ----
 ====
 
@@ -1117,13 +1117,13 @@ include::sample[dir="snippets/tasks/incrementalBuild-incrementalBuildAdvanced/ko
 .Output of `gradle clean alwaysInstrumentClasses`
 ----
 > gradle clean alwaysInstrumentClasses
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildUpToDateWhen.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildUpToDateWhen.out[]
 ----
 
 .Output of `gradle alwaysInstrumentClasses`
 ----
 > gradle alwaysInstrumentClasses
-include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildUpToDateWhenAgain.out
+include::{snippetsPath}/tasks/incrementalBuild-incrementalBuildAdvanced/tests/incrementalBuildUpToDateWhenAgain.out[]
 ----
 ====
 
@@ -1215,7 +1215,7 @@ include::sample[dir="snippets/tasks/addRules/kotlin",files="build.gradle.kts[tag
 .Output of **`gradle -q pingServer1`**
 ----
 > gradle -q pingServer1
-include::{snippetsPath}/tasks/addRules/tests/taskRule.out
+include::{snippetsPath}/tasks/addRules/tests/taskRule.out[]
 ----
 ====
 
@@ -1231,7 +1231,7 @@ include::sample[dir="snippets/tasks/addRules/kotlin",files="build.gradle.kts[tag
 .Output of **`gradle -q groupPing`**
 ----
 > gradle -q groupPing
-include::{snippetsPath}/tasks/addRules/tests/taskRuleDependsOn.out
+include::{snippetsPath}/tasks/addRules/tests/taskRuleDependsOn.out[]
 ----
 ====
 
@@ -1250,7 +1250,7 @@ include::sample[dir="snippets/tasks/finalizers/kotlin",files="build.gradle.kts[]
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/finalizers/tests/taskFinalizers.out
+include::{snippetsPath}/tasks/finalizers/tests/taskFinalizers.out[]
 ----
 ====
 
@@ -1264,7 +1264,7 @@ include::sample[dir="snippets/tasks/finalizersWithFailure/kotlin",files="build.g
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/finalizersWithFailure/tests/taskFinalizersWithFailureGroovy.out
+include::{snippetsPath}/tasks/finalizersWithFailure/tests/taskFinalizersWithFailureGroovy.out[]
 ----
 ====
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -1264,7 +1264,7 @@ include::sample[dir="snippets/tasks/finalizersWithFailure/kotlin",files="build.g
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tasks/finalizersWithFailure/tests/taskFinalizersWithFailureGroovy.out[]
+include::{snippetsPath}/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out[]
 ----
 ====
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
@@ -97,7 +97,7 @@ include::sample[dir="snippets/multiproject/firstExample/kotlin",files="build.gra
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/firstExample/tests/multiprojectFirstExample.out
+include::{snippetsPath}/multiproject/firstExample/tests/multiprojectFirstExample.out[]
 ----
 ====
 
@@ -149,7 +149,7 @@ include::sample[dir="snippets/multiproject/addKrill/kotlin",files="build.gradle.
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/addKrill/tests/multiprojectAddKrill.out
+include::{snippetsPath}/multiproject/addKrill/tests/multiprojectAddKrill.out[]
 ----
 ====
 
@@ -177,7 +177,7 @@ include::sample[dir="snippets/multiproject/useSubprojects/kotlin",files="build.g
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/useSubprojects/tests/multiprojectUseSubprojects.out
+include::{snippetsPath}/multiproject/useSubprojects/tests/multiprojectUseSubprojects.out[]
 ----
 ====
 
@@ -196,7 +196,7 @@ include::sample[dir="snippets/multiproject/subprojectsAddFromTop/kotlin",files="
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/subprojectsAddFromTop/tests/multiprojectSubprojectsAddFromTop.out
+include::{snippetsPath}/multiproject/subprojectsAddFromTop/tests/multiprojectSubprojectsAddFromTop.out[]
 ----
 ====
 
@@ -242,7 +242,7 @@ include::sample[dir="snippets/multiproject/spreadSpecifics/kotlin",files="settin
 .Output of `gradle -q hello`
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/spreadSpecifics/tests/multiprojectSpreadSpecifics.out
+include::{snippetsPath}/multiproject/spreadSpecifics/tests/multiprojectSpreadSpecifics.out[]
 ----
 ====
 
@@ -297,7 +297,7 @@ include::sample[dir="snippets/multiproject/addTropical/kotlin",files="settings.g
 .Output of `gradle -q hello`
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/addTropical/tests/multiprojectAddTropical.out
+include::{snippetsPath}/multiproject/addTropical/tests/multiprojectAddTropical.out[]
 ----
 ====
 
@@ -352,7 +352,7 @@ include::sample[dir="snippets/multiproject/tropicalWithProperties/kotlin",files=
 .Output of `gradle -q hello`
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectTropicalWithProperties.out
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectTropicalWithProperties.out[]
 ----
 ====
 
@@ -366,7 +366,7 @@ When we executed the `hello` task from the root project dir, things behaved in a
 .Running build from subproject
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectSubBuild.out
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectSubBuild.out[]
 ----
 
 The basic rule behind Gradle's behavior is simple. Gradle looks down the hierarchy, starting with the _current dir_, for tasks with the name `hello` and executes them. One thing is very important to note. Gradle _always_ evaluates _every_ project of the multi-project build and creates all existing task objects. Then, according to the task name arguments and the current dir, Gradle filters the tasks which should be executed. Because of Gradle's cross project configuration _every_ project has to be evaluated before _any_ task gets executed. We will have a closer look at this in the next section. Let's now have our last marine example. Let's add a task to `bluewhale` and `krill`.
@@ -379,7 +379,7 @@ include::sample[dir="snippets/multiproject/partialTasks/kotlin",files="bluewhale
 .Output of `gradle -q distanceToIceberg`
 ----
 > gradle -q distanceToIceberg
-include::{snippetsPath}/multiproject/partialTasks/tests/multiprojectPartialTasks.out
+include::{snippetsPath}/multiproject/partialTasks/tests/multiprojectPartialTasks.out[]
 ----
 
 Here's the output without the `-q` option:
@@ -387,7 +387,7 @@ Here's the output without the `-q` option:
 .Output of **`gradle distanceToIceberg`**
 ----
 > gradle distanceToIceberg
-include::{snippetsPath}/multiproject/partialTasks/tests/multiprojectPartialTasksNotQuiet.out
+include::{snippetsPath}/multiproject/partialTasks/tests/multiprojectPartialTasksNotQuiet.out[]
 ----
 ====
 
@@ -401,7 +401,7 @@ As we have seen, you can run a multi-project build by entering any subproject di
 .Running tasks by their absolute path
 ----
 > gradle -q :hello :krill:hello hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectAbsoluteTaskPaths.out
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectAbsoluteTaskPaths.out[]
 ----
 
 The build is executed from the `tropicalFish` project. We execute the `hello` tasks of the `water`, the `krill` and the `tropicalFish` project. The first two tasks are specified by their absolute path, the last task is executed using the name matching mechanism described above.
@@ -465,7 +465,7 @@ include::sample[dir="snippets/multiproject/dependencies-firstMessages/kotlin",fi
 .Output of `gradle -q action`
 ----
 > gradle -q action
-include::{snippetsPath}/multiproject/dependencies-firstMessages/tests/multiprojectFirstMessages.out
+include::{snippetsPath}/multiproject/dependencies-firstMessages/tests/multiprojectFirstMessages.out[]
 ----
 ====
 
@@ -510,7 +510,7 @@ include::sample[dir="snippets/multiproject/dependencies-messagesHack/kotlin",fil
 .Output of `gradle -q action`
 ----
 > gradle -q action
-include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHack.out
+include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHack.out[]
 ----
 
 We can show where this hack doesn't work if we now switch to the `consumer` dir and execute the build.
@@ -518,7 +518,7 @@ We can show where this hack doesn't work if we now switch to the `consumer` dir 
 .Output of `gradle -q action` from the `consumer` dir
 ----
 > gradle -q action
-include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHackBroken.out
+include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHackBroken.out[]
 ----
 ====
 
@@ -817,7 +817,7 @@ Assume you are working on a single project, the “`:api`” project. You have b
 .Output of **`gradle :api:build`**
 ----
 > gradle :api:build
-include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuild.out
+include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuild.out[]
 ----
 =====
 ====
@@ -831,7 +831,7 @@ If you have just gotten the latest version of source from your version control s
 .Output of **`gradle :api:buildNeeded`**
 ----
 > gradle :api:buildNeeded
-include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuildNeeded.out
+include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuildNeeded.out[]
 ----
 =====
 ====
@@ -845,7 +845,7 @@ You also might want to refactor some part of the “`:api`” project that is us
 .Output of **`gradle :api:buildDependents`**
 ----
 > gradle :api:buildDependents
-include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuildDependents.out
+include::{snippetsPath}/multiproject/dependencies-java/tests/multitestingBuildDependents.out[]
 ----
 =====
 ====

--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
@@ -352,7 +352,7 @@ include::sample[dir="snippets/multiproject/tropicalWithProperties/kotlin",files=
 .Output of `gradle -q hello`
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectTropicalWithProperties.out[]
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests-common/multiprojectTropicalWithProperties.out[]
 ----
 ====
 
@@ -366,7 +366,7 @@ When we executed the `hello` task from the root project dir, things behaved in a
 .Running build from subproject
 ----
 > gradle -q hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectSubBuild.out[]
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests-common/multiprojectSubBuild.out[]
 ----
 
 The basic rule behind Gradle's behavior is simple. Gradle looks down the hierarchy, starting with the _current dir_, for tasks with the name `hello` and executes them. One thing is very important to note. Gradle _always_ evaluates _every_ project of the multi-project build and creates all existing task objects. Then, according to the task name arguments and the current dir, Gradle filters the tasks which should be executed. Because of Gradle's cross project configuration _every_ project has to be evaluated before _any_ task gets executed. We will have a closer look at this in the next section. Let's now have our last marine example. Let's add a task to `bluewhale` and `krill`.
@@ -401,7 +401,7 @@ As we have seen, you can run a multi-project build by entering any subproject di
 .Running tasks by their absolute path
 ----
 > gradle -q :hello :krill:hello hello
-include::{snippetsPath}/multiproject/tropicalWithProperties/tests/multiprojectAbsoluteTaskPaths.out[]
+include::{snippetsPath}/multiproject/tropicalWithProperties/tests-common/multiprojectAbsoluteTaskPaths.out[]
 ----
 
 The build is executed from the `tropicalFish` project. We execute the `hello` tasks of the `water`, the `krill` and the `tropicalFish` project. The first two tasks are specified by their absolute path, the last task is executed using the name matching mechanism described above.
@@ -510,7 +510,7 @@ include::sample[dir="snippets/multiproject/dependencies-messagesHack/kotlin",fil
 .Output of `gradle -q action`
 ----
 > gradle -q action
-include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHack.out[]
+include::{snippetsPath}/multiproject/dependencies-messagesHack/tests-common/multiprojectMessagesHack.out[]
 ----
 
 We can show where this hack doesn't work if we now switch to the `consumer` dir and execute the build.
@@ -518,7 +518,7 @@ We can show where this hack doesn't work if we now switch to the `consumer` dir 
 .Output of `gradle -q action` from the `consumer` dir
 ----
 > gradle -q action
-include::{snippetsPath}/multiproject/dependencies-messagesHack/tests/multiprojectMessagesHackBroken.out[]
+include::{snippetsPath}/multiproject/dependencies-messagesHack/tests-common/multiprojectMessagesHackBroken.out[]
 ----
 ====
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/potential_traps.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/potential_traps.adoc
@@ -33,7 +33,7 @@ include::{snippetsPath}/tutorial/groovyScope/groovy/src/main/groovy/scope.groovy
 .Output of `groovy scope.groovy`
 ----
 > groovy scope.groovy
-include::{snippetsPath}/tutorial/groovyScope/tests/scope.out
+include::{snippetsPath}/tutorial/groovyScope/tests/scope.out[]
 ----
 
 Variables which are declared with a type modifier are visible within closures but not visible within methods.
@@ -52,7 +52,7 @@ include::sample[dir="snippets/tutorial/mkdirTrap/kotlin", files="build.gradle.kt
 .Output of **`gradle -q compile`**
 ----
 > gradle -q compile
-include::{snippetsPath}/tutorial/mkdirTrap/tests/mkdirTrap.out
+include::{snippetsPath}/tutorial/mkdirTrap/tests/mkdirTrap.out[]
 ----
 
 As the creation of the directory happens during the configuration phase, the `clean` task removes the directory during the execution phase.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
@@ -65,7 +65,7 @@ Most of the examples in this user guide are run with the `-q` command-line optio
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/tutorial/hello/tests/hello.out
+include::{snippetsPath}/tutorial/hello/tests/hello.out[]
 ----
 ====
 
@@ -86,7 +86,7 @@ include::sample[dir="snippets/tutorial/upper/kotlin", files="build.gradle.kts[]"
 .Output of **`gradle -q upper`**
 ----
 > gradle -q upper
-include::{snippetsPath}/tutorial/upper/tests/upper.out
+include::{snippetsPath}/tutorial/upper/tests/upper.out[]
 ----
 ====
 
@@ -100,7 +100,7 @@ include::sample[dir="snippets/tutorial/count/kotlin", files="build.gradle.kts[]"
 .Output of **`gradle -q count`**
 ----
 > gradle -q count
-include::{snippetsPath}/tutorial/count/tests/count.out
+include::{snippetsPath}/tutorial/count/tests/count.out[]
 ----
 ====
 
@@ -118,7 +118,7 @@ include::sample[dir="snippets/tutorial/intro/kotlin", files="build.gradle.kts[]"
 .Output of **`gradle -q intro`**
 ----
 > gradle -q intro
-include::{snippetsPath}/tutorial/intro/tests/intro.out
+include::{snippetsPath}/tutorial/intro/tests/intro.out[]
 ----
 ====
 
@@ -132,7 +132,7 @@ include::sample[dir="snippets/tutorial/lazyDependsOn/kotlin", files="build.gradl
 .Output of **`gradle -q taskX`**
 ----
 > gradle -q taskX
-include::{snippetsPath}/tutorial/lazyDependsOn/tests/lazyDependsOn.out
+include::{snippetsPath}/tutorial/lazyDependsOn/tests/lazyDependsOn.out[]
 ----
 ====
 
@@ -153,7 +153,7 @@ include::sample[dir="snippets/tutorial/dynamic/kotlin", files="build.gradle.kts[
 .Output of **`gradle -q task1`**
 ----
 > gradle -q task1
-include::{snippetsPath}/tutorial/dynamic/tests/dynamic.out
+include::{snippetsPath}/tutorial/dynamic/tests/dynamic.out[]
 ----
 ====
 
@@ -171,7 +171,7 @@ include::sample[dir="snippets/tutorial/dynamicDepends/kotlin", files="build.grad
 .Output of **`gradle -q task0`**
 ----
 > gradle -q task0
-include::{snippetsPath}/tutorial/dynamicDepends/tests/dynamicDepends.out
+include::{snippetsPath}/tutorial/dynamicDepends/tests/dynamicDepends.out[]
 ----
 ====
 
@@ -185,7 +185,7 @@ include::sample[dir="snippets/tutorial/helloEnhanced/kotlin", files="build.gradl
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/tutorial/helloEnhanced/tests/helloEnhanced.out
+include::{snippetsPath}/tutorial/helloEnhanced/tests/helloEnhanced.out[]
 ----
 ====
 
@@ -203,7 +203,7 @@ include::sample[dir="snippets/tutorial/helloWithShortCut/groovy", files="build.g
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/tutorial/helloWithShortCut/tests/helloWithShortCut.out
+include::{snippetsPath}/tutorial/helloWithShortCut/tests/helloWithShortCut.out[]
 ----
 ====
 
@@ -222,7 +222,7 @@ include::sample[dir="snippets/tutorial/extraProperties/kotlin", files="build.gra
 .Output of **`gradle -q printTaskProperties`**
 ----
 > gradle -q printTaskProperties
-include::{snippetsPath}/tutorial/extraProperties/tests/extraTaskProperties.out
+include::{snippetsPath}/tutorial/extraProperties/tests/extraTaskProperties.out[]
 ----
 ====
 
@@ -241,7 +241,7 @@ include::sample[dir="snippets/tutorial/antLoadfile/kotlin", files="build.gradle.
 .Output of **`gradle -q loadfile`**
 ----
 > gradle -q loadfile
-include::{snippetsPath}/tutorial/antLoadfile/tests/antLoadfile.out
+include::{snippetsPath}/tutorial/antLoadfile/tests/antLoadfile.out[]
 ----
 ====
 
@@ -260,7 +260,7 @@ include::sample[dir="snippets/tutorial/antLoadfileWithMethod/kotlin", files="bui
 .Output of **`gradle -q loadfile`**
 ----
 > gradle -q loadfile
-include::{snippetsPath}/tutorial/antLoadfileWithMethod/tests/antLoadfileWithMethod.out
+include::{snippetsPath}/tutorial/antLoadfileWithMethod/tests/antLoadfileWithMethod.out[]
 ----
 ====
 
@@ -279,7 +279,7 @@ include::sample[dir="snippets/tutorial/defaultTasks/kotlin", files="build.gradle
 .Output of **`gradle -q`**
 ----
 > gradle -q
-include::{snippetsPath}/tutorial/defaultTasks/tests/defaultTasks.out
+include::{snippetsPath}/tutorial/defaultTasks/tests/defaultTasks.out[]
 ----
 ====
 
@@ -304,13 +304,13 @@ include::sample[dir="snippets/tutorial/configByDag/kotlin", files="build.gradle.
 .Output of `gradle -q distribution`
 ----
 > gradle -q distribution
-include::{snippetsPath}/tutorial/configByDag/tests/configByDagNoRelease.out
+include::{snippetsPath}/tutorial/configByDag/tests/configByDagNoRelease.out[]
 ----
 
 .Output of `gradle -q release`
 ----
 > gradle -q release
-include::{snippetsPath}/tutorial/configByDag/tests/configByDag.out
+include::{snippetsPath}/tutorial/configByDag/tests/configByDag.out[]
 ----
 ====
 
@@ -350,7 +350,7 @@ include::sample[dir="snippets/tutorial/externalDependency/kotlin", files="build.
 .Output of **`gradle -q encode`**
 ----
 > gradle -q encode
-include::{snippetsPath}/tutorial/externalDependency/tests/externalBuildDependency.out
+include::{snippetsPath}/tutorial/externalDependency/tests/externalBuildDependency.out[]
 ----
 ====
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -381,7 +381,7 @@ include::sample[dir="snippets/files/fileCollections/kotlin",files="build.gradle.
 .Output of **`gradle -q list`**
 ----
 > gradle -q list
-include::{snippetsPath}/files/fileCollections/tests/fileCollectionsWithClosure.out
+include::{snippetsPath}/files/fileCollections/tests/fileCollectionsWithClosure.out[]
 ----
 
 The key to lazy creation is passing a closure (in Groovy) or a `Provider` (in Kotlin) to the `files()` method. Your closure/provider simply needs to return a value of a type accepted by `files()`, such as `List<File>`, `String`, `FileCollection`, etc.
@@ -411,7 +411,7 @@ include::sample[dir="snippets/files/fileCollections/kotlin",files="build.gradle.
 .Output of **`gradle -q filterTextFiles`**
 ----
 > gradle -q filterTextFiles
-include::{snippetsPath}/files/fileCollections/tests/fileCollectionsFiltering.out
+include::{snippetsPath}/files/fileCollections/tests/fileCollectionsFiltering.out[]
 ----
 
 If `collection` changes at any time, either by adding or removing files from itself, then `textFiles` will immediately reflect the change because it is also a live collection. Note that the closure you pass to `filter()` takes a `File` as an argument and should return a boolean.
@@ -783,7 +783,7 @@ include::sample[dir="snippets/files/archiveNaming/kotlin",files="build.gradle.kt
 .Output of **`gradle -q myZip`**
 ----
 > gradle -q myZip
-include::{snippetsPath}/files/archiveNaming/tests/archiveNaming.out
+include::{snippetsPath}/files/archiveNaming/tests/archiveNaming.out[]
 ----
 
 Note that the name of the archive does _not_ derive from the name of the task that creates it.
@@ -807,7 +807,7 @@ include::sample[dir="snippets/files/archiveNaming/kotlin",files="build.gradle.kt
 .Output of **`gradle -q myCustomZip`**
 ----
 > gradle -q myCustomZip
-include::{snippetsPath}/files/archiveNaming/tests/zipWithCustomName.out
+include::{snippetsPath}/files/archiveNaming/tests/zipWithCustomName.out[]
 ----
 
 You can also override the default `archiveBaseName` value for _all_ the archive tasks in your build by using the _project_ property `archivesBaseName`, as demonstrated by the following example:
@@ -821,7 +821,7 @@ include::sample[dir="snippets/files/archivesChangedBaseName/kotlin",files="build
 .Output of **`gradle -q echoNames`**
 ----
 > gradle -q echoNames
-include::{snippetsPath}/files/archivesChangedBaseName/tests/zipWithArchivesBaseName.out
+include::{snippetsPath}/files/archivesChangedBaseName/tests/zipWithArchivesBaseName.out[]
 ----
 
 You can find all the possible archive task properties in the API documentation for link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask], but we have also summarized the main ones here:

--- a/subprojects/docs/src/docs/userguide/authoring-builds/writing_build_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/writing_build_scripts.adoc
@@ -39,7 +39,7 @@ include::sample[dir="snippets/tutorial/projectApi/kotlin",files="build.gradle.kt
 .Output of **`gradle -q check`**
 ----
 > gradle -q check
-include::{snippetsPath}/tutorial/projectApi/tests/projectApi.out
+include::{snippetsPath}/tutorial/projectApi/tests/projectApi.out[]
 ----
 ====
 
@@ -145,7 +145,7 @@ include::sample[dir="snippets/tutorial/extraProperties/kotlin",files="build.grad
 .Output of **`gradle -q printProperties`**
 ----
 > gradle -q printProperties
-include::{snippetsPath}/tutorial/extraProperties/tests/extraProperties.out
+include::{snippetsPath}/tutorial/extraProperties/tests/extraProperties.out[]
 ----
 ====
 
@@ -172,7 +172,7 @@ include::sample[dir="snippets/tutorial/configureObject/kotlin",files="build.grad
 .Output of **`gradle -q configure`**
 ----
 > gradle -q configure
-include::{snippetsPath}/tutorial/configureObject/tests/configureObject.out
+include::{snippetsPath}/tutorial/configureObject/tests/configureObject.out[]
 ----
 ====
 
@@ -195,7 +195,7 @@ include::sample[dir="snippets/tutorial/configureObjectUsingScript/groovy",files=
 .Output of `gradle -q configure`
 ----
 > gradle -q configure
-include::{snippetsPath}/tutorial/configureObjectUsingScript/tests/configureObjectUsingScript.out
+include::{snippetsPath}/tutorial/configureObjectUsingScript/tests/configureObjectUsingScript.out[]
 ----
 ====
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
@@ -248,7 +248,7 @@ include::sample[dir="snippets/artifacts/generatedFileDependencies/kotlin",files=
 
 ----
 $ gradle -q list
-include::{snippetsPath}/artifacts/generatedFileDependencies/tests/generatedFileDependencies.out
+include::{snippetsPath}/artifacts/generatedFileDependencies/tests/generatedFileDependencies.out[]
 ----
 
 [[sec:versioning_file_dependencies]]
@@ -355,7 +355,7 @@ include::sample[dir="snippets/dependencyManagement/inspectingDependencies-depend
 .Output of **`gradle -q dependencyInsight --dependency asm`**
 ----
 > gradle -q dependencyInsight --dependency asm
-include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out
+include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out[]
 ----
 
 [[sec:resolve_specific_artifacts_from_dependency]]

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -62,7 +62,7 @@ include::sample[dir="snippets/dependencyManagement/inspectingDependencies-depend
 .Output of **`gradle -q dependencies --configuration scm`**
 ----
 > gradle -q dependencies --configuration scm
-include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependenciesReport/tests/dependencyReport.out
+include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependenciesReport/tests/dependencyReport.out[]
 ----
 
 The dependencies report provides detailed information about the dependencies available in the graph.
@@ -121,7 +121,7 @@ Be sure to always target the <<command_line_interface#executing_tasks_in_multi_p
 .Output of **`gradle -q dependencyInsight --dependency commons-codec --configuration scm`**
 ----
 > gradle -q dependencyInsight --dependency commons-codec --configuration scm
-include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependencyInsightReport/tests/dependencyInsightReport.out
+include::{snippetsPath}/dependencyManagement/inspectingDependencies-dependencyInsightReport/tests/dependencyInsightReport.out[]
 ----
 
 As indicated above, omitting the `--configuration` parameter in a project that is not a Java project will lead to an error:

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/artifact_transforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/artifact_transforms.adoc
@@ -104,7 +104,7 @@ Gradle transforms the binary dependencies when it executes the `resolveRuntimeCl
 ----
 > gradle resolveRuntimeClasspath
 
-include::{snippetsPath}/dependencyManagement/artifactTransforms-minify/tests/artifactTransformMinify.out
+include::{snippetsPath}/dependencyManagement/artifactTransforms-minify/tests/artifactTransformMinify.out[]
 ----
 
 [[sec:implementing-artifact-transforms]]

--- a/subprojects/docs/src/docs/userguide/dep-man/05-multirepo-environment/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/05-multirepo-environment/composite_builds.adoc
@@ -49,7 +49,7 @@ The `--include-build` command-line argument turns the executed build into a comp
 .Output of **`gradle --include-build ../my-utils run`**
 ----
 > gradle --include-build ../my-utils run
-include::{samplesPath}/build-organization/composite-builds/basic/tests/compositeBuilds_basic_cli.out
+include::{samplesPath}/build-organization/composite-builds/basic/tests/basicCli.out[]
 ----
 
 [[settings_defined_composite]]

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
@@ -151,7 +151,7 @@ include::sample[dir="snippets/maven-publish/conditional-publishing/kotlin",files
 .Output of `gradle publish`
 ----
 > gradle publish
-include::{snippetsPath}/maven-publish/conditional-publishing/tests/publishingMavenConditionally.out
+include::{snippetsPath}/maven-publish/conditional-publishing/tests/publishingMavenConditionally.out[]
 ----
 
 You may also want to define your own aggregate tasks to help with your workflow. For example, imagine that you have several publications that should be published to the external repository. It could be very useful to publish all of them in one go without publishing the internal ones.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_signing.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_signing.adoc
@@ -22,5 +22,5 @@ This will create a `Sign` task for each publication you specify and wire all `pu
 .Output of `gradle publish`
 ----
 > gradle publish
-include::{snippetsPath}/signing/maven-publish/tests/publishingMavenSignAndPublish.out
+include::{snippetsPath}/signing/maven-publish/tests/publishingMavenSignAndPublish.out[]
 ----

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
@@ -154,7 +154,7 @@ This will create a task (of type link:{groovyDslPath}/org.gradle.plugins.signing
 .Output of **`gradle signMavenJavaPublication`**
 ----
 > gradle signMavenJavaPublication
-include::{snippetsPath}/signing/maven-publish/tests/signingPluginSignPublication.out
+include::{snippetsPath}/signing/maven-publish/tests/signingPluginSignPublication.out[]
 ----
 
 In addition, the above DSL allows to `sign` multiple comma-separated publications. Alternatively, you may specify `publishing.publications` to sign all publications, or use `publishing.publications.matching { … }` to sign all publications that match the specified predicate.
@@ -177,7 +177,7 @@ This will create a task (of type link:{groovyDslPath}/org.gradle.plugins.signing
 .Output of **`gradle signArchives`**
 ----
 > gradle signArchives
-include::{snippetsPath}/signing/maven/tests/signingArchivesOutput.out
+include::{snippetsPath}/signing/maven/tests/signingArchivesOutput.out[]
 ----
 
 [[sec:signing_tasks]]
@@ -200,7 +200,7 @@ The signature file will be placed alongside the artifact being signed.
 .Output of **`gradle signStuffZip`**
 ----
 > gradle signStuffZip
-include::{snippetsPath}/signing/tasks/tests/signingTaskOutput.out
+include::{snippetsPath}/signing/tasks/tests/signingTaskOutput.out[]
 ----
 
 For a task to be _signable_, it must produce an archive of some type, i.e. it must extend link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask].

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_plugins.adoc
@@ -64,7 +64,7 @@ include::sample[dir="snippets/customPlugins/customPlugin/kotlin",files="build.gr
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/customPlugins/customPlugin/tests/customPlugin.out
+include::{snippetsPath}/customPlugins/customPlugin/tests/customPlugin.out[]
 ----
 
 One thing to note is that a new instance of a plugin is created for each project it is applied to. Also note that the link:{javadocPath}/org/gradle/api/Plugin.html[Plugin] class is a generic type.
@@ -92,7 +92,7 @@ include::sample[dir="snippets/customPlugins/customPluginWithConvention/kotlin",f
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/customPlugins/customPluginWithConvention/tests/customPluginWithConvention.out
+include::{snippetsPath}/customPlugins/customPluginWithConvention/tests/customPluginWithConvention.out[]
 ----
 
 In this example, `GreetingPluginExtension` is an object with a property called `message`. The extension object is added to the project with the name `greeting`.
@@ -110,7 +110,7 @@ include::sample[dir="snippets/customPlugins/customPluginWithAdvancedConvention/k
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/customPlugins/customPluginWithAdvancedConvention/tests/customPluginWithAdvancedConvention.out
+include::{snippetsPath}/customPlugins/customPluginWithAdvancedConvention/tests/customPluginWithAdvancedConvention.out[]
 ----
 
 [.multi-language-text.lang-groovy]
@@ -144,7 +144,7 @@ include::sample[dir="snippets/tasks/customTaskWithFileProperty/kotlin",files="bu
 .Output of **`gradle -q sayGreeting`**
 ----
 > gradle -q sayGreeting
-include::{snippetsPath}/tasks/customTaskWithFileProperty/tests/lazyFileProperties.out
+include::{snippetsPath}/tasks/customTaskWithFileProperty/tests/lazyFileProperties.out[]
 ----
 
 In this example, we configure the `greet` task `destination` property as a closure/provider, which is evaluated with

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
@@ -64,7 +64,7 @@ include::sample[dir="snippets/tasks/customTask/kotlin",files="build.gradle.kts[t
 .Output of **`gradle -q hello`**
 ----
 > gradle -q hello
-include::{snippetsPath}/tasks/customTask/tests/customTaskWithAction.out
+include::{snippetsPath}/tasks/customTask/tests/customTaskWithAction.out[]
 ----
 
 Let's add a property to the task, so we can customize it. Tasks are simply POGOs, and when you declare a task, you can set the properties or call methods on the task object. Here we add a `greeting` property, and set the value when we declare the `greeting` task.
@@ -78,7 +78,7 @@ include::sample[dir="snippets/tasks/customTaskWithProperty/kotlin",files="build.
 .Output of **`gradle -q hello greeting`**
 ----
 > gradle -q hello greeting
-include::{snippetsPath}/tasks/customTaskWithProperty/tests/customTaskWithProperty.out
+include::{snippetsPath}/tasks/customTaskWithProperty/tests/customTaskWithProperty.out[]
 ----
 
 
@@ -242,7 +242,7 @@ include::sample[dir="snippets/tasks/incrementalTask/kotlin",files="build.gradle.
 .Output of `gradle -q incrementalReverse`
 ----
 > gradle -q incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskFirstRun.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskFirstRun.out[]
 ----
 ====
 
@@ -253,7 +253,7 @@ Naturally when the task is executed again with no changes, then the entire task 
 .Output of `gradle incrementalReverse`
 ----
 > gradle incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskNoChange.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskNoChange.out[]
 ----
 ====
 
@@ -268,7 +268,7 @@ include::sample[dir="snippets/tasks/incrementalTask/kotlin",files="build.gradle.
 .Output of `gradle -q updateInputs incrementalReverse`
 ----
 > gradle -q updateInputs incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskUpdatedInputs.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskUpdatedInputs.out[]
 ----
 ====
 
@@ -286,7 +286,7 @@ include::sample[dir="snippets/tasks/incrementalTask/kotlin",files="build.gradle.
 .Output of `gradle -q removeInput incrementalReverse`
 ----
 > gradle -q removeInput incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskRemovedInput.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskRemovedInput.out[]
 ----
 ====
 
@@ -302,7 +302,7 @@ include::sample[dir="snippets/tasks/incrementalTask/kotlin",files="build.gradle.
 .Output of `gradle -q removeOutput incrementalReverse`
 ----
 > gradle -q removeOutput incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskRemovedOutput.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskRemovedOutput.out[]
 ----
 ====
 
@@ -317,7 +317,7 @@ Here's the output you can expect in this case:
 .Output of `gradle -q -PtaskInputProperty=changed incrementalReverse`
 ----
 > gradle -q -PtaskInputProperty=changed incrementalReverse
-include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskChangedProperty.out
+include::{snippetsPath}/tasks/incrementalTask/tests/incrementalTaskChangedProperty.out[]
 ----
 ====
 
@@ -376,7 +376,7 @@ include::sample[dir="snippets/tasks/commandLineOption-stringOption/kotlin",files
 .Output of **`gradle -q verifyUrl --url=http://www.google.com/`**
 ----
 > gradle -q verifyUrl --url=http://www.google.com/
-include::{snippetsPath}/tasks/commandLineOption-stringOption/tests/taskCommandLineOption.out
+include::{snippetsPath}/tasks/commandLineOption-stringOption/tests/taskCommandLineOption.out[]
 ----
 
 [[sec:supported_task_option_data_types]]
@@ -426,7 +426,7 @@ Command line options using the annotations link:{javadocPath}/org/gradle/api/tas
 .Output of **`gradle -q help --task processUrl`**
 ----
 > gradle -q help --task processUrl
-include::{snippetsPath}/tasks/commandLineOption-optionValues/tests/helpTaskOptions.out
+include::{snippetsPath}/tasks/commandLineOption-optionValues/tests/helpTaskOptions.out[]
 ----
 
 === Limitations

--- a/subprojects/docs/src/docs/userguide/extending-gradle/lazy_configuration.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/lazy_configuration.adoc
@@ -54,7 +54,7 @@ include::sample[dir="snippets/providers/propertyAndProvider/kotlin",files="build
 .Output of **`gradle greeting`**
 ----
 $ gradle greeting
-include::{snippetsPath}/providers/propertyAndProvider/tests/usePropertyAndProvider.out
+include::{snippetsPath}/providers/propertyAndProvider/tests/usePropertyAndProvider.out[]
 ----
 
 The `Greeting` task has a property of type `Property<String>` to represent the configurable greeting and a property of type `Provider<String>` to represent the calculated, read-only, message. The message `Provider` is created from the greeting `Property` using the `map()` method, and so its value is kept up-to-date as the value of the greeting property changes.
@@ -101,7 +101,7 @@ include::sample[dir="snippets/providers/connectProperties/kotlin",files="build.g
 .Output of **`gradle greeting`**
 ----
 $ gradle greeting
-include::{snippetsPath}/providers/connectProperties/tests/connectProperties.out
+include::{snippetsPath}/providers/connectProperties/tests/connectProperties.out[]
 ----
 
 This example calls the link:{javadocPath}/org/gradle/api/provider/Property.html#set-org.gradle.api.provider.Provider-[Property.set(Provider)] method to attach a `Provider` to a `Property` to supply the value of the property. In this case, the `Provider` happens to be a `Property` as well, but you can connect any `Provider` implementation, for example one created using `Provider.map()`
@@ -141,13 +141,13 @@ include::sample[dir="snippets/providers/fileAndDirectoryProperty/kotlin",files="
 [.multi-language-text.lang-groovy]
 ----
 $ gradle print
-include::{snippetsPath}/providers/fileAndDirectoryProperty/tests/workingWithFilesGroovy.out
+include::{snippetsPath}/providers/fileAndDirectoryProperty/tests/workingWithFilesGroovy.out[]
 ----
 .Output of **`gradle print`**
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle print
-include::{snippetsPath}/providers/fileAndDirectoryProperty/tests/workingWithFilesKotlin.out
+include::{snippetsPath}/providers/fileAndDirectoryProperty/tests/workingWithFilesKotlin.out[]
 ----
 
 This example creates providers that represent locations in the project and build directories through link:{javadocPath}/org/gradle/api/Project.html#getLayout--[Project.getLayout()] with link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#getBuildDirectory--[ProjectLayout.getBuildDirectory()] and link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#getProjectDirectory--[ProjectLayout.getProjectDirectory()].
@@ -171,13 +171,13 @@ include::sample[dir="snippets/providers/implicitTaskInputFileDependency/kotlin",
 [.multi-language-text.lang-groovy]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/implicitTaskInputFileDependency/tests/implicitTaskInputFileDependencyGroovy.out
+include::{snippetsPath}/providers/implicitTaskInputFileDependency/tests/implicitTaskInputFileDependencyGroovy.out[]
 ----
 .Output of **`gradle consumer`**
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/implicitTaskInputFileDependency/tests/implicitTaskInputFileDependencyKotlin.out
+include::{snippetsPath}/providers/implicitTaskInputFileDependency/tests/implicitTaskInputFileDependencyKotlin.out[]
 ----
 
 In the example above, the task outputs and inputs are connected before any location is defined. The setters can be called at any time before the task is executed and the change will automatically affect all related input and output properties.
@@ -196,13 +196,13 @@ include::sample[dir="snippets/providers/implicitTaskInputDependency/kotlin",file
 [.multi-language-text.lang-groovy]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/implicitTaskInputDependency/tests/implicitTaskInputDependencyGroovy.out
+include::{snippetsPath}/providers/implicitTaskInputDependency/tests/implicitTaskInputDependencyGroovy.out[]
 ----
 .Output of **`gradle consumer`**
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/implicitTaskInputDependency/tests/implicitTaskInputDependencyKotlin.out
+include::{snippetsPath}/providers/implicitTaskInputDependency/tests/implicitTaskInputDependencyKotlin.out[]
 ----
 
 [[working_with_collections]]
@@ -231,13 +231,13 @@ include::sample[dir="snippets/providers/listProperty/kotlin",files="build.gradle
 [.multi-language-text.lang-groovy]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/listProperty/tests/listPropertyGroovy.out
+include::{snippetsPath}/providers/listProperty/tests/listPropertyGroovy.out[]
 ----
 .Output of **`gradle consumer`**
 [.multi-language-text.lang-kotlin]
 ----
 $ gradle consumer
-include::{snippetsPath}/providers/listProperty/tests/listPropertyKotlin.out
+include::{snippetsPath}/providers/listProperty/tests/listPropertyKotlin.out[]
 ----
 
 [[working_with_maps]]
@@ -257,7 +257,7 @@ include::sample[dir="snippets/providers/mapProperty/kotlin",files="build.gradle.
 .Output of **`gradle consumer`**
 ----
 $ gradle generate
-include::{snippetsPath}/providers/mapProperty/tests/mapProperty.out
+include::{snippetsPath}/providers/mapProperty/tests/mapProperty.out[]
 ----
 
 [[applying_conventions]]
@@ -274,7 +274,7 @@ include::sample[dir="snippets/providers/propertyConvention/kotlin",files="build.
 .Output of **`gradle show`**
 ----
 $ gradle show
-include::{snippetsPath}/providers/propertyConvention/tests/propertyConvention.out
+include::{snippetsPath}/providers/propertyConvention/tests/propertyConvention.out[]
 ----
 
 [[unmodifiable_property]]

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -213,7 +213,7 @@ include::sample[dir="snippets/java/customDirs/kotlin",files="build.gradle.kts[ta
 .Output of **`gradle -q showDirs`**
 ----
 > gradle -q showDirs
-include::{snippetsPath}/java/customDirs/tests/javaCustomReportDirs.out
+include::{snippetsPath}/java/customDirs/tests/javaCustomReportDirs.out[]
 ----
 
 Follow the link to the convention properties for more details.
@@ -633,7 +633,7 @@ It's worth noting that if the external project is _not_ publishing Gradle Module
 .Output of **`gradle dependencyInsight --configuration functionalTestClasspath --dependency gson`**
 ----
 > gradle dependencyInsight --configuration functionalTestClasspath --dependency gson
-include::{snippetsPath}/java/fixtures/tests/dependencyInsight.out
+include::{snippetsPath}/java/fixtures/tests/dependencyInsight.out[]
 ----
 
 The error message mentions the missing `com.google.code.gson:gson-test-fixtures` capability, which is indeed not defined for this library.

--- a/subprojects/docs/src/docs/userguide/legacy/software_model.adoc
+++ b/subprojects/docs/src/docs/userguide/legacy/software_model.adoc
@@ -78,7 +78,7 @@ include::{snippetsPath}/modelRules/basicRuleSourcePlugin/groovy/build.gradle[tag
 .Output of **`gradle hello`**
 ----
 > gradle hello
-include::{snippetsPath}/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-all.out
+include::{snippetsPath}/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-all.out[]
 ----
 
 Each of the different methods of the rule source are discrete, independent rules. Their order, or the fact that they belong to the same class, do not affect their behavior.
@@ -404,7 +404,7 @@ include::{snippetsPath}/modelRules/configureAsRequired/groovy/build.gradle[tag=c
 .Output of **`gradle showPerson`**
 ----
 > gradle showPerson
-include::{snippetsPath}/modelRules/configureAsRequired/tests/modelDslConfigureRuleRunWhenRequired.out
+include::{snippetsPath}/modelRules/configureAsRequired/tests/modelDslConfigureRuleRunWhenRequired.out[]
 ----
 
 You can see that before the task is run, the "person" element is configured by running the rule closure. Now let's run a task that does not require the "person" element:
@@ -414,7 +414,7 @@ You can see that before the task is run, the "person" element is configured by r
 .Output of **`gradle somethingElse`**
 ----
 > gradle somethingElse
-include::{snippetsPath}/modelRules/configureAsRequired/tests/modelDslConfigureRuleNotRunWhenNotRequired.out
+include::{snippetsPath}/modelRules/configureAsRequired/tests/modelDslConfigureRuleNotRunWhenNotRequired.out[]
 ----
 
 In this instance, you can see that the "person" element is not configured at all.
@@ -471,7 +471,7 @@ include::{snippetsPath}/modelRules/initializationRuleRunsBeforeConfigurationRule
 .Output of **`gradle showPerson`**
 ----
 > gradle showPerson
-include::{snippetsPath}/modelRules/initializationRuleRunsBeforeConfigurationRules/tests/modelDslInitializationRuleRunsBeforeConfigurationRule.out
+include::{snippetsPath}/modelRules/initializationRuleRunsBeforeConfigurationRules/tests/modelDslInitializationRuleRunsBeforeConfigurationRule.out[]
 ----
 
 Notice that the creation rule appears in the build script _after_ the configuration rule, but its code runs before the code of the configuration rule. Gradle collects up all the rules for a particular subject before running any of them, then runs the rules in the appropriate order.
@@ -533,7 +533,7 @@ include::{snippetsPath}/modelRules/configureElementsOfMap/groovy/build.gradle[ta
 .Output of **`gradle listPeople`**
 ----
 > gradle listPeople
-include::{snippetsPath}/modelRules/configureElementsOfMap/tests/modelDslModelMapNestedAll.out
+include::{snippetsPath}/modelRules/configureElementsOfMap/tests/modelDslModelMapNestedAll.out[]
 ----
 
 Any method on link:{javadocPath}/org/gradle/model/ModelMap.html[ModelMap] that accepts an link:{javadocPath}/org/gradle/api/Action.html[Action] as its last parameter can also be used to define a nested rule.
@@ -638,7 +638,7 @@ The built-in link:{groovyDslPath}/org.gradle.api.reporting.model.ModelReport.htm
 .Output of `gradle model`
 ----
 > gradle model
-include::{snippetsPath}/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.out
+include::{snippetsPath}/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.out[]
 ----
 
 

--- a/subprojects/docs/src/docs/userguide/legacy/software_model_extend.adoc
+++ b/subprojects/docs/src/docs/userguide/legacy/software_model_extend.adoc
@@ -209,7 +209,7 @@ And in the components reports for such a build script we can see our model types
 .Output of **`gradle -q components`**
 ----
 > gradle -q components
-include::{snippetsPath}/customModel/languageType/tests/softwareModelExtend-components.out
+include::{snippetsPath}/customModel/languageType/tests/softwareModelExtend-components.out[]
 ----
 
 
@@ -263,7 +263,7 @@ include::{snippetsPath}/customModel/internalViews/groovy/build.gradle[tag=build-
 .Output of `gradle -q model`
 ----
 > gradle -q model
-include::{snippetsPath}/customModel/internalViews/tests/softwareModelExtend-iv-model.out
+include::{snippetsPath}/customModel/internalViews/tests/softwareModelExtend-iv-model.out[]
 ----
 
 We can see in this report that `publicData` is present and that `internalData` is not.

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
@@ -399,7 +399,7 @@ include::sample[dir="snippets/mavenMigration/multiModule/kotlin",files="settings
 .Output of **`gradle projects`**
 ----
 > gradle projects
-include::{snippetsPath}/mavenMigration/multiModule/tests/projects.out
+include::{snippetsPath}/mavenMigration/multiModule/tests/projects.out[]
 ----
  2. Replace cross-module dependencies with <<declaring_dependencies.adoc#sub:project_dependencies,project dependencies>>.
  3. Replicate project inheritance with <<multi_project_builds#sec:cross_project_configuration,cross-project configuration>>.
@@ -460,12 +460,12 @@ With this setup in place, you can activate one of the profiles by passing a valu
 .Output of **`gradle greeting`**
 ----
 > gradle greeting
-include::{snippetsPath}/mavenMigration/profiles/tests/greeting-default.out
+include::{snippetsPath}/mavenMigration/profiles/tests/greeting-default.out[]
 ----
 .Output of **`gradle -PbuildProfile=test greeting`**
 ----
 > gradle -PbuildProfile=test greeting
-include::{snippetsPath}/mavenMigration/profiles/tests/greeting-test.out
+include::{snippetsPath}/mavenMigration/profiles/tests/greeting-test.out[]
 ----
 
 You're not limited to checking project properties.

--- a/subprojects/docs/src/docs/userguide/native/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native/native_software.adoc
@@ -244,7 +244,7 @@ Gradle provides a report that you can run from the command-line that shows a gra
 .Output of **`gradle dependentComponents`**
 ----
 > gradle dependentComponents
-include::{snippetsPath}/native-binaries/cunit/tests/dependentComponentsReport.out
+include::{snippetsPath}/native-binaries/cunit/tests/dependentComponentsReport.out[]
 ----
 
 [NOTE]
@@ -259,7 +259,7 @@ By default, non-buildable binaries and test suites are hidden from the report. T
 .Output of **`gradle dependentComponents --all`**
 ----
 > gradle dependentComponents --all
-include::{snippetsPath}/native-binaries/cunit/tests/dependentComponentsReportAll.out
+include::{snippetsPath}/native-binaries/cunit/tests/dependentComponentsReportAll.out[]
 ----
 
 Here is the corresponding report for the `operators` component, showing dependents of all its binaries:
@@ -269,7 +269,7 @@ Here is the corresponding report for the `operators` component, showing dependen
 .Output of **`gradle dependentComponents --component operators`**
 ----
 > gradle dependentComponents --component operators
-include::{snippetsPath}/native-binaries/cunit/tests/assembleDependentComponentsReport.out
+include::{snippetsPath}/native-binaries/cunit/tests/assembleDependentComponentsReport.out[]
 ----
 
 Here is the corresponding report for the `operators` component, showing dependents of all its binaries, including test suites:
@@ -279,7 +279,7 @@ Here is the corresponding report for the `operators` component, showing dependen
 .Output of **`gradle dependentComponents --test-suites --component operators`**
 ----
 > gradle dependentComponents --test-suites --component operators
-include::{snippetsPath}/native-binaries/cunit/tests/buildDependentComponentsReport.out
+include::{snippetsPath}/native-binaries/cunit/tests/buildDependentComponentsReport.out[]
 ----
 
 
@@ -297,7 +297,7 @@ For example, to assemble the dependents of the "passing" flavor of the "static" 
 .Output of **`gradle assembleDependentsOperatorsPassingStaticLibrary --max-workers=1`**
 ----
 > gradle assembleDependentsOperatorsPassingStaticLibrary --max-workers=1
-include::{snippetsPath}/native-binaries/cunit/tests/assembleDependentComponents.out
+include::{snippetsPath}/native-binaries/cunit/tests/assembleDependentComponents.out[]
 ----
 
 In the output above, the targeted binary gets assembled as well as the test suite binary that depends on it.
@@ -318,7 +318,7 @@ For example, to build the dependents of the "passing" flavor of the "static" lib
 .Output of **`gradle buildDependentsOperatorsPassingStaticLibrary --max-workers=1`**
 ----
 > gradle buildDependentsOperatorsPassingStaticLibrary --max-workers=1
-include::{snippetsPath}/native-binaries/cunit/tests/buildDependentComponents.out
+include::{snippetsPath}/native-binaries/cunit/tests/buildDependentComponents.out[]
 ----
 
 In the output above, the targeted binary as well as the test suite binary that depends on it are built and the test suite has run.
@@ -402,7 +402,7 @@ Now, running `check` or any of the _check tasks_ for the `hello` binaries will r
 .Output of **`gradle checkHelloSharedLibrary`**
 ----
 > gradle checkHelloSharedLibrary
-include::{snippetsPath}/native-binaries/custom-check/tests/nativeComponentCustomCheckOutput.out
+include::{snippetsPath}/native-binaries/custom-check/tests/nativeComponentCustomCheckOutput.out[]
 ----
 
 
@@ -421,7 +421,7 @@ Gradle provides a report that you can run from the command-line that shows some 
 .Output of **`gradle components`**
 ----
 > gradle components
-include::{snippetsPath}/native-binaries/cpp/tests/nativeComponentReport.out
+include::{snippetsPath}/native-binaries/cpp/tests/nativeComponentReport.out[]
 ----
 
 
@@ -968,7 +968,7 @@ include::{snippetsPath}/native-binaries/cunit/groovy/build.gradle[tag=complete-e
 .Output of `gradle -q runOperatorsTestFailingCUnitExe`
 ----
 > gradle -q runOperatorsTestFailingCUnitExe
-include::{snippetsPath}/native-binaries/cunit/tests/completeCUnitExample.out
+include::{snippetsPath}/native-binaries/cunit/tests/completeCUnitExample.out[]
 ----
 
 

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -107,7 +107,7 @@ image::commandLineTutorialTasks.png[]
 .Excluding tasks
 ----
 $ gradle dist --exclude-task test
-include::{snippetsPath}/tutorial/excludeTasks/tests/excludeTask.out
+include::{snippetsPath}/tutorial/excludeTasks/tests/excludeTask.out[]
 ----
 
 You can see that the `test` task is not executed, even though it is a dependency of the `dist` task. The `test` task's dependencies such as `compileTest` are not executed either. Those dependencies of `test` that are required by another task, such as `compile`, are still executed.
@@ -145,7 +145,7 @@ You can also abbreviate each word in a camel case task name. For example, you ca
 .Abbreviated camel case task name
 ----
 $ gradle cT
-include::{snippetsPath}/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.out
+include::{snippetsPath}/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.out[]
 ----
 
 You can also use these abbreviations with the -x command-line option.
@@ -232,7 +232,7 @@ Running `gradle help --task someTask` gives you detailed information about a spe
 .Obtaining detailed help for tasks
 ----
 $ gradle -q help --task libs
-include::{snippetsPath}/tutorial/projectReports/tests/taskHelp.out
+include::{snippetsPath}/tutorial/projectReports/tests/taskHelp.out[]
 ----
 
 This information includes the full task path, the task type, possible command line options and the description of the given task.
@@ -283,7 +283,7 @@ Running `gradle properties` gives you a list of the properties of the selected p
 .Information about properties
 ----
 $ gradle -q api:properties
-include::{snippetsPath}/tutorial/projectReports/tests/propertyListReport.out
+include::{snippetsPath}/tutorial/projectReports/tests/propertyListReport.out[]
 ----
 
 === Software Model reports

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -43,7 +43,7 @@ Every vanilla Gradle build comes with a built-in task called `wrapper`. You’ll
 .Running the Wrapper task
 ----
 $ gradle wrapper
-include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out
+include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out[]
 ----
 
 [NOTE]
@@ -85,7 +85,7 @@ Let’s assume the following use case to illustrate the use of the command line 
 [listing,subs=+attributes]
 ----
 $ gradle wrapper --gradle-version {gradleVersion} --distribution-type all
-include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out
+include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out[]
 ----
 
 As a result you can find the desired information in the Wrapper properties file.
@@ -132,7 +132,7 @@ It is recommended to always execute a build with the Wrapper to ensure a reliabl
 .Executing the build with the Wrapper batch file
 ----
 $ gradlew.bat build
-include::{snippetsPath}/wrapper/simple/tests/wrapperBatchFileExecution.out
+include::{snippetsPath}/wrapper/simple/tests/wrapperBatchFileExecution.out[]
 ----
 
 In case the Gradle distribution is not available on the machine, the Wrapper will download it and store in the local file system. Any subsequent build invocation is going to reuse the existing local distribution as long as the distribution URL in the Gradle properties doesn't change.
@@ -155,7 +155,7 @@ Use the Gradle `wrapper` task to generate the wrapper, specifying a version. The
 [listing,subs=+attributes]
 ----
 $ ./gradlew wrapper --gradle-version {gradleVersion}
-include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out
+include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 ----
 
 [[customizing_wrapper]]

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -104,7 +104,7 @@ include::sample[dir="snippets/tutorial/properties/kotlin",files="build.gradle.kt
 
 ----
 $ gradle -q -PcommandLineProjectProp=commandLineProjectPropValue -Dorg.gradle.project.systemProjectProp=systemPropertyValue printProps
-include::{snippetsPath}/tutorial/properties/tests/properties.out
+include::{snippetsPath}/tutorial/properties/tests/properties.out[]
 ----
 
 [[sec:gradle_system_properties]]
@@ -234,7 +234,7 @@ include::sample[dir="snippets/tutorial/configureTaskUsingProjectProperty/kotlin"
 
 ----
 $ gradle performRelease -PisCI=true --quiet
-include::{snippetsPath}/tutorial/configureTaskUsingProjectProperty/tests/configureTaskUsingProjectProperty.out
+include::{snippetsPath}/tutorial/configureTaskUsingProjectProperty/tests/configureTaskUsingProjectProperty.out[]
 ----
 
 [[sec:accessing_the_web_via_a_proxy]]

--- a/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
@@ -69,12 +69,12 @@ include::sample[dir="snippets/initScripts/configurationInjection/kotlin",files="
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q showRepos
-include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out
+include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q showRepos
-include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out
+include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out[]
 ----
 
 [[sec:custom_classpath]]
@@ -106,12 +106,12 @@ Output when applying the init script
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q doNothing
-include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out
+include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q doNothing
-include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out
+include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out[]
 ----
 
 [[sec:init_script_plugins]]
@@ -130,12 +130,12 @@ Output when applying the init script
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q showRepositories
-include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out
+include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q showRepositories
-include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out
+include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out[]
 ----
 
 The plugin in the init script ensures that only a specified repository is used when running the build.

--- a/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
@@ -69,12 +69,12 @@ include::sample[dir="snippets/initScripts/configurationInjection/kotlin",files="
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q showRepos
-include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out[]
+include::{snippetsPath}/initScripts/configurationInjection/tests-common/initScriptConfiguration.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q showRepos
-include::{snippetsPath}/initScripts/configurationInjection/tests/initScriptConfiguration.out[]
+include::{snippetsPath}/initScripts/configurationInjection/tests-common/initScriptConfiguration.out[]
 ----
 
 [[sec:custom_classpath]]
@@ -106,12 +106,12 @@ Output when applying the init script
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q doNothing
-include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out[]
+include::{snippetsPath}/initScripts/externalDependency/tests-common/externalInitDependency.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q doNothing
-include::{snippetsPath}/initScripts/externalDependency/tests/externalInitDependency.out[]
+include::{snippetsPath}/initScripts/externalDependency/tests-common/externalInitDependency.out[]
 ----
 
 [[sec:init_script_plugins]]
@@ -130,12 +130,12 @@ Output when applying the init script
 [source.multi-language-sample,groovy]
 ----
 > gradle --init-script init.gradle -q showRepositories
-include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out[]
+include::{snippetsPath}/initScripts/plugins/tests-common/usePluginsInInitScripts.out[]
 ----
 [source.multi-language-sample,kotlin]
 ----
 > gradle --init-script init.gradle.kts -q showRepositories
-include::{snippetsPath}/initScripts/plugins/tests/usePluginsInInitScripts.out[]
+include::{snippetsPath}/initScripts/plugins/tests-common/usePluginsInInitScripts.out[]
 ----
 
 The plugin in the init script ensures that only a specified repository is used when running the build.

--- a/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
@@ -39,7 +39,7 @@ The `settings.gradle` file tells Gradle how the project and subprojects are stru
 .Output of **`gradle -q projects`**
 ----
 > gradle -q projects
-include::{snippetsPath}/java/multiproject/tests/listProjects.out
+include::{snippetsPath}/java/multiproject/tests/listProjects.out[]
 ----
 
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/13320

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
During the snippets refactoring we accidentally removed a couple of required markers (i.e. `[]` characters at the end of the file references) from the adoc files. Because of those missing markers, the build also didn't fail when we shuffled the snippet files. This PR fixes both problems. 
