### PR TITLE
Reduce likeliness of a fluke with configuration cache cleanup test

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCacheCleanupIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCacheCleanupIntegrationTest.groovy
@@ -36,7 +36,7 @@ class InstantExecutionCacheCleanupIntegrationTest
         writeLastFileAccessTimeToJournal(outdated, daysAgo(15))
 
         expect:
-        ConcurrentTestUtil.poll(20) {
+        ConcurrentTestUtil.poll(10, 0, 2) {
             instantRun 'help'
             run '--stop'
             assert !outdated.isDirectory()

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
@@ -67,11 +67,11 @@ class ConcurrentTestUtil extends ExternalResource {
     }
 
     //simplistic polling assertion. attempts asserting every x millis up to some max timeout
-    static void poll(double timeout = 10, double initialDelay = 0, Closure assertion) {
+    static void poll(double timeout = 10, double initialDelay = 0, double pollInterval = 0.1, Closure assertion) {
         def start = monotonicClockMillis()
         Thread.sleep(toMillis(initialDelay))
         def expiry = start + toMillis(timeout) // convert to ms
-        long sleepTime = 100
+        long sleepTime = toMillis(pollInterval)
         while(true) {
             try {
                 assertion()


### PR DESCRIPTION
by polling less often
