### PR TITLE
Let Exec and JavaExec tasks work with configuration caching

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.caching.http.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.keystore.TestKeyStore
 
@@ -67,7 +66,6 @@ class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec imple
         skipped ":compileJava"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "outputs are correctly loaded from cache"() {
         buildFile << """
             apply plugin: "application"

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class GroovyApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
@@ -26,7 +25,6 @@ class GroovyApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     public static final String SAMPLE_APP_TEST_CLASS = "some/thing/AppTest.groovy"
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'groovy-application', '--dsl', scriptDsl.id)
@@ -90,7 +88,6 @@ class GroovyApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source with package and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'groovy-application', '--package', 'my.app', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -139,7 +139,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     @ToBeFixedForInstantExecution
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
-        run('init', '--type', 'java-application', '--test-framework', 'testng', '--package', 'my.app', '--dsl', scriptDsl.id)
+        run('init', '--type', 'java-application', '--test-framework', testFramework.id, '--package', 'my.app', '--dsl', scriptDsl.id)
 
         then:
         targetDir.file("src/main/java").assertHasDescendants("my/app/App.java")
@@ -152,7 +152,14 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("my.app.AppTest", "appHasAGreeting")
+        switch (testFramework) {
+            case BuildInitTestFramework.JUNIT:
+                assertTestPassed("my.app.AppTest", "testAppHasAGreeting")
+                break
+            case BuildInitTestFramework.TESTNG:
+                assertTestPassed("my.app.AppTest", "appHasAGreeting")
+                break
+        }
 
         when:
         run("run")

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -38,7 +38,6 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--dsl', scriptDsl.id)
@@ -91,7 +90,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'testng', '--dsl', scriptDsl.id)
@@ -136,7 +135,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*TestNG.*")
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', testFramework.id, '--package', 'my.app', '--dsl', scriptDsl.id)
@@ -172,7 +171,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "gradle/instant-execution#270")
     def "creates sample source with package and spock and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'spock', '--package', 'my.app', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -141,7 +141,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     @ToBeFixedForInstantExecution
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
-        run('init', '--type', 'java-library', '--test-framework', 'testng', '--package', 'my.lib', '--dsl', scriptDsl.id)
+        run('init', '--type', 'java-library', '--test-framework', testFramework.id, '--package', 'my.lib', '--dsl', scriptDsl.id)
 
         then:
         targetDir.file("src/main/java").assertHasDescendants("my/lib/Library.java")
@@ -154,7 +154,14 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("my.lib.LibraryTest", "someLibraryMethodReturnsTrue")
+        switch (testFramework) {
+            case BuildInitTestFramework.JUNIT:
+                assertTestPassed("my.lib.LibraryTest", "testSomeLibraryMethod")
+                break
+            case BuildInitTestFramework.TESTNG:
+                assertTestPassed("my.lib.LibraryTest", "someLibraryMethodReturnsTrue")
+                break
+        }
 
         where:
         [scriptDsl, testFramework] << [ScriptDslFixture.SCRIPT_DSLS, [BuildInitTestFramework.JUNIT, BuildInitTestFramework.TESTNG]].combinations()

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -89,7 +89,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'testng', '--dsl', scriptDsl.id)
@@ -138,7 +138,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*TestNG.*")
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', testFramework.id, '--package', 'my.lib', '--dsl', scriptDsl.id)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecutionResultExecTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecutionResultExecTaskIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 abstract class AbstractExecutionResultExecTaskIntegrationTest extends AbstractIntegrationSpec {
     protected abstract void makeExecProject()
@@ -50,7 +49,6 @@ abstract class AbstractExecutionResultExecTaskIntegrationTest extends AbstractIn
         result.assertTasksExecutedAndNotSkipped(':verify')
     }
 
-    @ToBeFixedForInstantExecution
     def "returns ExecResult when is executed"() {
         makeExecProject()
         writeSucceedingExec()
@@ -71,7 +69,6 @@ abstract class AbstractExecutionResultExecTaskIntegrationTest extends AbstractIn
         result.assertTasksExecutedAndNotSkipped(':compileJava', ":$taskNameUnderTest", ':verify')
     }
 
-    @ToBeFixedForInstantExecution
     def "execute with non-zero exit value and ignore exit value should not throw exception"() {
         makeExecProject()
         writeFailingExec()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks
 import org.gradle.initialization.StartParameterBuildOptions.BuildCacheDebugLoggingOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
@@ -89,13 +88,12 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*upToDateWhen.*")
     def "cached tasks are executed with #rerunMethod"() {
         expect:
         cacheDir.listFiles() as List == []
         buildFile << """
-            def upToDate = project.findProperty("upToDateWhenFalse") == null
-            tasks.withType(JavaCompile).configureEach { it.outputs.upToDateWhen { upToDate } }
+            def upToDate = providers.gradleProperty('upToDateWhenFalse')
+            tasks.withType(JavaCompile).configureEach { it.outputs.upToDateWhen { !upToDate.present } }
         """
 
         when:
@@ -147,7 +145,6 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         executedAndNotSkipped ":compileJava", ":jar"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "outputs are correctly loaded from cache"() {
         buildFile << """
             apply plugin: "application"
@@ -280,7 +277,6 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "can load twice from the cache with no changes"() {
         given:
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.workers.IsolationMode
@@ -93,7 +92,6 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @IntegrationTestTimeout(60)
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "timeout stops long running exec()"() {
         given:
         file('src/main/java/Block.java') << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/console/AbstractExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/console/AbstractExecOutputIntegrationTest.groovy
@@ -56,7 +56,6 @@ abstract class AbstractExecOutputIntegrationTest extends AbstractConsoleGroupedT
         errorOutput.contains(EXPECTED_ERROR)
     }
 
-    @ToBeFixedForInstantExecution
     def "JavaExec task output is grouped with its task output"() {
         given:
         generateMainJavaFileEchoing(EXPECTED_OUTPUT, EXPECTED_ERROR)

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.process.internal
 
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
@@ -32,7 +31,6 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.exec")
-    @ToBeFixedForInstantExecution(iterationMatchers = "can cancel JavaExec")
     def "can cancel #scenario"() {
         given:
         blockCode()
@@ -77,7 +75,6 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "JavaExec", skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT)
     def "task gets rerun after cancellation when buildcache = #buildCacheEnabled and ignoreExitValue = #ignoreExitValue"() {
         given:
         file('outputFile') << ''

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -209,7 +209,7 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
         startBuild(task, buildCacheEnabled)
         cancelBuild(task)
 
-        def build = executer.withTasks("tasks").withArguments("--debug").start()
+        def build = executer.withTasks("help").withArguments("--debug").start()
         build.waitForFinish()
         assert daemons.daemons.size() == 1
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.process.internal
 
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.internal.jvm.Jvm
@@ -30,7 +31,8 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
     private int daemonLogCheckpoint
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "Exec & JavaExec")
+    @UnsupportedWithInstantExecution(iterationMatchers = ".* project.exec")
+    @ToBeFixedForInstantExecution(iterationMatchers = "can cancel JavaExec")
     def "can cancel #scenario"() {
         given:
         blockCode()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -75,7 +75,7 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "JavaExec")
+    @ToBeFixedForInstantExecution(because = "JavaExec", skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT)
     def "task gets rerun after cancellation when buildcache = #buildCacheEnabled and ignoreExitValue = #ignoreExitValue"() {
         given:
         file('outputFile') << ''

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -45,7 +45,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
 
     private final Class<T> taskType;
     private final Property<ExecResult> execResult;
-    private final ExecSpec execSpec;
+    private final DefaultExecSpec execSpec;
 
     public AbstractExecTask(Class<T> taskType) {
         execSpec = getObjectFactory().newInstance(DefaultExecSpec.class);
@@ -65,25 +65,9 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
 
     @TaskAction
     protected void exec() {
-        execResult.set(createExecAction().execute());
-    }
-
-    private ExecAction createExecAction() {
         ExecAction execAction = getExecActionFactory().newExecAction();
         execSpec.copyTo(execAction);
-        execAction.setExecutable(execSpec.getExecutable());
-        execAction.setCommandLine(execSpec.getCommandLine());
-        execAction.setIgnoreExitValue(execSpec.isIgnoreExitValue());
-        if (execSpec.getStandardInput() != null) {
-            execAction.setStandardInput(execSpec.getStandardInput());
-        }
-        if (execSpec.getStandardOutput() != null) {
-            execAction.setStandardOutput(execSpec.getStandardOutput());
-        }
-        if (execSpec.getErrorOutput() != null) {
-            execAction.setErrorOutput(execSpec.getErrorOutput());
-        }
-        return execAction;
+        execResult.set(execAction.execute());
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
@@ -49,7 +48,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     private final ExecSpec execSpec;
 
     public AbstractExecTask(Class<T> taskType) {
-        execSpec = new DefaultExecSpec(getServices().get(PathToFileResolver.class));
+        execSpec = getObjectFactory().newInstance(DefaultExecSpec.class);
         execResult = getObjectFactory().property(ExecResult.class);
         this.taskType = taskType;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -109,7 +109,7 @@ import java.util.Map;
  * </pre>
  */
 public class JavaExec extends ConventionTask implements JavaExecSpec {
-    private final JavaExecSpec javaExecSpec;
+    private final DefaultJavaExecSpec javaExecSpec;
     private final Property<String> mainModule;
     private final Property<String> mainClass;
     private final ModularitySpec modularity;
@@ -156,30 +156,9 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     @TaskAction
     public void exec() {
         setJvmArgs(getJvmArgs()); // convention mapping for 'jvmArgs'
-        execResult.set(createJavaExecAction().execute());
-    }
-
-    private JavaExecAction createJavaExecAction() {
-        JavaExecAction action = getDslExecActionFactory().newDecoratedJavaExecAction();
-        javaExecSpec.copyTo(action);
-        action.setExecutable(javaExecSpec.getExecutable());
-        action.setIgnoreExitValue(javaExecSpec.isIgnoreExitValue());
-        if (javaExecSpec.getStandardInput() != null) {
-            action.setStandardInput(javaExecSpec.getStandardInput());
-        }
-        if (javaExecSpec.getStandardOutput() != null) {
-            action.setStandardOutput(javaExecSpec.getStandardOutput());
-        }
-        if (javaExecSpec.getErrorOutput() != null) {
-            action.setErrorOutput(javaExecSpec.getErrorOutput());
-        }
-        action.getMainClass().set(javaExecSpec.getMainClass());
-        action.getMainModule().set(javaExecSpec.getMainModule());
-        action.getModularity().getInferModulePath().set(javaExecSpec.getModularity().getInferModulePath());
-        action.classpath(javaExecSpec.getClasspath());
-        action.setArgs(javaExecSpec.getArgs());
-        action.getArgumentProviders().addAll(javaExecSpec.getArgumentProviders());
-        return action;
+        JavaExecAction javaExecAction = getDslExecActionFactory().newDecoratedJavaExecAction();
+        javaExecSpec.copyTo(javaExecAction);
+        execResult.set(javaExecAction.execute());
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -44,7 +44,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
     private StreamsHandler streamsHandler;
     private int timeoutMillis = Integer.MAX_VALUE;
     protected boolean daemon;
-    private Executor executor;
+    private final Executor executor;
 
     AbstractExecHandleBuilder(PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
         super(fileResolver);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -33,10 +33,8 @@ import java.util.concurrent.Executor;
 public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOptions implements BaseExecSpec {
     private static final EmptyStdInStreamsHandler DEFAULT_STDIN = new EmptyStdInStreamsHandler();
     private final BuildCancellationToken buildCancellationToken;
-    private final List<ExecHandleListener> listeners = new ArrayList<ExecHandleListener>();
-    private OutputStream standardOutput;
-    private OutputStream errorOutput;
-    private InputStream input;
+    private final List<ExecHandleListener> listeners = new ArrayList<>();
+    private final ProcessStreamsSpec streamsSpec = new ProcessStreamsSpec();
     private StreamsHandler inputHandler = DEFAULT_STDIN;
     private String displayName;
     private boolean ignoreExitValue;
@@ -50,9 +48,9 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
         super(fileResolver);
         this.buildCancellationToken = buildCancellationToken;
         this.executor = executor;
-        standardOutput = SafeStreams.systemOut();
-        errorOutput = SafeStreams.systemErr();
-        input = SafeStreams.emptyInput();
+        streamsSpec.setStandardOutput(SafeStreams.systemOut());
+        streamsSpec.setErrorOutput(SafeStreams.systemErr());
+        streamsSpec.setStandardInput(SafeStreams.emptyInput());
     }
 
     public abstract List<String> getAllArguments();
@@ -63,7 +61,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
     @Override
     public List<String> getCommandLine() {
-        List<String> commandLine = new ArrayList<String>();
+        List<String> commandLine = new ArrayList<>();
         commandLine.add(getExecutable());
         commandLine.addAll(getAllArguments());
         return commandLine;
@@ -71,7 +69,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
     @Override
     public AbstractExecHandleBuilder setStandardInput(InputStream inputStream) {
-        this.input = inputStream;
+        streamsSpec.setStandardInput(inputStream);
         this.inputHandler = new ForwardStdinStreamsHandler(inputStream);
         return this;
     }
@@ -82,35 +80,29 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
     @Override
     public InputStream getStandardInput() {
-        return input;
+        return streamsSpec.getStandardInput();
     }
 
     @Override
     public AbstractExecHandleBuilder setStandardOutput(OutputStream outputStream) {
-        if (outputStream == null) {
-            throw new IllegalArgumentException("outputStream == null!");
-        }
-        this.standardOutput = outputStream;
+        streamsSpec.setStandardOutput(outputStream);
         return this;
     }
 
     @Override
     public OutputStream getStandardOutput() {
-        return standardOutput;
+        return streamsSpec.getStandardOutput();
     }
 
     @Override
     public AbstractExecHandleBuilder setErrorOutput(OutputStream outputStream) {
-        if (outputStream == null) {
-            throw new IllegalArgumentException("outputStream == null!");
-        }
-        this.errorOutput = outputStream;
+        streamsSpec.setErrorOutput(outputStream);
         return this;
     }
 
     @Override
     public OutputStream getErrorOutput() {
-        return errorOutput;
+        return streamsSpec.getErrorOutput();
     }
 
     @Override
@@ -146,7 +138,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
         StreamsHandler effectiveOutputHandler = getEffectiveStreamsHandler();
         return new DefaultExecHandle(getDisplayName(), getWorkingDir(), executable, getEffectiveArguments(), getActualEnvironment(),
-                effectiveOutputHandler, inputHandler, listeners, redirectErrorStream, timeoutMillis, daemon, executor, buildCancellationToken);
+            effectiveOutputHandler, inputHandler, listeners, redirectErrorStream, timeoutMillis, daemon, executor, buildCancellationToken);
     }
 
     private StreamsHandler getEffectiveStreamsHandler() {
@@ -155,7 +147,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
             effectiveHandler = this.streamsHandler;
         } else {
             boolean shouldReadErrorStream = !redirectErrorStream;
-            effectiveHandler = new OutputStreamsForwarder(standardOutput, errorOutput, shouldReadErrorStream);
+            effectiveHandler = new OutputStreamsForwarder(streamsSpec.getStandardOutput(), streamsSpec.getErrorOutput(), shouldReadErrorStream);
         }
         return effectiveHandler;
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
@@ -16,27 +16,22 @@
 
 package org.gradle.process.internal;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.DefaultBuildCancellationToken;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.CommandLineArgumentProvider;
-import org.gradle.util.GUtil;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 
 /**
  * Use {@link ExecHandleFactory} instead.
  */
-public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implements ExecHandleBuilder {
-    private final List<Object> arguments = new ArrayList<Object>();
-    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<CommandLineArgumentProvider>();
+public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implements ExecHandleBuilder, ProcessArgumentsSpec.HasExecutable {
+
+    private final ProcessArgumentsSpec argumentsSpec = new ProcessArgumentsSpec(this);
 
     public DefaultExecHandleBuilder(PathToFileResolver fileResolver, Executor executor) {
         this(fileResolver, executor, new DefaultBuildCancellationToken());
@@ -54,83 +49,68 @@ public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implemen
 
     @Override
     public DefaultExecHandleBuilder commandLine(Object... arguments) {
-        commandLine(Arrays.asList(arguments));
+        argumentsSpec.commandLine(arguments);
         return this;
     }
 
     @Override
     public DefaultExecHandleBuilder commandLine(Iterable<?> args) {
-        List<Object> argsList = Lists.newArrayList(args);
-        executable(argsList.get(0));
-        setArgs(argsList.subList(1, argsList.size()));
+        argumentsSpec.commandLine(args);
         return this;
     }
 
     @Override
     public void setCommandLine(List<String> args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public void setCommandLine(Object... args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public void setCommandLine(Iterable<?> args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public DefaultExecHandleBuilder args(Object... args) {
-        if (args == null) {
-            throw new IllegalArgumentException("args == null!");
-        }
-        this.arguments.addAll(Arrays.asList(args));
+        argumentsSpec.args(args);
         return this;
     }
 
     @Override
     public DefaultExecHandleBuilder args(Iterable<?> args) {
-        GUtil.addToCollection(arguments, args);
+        argumentsSpec.args(args);
         return this;
     }
 
     @Override
     public DefaultExecHandleBuilder setArgs(List<String> arguments) {
-        this.arguments.clear();
-        this.arguments.addAll(arguments);
+        argumentsSpec.setArgs(arguments);
         return this;
     }
 
     @Override
     public DefaultExecHandleBuilder setArgs(Iterable<?> arguments) {
-        this.arguments.clear();
-        GUtil.addToCollection(this.arguments, arguments);
+        argumentsSpec.setArgs(arguments);
         return this;
     }
 
     @Override
     public List<String> getArgs() {
-        List<String> args = new ArrayList<String>();
-        for (Object argument : arguments) {
-            args.add(argument.toString());
-        }
-        return args;
+        return argumentsSpec.getArgs();
     }
 
     @Override
     public List<CommandLineArgumentProvider> getArgumentProviders() {
-        return argumentProviders;
+        return argumentsSpec.getArgumentProviders();
     }
 
     @Override
     public List<String> getAllArguments() {
-        List<String> args = new ArrayList<String>(getArgs());
-        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
-            Iterables.addAll(args, argumentProvider.asArguments());
-        }
-        return args;
+        return argumentsSpec.getAllArguments();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.process.BaseExecSpec;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.ExecSpec;
+import org.gradle.util.GUtil;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSpec {
+
+    private boolean ignoreExitValue;
+    private final List<Object> arguments = new ArrayList<>();
+    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+
+    private InputStream standardInput;
+    private OutputStream standardOutput;
+    private OutputStream errorOutput;
+
+    public DefaultExecSpec(PathToFileResolver resolver) {
+        super(resolver);
+    }
+
+    @Override
+    public ExecSpec commandLine(Object... arguments) {
+        commandLine(Arrays.asList(arguments));
+        return this;
+    }
+
+    @Override
+    public ExecSpec commandLine(Iterable<?> args) {
+        List<Object> argsList = Lists.newArrayList(args);
+        executable(argsList.get(0));
+        setArgs(argsList.subList(1, argsList.size()));
+        return this;
+    }
+
+    @Override
+    public void setCommandLine(List<String> args) {
+        commandLine(args);
+    }
+
+    @Override
+    public void setCommandLine(Object... args) {
+        commandLine(args);
+    }
+
+    @Override
+    public void setCommandLine(Iterable<?> args) {
+        commandLine(args);
+    }
+
+    @Override
+    public ExecSpec args(Object... args) {
+        if (args == null) {
+            throw new IllegalArgumentException("args == null!");
+        }
+        this.arguments.addAll(Arrays.asList(args));
+        return this;
+    }
+
+    @Override
+    public ExecSpec args(Iterable<?> args) {
+        GUtil.addToCollection(arguments, args);
+        return this;
+    }
+
+    @Override
+    public ExecSpec setArgs(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.addAll(arguments);
+        return this;
+    }
+
+    @Override
+    public ExecSpec setArgs(Iterable<?> arguments) {
+        this.arguments.clear();
+        GUtil.addToCollection(this.arguments, arguments);
+        return this;
+    }
+
+    @Override
+    public List<String> getArgs() {
+        List<String> args = new ArrayList<>();
+        for (Object argument : arguments) {
+            args.add(argument.toString());
+        }
+        return args;
+    }
+
+    @Override
+    public List<CommandLineArgumentProvider> getArgumentProviders() {
+        return argumentProviders;
+    }
+
+    // TODO ExecSpecInternal?
+    public List<String> getAllArguments() {
+        List<String> args = new ArrayList<>(getArgs());
+        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
+            Iterables.addAll(args, argumentProvider.asArguments());
+        }
+        return args;
+    }
+
+    @Override
+    public ExecSpec setIgnoreExitValue(boolean ignoreExitValue) {
+        this.ignoreExitValue = ignoreExitValue;
+        return this;
+    }
+
+    @Override
+    public boolean isIgnoreExitValue() {
+        return ignoreExitValue;
+    }
+
+    @Override
+    public BaseExecSpec setStandardInput(InputStream inputStream) {
+        standardInput = inputStream;
+        return this;
+    }
+
+    @Override
+    public InputStream getStandardInput() {
+        return standardInput;
+    }
+
+    @Override
+    public BaseExecSpec setStandardOutput(OutputStream outputStream) {
+        standardOutput = outputStream;
+        return this;
+    }
+
+    @Override
+    public OutputStream getStandardOutput() {
+        return standardOutput;
+    }
+
+    @Override
+    public BaseExecSpec setErrorOutput(OutputStream outputStream) {
+        errorOutput = outputStream;
+        return this;
+    }
+
+    @Override
+    public OutputStream getErrorOutput() {
+        return errorOutput;
+    }
+
+    @Override
+    public List<String> getCommandLine() {
+        List<String> commandLine = new ArrayList<String>();
+        commandLine.add(getExecutable());
+        commandLine.addAll(getAllArguments());
+        return commandLine;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
@@ -24,6 +24,7 @@ import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecSpec;
 import org.gradle.util.GUtil;
 
+import javax.inject.Inject;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSp
     private OutputStream standardOutput;
     private OutputStream errorOutput;
 
+    @Inject
     public DefaultExecSpec(PathToFileResolver resolver) {
         super(resolver);
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
@@ -16,31 +16,22 @@
 
 package org.gradle.process.internal;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecSpec;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 
-public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSpec {
+public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSpec, ProcessArgumentsSpec.HasExecutable {
 
     private boolean ignoreExitValue;
-    private InputStream standardInput;
-    private OutputStream standardOutput;
-    private OutputStream errorOutput;
-
-    private final List<Object> arguments = new ArrayList<>();
-    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+    private final ProcessStreamsSpec streamsSpec = new ProcessStreamsSpec();
+    private final ProcessArgumentsSpec argumentsSpec = new ProcessArgumentsSpec(this);
 
     @Inject
     public DefaultExecSpec(PathToFileResolver resolver) {
@@ -72,90 +63,68 @@ public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSp
 
     @Override
     public List<String> getCommandLine() {
-        List<String> commandLine = new ArrayList<>();
-        commandLine.add(getExecutable());
-        commandLine.addAll(getAllArguments());
-        return commandLine;
-    }
-
-    private List<String> getAllArguments() {
-        List<String> args = new ArrayList<>(getArgs());
-        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
-            Iterables.addAll(args, argumentProvider.asArguments());
-        }
-        return args;
+        return argumentsSpec.getCommandLine();
     }
 
     @Override
     public ExecSpec commandLine(Object... arguments) {
-        commandLine(Arrays.asList(arguments));
+        argumentsSpec.commandLine(arguments);
         return this;
     }
 
     @Override
     public ExecSpec commandLine(Iterable<?> args) {
-        List<Object> argsList = Lists.newArrayList(args);
-        executable(argsList.get(0));
-        setArgs(argsList.subList(1, argsList.size()));
+        argumentsSpec.commandLine(args);
         return this;
     }
 
     @Override
     public void setCommandLine(List<String> args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public void setCommandLine(Object... args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public void setCommandLine(Iterable<?> args) {
-        commandLine(args);
+        argumentsSpec.commandLine(args);
     }
 
     @Override
     public ExecSpec args(Object... args) {
-        if (args == null) {
-            throw new IllegalArgumentException("args == null!");
-        }
-        this.arguments.addAll(Arrays.asList(args));
+        argumentsSpec.args(args);
         return this;
     }
 
     @Override
     public ExecSpec args(Iterable<?> args) {
-        GUtil.addToCollection(arguments, args);
+        argumentsSpec.args(args);
         return this;
     }
 
     @Override
     public ExecSpec setArgs(List<String> arguments) {
-        this.arguments.clear();
-        this.arguments.addAll(arguments);
+        argumentsSpec.setArgs(arguments);
         return this;
     }
 
     @Override
     public ExecSpec setArgs(Iterable<?> arguments) {
-        this.arguments.clear();
-        GUtil.addToCollection(this.arguments, arguments);
+        argumentsSpec.setArgs(arguments);
         return this;
     }
 
     @Override
     public List<String> getArgs() {
-        List<String> args = new ArrayList<>();
-        for (Object argument : arguments) {
-            args.add(argument.toString());
-        }
-        return args;
+        return argumentsSpec.getArgs();
     }
 
     @Override
     public List<CommandLineArgumentProvider> getArgumentProviders() {
-        return argumentProviders;
+        return argumentsSpec.getArgumentProviders();
     }
 
     @Override
@@ -171,34 +140,34 @@ public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSp
 
     @Override
     public BaseExecSpec setStandardInput(InputStream inputStream) {
-        standardInput = inputStream;
+        streamsSpec.setStandardInput(inputStream);
         return this;
     }
 
     @Override
     public InputStream getStandardInput() {
-        return standardInput;
+        return streamsSpec.getStandardInput();
     }
 
     @Override
     public BaseExecSpec setStandardOutput(OutputStream outputStream) {
-        standardOutput = outputStream;
+        streamsSpec.setStandardOutput(outputStream);
         return this;
     }
 
     @Override
     public OutputStream getStandardOutput() {
-        return standardOutput;
+        return streamsSpec.getStandardOutput();
     }
 
     @Override
     public BaseExecSpec setErrorOutput(OutputStream outputStream) {
-        errorOutput = outputStream;
+        streamsSpec.setErrorOutput(outputStream);
         return this;
     }
 
     @Override
     public OutputStream getErrorOutput() {
-        return errorOutput;
+        return streamsSpec.getErrorOutput();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import com.google.common.collect.Iterables;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.jvm.ModularitySpec;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaExecSpec;
+import org.gradle.util.GUtil;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaExecSpec {
+
+    private boolean ignoreExitValue;
+    private final List<Object> arguments = new ArrayList<>();
+    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+
+    private InputStream standardInput;
+    private OutputStream standardOutput;
+    private OutputStream errorOutput;
+
+    private final Property<String> mainClass;
+    private final Property<String> mainModule;
+    private final ModularitySpec modularity;
+
+    private final FileCollectionFactory fileCollectionFactory;
+    private ConfigurableFileCollection classpath;
+
+    @Inject
+    public DefaultJavaExecSpec(
+        PathToFileResolver resolver,
+        FileCollectionFactory fileCollectionFactory,
+        ObjectFactory objectFactory
+    ) {
+        super(resolver, fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class));
+        this.mainClass = objectFactory.property(String.class);
+        this.mainModule = objectFactory.property(String.class);
+        this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
+        this.fileCollectionFactory = fileCollectionFactory;
+        this.classpath = fileCollectionFactory.configurableFiles("classpath");
+    }
+
+    @Override
+    public List<String> getCommandLine() {
+        List<String> commandLine = new ArrayList<String>();
+        commandLine.add(getExecutable());
+        commandLine.addAll(getAllArguments());
+        return commandLine;
+    }
+
+    @Override
+    public JavaExecSpec args(Object... args) {
+        if (args == null) {
+            throw new IllegalArgumentException("args == null!");
+        }
+        this.arguments.addAll(Arrays.asList(args));
+        return this;
+    }
+
+    @Override
+    public JavaExecSpec args(Iterable<?> args) {
+        GUtil.addToCollection(arguments, args);
+        return this;
+    }
+
+    @Override
+    public JavaExecSpec setArgs(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.addAll(arguments);
+        return this;
+    }
+
+    @Override
+    public JavaExecSpec setArgs(Iterable<?> arguments) {
+        this.arguments.clear();
+        GUtil.addToCollection(this.arguments, arguments);
+        return this;
+    }
+
+    @Override
+    public List<String> getArgs() {
+        List<String> args = new ArrayList<>();
+        for (Object argument : arguments) {
+            args.add(argument.toString());
+        }
+        return args;
+    }
+
+    @Override
+    public List<CommandLineArgumentProvider> getArgumentProviders() {
+        return argumentProviders;
+    }
+
+    @Override
+    public JavaExecSpec classpath(Object... paths) {
+        this.classpath.from(paths);
+        return this;
+    }
+
+    @Override
+    public FileCollection getClasspath() {
+        return classpath;
+    }
+
+    @Override
+    public JavaExecSpec setClasspath(FileCollection classpath) {
+        this.classpath = fileCollectionFactory.configurableFiles("classpath");
+        this.classpath.setFrom(classpath);
+        return this;
+    }
+
+    // TODO wrong?
+    public List<String> getAllArguments() {
+        List<String> args = new ArrayList<>(getArgs());
+        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
+            Iterables.addAll(args, argumentProvider.asArguments());
+        }
+        return args;
+    }
+
+    @Override
+    public boolean isIgnoreExitValue() {
+        return ignoreExitValue;
+    }
+
+    @Override
+    public JavaExecSpec setIgnoreExitValue(boolean ignoreExitValue) {
+        this.ignoreExitValue = ignoreExitValue;
+        return this;
+    }
+
+    @Override
+    public InputStream getStandardInput() {
+        return standardInput;
+    }
+
+    @Override
+    public JavaExecSpec setStandardInput(InputStream standardInput) {
+        this.standardInput = standardInput;
+        return this;
+    }
+
+    @Override
+    public OutputStream getStandardOutput() {
+        return standardOutput;
+    }
+
+    @Override
+    public JavaExecSpec setStandardOutput(OutputStream standardOutput) {
+        this.standardOutput = standardOutput;
+        return this;
+    }
+
+    @Override
+    public OutputStream getErrorOutput() {
+        return errorOutput;
+    }
+
+    @Override
+    public JavaExecSpec setErrorOutput(OutputStream errorOutput) {
+        this.errorOutput = errorOutput;
+        return this;
+    }
+
+    @Override
+    public Property<String> getMainClass() {
+        return mainClass;
+    }
+
+    @Nullable
+    @Override
+    public String getMain() {
+        return getMainClass().getOrNull();
+    }
+
+    @Override
+    public JavaExecSpec setMain(String main) {
+        getMainClass().set(main);
+        return this;
+    }
+
+    @Override
+    public Property<String> getMainModule() {
+        return mainModule;
+    }
+
+    @Override
+    public ModularitySpec getModularity() {
+        return modularity;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
@@ -57,9 +57,9 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
 
     @Inject
     public DefaultJavaExecSpec(
+        ObjectFactory objectFactory,
         PathToFileResolver resolver,
-        FileCollectionFactory fileCollectionFactory,
-        ObjectFactory objectFactory
+        FileCollectionFactory fileCollectionFactory
     ) {
         super(resolver, fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class));
         this.mainClass = objectFactory.property(String.class);
@@ -71,7 +71,7 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
 
     @Override
     public List<String> getCommandLine() {
-        List<String> commandLine = new ArrayList<String>();
+        List<String> commandLine = new ArrayList<>();
         commandLine.add(getExecutable());
         commandLine.addAll(getAllArguments());
         return commandLine;
@@ -93,19 +93,24 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
     }
 
     @Override
-    public JavaExecSpec setArgs(List<String> arguments) {
+    public JavaExecSpec setArgs(@Nullable List<String> arguments) {
         this.arguments.clear();
-        this.arguments.addAll(arguments);
+        if (arguments != null) {
+            this.arguments.addAll(arguments);
+        }
         return this;
     }
 
     @Override
-    public JavaExecSpec setArgs(Iterable<?> arguments) {
+    public JavaExecSpec setArgs(@Nullable Iterable<?> arguments) {
         this.arguments.clear();
-        GUtil.addToCollection(this.arguments, arguments);
+        if (arguments != null) {
+            GUtil.addToCollection(this.arguments, arguments);
+        }
         return this;
     }
 
+    @Nullable
     @Override
     public List<String> getArgs() {
         List<String> args = new ArrayList<>();
@@ -140,11 +145,17 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
 
     // TODO wrong?
     public List<String> getAllArguments() {
-        List<String> args = new ArrayList<>(getArgs());
-        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
-            Iterables.addAll(args, argumentProvider.asArguments());
+        List<String> allArgs;
+        List<String> args = getArgs();
+        if (args == null) {
+            allArgs = new ArrayList<>();
+        } else {
+            allArgs = new ArrayList<>(args);
         }
-        return args;
+        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
+            Iterables.addAll(allArgs, argumentProvider.asArguments());
+        }
+        return allArgs;
     }
 
     @Override
@@ -203,7 +214,7 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
     }
 
     @Override
-    public JavaExecSpec setMain(String main) {
+    public JavaExecSpec setMain(@Nullable String main) {
         getMainClass().set(main);
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.process.internal;
 
-import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -34,7 +33,6 @@ import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.CollectionUtils;
-import org.gradle.util.GUtil;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,7 +41,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -58,16 +55,15 @@ import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasC
 /**
  * Use {@link JavaExecHandleFactory} instead.
  */
-public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements JavaExecSpec {
+public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements JavaExecSpec, ProcessArgumentsSpec.HasExecutable {
     private static final Logger LOGGER = Logging.getLogger(JavaExecHandleBuilder.class);
     private final FileCollectionFactory fileCollectionFactory;
     private JavaModuleDetector javaModuleDetector;
-    private Property<String> mainModule;
-    private Property<String> mainClass;
-    private final List<Object> applicationArgs = new ArrayList<>();
+    private final Property<String> mainModule;
+    private final Property<String> mainClass;
     private ConfigurableFileCollection classpath;
     private final JavaForkOptions javaOptions;
-    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+    private final ProcessArgumentsSpec applicationArgsSpec = new ProcessArgumentsSpec(this);
     private final ModularitySpec modularity;
 
     public JavaExecHandleBuilder(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, ObjectFactory objectFactory, Executor executor, BuildCancellationToken buildCancellationToken, @Nullable JavaModuleDetector javaModuleDetector, JavaForkOptions javaOptions) {
@@ -303,42 +299,36 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     @Override
     @Nonnull
     public List<String> getArgs() {
-        List<String> args = new ArrayList<String>();
-        for (Object applicationArg : applicationArgs) {
-            args.add(applicationArg.toString());
-        }
-        return args;
+        return applicationArgsSpec.getArgs();
     }
 
     @Override
     public JavaExecHandleBuilder setArgs(List<String> applicationArgs) {
-        this.applicationArgs.clear();
-        args(applicationArgs);
+        applicationArgsSpec.setArgs(applicationArgs);
         return this;
     }
 
     @Override
     public JavaExecHandleBuilder setArgs(Iterable<?> applicationArgs) {
-        this.applicationArgs.clear();
-        args(applicationArgs);
+        applicationArgsSpec.setArgs(applicationArgs);
         return this;
     }
 
     @Override
     public JavaExecHandleBuilder args(Object... args) {
-        args(Arrays.asList(args));
+        applicationArgsSpec.args(args);
         return this;
     }
 
     @Override
     public JavaExecSpec args(Iterable<?> args) {
-        GUtil.addToCollection(applicationArgs, true, args);
+        applicationArgsSpec.args(args);
         return this;
     }
 
     @Override
     public List<CommandLineArgumentProvider> getArgumentProviders() {
-        return argumentProviders;
+        return applicationArgsSpec.getArgumentProviders();
     }
 
     @Override
@@ -373,10 +363,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
 
     private List<String> getAllArguments(FileCollection realClasspath) {
         List<String> arguments = new ArrayList<>(getAllJvmArgs(realClasspath));
-        arguments.addAll(getArgs());
-        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
-            Iterables.addAll(arguments, argumentProvider.asArguments());
-        }
+        arguments.addAll(applicationArgsSpec.getAllArguments());
         return arguments;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ProcessArgumentsSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ProcessArgumentsSpec.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.util.GUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class ProcessArgumentsSpec {
+
+    interface HasExecutable {
+
+        String getExecutable();
+
+        void setExecutable(Object executable);
+    }
+
+    private final HasExecutable hasExecutable;
+    private final List<Object> arguments = new ArrayList<>();
+    private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+
+    public ProcessArgumentsSpec(HasExecutable hasExecutable) {
+        this.hasExecutable = hasExecutable;
+    }
+
+    public List<String> getCommandLine() {
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(hasExecutable.getExecutable());
+        commandLine.addAll(getAllArguments());
+        return commandLine;
+    }
+
+    public ProcessArgumentsSpec commandLine(Object... arguments) {
+        commandLine(Arrays.asList(arguments));
+        return this;
+    }
+
+    public ProcessArgumentsSpec commandLine(Iterable<?> args) {
+        List<Object> argsList = Lists.newArrayList(args);
+        hasExecutable.setExecutable(argsList.get(0));
+        setArgs(argsList.subList(1, argsList.size()));
+        return this;
+    }
+
+    public List<String> getAllArguments() {
+        List<String> allArgs;
+        List<String> args = getArgs();
+        if (args == null) {
+            allArgs = new ArrayList<>();
+        } else {
+            allArgs = new ArrayList<>(args);
+        }
+        for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
+            Iterables.addAll(allArgs, argumentProvider.asArguments());
+        }
+        return allArgs;
+    }
+
+    public ProcessArgumentsSpec args(Object... args) {
+        if (args == null) {
+            throw new IllegalArgumentException("args == null!");
+        }
+        args(Arrays.asList(args));
+        return this;
+    }
+
+    public ProcessArgumentsSpec args(Iterable<?> args) {
+        GUtil.addToCollection(arguments, true, args);
+        return this;
+    }
+
+    public ProcessArgumentsSpec setArgs(List<String> arguments) {
+        this.arguments.clear();
+        args(arguments);
+        return this;
+    }
+
+    public ProcessArgumentsSpec setArgs(Iterable<?> arguments) {
+        this.arguments.clear();
+        args(arguments);
+        return this;
+    }
+
+    public List<String> getArgs() {
+        List<String> args = new ArrayList<>();
+        for (Object argument : arguments) {
+            args.add(argument.toString());
+        }
+        return args;
+    }
+
+    public List<CommandLineArgumentProvider> getArgumentProviders() {
+        return argumentProviders;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ProcessStreamsSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ProcessStreamsSpec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+
+public class ProcessStreamsSpec {
+
+    private InputStream standardInput;
+    private OutputStream standardOutput;
+    private OutputStream errorOutput;
+
+    public ProcessStreamsSpec setStandardInput(InputStream inputStream) {
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream == null!");
+        }
+        standardInput = inputStream;
+        return this;
+    }
+
+    public InputStream getStandardInput() {
+        return standardInput;
+    }
+
+    public ProcessStreamsSpec setStandardOutput(OutputStream outputStream) {
+        if (outputStream == null) {
+            throw new IllegalArgumentException("outputStream == null!");
+        }
+        standardOutput = outputStream;
+        return this;
+    }
+
+    public OutputStream getStandardOutput() {
+        return standardOutput;
+    }
+
+    public ProcessStreamsSpec setErrorOutput(OutputStream outputStream) {
+        if (outputStream == null) {
+            throw new IllegalArgumentException("outputStream == null!");
+        }
+        errorOutput = outputStream;
+        return this;
+    }
+
+    public OutputStream getErrorOutput() {
+        return errorOutput;
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
@@ -16,67 +16,15 @@
 package org.gradle.api.tasks
 
 import org.gradle.api.internal.AbstractTask
-import org.gradle.process.ExecResult
-import org.gradle.process.internal.ExecAction
-import org.gradle.process.internal.ExecException
 
 class ExecTest extends AbstractTaskTest {
     Exec execTask
-    def execAction = Mock(ExecAction) {
-        getArgumentProviders() >> []
-    }
 
     def setup() {
         execTask = createTask(Exec.class)
-        execTask.setExecAction(execAction)
     }
 
     AbstractTask getTask() {
         return execTask
-    }
-
-    def "executes action on execute"() {
-        when:
-        execTask.setExecutable("ls")
-        execute(execTask)
-
-        then:
-        1 * execAction.setExecutable("ls")
-        1 * execAction.execute() >> new ExpectedExecResult(0)
-        execTask.execResult.exitValue == 0
-        execTask.executionResult.get().exitValue == 0
-    }
-
-    def "execute with non-zero exit value and ignore exit value should not throw exception"() {
-        when:
-        execute(execTask)
-
-        then:
-        1 * execAction.execute() >> new ExpectedExecResult(1)
-        execTask.execResult.exitValue == 1
-        execTask.executionResult.get().exitValue == 1
-    }
-
-    private class ExpectedExecResult implements ExecResult {
-        int exitValue
-
-        ExpectedExecResult(int exitValue) {
-            this.exitValue = exitValue
-        }
-
-        @Override
-        int getExitValue() {
-            return exitValue
-        }
-
-        @Override
-        ExecResult assertNormalExitValue() throws ExecException {
-            return this
-        }
-
-        @Override
-        ExecResult rethrowFailure() throws ExecException {
-            return this
-        }
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.junit.Rule
@@ -31,7 +30,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".*javaexecProjectMethod")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*javaexecTask")
     def 'can execute java with #task'() {
         given:
         buildFile << """

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -52,7 +52,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                 def testFile = file("${'$'}buildDir/${'$'}name")
                 dependsOn(sourceSets.main.output)
                 doFirst {
-                    javaexec {
+                    project.javaexec {
                         assert !(delegate instanceof ExtensionAware)
                         classpath(sourceSets.main.output.classesDirs)
                         main 'org.gradle.TestMain'
@@ -111,7 +111,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn sourceSets.main.runtimeClasspath
                 def testFile = file("${'$'}buildDir/${'$'}name")
                 doFirst {
-                    exec {
+                    project.exec {
                         executable Jvm.current().getJavaExecutable()
                         args '-cp', sourceSets.main.runtimeClasspath.asPath, 'org.gradle.TestMain', projectDir, testFile
                         assert !(delegate instanceof ExtensionAware)
@@ -145,7 +145,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
 
     private static String injectedTaskActionTask(String taskName, String taskActionBody) {
         return """
-            abstract class InjectedServiceTask extends DefaultTask {
+            abstract class InjectedServiceTask_$taskName extends DefaultTask {
 
                 @Classpath
                 abstract ConfigurableFileCollection getExecClasspath()
@@ -162,7 +162,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            task $taskName(type: InjectedServiceTask) {
+            task $taskName(type: InjectedServiceTask_$taskName) {
                 dependsOn(sourceSets.main.runtimeClasspath)
             }
         """
@@ -264,5 +264,127 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         run "run"
         then:
         executedAndNotSkipped ":run"
+    }
+
+    @Unroll
+    @UnsupportedWithInstantExecution(iterationMatchers = [".*Task", ".*ProjectMethod"])
+    def "can capture output of #task"() {
+
+        given:
+        buildFile << """
+            import org.gradle.internal.jvm.Jvm
+            import javax.inject.Inject
+            import static org.gradle.util.TextUtil.normaliseFileAndLineSeparators
+
+            apply plugin: 'java'
+
+            // Exec
+
+            task execTask(type: Exec) {
+                dependsOn sourceSets.main.runtimeClasspath
+                def testFile = file("${'$'}buildDir/${'$'}name")
+                executable = Jvm.current().getJavaExecutable()
+                args '-cp', sourceSets.main.runtimeClasspath.asPath, 'org.gradle.TestMain', projectDir, testFile
+                def output = new ByteArrayOutputStream()
+                standardOutput = output
+                doLast {
+                    assert testFile.exists()
+                    assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+                }
+                assert delegate instanceof ExtensionAware
+            }
+
+            task execProjectMethod {
+                dependsOn sourceSets.main.runtimeClasspath
+                def testFile = file("${'$'}buildDir/${'$'}name")
+                doLast {
+                    def output = new ByteArrayOutputStream()
+                    project.exec {
+                        executable Jvm.current().getJavaExecutable()
+                        args '-cp', sourceSets.main.runtimeClasspath.asPath, 'org.gradle.TestMain', projectDir, testFile
+                        standardOutput = output
+                        assert !(delegate instanceof ExtensionAware)
+                    }
+                    assert testFile.exists()
+                    assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+                }
+            }
+
+            ${
+            injectedTaskActionTask('execInjectedTaskAction', '''
+                File testFile = layout.buildDirectory.file(name).get().asFile
+                def output = new ByteArrayOutputStream()
+                execOperations.exec {
+                    assert !(it instanceof ExtensionAware)
+                    it.executable Jvm.current().getJavaExecutable()
+                    it.args '-cp', execClasspath.asPath, 'org.gradle.TestMain', layout.projectDirectory.asFile, testFile
+                    it.standardOutput = output
+                }
+                assert testFile.exists()
+                assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+            ''')
+        }
+            execInjectedTaskAction.execClasspath.from(project.sourceSets['main'].runtimeClasspath)
+
+            // JavaExec
+
+            task javaexecTask(type: JavaExec) {
+                def testFile = file("${'$'}buildDir/${'$'}name")
+                classpath(sourceSets.main.output.classesDirs)
+                main = 'org.gradle.TestMain'
+                args projectDir, testFile
+                def output = new ByteArrayOutputStream()
+                standardOutput = output
+                doLast {
+                    assert testFile.exists()
+                    assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+                }
+                assert delegate instanceof ExtensionAware
+            }
+
+            task javaexecProjectMethod() {
+                def testFile = file("${'$'}buildDir/${'$'}name")
+                dependsOn(sourceSets.main.output)
+                doLast {
+                    def output = new ByteArrayOutputStream()
+                    project.javaexec {
+                        assert !(delegate instanceof ExtensionAware)
+                        classpath(sourceSets.main.output.classesDirs)
+                        main 'org.gradle.TestMain'
+                        args projectDir, testFile
+                        standardOutput = output
+                    }
+                    assert testFile.exists()
+                    assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+                }
+            }
+
+            ${
+            injectedTaskActionTask('javaexecInjectedTaskAction', '''
+                File testFile = layout.buildDirectory.file(name).get().asFile
+                def output = new ByteArrayOutputStream()
+                execOperations.javaexec {
+                    assert !(it instanceof ExtensionAware)
+                    it.classpath(execClasspath)
+                    it.main 'org.gradle.TestMain'
+                    it.args layout.projectDirectory.asFile, testFile
+                    it.standardOutput = output
+                }
+                assert testFile.exists()
+                assert normaliseFileAndLineSeparators(output.toString()) == "Created file \${normaliseFileAndLineSeparators(testFile.canonicalPath)}\\n"
+            ''')
+        }
+            javaexecInjectedTaskAction.execClasspath.from(project.sourceSets['main'].output.classesDirs)
+
+        """.stripIndent()
+
+        expect:
+        succeeds task
+
+        where:
+        task << [
+            'execTask', 'execProjectMethod', 'execInjectedTaskAction',
+            'javaexecTask', 'javaexecProjectMethod', 'javaexecInjectedTaskAction'
+        ]
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -265,29 +265,4 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped ":run"
     }
-
-    def "when ignoring exit value a non-zero exit value doesn't fail the build"() {
-        given:
-        buildFile << '''
-            apply plugin: 'java'
-
-            task run(type: Exec) {
-                executable = org.gradle.internal.jvm.Jvm.current().getJavaExecutable()
-                args 'not.found.MainClass'
-                ignoreExitValue = true
-            }
-        '''.stripIndent()
-
-        when:
-        run "run"
-
-        then:
-        executedAndNotSkipped(":run")
-
-        when:
-        run "run"
-
-        then:
-        executedAndNotSkipped(":run")
-    }
 }

--- a/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/ExecIntegrationTest/shared/src/main/java/org/gradle/TestMain.java
+++ b/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/ExecIntegrationTest/shared/src/main/java/org/gradle/TestMain.java
@@ -12,5 +12,6 @@ public class TestMain {
         File file = new File(args[1]);
         file.getParentFile().mkdirs();
         file.createNewFile();
+        System.out.println("Created file " + file.getCanonicalPath());
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.launcher
 
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -170,7 +169,6 @@ task check {
     }
 
     @Unroll("forked java processes inherit default encoding - input = #inputEncoding, expectedEncoding: #expectedEncoding")
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "forked java processes inherit default encoding"() {
         given:
         executerEncoding inputEncoding

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -163,7 +163,7 @@ class CustomWindowsStartScriptGenerator implements ScriptGenerator {
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script"() {
         when:
         succeeds('installDist')
@@ -179,7 +179,7 @@ class CustomWindowsStartScriptGenerator implements ScriptGenerator {
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script using JAVA_HOME with spaces"() {
         given:
         def testJavaHome = file("javahome/java home with spaces")
@@ -202,7 +202,7 @@ class CustomWindowsStartScriptGenerator implements ScriptGenerator {
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "java PID equals script PID"() {
         given:
         succeeds('installDist')
@@ -294,7 +294,7 @@ dependencies {
         file('build/install/sample/lib').allDescendants() == ['sample.jar', 'compile-1.0.jar'] as Set
     }
 
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "executables can be placed at the root of the distribution"() {
         given:
         buildFile << """
@@ -313,7 +313,7 @@ executableDir = ''
         outputContains("Hello World")
     }
 
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "executables can be placed in a custom directory"() {
         given:
         buildFile << """
@@ -496,7 +496,7 @@ dependencies {
         (lines.find { it.startsWith 'set CLASSPATH='} - 'set CLASSPATH=').split(';').collect([] as Set) { it - '%APP_HOME%\\lib\\'}
     }
 
-    @ToBeFixedForInstantExecution(because = ":installDist & JavaExec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script"() {
         given:
         buildFile << """
@@ -651,7 +651,6 @@ rootProject.name = 'sample'
         assert file("build/install/sample/not-the-root/bin/sample").permissions == "rwxr-xr-x"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "runs the classes folder for traditional applications"() {
         when:
         succeeds("run")
@@ -661,7 +660,6 @@ rootProject.name = 'sample'
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "runs the jar for modular applications"() {
         given:
         configureMainModule()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -41,7 +41,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script in Bash"() {
         given:
         succeeds('installDist')
@@ -54,7 +54,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script in Dash"() {
         given:
         succeeds('installDist')
@@ -67,7 +67,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script in BusyBox"() {
         given:
         succeeds('installDist')
@@ -80,7 +80,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script in Bash"() {
         given:
         extendBuildFileWithAppHomeProperty()
@@ -94,7 +94,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script in Dash"() {
         given:
         extendBuildFileWithAppHomeProperty()
@@ -108,7 +108,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script in BusyBox"() {
         given:
         extendBuildFileWithAppHomeProperty()
@@ -122,7 +122,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can pass argument to App with custom start script in Bash"() {
         given:
         succeeds('installDist')
@@ -138,7 +138,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can pass argument to App with custom start script in Dash"() {
         given:
         succeeds('installDist')
@@ -154,7 +154,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can pass argument to App with custom start script in BusyBox"() {
         given:
         succeeds('installDist')
@@ -170,7 +170,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { TestPrecondition.JDK9_OR_LATER.fulfilled && ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script for Java module in Bash"() {
         given:
         turnSampleProjectIntoModule()
@@ -184,7 +184,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { TestPrecondition.JDK9_OR_LATER.fulfilled && ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script for Java module in Dash"() {
         given:
         turnSampleProjectIntoModule()
@@ -198,7 +198,7 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Requires(adhoc = { TestPrecondition.JDK9_OR_LATER.fulfilled && ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
-    @ToBeFixedForInstantExecution(because = "Exec")
+    @ToBeFixedForInstantExecution(because = ":installDist")
     def "can execute generated Unix start script for Java module in BusyBox"() {
         given:
         turnSampleProjectIntoModule()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
 import org.gradle.test.fixtures.ConcurrentTestUtil
@@ -32,7 +31,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "debug is disabled by default with task :#taskName"() {
         setup:
         sampleProject """
@@ -49,7 +47,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "debug session fails without debugger with task :#taskName"() {
         setup:
         sampleProject """
@@ -69,7 +66,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "can debug Java exec with socket listen type debugger (server = false) with task :#taskName"() {
         setup:
         sampleProject """
@@ -92,7 +88,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
     @Ignore
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "can debug Java exec with socket attach type debugger (server = true) with task :#taskName"() {
         setup:
         sampleProject """
@@ -122,7 +117,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "debug options overrides debug property with task :#taskName"() {
         setup:
         sampleProject """
@@ -143,7 +137,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* :runProjectJavaExec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* :runJavaExec")
     def "if custom debug argument is passed to the build then debug options is ignored with task :#taskName"() {
         setup:
         sampleProject """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -67,7 +67,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "java exec is not incremental by default"() {
         when:
         run "run"
@@ -82,7 +81,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":run"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def 'arguments passed via command line take precedence and is not incremental by default'() {
         when:
         run("run", "--args", "2 '3' \"4\"")
@@ -108,7 +106,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue(["GRADLE-1483", "GRADLE-3528"])
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "when the user declares outputs it becomes incremental"() {
         given:
         buildFile << """
@@ -137,7 +134,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":run"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def 'arguments passed via command line matter in incremental check'() {
         given:
         buildFile << """
@@ -237,7 +233,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         outputFile.text == "different"
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "main class can be configured through a convention mapping"() {
         given:
         buildFile.text = """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Issue
 
@@ -164,37 +163,48 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         assertOutputFileIs("2\n")
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "arguments can be passed by using argument providers"() {
         given:
         def inputFile = file("input.txt")
         def outputFile = file("out.txt")
         buildFile << """
-            class MyApplicationJvmArguments implements CommandLineArgumentProvider {
+            abstract class MyApplicationJvmArguments implements CommandLineArgumentProvider {
                 @InputFile
                 @PathSensitive(PathSensitivity.NONE)
-                File inputFile
-            
-                @Override
-                Iterable<String> asArguments() {
-                    return ["-Dinput.file=\${inputFile.absolutePath}".toString()]
-                }            
-            }
-            
-            class MyApplicationCommandLineArguments implements CommandLineArgumentProvider {
-                @OutputFile
-                File outputFile
+                abstract RegularFileProperty getInputFile()
 
                 @Override
                 Iterable<String> asArguments() {
-                    return [outputFile.absolutePath]
-                }            
+                    return ["-Dinput.file=\${inputFile.get().asFile.absolutePath}".toString()]
+                }
             }
-            
-            run.jvmArgumentProviders << new MyApplicationJvmArguments(inputFile: new File(project.property('inputFile')))
-            
-            run.argumentProviders << new MyApplicationCommandLineArguments(outputFile: new File(project.property('outputFile')))
-             
+
+            abstract class MyApplicationCommandLineArguments implements CommandLineArgumentProvider {
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
+                @Override
+                Iterable<String> asArguments() {
+                    return [outputFile.get().asFile.absolutePath]
+                }
+            }
+
+            def projectDir = layout.projectDirectory
+
+            def input = providers.gradleProperty('inputFile').forUseAtConfigurationTime().map {
+                projectDir.file(it)
+            }
+            run.jvmArgumentProviders << objects.newInstance(MyApplicationJvmArguments).tap {
+                it.inputFile.set(input)
+            }
+
+            def output = providers.gradleProperty('outputFile').forUseAtConfigurationTime().map {
+                projectDir.file(it)
+            }
+            run.argumentProviders << objects.newInstance(MyApplicationCommandLineArguments).tap {
+                it.outputFile.set(output)
+            }
+
         """
         inputFile.text = "first"
         mainJavaFile.text = mainClass("""
@@ -209,7 +219,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            
+
         """)
 
         when:
@@ -252,7 +262,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     @Issue("https://github.com/gradle/gradle/issues/12832")
     def "classpath can be replaced with a file collection including the replaced value"() {
         given:
@@ -261,7 +270,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
 
             task run(type: JavaExec) {
                 classpath = project.layout.files(compileJava)
-                classpath = files(classpath, "someOtherFile.jar").filter { true }
+                classpath = files(classpath, "someOtherFile.jar").filter(Specs.SATISFIES_ALL)
                 mainClass = "driver.Driver"
             }
         """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -80,7 +79,6 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://github.com/gradle/gradle/issues/1346")
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "can run executable jar with #method"() {
 
         buildFile << """
@@ -107,7 +105,6 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
     @Ignore("Change rolled back, to be added again in 7.0")
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "can run executable jar configured in the application plugin with #method"() {
 
         buildFile << """
@@ -133,7 +130,6 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://github.com/gradle/gradle/issues/1346")
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "helpful message when jar is not executable with #method"() {
 
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.internal.util.LongCommandLineDetectionUtil
@@ -84,7 +83,6 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "still fail when classpath doesn't shorten the command line enough with #method"() {
         def veryLongCommandLineArgs = getLongCommandLine(getMaxArgs() * 16)
         buildFile << """
@@ -108,7 +106,6 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "does not suggest long command line failures when execution fails with #method"() {
         buildFile << """
             extraClasspath.from('${veryLongFileNames.join("','")}')
@@ -131,7 +128,6 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "does not suggest long command line failures when execution fails for short command line with #method"() {
         buildFile << """
             run.executable 'does-not-exist'
@@ -153,7 +149,6 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = ".* project.javaexec")
-    @ToBeFixedForInstantExecution(iterationMatchers = ".* JavaExec task")
     def "succeeds with long classpath with #method"() {
         buildFile << """
             extraClasspath.from('${veryLongFileNames.join("','")}')

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.java
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.internal.FileUtils
@@ -118,7 +117,6 @@ public class ThingTest {
         succeeds 'test'
     }
 
-    @ToBeFixedForInstantExecution(because = "JavaExec")
     def "can build and run application using target Java version"() {
         given:
         buildFile << """

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.testkit.runner.BuildResult
@@ -25,11 +24,11 @@ import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
     private static final String NO_INSTANT_EXECUTION_ITERATION_MATCHER = ".*kotlin=1\\.3\\.[2-6].*"
-    private static final String INSTANT_EXECUTION_ITERATION_MATCHER = ".*kotlin=1\\.3\\.[7].*"
 
     // TODO:instant-execution remove once fixed upstream
     @Override
@@ -39,7 +38,6 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
     @Unroll
     @UnsupportedWithInstantExecution(iterationMatchers = NO_INSTANT_EXECUTION_ITERATION_MATCHER)
-    @ToBeFixedForInstantExecution(because = "run task", iterationMatchers = INSTANT_EXECUTION_ITERATION_MATCHER)
     def 'kotlin jvm (kotlin=#version, workers=#workers)'() {
         given:
         useSample("kotlin-example")

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -48,10 +48,18 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
         then:
         result.task(':compileKotlin').outcome == SUCCESS
+        assert result.output.contains("Hello world!")
 
         if (version == TestedVersions.kotlin.latest()) {
             expectNoDeprecationWarnings(result)
         }
+
+        when:
+        result = build(workers, 'run')
+
+        then:
+        result.task(':compileKotlin').outcome == UP_TO_DATE
+        assert result.output.contains("Hello world!")
 
         where:
         [version, workers] << [
@@ -92,10 +100,10 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
         where:
 // To run a specific combination, set the values here, uncomment the following four lines
 //  and comment out the lines coming after
-//        kotlinPluginVersion = '1.3.61'
-//        androidPluginVersion = '3.5.1'
+//        kotlinPluginVersion = TestedVersions.kotlin.versions.last()
+//        androidPluginVersion = TestedVersions.androidGradle.versions.last()
 //        workers = false
-//        sampleName = 'android-kotlin-example-kotlin-dsl'
+//        sampleName = 'android-kotlin-example'
 
         [kotlinPluginVersion, androidPluginVersion, workers, sampleName] << [
             TestedVersions.kotlin.versions,


### PR DESCRIPTION
Let Exec and JavaExec tasks work with configuration caching except when `standardInput`, `standardOutput` or `errorOutput` properties are set because streams aren't supported.

`Exec` and `JavaExec` tasks implementations are changed to hold lightweight state introduced as respectively `DefaultExecSpec` and `DefaultJavaExecSpec` instead of the heavyweight `*ExecHandleBuilder` implementations. The handle builders usage is moved to execution time.
