### PR TITLE
Remove thread locals to avoid performance problems

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
@@ -28,7 +28,11 @@ public class DefaultMutationGuard extends AbstractMutationGuard {
 
     @Override
     public boolean isMutationAllowed() {
-        return mutationGuardState.get();
+        boolean mutationAllowed = mutationGuardState.get();
+        if (mutationAllowed) {
+            mutationGuardState.remove();
+        }
+        return mutationAllowed;
     }
 
     @Override
@@ -36,12 +40,16 @@ public class DefaultMutationGuard extends AbstractMutationGuard {
         return new Action<T>() {
             @Override
             public void execute(T t) {
-                boolean oldIsMutationAllowed = isMutationAllowed();
+                boolean oldIsMutationAllowed = mutationGuardState.get();
                 mutationGuardState.set(allowMutationMethods);
                 try {
                     action.execute(t);
                 } finally {
-                    mutationGuardState.set(oldIsMutationAllowed);
+                    if (oldIsMutationAllowed) {
+                        mutationGuardState.remove();
+                    } else {
+                        mutationGuardState.set(false);
+                    }
                 }
             }
         };


### PR DESCRIPTION
After a few runs the `ThreadLocal` table for the
`Daemon worker` thread has more than 100000 entries,
which makes querying mutation guard much slower. All those entries seem to be created by the `DefaultMutationGuard` thread local.

This change fixes the problem to remove the
thread local whenever it doesn't add any new
information, aka when its value is equal to its
initial value. It would be better to remove all
the mutation guard `ThreadLocal`s at one time, e.g.
when the build finished, though that is probably a
bigger change.

Fixes https://github.com/gradle/gradle-private/issues/3111.

This is a good explanation of the problem:
http://cs.oswego.edu/pipermail/concurrency-interest/2018-October/016685.html