### PR TITLE
Fix :compileKotlin build cache misses when precompiled script plugins are present

### DIFF
--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -23,8 +23,8 @@ import org.gradle.api.tasks.TaskAction
 
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver.EnvironmentProperties.kotlinDslImplicitImports
 import org.gradle.kotlin.dsl.support.ImplicitImports
+import org.gradle.kotlin.dsl.support.listFilesOrdered
 
-import java.io.File
 import javax.inject.Inject
 
 
@@ -76,8 +76,4 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
         properties.joinToString(separator = ",") { (key, values) ->
             "$key=\"${values.joinToString(":")}\""
         }
-
-    private
-    fun File.listFilesOrdered(): List<File> =
-        listFiles()?.sortedBy { it.name } ?: emptyList()
 }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver.EnvironmentProperties.kotlinDslImplicitImports
 import org.gradle.kotlin.dsl.support.ImplicitImports
 
+import java.io.File
 import javax.inject.Inject
 
 
@@ -62,7 +63,7 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
     fun precompiledScriptPluginImports(): List<Pair<String, List<String>>> =
         metadataDirFile().run {
             require(isDirectory)
-            listFiles().map {
+            listFilesOrdered().map {
                 it.name to it.readLines()
             }
         }
@@ -75,4 +76,8 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
         properties.joinToString(separator = ",") { (key, values) ->
             "$key=\"${values.joinToString(":")}\""
         }
+
+    private
+    fun File.listFilesOrdered(): List<File> =
+        listFiles()?.sortedBy { it.name } ?: emptyList()
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
@@ -20,6 +20,7 @@ import org.gradle.internal.classpath.ClassPath
 
 import org.gradle.kotlin.dsl.support.filter
 import org.gradle.kotlin.dsl.support.isGradleKotlinDslJar
+import org.gradle.kotlin.dsl.support.listFilesOrdered
 
 import java.io.File
 
@@ -74,5 +75,5 @@ object SourcePathProvider {
 
 internal
 fun subDirsOf(dir: File): Collection<File> =
-    if (dir.isDirectory) dir.listFiles().filter { it.isDirectory }.sortedBy { it.name }
+    if (dir.isDirectory) dir.listFilesOrdered { it.isDirectory }
     else emptyList()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -39,3 +39,11 @@ fun Appendable.appendReproducibleNewLine(value: CharSequence = ""): Appendable =
 internal
 fun File.isParentOf(child: File): Boolean =
     child.canonicalPath.startsWith(canonicalPath)
+
+
+/**
+ * List files ordered by filename for reproducibility.
+ * Never returns null.
+ */
+fun File.listFilesOrdered(filter: (File) -> Boolean = { true }): List<File> =
+    listFiles()?.filter(filter)?.sortedBy { it.name } ?: emptyList()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -46,7 +46,7 @@ fun File.walkReproducibly(): Sequence<File> = sequence {
     while (directories.isNotEmpty()) {
         val subDirectories = mutableListOf<File>()
         directories.forEach { dir ->
-            dir.listFiles()?.sortedBy(fileName)?.partition { it.isDirectory }?.let { (childDirectories, childFiles) ->
+            dir.listFilesOrdered().partition { it.isDirectory }.let { (childDirectories, childFiles) ->
                 yieldAll(childFiles)
                 childDirectories.let {
                     yieldAll(it)
@@ -57,10 +57,6 @@ fun File.walkReproducibly(): Sequence<File> = sequence {
         directories = subDirectories
     }
 }
-
-
-private
-val fileName: (File) -> String = { it.name }
 
 
 private


### PR DESCRIPTION
By making sure file system listing always use the same order.
See https://github.com/gradle/gradle/issues/13369
