### PR TITLE
Improve tracking of unattached dependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -66,6 +66,7 @@ class EdgeState implements DependencyGraphEdge {
     private ExcludeSpec cachedExclusions;
 
     private ResolvedVariantResult resolvedVariant;
+    private boolean unattached;
 
     EdgeState(NodeState from, DependencyState dependencyState, ExcludeSpec transitiveExclusions, ResolveState resolveState) {
         this.from = from;
@@ -181,9 +182,13 @@ class EdgeState implements DependencyGraphEdge {
         targetNodeSelectionFailure = new ModuleVersionResolveException(dependencyState.getRequested(), err);
     }
 
-    public void restart() {
+    public void restart(boolean checkUnattached) {
         if (from.isSelected()) {
             removeFromTargetConfigurations();
+            // We now have corner cases that can lead to this restart not succeeding
+            if (checkUnattached && !isUnattached()) {
+                selector.getTargetModule().addUnattachedDependency(this);
+            }
             attachToTargetConfigurations();
         }
     }
@@ -429,5 +434,17 @@ class EdgeState implements DependencyGraphEdge {
         for (NodeState targetNode : targetNodes) {
             targetNode.updateTransitiveExcludes();
         }
+    }
+
+    public void markUnattached() {
+        this.unattached = true;
+    }
+
+    public void markAttached() {
+        this.unattached = false;
+    }
+
+    public boolean isUnattached() {
+        return unattached;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -262,20 +262,23 @@ class ModuleResolveState implements CandidateModule {
     private void restartUnattachedDependencies() {
         if (unattachedDependencies.size() == 1) {
             EdgeState singleDependency = unattachedDependencies.get(0);
-            singleDependency.restart();
+            singleDependency.restart(false);
         } else {
             for (EdgeState dependency : new ArrayList<>(unattachedDependencies)) {
-                dependency.restart();
+                dependency.restart(false);
             }
         }
     }
 
     public void addUnattachedDependency(EdgeState edge) {
         unattachedDependencies.add(edge);
+        edge.markUnattached();
     }
 
     public void removeUnattachedDependency(EdgeState edge) {
-        unattachedDependencies.remove(edge);
+        if (unattachedDependencies.remove(edge)) {
+            edge.markAttached();
+        }
     }
 
     public ComponentState getVersion(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -615,7 +615,7 @@ public class NodeState implements DependencyGraphNode {
 
     public void evict() {
         evicted = true;
-        restartIncomingEdges();
+        restartIncomingEdges(false);
     }
 
     boolean shouldIncludedInGraphResult() {
@@ -976,18 +976,18 @@ public class NodeState implements DependencyGraphNode {
             }
         } else {
             if (!incomingEdges.isEmpty()) {
-                restartIncomingEdges();
+                restartIncomingEdges(true);
             }
         }
     }
 
-    private void restartIncomingEdges() {
+    private void restartIncomingEdges(boolean checkUnattached) {
         if (incomingEdges.size() == 1) {
             EdgeState singleEdge = incomingEdges.get(0);
-            singleEdge.restart();
+            singleEdge.restart(checkUnattached);
         } else {
             for (EdgeState dependency : new ArrayList<>(incomingEdges)) {
-                dependency.restart();
+                dependency.restart(checkUnattached);
             }
         }
         clearIncomingEdges();


### PR DESCRIPTION
When restarting an edge, it is possible that the new state fails to
compute the target node. In some cases, it is important to make sure the
detached edge is effectively tracked as an unattached edge.

This PR still needs a test illustrating the problem - work ongoing