### PR TITLE
Update NameMatcher test condition to pass with JDK15

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.java
@@ -121,7 +121,7 @@ public class NameMatcherTest {
         assertDoesNotMatch("name", "other");
         assertDoesNotMatch("name", "na");
         assertDoesNotMatch("sN", "otherName");
-        assertDoesNotMatch("sN", "someThing");
+        assertDoesNotMatch("sA", "someThing");
         assertDoesNotMatch("soN", "saN");
         assertDoesNotMatch("soN", "saName");
     }


### PR DESCRIPTION
JDK15 fixes a regular expression handling bug: https://bugs.openjdk.java.net/browse/JDK-8214245
which makes one of the regex related test conditions for NameMatcher fail.
JDK15 release notes containing the note about the included bugfix: https://jdk.java.net/15/release-notes
