### PR TITLE
Rewrite @Unroll tests

### DIFF
--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -85,7 +85,7 @@ class BuildActionSerializerTest extends SerializerSpec {
         ]
     }
 
-    def "serializes other actions"() {
+    def "serializes other actions #action.class"() {
         expect:
         def result = serialize(action, BuildActionSerializer.create())
         result.class == action.class


### PR DESCRIPTION
This is to fix 'Received a failure event for test with unknown id '2.9'' error
which is cuased by non-unique Spock @Unroll test names.

<!--- The issue this PR addresses -->
Fixes #?

See https://builds.gradle.org/viewLog.html?buildId=35948514&buildTypeId=Gradle_Check_VfsRetention_30_bucket48&tab=buildResultsDiv

and https://github.com/gradle/gradle/issues/8787