### PR TITLE
Bump smoke tested errorprone plugin from 1.1.1 to 1.2.1

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -118,7 +118,7 @@ abstract class AbstractSmokeTest extends Specification {
         static playframework = "0.9"
 
         // https://plugins.gradle.org/plugin/net.ltgt.errorprone
-        static errorProne = "1.1.1"
+        static errorProne = "1.2.1"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
         static protobufPlugin = "0.8.12"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -16,9 +16,7 @@
 
 package org.gradle.smoketests
 
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -31,9 +29,6 @@ import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
-import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.CoreMatchers.not
-import static org.junit.Assume.assumeThat
 
 class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
 
@@ -455,10 +450,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
     @Issue("https://github.com/gradle/gradle/issues/9897")
     def 'errorprone plugin'() {
 
-        if (GradleContextualExecuter.isInstant()) {
-            // errorprone plugin use a task that has a Configuration field on Java 8
-            assumeThat(JavaVersion.current().majorVersion, not(equalTo("8")))
-        }
+        // TODO comment on https://github.com/gradle/gradle/commit/c45540059cef1e72254188c636e8ca68aba7a369#commitcomment-39777864
 
         given:
         buildFile << """


### PR DESCRIPTION
and re-enable the configuration cache test on Java 8

1.2 has fixes for the configuration cache
