### PR TITLE
Add api jar path to sample tests

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import org.gradle.gradlebuild.test.integrationtests.GeneratedGradleApiJarCacheDirProvider
+
 plugins {
     id 'gradlebuild.distribution.core-api-java'
     // TODO: Apply asciidoctor in documentation plugin instead.
@@ -546,8 +548,9 @@ tasks.named("checkAsciidoctorSampleContents") {
     enabled = false
 }
 
+
 // TODO add some kind of test precondition support in sample test conf
-tasks.named("docsTest") { task ->
+tasks.named("docsTest") { Test task ->
     // The org.gradle.samples plugin uses Exemplar to execute integration tests on the samples.
     // Exemplar doesn't know about that it's running in the context of the gradle/gradle build
     // so it uses the Gradle distribution from the running build. This is not correct, because
@@ -556,6 +559,7 @@ tasks.named("docsTest") { task ->
     task.dependsOn(tasks.named('intTestImage'))
     // TODO we use an absolute path here which makes the task not cacheable
     task.systemProperty("integTest.gradleHomeDir", new File(project.buildDir, "integ test").absolutePath)
+    task.jvmArgumentProviders.add(new GeneratedGradleApiJarCacheDirProvider(task, rootProject.providers, rootProject.layout))
 
     // // TODO (donat) investigate ignored snippets
     filter {

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/ExemplarExternalSamplesFunctionalTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/ExemplarExternalSamplesFunctionalTest.java
@@ -17,6 +17,7 @@
 package org.gradle.docs.samples;
 
 import org.gradle.integtests.fixtures.FailOnDeprecationSampleModifier;
+import org.gradle.integtests.fixtures.SetCorrectGeneratedApiJarCacheDir;
 import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier;
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
@@ -46,6 +47,7 @@ import org.junit.runner.RunWith;
 @SampleModifiers({
     SetMirrorsSampleModifier.class,
     MoreMemorySampleModifier.class,
-    FailOnDeprecationSampleModifier.class
+    FailOnDeprecationSampleModifier.class,
+    SetCorrectGeneratedApiJarCacheDir.class
 })
 public class ExemplarExternalSamplesFunctionalTest {}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SetCorrectGeneratedApiJarCacheDir.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SetCorrectGeneratedApiJarCacheDir.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures;
+
+import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
+import org.gradle.samples.model.Command;
+import org.gradle.samples.model.Sample;
+import org.gradle.samples.test.runner.SampleModifier;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SetCorrectGeneratedApiJarCacheDir implements SampleModifier {
+    @Override
+    public Sample modify(Sample sample) {
+        List<Command> commands = sample.getCommands();
+        List<Command> modifiedCommands = new ArrayList<Command>();
+        for (Command command : commands) {
+            File generatedApiJarCacheDir = IntegrationTestBuildContext.INSTANCE.getGradleGeneratedApiJarCacheDir();
+            if ("gradle".equals(command.getExecutable()) && generatedApiJarCacheDir != null) {
+                List<String> args = new ArrayList<String>(command.getArgs());
+                args.add(String.format("-D%s=%s", DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY, generatedApiJarCacheDir.getAbsolutePath()));
+                modifiedCommands.add(command.toBuilder().setArgs(args).build());
+            } else {
+                modifiedCommands.add(command);
+            }
+        }
+        return new Sample(sample.getId(), sample.getProjectDir(), modifiedCommands);
+    }
+}


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/3117

Previously sample tests are not using correct generateApiJar path, which sometimes results in weird failures. This PR fixes by adding the jar to sample tests.