### PR TITLE
Add support for classpath hashing of zips nested in directories

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -182,7 +182,11 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
             if (shouldBeIgnored) {
                 return null;
             }
-            return classpathResourceHasher.hash(fileSnapshot);
+            if (ZipHasher.isZipFile(fileSnapshot.getName())) {
+                return fingerprintZipContents(fileSnapshot);
+            } else {
+                return classpathResourceHasher.hash(fileSnapshot);
+            }
         }
 
         @Override


### PR DESCRIPTION
We currently hash entries in zips/jars that we find inside other zips/jars - this adds support for hashing the entries of zips/jars that we find in directories as well.