### PR TITLE
Make the groovy DSL script cache lenient when an empty classes dir goes missing

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
@@ -657,7 +657,7 @@ task fastTask { }
     }
 
     int scriptCacheSize() {
-        scriptCachesDir.listFiles().collect { it.listFiles() ?: [] }.flatten().size()
+        scriptCachesDir.listFiles().collect { it.directory }.size()
     }
 
     void hasScript(String path, List<ClassDetails> scripts) {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildOperationBackedScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildOperationBackedScriptCompilationHandler.java
@@ -21,6 +21,7 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.gradle.api.Action;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -66,8 +67,8 @@ public class BuildOperationBackedScriptCompilationHandler implements ScriptCompi
     }
 
     @Override
-    public <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, File scriptCacheDir, File metadataCacheDir, CompileOperation<M> transformer, Class<T> scriptBaseClass) {
-        return delegate.loadFromDir(source, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, transformer, scriptBaseClass);
+    public <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, ClassPath scriptClassPath, File metadataCacheDir, CompileOperation<M> transformer, Class<T> scriptBaseClass) {
+        return delegate.loadFromDir(source, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, transformer, scriptBaseClass);
     }
 
     private static class Details implements CompileScriptBuildOperationType.Details {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -43,7 +43,6 @@ import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.ImplementationHashAware;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
-import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.Serializer;
@@ -200,7 +199,7 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
     }
 
     @Override
-    public <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, File scriptCacheDir,
+    public <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, ClassPath scriptClassPath,
                                                                   File metadataCacheDir, CompileOperation<M> transformer, Class<T> scriptBaseClass) {
         File metadataFile = new File(metadataCacheDir, METADATA_FILE_NAME);
         try (KryoBackedDecoder decoder = new KryoBackedDecoder(new FileInputStream(metadataFile))) {
@@ -213,7 +212,7 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
             } else {
                 data = null;
             }
-            return new ClassesDirCompiledScript<>(isEmpty, hasMethods, scriptBaseClass, scriptCacheDir, targetScope, source, sourceHashCode, data);
+            return new ClassesDirCompiledScript<>(isEmpty, hasMethods, scriptBaseClass, scriptClassPath, targetScope, source, sourceHashCode, data);
         } catch (Exception e) {
             throw new IllegalStateException(String.format("Failed to deserialize script metadata extracted for %s", source.getDisplayName()), e);
         }
@@ -286,7 +285,7 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         private final boolean isEmpty;
         private final boolean hasMethods;
         private final Class<T> scriptBaseClass;
-        private final File scriptCacheDir;
+        private final ClassPath scriptClassPath;
         private final ClassLoaderScope targetScope;
         private final ScriptSource source;
         private final HashCode sourceHashCode;
@@ -294,11 +293,11 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         private Class<? extends T> scriptClass;
         private ClassLoaderScope scope;
 
-        public ClassesDirCompiledScript(boolean isEmpty, boolean hasMethods, Class<T> scriptBaseClass, File scriptCacheDir, ClassLoaderScope targetScope, ScriptSource source, HashCode sourceHashCode, M metadata) {
+        public ClassesDirCompiledScript(boolean isEmpty, boolean hasMethods, Class<T> scriptBaseClass, ClassPath scriptClassPath, ClassLoaderScope targetScope, ScriptSource source, HashCode sourceHashCode, M metadata) {
             this.isEmpty = isEmpty;
             this.hasMethods = hasMethods;
             this.scriptBaseClass = scriptBaseClass;
-            this.scriptCacheDir = scriptCacheDir;
+            this.scriptClassPath = scriptClassPath;
             this.targetScope = targetScope;
             this.source = source;
             this.sourceHashCode = sourceHashCode;
@@ -340,9 +339,8 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
                     ClassLoader loader = scope.getLocalClassLoader();
                     scriptClass = loader.loadClass(source.getClassName()).asSubclass(scriptBaseClass);
                 } catch (Exception e) {
-                    File expectedClassFile = new File(scriptCacheDir, source.getClassName() + ".class");
-                    if (!expectedClassFile.exists()) {
-                        throw new GradleException(String.format("Could not load compiled classes for %s from cache. Expected class file %s does not exist.", source.getDisplayName(), expectedClassFile.getAbsolutePath()), e);
+                    if (scriptClassPath.isEmpty()) {
+                        throw new IllegalStateException(String.format("The cache entry for %s appears to be corrupted.", source.getDisplayName()));
                     }
                     throw new GradleException(String.format("Could not load compiled classes for %s from cache.", source.getDisplayName()), e);
                 }
@@ -351,7 +349,6 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         }
 
         private ClassLoaderScope prepareClassLoaderScope() {
-            ClassPath scriptClassPath = DefaultClassPath.of(scriptCacheDir);
             String scopeName = "groovy-dsl:" + source.getFileName() + ":" + scriptBaseClass.getSimpleName();
             return targetScope.createLockedChild(scopeName, scriptClassPath, sourceHashCode, parent -> new ScriptClassLoader(source, parent, scriptClassPath, sourceHashCode));
         }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptCompilationHandler.java
@@ -20,6 +20,7 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.gradle.api.Action;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
@@ -29,6 +30,6 @@ public interface ScriptCompilationHandler {
     void compileToDir(ScriptSource source, ClassLoader classLoader, File classesDir, File metadataDir, CompileOperation<?> transformer,
                       Class<? extends Script> scriptBaseClass, Action<? super ClassNode> verifier);
 
-    <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, File scriptCacheDir,
+    <T extends Script, M> CompiledScript<T, M> loadFromDir(ScriptSource source, HashCode sourceHashCode, ClassLoaderScope targetScope, ClassPath scriptClassPath,
                                                            File metadataCacheDir, CompileOperation<M> transformer, Class<T> scriptBaseClass);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScriptTransformerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScriptTransformerSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.configuration.ImportsReader
 import org.gradle.configuration.ScriptTarget
 import org.gradle.groovy.scripts.TextResourceScriptSource
 import org.gradle.internal.Actions
+import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.resource.StringTextResource
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -67,7 +68,7 @@ class BuildScriptTransformerSpec extends Specification {
         def transformer = new BuildScriptTransformer(source, target)
         def operation = new FactoryBackedCompileOperation<BuildScriptData>("id", 'stage', transformer, transformer, new BuildScriptDataSerializer())
         scriptCompilationHandler.compileToDir(source, loader, scriptCacheDir, metadataCacheDir, operation, ProjectScript, Actions.doNothing())
-        return scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, operation, ProjectScript)
+        return scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, DefaultClassPath.of(scriptCacheDir), metadataCacheDir, operation, ProjectScript)
     }
 
     def "empty script does not contain any code"() {

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
@@ -40,6 +40,8 @@ import org.gradle.groovy.scripts.Transformer
 import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.internal.Actions
 import org.gradle.internal.Describables
+import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.reflect.JavaReflectionUtil
@@ -72,6 +74,7 @@ class DefaultScriptCompilationHandlerTest extends Specification {
     private File scriptCacheDir
     private File metadataCacheDir
     private File cachedFile
+    private ClassPath scriptClassPath
 
     private String scriptText
     private String scriptClassName
@@ -98,6 +101,7 @@ class DefaultScriptCompilationHandlerTest extends Specification {
             importsReader
         )
         scriptCacheDir = new File(testProjectDir, "cache")
+        scriptClassPath = DefaultClassPath.of(scriptCacheDir)
         metadataCacheDir = new File(testProjectDir, "metadata")
         scriptText = "System.setProperty('" + TEST_EXPECTED_SYSTEM_PROP_KEY + "', '" + TEST_EXPECTED_SYSTEM_PROP_VALUE + "')"
 
@@ -130,7 +134,7 @@ class DefaultScriptCompilationHandlerTest extends Specification {
         checkScriptClassesInCache()
 
         when:
-        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass)
 
         then:
         compiledScript.runDoesSomething
@@ -163,7 +167,7 @@ println 'hi'
         checkEmptyScriptInCache()
 
         when:
-        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass)
 
         then:
         !compiledScript.runDoesSomething
@@ -191,7 +195,7 @@ println 'hi'
         checkEmptyScriptInCache()
 
         when:
-        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass)
 
         then:
         !compiledScript.runDoesSomething
@@ -211,7 +215,7 @@ println 'hi'
         checkScriptClassesInCache(true)
 
         when:
-        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass)
 
         then:
         !compiledScript.runDoesSomething
@@ -236,7 +240,7 @@ println 'hi'
         checkScriptClassesInCache(true)
 
         when:
-        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass)
 
         then:
         !compiledScript.runDoesSomething
@@ -253,7 +257,7 @@ println 'hi'
         scriptCompilationHandler.compileToDir(scriptSource, classLoader, scriptCacheDir, metadataCacheDir, null, Script.class, verifier)
 
         when:
-        scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, null, expectedScriptClass).loadClass()
+        scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, null, expectedScriptClass).loadClass()
 
         then:
         GradleException e = thrown()
@@ -331,7 +335,7 @@ println 'hi'
 
         when:
         scriptCompilationHandler.compileToDir(source, classLoader, scriptCacheDir, metadataCacheDir, transformer, expectedScriptClass, verifier)
-        def compiledScript = scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, transformer, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, transformer, expectedScriptClass)
 
         then:
         compiledScript.runDoesSomething
@@ -387,7 +391,7 @@ println 'hi'
 
         when:
         scriptCompilationHandler.compileToDir(source, classLoader, scriptCacheDir, metadataCacheDir, transformer, expectedScriptClass, verifier)
-        def compiledScript = scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, scriptCacheDir, metadataCacheDir, transformer, expectedScriptClass)
+        def compiledScript = scriptCompilationHandler.loadFromDir(source, sourceHashCode, targetScope, scriptClassPath, metadataCacheDir, transformer, expectedScriptClass)
 
         then:
         !compiledScript.runDoesSomething

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/WorkNodeCodec.kt
@@ -142,6 +142,7 @@ class WorkNodeCodec(
         scheduledNodeIds: Map<Node, Int>
     ) {
         for (successor in successors) {
+            // Discard should/must run after relationships to nodes that are not scheduled to run
             scheduledNodeIds[successor]?.let { successorId ->
                 writeSmallInt(successorId)
             }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
@@ -19,9 +19,6 @@ package org.gradle.integtests
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-import org.gradle.internal.hash.HashUtil
-import org.gradle.internal.resource.CachingTextResource
-import org.gradle.internal.resource.UriTextResource
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
@@ -29,18 +26,22 @@ import org.gradle.util.GradleVersion
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import spock.lang.Issue
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 
 class CacheProjectIntegrationTest extends AbstractIntegrationTest {
     static final String TEST_FILE = "build/test.txt"
 
-    @Rule public final HttpServer server = new HttpServer()
+    @Rule
+    public final HttpServer server = new HttpServer()
 
     TestFile projectDir
     TestFile userHomeDir
     TestFile buildFile
     TestFile propertiesFile
+    TestFile classPathClassesDir
     TestFile classFile
     TestFile artifactsCache
 
@@ -69,15 +70,16 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
 
     private void updateCaches() {
         String version = GradleVersion.current().version
-        def hash = HashUtil.compactStringFor(new CachingTextResource(new UriTextResource("build file", buildFile, null)).contentHash.toByteArray())
-        String dirName = userHomeDir.file("caches/$version/scripts/$hash").list().find { it.startsWith("proj") }
-        String baseDir = "caches/$version/scripts/$hash/$dirName"
-        propertiesFile = userHomeDir.file("$baseDir/cache.properties")
-        classFile = userHomeDir.file("$baseDir/proj/_BuildScript_.class")
+        classPathClassesDir = userHomeDir.file("caches/$version/scripts").listFiles().find { it.file("cp_proj").isDirectory() }?.file("cp_proj")
+        def candidates = userHomeDir.file("caches/$version/scripts").listFiles().findAll { it.file("proj").isDirectory() }
+        // when there are multiple candidates, assume that a different entry to that used last time is the one required
+        def baseDir = candidates.size() == 1 ? candidates.first() : candidates.find { propertiesFile == null || it != propertiesFile.parentFile }
+        propertiesFile = baseDir.file("cache.properties")
+        classFile = baseDir.file("proj/_BuildScript_.class")
     }
 
     @Test
-    public void "caches compiled build script"() {
+    void "caches compiled build script"() {
         createLargeBuildScript()
         testBuild("hello1", "Hello 1")
         TestFile.Snapshot classFileSnapshot = classFile.snapshot()
@@ -90,9 +92,29 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
         classFile.assertHasChangedSince(classFileSnapshot)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/13367")
+    @Test
+    void "recovers from discarded empty classes directory from classpath entry"() {
+        buildFile << """
+            task hello1 {
+                def f = file("build/test.txt")
+                outputs.file(f)
+                doLast {
+                    f.text = "Hello 1"
+                }
+            }
+        """
+
+        testBuild("hello1", "Hello 1")
+        assertTrue(classPathClassesDir.isDirectory() && classPathClassesDir.list().length == 0)
+        classPathClassesDir.deleteDir()
+
+        testBuild("hello1", "Hello 1")
+    }
+
     @Test
     @ToBeFixedForInstantExecution
-    public void "caches incremental build state"() {
+    void "caches incremental build state"() {
         createLargeBuildScript()
         testBuild("hello1", "Hello 1")
         TestFile.Snapshot artifactsCacheSnapshot = artifactsCache.snapshot()
@@ -150,7 +172,7 @@ configurations { compile }
 dependencies { compile 'commons-io:commons-io:1.4@jar' }
 """
 
-        50.times {i ->
+        50.times { i ->
             content += """
 task 'hello$i' {
     File file = file('$TEST_FILE')

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
@@ -35,6 +35,7 @@ import org.gradle.groovy.scripts.internal.CompileOperation;
 import org.gradle.groovy.scripts.internal.CompiledScript;
 import org.gradle.groovy.scripts.internal.ScriptCompilationHandler;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
+import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.plugin.management.PluginRequest;
@@ -133,7 +134,7 @@ abstract class GeneratePluginAdaptersTask extends DefaultTask {
         CompileOperation<?> pluginsCompileOperation = compileOperationFactory.getPluginsBlockCompileOperation(scriptPlugin.getScriptTarget());
         File compiledPluginRequestsDir = getExtractedPluginRequestsClassesDirectory().get().dir(scriptPlugin.getId()).getAsFile();
         return scriptCompilationHandler.loadFromDir(scriptPlugin.getSource(), scriptPlugin.getContentHash(),
-            classLoaderScope, compiledPluginRequestsDir, compiledPluginRequestsDir, pluginsCompileOperation, PluginsAwareScript.class);
+            classLoaderScope, DefaultClassPath.of(compiledPluginRequestsDir), compiledPluginRequestsDir, pluginsCompileOperation, PluginsAwareScript.class);
     }
 
     private void generateScriptPluginAdapter(PrecompiledGroovyScript scriptPlugin, PluginRequests pluginRequests) {


### PR DESCRIPTION

### Context

In Gradle 6.5, the Groovy DSL script cache became more strict wrt to the classes directory going missing. However, for an empty script stage (for example the plugins/buildscript block) this directory is empty and can go missing when the cache is restored from some kind of archive that ignores empty directories. This PR make the cache lenient again, as it really makes no difference when the script stage is known to be empty. The cache is still strict when the script stage is known to be not empty.

This PR also simplifies and shortens the path of a compiled script state within the cache, making it more similar to several other caches.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
