### PR TITLE
Don't unpack embeddable Kotlin compiler

### DIFF
--- a/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
@@ -59,16 +59,4 @@ tasks {
         dependsOn(patchKotlinCompilerEmbeddable)
         actions.clear()
     }
-
-    val classesDir = layout.buildDirectory.dir("classes/patched")
-
-    val unpackPatchedKotlinCompilerEmbeddable by registering(Sync::class) {
-        dependsOn(patchKotlinCompilerEmbeddable)
-        from(zipTree(patchKotlinCompilerEmbeddable.get().outputFile))
-        into(classesDir)
-    }
-
-    sourceSets.main {
-        output.dir(files(classesDir).builtBy(unpackPatchedKotlinCompilerEmbeddable))
-    }
 }


### PR DESCRIPTION
The unpacking only seems to be there for IDEA support.
The classes show errors in IDEA nonetheless.
So let's remove the task and fix the IDEA problem differently.

Fixes #11693 by removing the task.