### PR TITLE
Ignore some tests under vfsRetentionTest

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -19,10 +19,13 @@ package org.gradle.integtests.resolve.attributes
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Unroll
 
+@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/13135", failsOnlyIf = TestPrecondition.WINDOWS)
 class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def setup() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.integtests.resolve.verification
 
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.security.fixtures.KeyServer
 import org.gradle.security.fixtures.SigningFixtures
 import org.gradle.security.internal.Fingerprint
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
 import static org.gradle.security.fixtures.SigningFixtures.getValidPublicKeyLongIdHexString
@@ -29,6 +31,7 @@ import static org.gradle.security.fixtures.SigningFixtures.signAsciiArmored
 import static org.gradle.security.fixtures.SigningFixtures.validPublicKeyHexString
 import static org.gradle.security.internal.SecuritySupport.toLongIdHexString
 
+@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/13135", failsOnlyIf = TestPrecondition.WINDOWS)
 class DependencyVerificationSignatureCheckIntegTest extends AbstractSignatureVerificationIntegrationTest {
 
     def "doesn't need checksums if signature is verified"() {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
@@ -17,8 +17,11 @@
 package org.gradle.internal.logging.console.taskgrouping.rich
 
 import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleCompositeBuildGroupedTaskFunctionalTest
+import org.gradle.util.TestPrecondition
 
+@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/13366", failsOnlyIf = TestPrecondition.WINDOWS)
 class RichConsoleCompositeBuildGroupedTaskFunctionalTest extends AbstractConsoleCompositeBuildGroupedTaskFunctionalTest {
     ConsoleOutput consoleType = ConsoleOutput.Rich
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -17,11 +17,14 @@ package org.gradle.groovy
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.archive.JarTestFixture
+import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Unroll
 
+@ToBeFixedForVfsRetention(because = "https://github.com/gradle/gradle/issues/13135", failsOnlyIf = TestPrecondition.WINDOWS)
 class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyResolutionTest {
 
     ResolveTestFixture resolve


### PR DESCRIPTION
Some tests are very fragile under vfsRetentionTest, ignore them
before we have a fix.

https://e.grdev.net/scans/tests?search.buildToolType=gradle&search.buildToolType=maven&search.relativeStartTime=P7D&search.startTimeMax=1592183865957&search.startTimeMin=1591545600000&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.internal.logging.console.taskgrouping.rich.RichConsoleCompositeBuildGroupedTaskFunctionalTest&tests.sortField=FAILED&tests.test=can%20group%20task%20output%20in%20composite%20build%20%5Bconsole%20attached%20to%20both%20stdout%20and%20stderr%5D&tests.unstableOnly=true

https://e.grdev.net/scans/tests?search.buildToolType=gradle&search.buildToolType=maven&search.relativeStartTime=P7D&search.startTimeMax=1592183892694&search.startTimeMin=1591545600000&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.integtests.resolve.verification.DependencyVerificationSignatureCheckIntegTest&tests.sortField=FAILED&tests.unstableOnly=true

https://e.grdev.net/scans/tests?search.buildToolType=gradle&search.buildToolType=maven&search.relativeStartTime=P7D&search.startTimeMax=1592183944093&search.startTimeMin=1591545600000&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.integtests.resolve.attributes.DependenciesAttributesIntegrationTest&tests.sortField=FAILED&tests.unstableOnly=true

https://e.grdev.net/scans/tests?search.buildToolType=gradle&search.buildToolType=maven&search.relativeStartTime=P7D&search.startTimeMax=1592183992971&search.startTimeMin=1591545600000&search.tags=CI&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.groovy.GroovyJavaLibraryInteractionIntegrationTest&tests.sortField=FAILED&tests.unstableOnly=true