### PR TITLE
Properly clean up constraints when node leaves graph

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
@@ -65,7 +65,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
         boolean activatedPending = false;
         if (pendingDependencies.hasPendingComponents()) {
             if (noLongerPending == null) {
-                noLongerPending = Lists.newLinkedList();
+                noLongerPending = Lists.newArrayList();
             }
             noLongerPending.add(pendingDependencies);
             activatedPending = pendingDependencies.shouldReportActivatePending();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
@@ -52,7 +52,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
         }
 
         // No hard dependency, queue up pending dependency in case we see a hard dependency later.
-        module.addPendingNode(node);
+        module.registerConstraintProvider(node);
         return PendingState.PENDING;
     }
 
@@ -63,7 +63,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
 
     private boolean markNoLongerPending(PendingDependencies pendingDependencies) {
         boolean activatedPending = false;
-        if (pendingDependencies.hasPendingComponents()) {
+        if (pendingDependencies.hasConstraintProviders()) {
             if (noLongerPending == null) {
                 noLongerPending = Lists.newArrayList();
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -141,7 +141,7 @@ class EdgeState implements DependencyGraphEdge {
             if (module.isPending()) {
                 selector.getTargetModule().removeUnattachedDependency(this);
                 from.makePending(this);
-                module.addPendingNode(from);
+                module.registerConstraintProvider(from);
                 return;
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -391,6 +391,10 @@ class ModuleResolveState implements CandidateModule {
         pendingDependencies.addNode(node);
     }
 
+    void removePendingNode(NodeState nodeState) {
+        pendingDependencies.removeNode(nodeState);
+    }
+
     public void maybeUpdateSelection() {
         if (replaced) {
             // Never update selection for a replaced module

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -387,12 +387,12 @@ class ModuleResolveState implements CandidateModule {
         return pendingDependencies;
     }
 
-    void addPendingNode(NodeState node) {
-        pendingDependencies.addNode(node);
+    void registerConstraintProvider(NodeState node) {
+        pendingDependencies.registerConstraintProvider(node);
     }
 
-    void removePendingNode(NodeState nodeState) {
-        pendingDependencies.removeNode(nodeState);
+    void unregisterConstraintProvider(NodeState nodeState) {
+        pendingDependencies.unregisterConstraintProvider(nodeState);
     }
 
     public void maybeUpdateSelection() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -306,7 +306,7 @@ public class NodeState implements DependencyGraphNode {
                 if (dependencyState.getDependency().isConstraint()) {
                     ModuleResolveState targetModule = resolveState.getModule(dependencyState.getModuleIdentifier());
                     if (targetModule.isPending()) {
-                        targetModule.removePendingNode(this);
+                        targetModule.unregisterConstraintProvider(this);
                     }
                 }
             }
@@ -1091,7 +1091,7 @@ public class NodeState implements DependencyGraphNode {
                 incomingEdge.getSelector().release();
                 from.removeOutgoingEdge(incomingEdge);
             }
-            pendingDependencies.addNode(from);
+            pendingDependencies.registerConstraintProvider(from);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -235,23 +235,11 @@ public class NodeState implements DependencyGraphNode {
 
         if (!component.isSelected()) {
             LOGGER.debug("version for {} is not selected. ignoring.", this);
-            if (upcomingNoLongerPendingConstraints != null) {
-                for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
-                    ModuleResolveState module = resolveState.getModule(identifier);
-                    for (EdgeState unattachedDependency : module.getUnattachedDependencies()) {
-                        if (!unattachedDependency.getSelector().isResolved()) {
-                            // Unresolved - we have a selector that was deferred but the constraint has been removed in between
-                            NodeState from = unattachedDependency.getFrom();
-                            from.prepareToRecomputeEdge(unattachedDependency);
-                        }
-                    }
-                }
-                upcomingNoLongerPendingConstraints = null;
-            }
+            cleanupConstraints();
             return;
         }
 
-        // Check if there are any transitive incoming edges at all. Don't traverse if not.
+         // Check if there are any transitive incoming edges at all. Don't traverse if not.
         if (transitiveEdgeCount == 0 && !isRoot()) {
             handleNonTransitiveNode(discoveredEdges);
             return;
@@ -287,6 +275,42 @@ public class NodeState implements DependencyGraphNode {
 
         visitDependencies(resolutionFilter, discoveredEdges);
         visitOwners(discoveredEdges);
+    }
+
+    /*
+     * When a node exits the graph, its constraints need to be cleaned up.
+     * This means:
+     * * Rescheduling any deferred selection impacted by a constraint coming from this node
+     * * Making sure we no longer are registered as pending interest on nodes pointed by constraints
+     */
+    private void cleanupConstraints() {
+        // This part covers constraint that were taken into account between a selection being deferred and this node being scheduled for traversal
+        if (upcomingNoLongerPendingConstraints != null) {
+            for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
+                ModuleResolveState module = resolveState.getModule(identifier);
+                for (EdgeState unattachedDependency : module.getUnattachedDependencies()) {
+                    if (!unattachedDependency.getSelector().isResolved()) {
+                        // Unresolved - we have a selector that was deferred but the constraint has been removed in between
+                        NodeState from = unattachedDependency.getFrom();
+                        from.prepareToRecomputeEdge(unattachedDependency);
+                    }
+                }
+            }
+            upcomingNoLongerPendingConstraints = null;
+        }
+        // This part covers constraint that might be triggered in the future if the node they point gains a real edge
+        if (cachedFilteredDependencyStates != null && !cachedFilteredDependencyStates.isEmpty()) {
+            // We may have registered this node as pending if it had constraints.
+            // Let's clear that state since it is no longer part of selection
+            for (DependencyState dependencyState : cachedFilteredDependencyStates) {
+                if (dependencyState.getDependency().isConstraint()) {
+                    ModuleResolveState targetModule = resolveState.getModule(dependencyState.getModuleIdentifier());
+                    if (targetModule.isPending()) {
+                        targetModule.removePendingNode(this);
+                    }
+                }
+            }
+        }
     }
 
     private boolean excludesSameDependenciesAsPreviousTraversal(ExcludeSpec newResolutionFilter) {
@@ -361,6 +385,7 @@ public class NodeState implements DependencyGraphNode {
      * @param discoveredEdges In/Out parameter collecting dependencies or platforms
      */
     private void handleNonTransitiveNode(Collection<EdgeState> discoveredEdges) {
+        cleanupConstraints();
         // If node was previously traversed, need to remove outgoing edges.
         if (previousTraversalExclusions != null) {
             removeOutgoingEdges();
@@ -601,10 +626,10 @@ public class NodeState implements DependencyGraphNode {
     void removeIncomingEdge(EdgeState dependencyEdge) {
         if (incomingEdges.remove(dependencyEdge)) {
             incomingHash -= dependencyEdge.hashCode();
-            resolveState.onFewerSelected(this);
             if (dependencyEdge.isTransitive()) {
                 transitiveEdgeCount--;
             }
+            resolveState.onFewerSelected(this);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
@@ -33,14 +33,22 @@ public class PendingDependencies {
         this.reportActivePending = true;
     }
 
-    void addNode(NodeState state) {
+    void addNode(NodeState nodeState) {
         if (hardEdges != 0) {
             throw new IllegalStateException("Cannot add a pending node for a dependency which is not pending");
         }
-        affectedComponents.add(state);
-        if (state.getComponent().getModule().isVirtualPlatform()) {
+        affectedComponents.add(nodeState);
+        if (nodeState.getComponent().getModule().isVirtualPlatform()) {
             reportActivePending = false;
         }
+    }
+
+    public void removeNode(NodeState nodeState) {
+        if (hardEdges != 0) {
+            throw new IllegalStateException("Cannot remove a pending node for a dependency which is not pending");
+        }
+        boolean removed = affectedComponents.remove(nodeState);
+        assert removed : "Removed a pending node that was not registered";
     }
 
     void turnIntoHardDependencies() {
@@ -71,4 +79,5 @@ public class PendingDependencies {
     public boolean shouldReportActivatePending() {
         return reportActivePending;
     }
+
 }


### PR DESCRIPTION
Before this change, some node that carried constraints would remain
registered as interested in pending dependencies. This could cause
invalid deferred selection.
With this set of changes, such state is cleaned up when a node that
carries constraints no longer participates in the graph, either because
it is not transitive or because it is no longer selected.

~Still needs an integration test to guard against that particular setup.~ Test added