### PR TITLE
Log number of watched directory hierarchies

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -431,8 +431,9 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         // Spent 18 ms registering watches for file system events
         // Virtual file system retained information about 0 files, 0 directories and 0 missing files since last build
         // Received 50 file system events for current build
+        // Watching 20 directories to track changes
         // Virtual file system retains information about 21 files, 15 directories and 3 missing files till next build
-        def watchFsExtraEvents = GradleContextualExecuter.watchFs ? 5 : 0
+        def watchFsExtraEvents = GradleContextualExecuter.watchFs ? 6 : 0
         assert progressOutputEvents
             .size() == 14 + watchFsExtraEvents // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed" +
     }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -90,6 +90,7 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         watchedRootProjectDirectoriesFromPreviousBuild.retainAll(watchedHierarchies);
         knownRootProjectDirectoriesFromCurrentBuild.clear();
         determineAndUpdateWatchedHierarchies();
+        LOGGER.warn("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -72,6 +72,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
     @Override
     public void buildFinished() {
+        LOGGER.warn("Watching {} directories to track changes", watchedRoots.entrySet().size());
     }
 
     @Override


### PR DESCRIPTION
on WARN every time there is a change in the watched
directory hierarchies for hierarchical watchers.

That should help diagnose when we hit a pathological case and start watching many directories.