### PR TITLE
Fix missing-project bug with configuration caching

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
@@ -228,8 +228,10 @@ fun fillTheGapsOf(projects: Collection<Project>): List<Project> {
             added += 1
             parent = parent.parent
         }
-        projectsWithoutGaps.add(project)
-        added += 1
+        if (project !in projectsWithoutGaps) {
+            projectsWithoutGaps.add(project)
+            added += 1
+        }
         index += added
     }
     return projectsWithoutGaps

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
@@ -188,14 +188,14 @@ class InstantExecutionState(
 
     private
     fun Encoder.writeRelevantProjectsFor(nodes: List<Node>) {
-        writeCollection(fillTheGapsOf(relevantProjectPathsFor(nodes))) { project ->
+        writeCollection(fillTheGapsOf(relevantProjectsFor(nodes))) { project ->
             writeString(project.path)
             writeFile(project.projectDir)
         }
     }
 
     private
-    fun relevantProjectPathsFor(nodes: List<Node>): List<Project> =
+    fun relevantProjectsFor(nodes: List<Node>): List<Project> =
         nodes.mapNotNullTo(mutableListOf()) { node ->
             node.owningProject
                 ?.takeIf { it.parent != null }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/FillTheProjectGapsTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/FillTheProjectGapsTest.kt
@@ -23,7 +23,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
 
-class InstantExecutionTest {
+class FillTheProjectGapsTest {
 
     @Test
     fun `mind the gaps`() {


### PR DESCRIPTION
On large multi-project builds with deeply nested subprojects the following can happen:

```
Configuration cache is an incubating feature.
Reusing configuration cache.
FAILURE: Build failed with an exception.
* What went wrong:
Project with path ':first:second:third:fourth' could not be found in root project 'root'.
```

This PR fixes that bug by taking implicit node dependencies into account and removing duplicated entries for relevant project paths from the configuration cache state, also making the state smaller on large builds.
