### PR TITLE
Introduce release property on CompileOptions

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -111,6 +111,10 @@ public class JavaCompilerArgumentsBuilder {
                 throw new InvalidUserDataException("Cannot specify -J flags via `CompileOptions.compilerArgs`. " +
                     "Use the `CompileOptions.forkOptions.jvmArgs` property instead.");
             }
+
+            if ("--release".equals(arg) && spec.getRelease() != null) {
+                throw new InvalidUserDataException("Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release`.");
+            }
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -135,9 +135,13 @@ public class JavaCompilerArgumentsBuilder {
         if (!includeMainOptions) {
             return;
         }
-
+        Integer release = spec.getRelease();
         final MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
-        if (!releaseOptionIsSet(compilerArgs)) {
+
+        if (release != null) {
+            args.add("--release");
+            args.add(release.toString());
+        } else if (!releaseOptionIsSet(compilerArgs)) {
             String sourceCompatibility = spec.getSourceCompatibility();
             if (sourceCompatibility != null) {
                 args.add("-source");

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -90,6 +90,7 @@ public class CompileOptions extends AbstractOptions {
 
     private final Property<String> javaModuleVersion;
     private final Property<String> javaModuleMainClass;
+    private final Property<Integer> release;
 
     private final DirectoryProperty generatedSourceOutputDirectory;
 
@@ -101,6 +102,7 @@ public class CompileOptions extends AbstractOptions {
         this.javaModuleMainClass = objectFactory.property(String.class);
         this.generatedSourceOutputDirectory = objectFactory.directoryProperty();
         this.headerOutputDirectory = objectFactory.directoryProperty();
+        this.release = objectFactory.property(Integer.class);
     }
 
     /**
@@ -476,6 +478,22 @@ public class CompileOptions extends AbstractOptions {
     public void setAnnotationProcessorPath(@Nullable FileCollection annotationProcessorPath) {
         this.annotationProcessorPath = annotationProcessorPath;
     }
+
+    /**
+     * Configure the minimal Java release version for this compile task (--release compiler flag)
+     *
+     * If set, it will take precedences over the {@link AbstractCompile#getSourceCompatibility()} and {@link AbstractCompile#getTargetCompatibility()} settings,
+     * which will have no effect in that case.
+     *
+     * @since 6.6
+     */
+    @Incubating
+    @Input
+    @Optional
+    public Property<Integer> getRelease() {
+        return release;
+    }
+
 
     /**
      * Set the version of the Java module - defaults to {@link org.gradle.api.Project#getVersion()}.

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -310,9 +310,12 @@ public class JavaCompile extends AbstractCompile {
             compileOptions.setSourcepath(getProjectLayout().files(sourcesRoots));
         }
         spec.setAnnotationProcessorPath(compileOptions.getAnnotationProcessorPath() == null ? ImmutableList.of() : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
-        spec.setTargetCompatibility(getTargetCompatibility());
-        spec.setSourceCompatibility(getSourceCompatibility());
-
+        if (getRelease().isPresent()) {
+            spec.setRelease(getRelease().get());
+        } else {
+            spec.setTargetCompatibility(getTargetCompatibility());
+            spec.setSourceCompatibility(getSourceCompatibility());
+        }
         spec.setCompileOptions(compileOptions);
         spec.setSourcesRoots(sourcesRoots);
         if (((JavaToolChainInternal) getToolChain()).getJavaVersion().compareTo(JavaVersion.VERSION_1_8) < 0) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -310,8 +310,8 @@ public class JavaCompile extends AbstractCompile {
             compileOptions.setSourcepath(getProjectLayout().files(sourcesRoots));
         }
         spec.setAnnotationProcessorPath(compileOptions.getAnnotationProcessorPath() == null ? ImmutableList.of() : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
-        if (getRelease().isPresent()) {
-            spec.setRelease(getRelease().get());
+        if (compileOptions.getRelease().isPresent()) {
+            spec.setRelease(compileOptions.getRelease().get());
         } else {
             spec.setTargetCompatibility(getTargetCompatibility());
             spec.setSourceCompatibility(getSourceCompatibility());

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
@@ -28,6 +29,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     private List<File> classpath;
     private File destinationDir;
     private Iterable<File> sourceFiles;
+    private Integer release;
     private String sourceCompatibility;
     private String targetCompatibility;
     private List<File> sourceRoots;
@@ -46,6 +48,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     public File getDestinationDir() {
         return destinationDir;
     }
+
     @Override
     public void setDestinationDir(File destinationDir) {
         this.destinationDir = destinationDir;
@@ -85,22 +88,35 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     }
 
     @Override
+    @Nullable
+    public Integer getRelease() {
+        return release;
+    }
+
+    @Override
+    public void setRelease(@Nullable Integer release) {
+        this.release = release;
+    }
+
+    @Override
+    @Nullable
     public String getSourceCompatibility() {
         return sourceCompatibility;
     }
 
     @Override
-    public void setSourceCompatibility(String sourceCompatibility) {
+    public void setSourceCompatibility(@Nullable String sourceCompatibility) {
         this.sourceCompatibility = sourceCompatibility;
     }
 
     @Override
+    @Nullable
     public String getTargetCompatibility() {
         return targetCompatibility;
     }
 
     @Override
-    public void setTargetCompatibility(String targetCompatibility) {
+    public void setTargetCompatibility(@Nullable String targetCompatibility) {
         this.targetCompatibility = targetCompatibility;
     }
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.language.base.internal.compile.CompileSpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -42,13 +43,20 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
 
     void setCompileClasspath(List<File> classpath);
 
+    @Nullable
+    Integer getRelease();
+
+    void setRelease(@Nullable Integer release);
+
+    @Nullable
     String getSourceCompatibility();
 
-    void setSourceCompatibility(String sourceCompatibility);
+    void setSourceCompatibility(@Nullable String sourceCompatibility);
 
+    @Nullable
     String getTargetCompatibility();
 
-    void setTargetCompatibility(String targetCompatibility);
+    void setTargetCompatibility(@Nullable String targetCompatibility);
 
     List<File> getSourceRoots();
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
@@ -21,9 +21,11 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 
@@ -39,10 +41,12 @@ public abstract class AbstractCompile extends SourceTask {
     private FileCollection classpath;
     private String sourceCompatibility;
     private String targetCompatibility;
+    private Property<Integer> release;
 
     public AbstractCompile() {
         this.destinationDirectory = getProject().getObjects().directoryProperty();
         this.destinationDirectory.convention(getProject().getProviders().provider(new BackwardCompatibilityOutputDirectoryConvention()));
+        this.release = getProject().getObjects().property(Integer.class);
     }
 
     /**
@@ -103,6 +107,21 @@ public abstract class AbstractCompile extends SourceTask {
      */
     public void setDestinationDir(Provider<File> destinationDir) {
         this.destinationDirectory.set(getProject().getLayout().dir(destinationDir));
+    }
+
+    /**
+     * Configure the minimal Java release version for this compile task (--release compiler flag)
+     *
+     * If set, it will take precedences over the {@link #getSourceCompatibility()} and {@link #getTargetCompatibility()} settings,
+     * which will have no effect in that case.
+     *
+     * @since 6.6
+     */
+    @Incubating
+    @Input
+    @Optional
+    public Property<Integer> getRelease() {
+        return release;
     }
 
     /**

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
@@ -21,11 +21,9 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.model.ReplacedBy;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 
@@ -41,12 +39,10 @@ public abstract class AbstractCompile extends SourceTask {
     private FileCollection classpath;
     private String sourceCompatibility;
     private String targetCompatibility;
-    private Property<Integer> release;
 
     public AbstractCompile() {
         this.destinationDirectory = getProject().getObjects().directoryProperty();
         this.destinationDirectory.convention(getProject().getProviders().provider(new BackwardCompatibilityOutputDirectoryConvention()));
-        this.release = getProject().getObjects().property(Integer.class);
     }
 
     /**
@@ -107,21 +103,6 @@ public abstract class AbstractCompile extends SourceTask {
      */
     public void setDestinationDir(Provider<File> destinationDir) {
         this.destinationDirectory.set(getProject().getLayout().dir(destinationDir));
-    }
-
-    /**
-     * Configure the minimal Java release version for this compile task (--release compiler flag)
-     *
-     * If set, it will take precedences over the {@link #getSourceCompatibility()} and {@link #getTargetCompatibility()} settings,
-     * which will have no effect in that case.
-     *
-     * @since 6.6
-     */
-    @Incubating
-    @Input
-    @Optional
-    public Property<Integer> getRelease() {
-        return release;
     }
 
     /**

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -178,7 +178,7 @@ compileJava {
         buildFile << """
 java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
 compileJava.targetCompatibility = '10' // ignored
-compileJava.release.set(8)
+compileJava.options.release.set(8)
 compileJava {
     doFirst {
         assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
@@ -200,7 +200,7 @@ compileJava {
         goodCode()
         buildFile << """
 compileJava.options.compilerArgs.addAll(['--release', '12'])
-compileJava.release.set(8)
+compileJava.options.release.set(8)
 """
 
         expect:
@@ -215,7 +215,7 @@ compileJava.release.set(8)
         buildFile << """
 java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
 compileJava.targetCompatibility = '10' // ignored
-compileJava.release.set(8)
+compileJava.options.release.set(8)
 java.disableAutoTargetJvm()
 compileJava {
     doFirst {
@@ -321,7 +321,7 @@ public class FailsOnJava8<T> {
 '''
 
         buildFile << """
-compileJava.release.set(8)
+compileJava.options.release.set(8)
 """
 
         expect:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -195,6 +195,20 @@ compileJava {
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "fails to compile with release property and flag set"() {
+        given:
+        goodCode()
+        buildFile << """
+compileJava.options.compilerArgs.addAll(['--release', '12'])
+compileJava.release.set(8)
+"""
+
+        expect:
+        fails 'compileJava'
+        failureHasCause('Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release`.')
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     def "compile with release property and autoTargetJvmDisabled"() {
         given:
         goodCode()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -143,18 +143,18 @@ public class FxApp extends Application {
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
     @Unroll
-    def "compile with release option"() {
+    def "compile with release flag"() {
         given:
         goodCode()
         buildFile << """
-java.targetCompatibility = JavaVersion.VERSION_1_7
+java.targetCompatibility = JavaVersion.VERSION_1_7 // this will be ignored when compiling, but used for the TargetJvmVersion attribute
 compileJava.options.compilerArgs.addAll(['--release', $notation])
 compileJava {
     doFirst {
-        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
-        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
-        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
-        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
     }
 }
 """
@@ -172,13 +172,36 @@ compileJava {
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
-    def "compile with release option and autoTargetJvmDisabled"() {
+    def "compile with release property set"() {
         given:
         goodCode()
         buildFile << """
 java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
 compileJava.targetCompatibility = '10' // ignored
-compileJava.options.compilerArgs.addAll(['--release', '8'])
+compileJava.release.set(8)
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+    }
+}
+"""
+
+        expect:
+        succeeds 'compileJava'
+        bytecodeVersion() == 52
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile with release property and autoTargetJvmDisabled"() {
+        given:
+        goodCode()
+        buildFile << """
+java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
+compileJava.targetCompatibility = '10' // ignored
+compileJava.release.set(8)
 java.disableAutoTargetJvm()
 compileJava {
     doFirst {
@@ -258,6 +281,33 @@ public class FailsOnJava8<T> {
 
         buildFile << """
 compileJava.options.compilerArgs.addAll(['--release', '8'])
+"""
+
+        expect:
+        fails 'compileJava'
+        output.contains(logStatement())
+        failure.assertHasErrorOutput("cannot find symbol")
+        failure.assertHasErrorOutput("method takeWhile")
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile fails when using newer API with release property"() {
+        given:
+        file("src/main/java/compile/test/FailsOnJava8.java") << '''
+package compile.test;
+
+import java.util.stream.Stream;
+import java.util.function.Predicate;
+
+public class FailsOnJava8<T> {
+    public Stream<T> takeFromStream(Stream<T> stream) {
+        return stream.takeWhile(Predicate.isEqual("foo"));
+    }
+}
+'''
+
+        buildFile << """
+compileJava.release.set(8)
 """
 
         expect:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -147,14 +147,14 @@ public class FxApp extends Application {
         given:
         goodCode()
         buildFile << """
-java.targetCompatibility = JavaVersion.VERSION_1_7 // this will be ignored when compiling, but used for the TargetJvmVersion attribute
+java.targetCompatibility = JavaVersion.VERSION_1_7
 compileJava.options.compilerArgs.addAll(['--release', $notation])
 compileJava {
     doFirst {
-        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
-        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
-        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
-        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 7
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
     }
 }
 """

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -313,10 +314,29 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private void configureCompileDefaults(final Project project, final JavaPluginConvention javaConvention) {
-        project.getTasks().withType(AbstractCompile.class).configureEach(compile -> {
-            ConventionMapping conventionMapping = compile.getConventionMapping();
-            conventionMapping.map("sourceCompatibility", () -> javaConvention.getSourceCompatibility().toString());
-            conventionMapping.map("targetCompatibility", () -> javaConvention.getTargetCompatibility().toString());
+        project.getTasks().withType(AbstractCompile.class).configureEach(new Action<AbstractCompile>() {
+            @Override
+            public void execute(final AbstractCompile compile) {
+                ConventionMapping conventionMapping = compile.getConventionMapping();
+                conventionMapping.map("sourceCompatibility", new Callable<Object>() {
+                    @Override
+                    public Object call() {
+                        if (compile.getRelease().isPresent()) {
+                            return JavaVersion.toVersion(compile.getRelease().get()).toString();
+                        }
+                        return javaConvention.getSourceCompatibility().toString();
+                    }
+                });
+                conventionMapping.map("targetCompatibility", new Callable<Object>() {
+                    @Override
+                    public Object call() {
+                        if (compile.getRelease().isPresent()) {
+                            return JavaVersion.toVersion(compile.getRelease().get()).toString();
+                        }
+                        return javaConvention.getTargetCompatibility().toString();
+                    }
+                });
+            }
         });
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -123,7 +123,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     @Override
     public Manifest manifest() {
-        return manifest(Actions.<Manifest>doNothing());
+        return manifest(Actions.doNothing());
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -266,11 +266,26 @@ public class JvmPluginsHelper {
                 if (javaCompile.getRelease().isPresent()) {
                     majorVersion = javaCompile.getRelease().get();
                 } else {
-                    majorVersion = Integer.parseInt(JavaVersion.toVersion(javaCompile.getTargetCompatibility()).getMajorVersion());
+                    int releaseFlag = getReleaseOption(javaCompile.getOptions().getCompilerArgs());
+                    if (releaseFlag != 0) {
+                        majorVersion = releaseFlag;
+                    } else {
+                        majorVersion = Integer.parseInt(JavaVersion.toVersion(javaCompile.getTargetCompatibility()).getMajorVersion());
+                    }
                 }
                 JavaEcosystemSupport.configureDefaultTargetPlatform(conf, majorVersion);
             }
         };
+    }
+
+    private static int getReleaseOption(List<String> compilerArgs) {
+        int flagIndex = compilerArgs.indexOf("--release");
+        if (flagIndex != -1 && flagIndex + 1 < compilerArgs.size()) {
+            // Using String.valueOf because despite the type signature being List<String>
+            // a user can put anything in that list, including Groovy's GString
+            return Integer.parseInt(String.valueOf(compilerArgs.get(flagIndex + 1)));
+        }
+        return 0;
     }
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -263,25 +263,14 @@ public class JvmPluginsHelper {
             if (alwaysEnabled || !convention.getAutoTargetJvmDisabled()) {
                 JavaCompile javaCompile = compileTaskProvider.get();
                 int majorVersion;
-                int releaseOption = getReleaseOption(javaCompile.getOptions().getCompilerArgs());
-                if (releaseOption > 0) {
-                    majorVersion = releaseOption;
+                if (javaCompile.getRelease().isPresent()) {
+                    majorVersion = javaCompile.getRelease().get();
                 } else {
                     majorVersion = Integer.parseInt(JavaVersion.toVersion(javaCompile.getTargetCompatibility()).getMajorVersion());
                 }
                 JavaEcosystemSupport.configureDefaultTargetPlatform(conf, majorVersion);
             }
         };
-    }
-
-    private static int getReleaseOption(List<String> compilerArgs) {
-        int flagIndex = compilerArgs.indexOf("--release");
-        if (flagIndex != -1 && flagIndex + 1 < compilerArgs.size()) {
-            // Using String.valueOf because despite the type signature being List<String>
-            // a user can put anything in that list, including Groovy's GString
-            return Integer.parseInt(String.valueOf(compilerArgs.get(flagIndex + 1)));
-        }
-        return 0;
     }
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -263,8 +263,8 @@ public class JvmPluginsHelper {
             if (alwaysEnabled || !convention.getAutoTargetJvmDisabled()) {
                 JavaCompile javaCompile = compileTaskProvider.get();
                 int majorVersion;
-                if (javaCompile.getRelease().isPresent()) {
-                    majorVersion = javaCompile.getRelease().get();
+                if (javaCompile.getOptions().getRelease().isPresent()) {
+                    majorVersion = javaCompile.getOptions().getRelease().get();
                 } else {
                     int releaseFlag = getReleaseOption(javaCompile.getOptions().getCompilerArgs());
                     if (releaseFlag != 0) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -557,5 +558,22 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task.taskDependencies.getDependencies(task)*.path as Set == [':middle:build', ':app:buildDependents'] as Set
+    }
+
+    void "source and target compatibility of compile tasks default to release if set"() {
+        given:
+        project.pluginManager.apply(JavaPlugin)
+        def compileJava = project.tasks.named("compileJava", AbstractCompile).get()
+        def testCompileJava = project.tasks.named("compileTestJava", AbstractCompile).get()
+
+        when:
+        compileJava.release.set(8)
+        testCompileJava.release.set(9)
+
+        then:
+        compileJava.targetCompatibility == "1.8"
+        compileJava.sourceCompatibility == "1.8"
+        testCompileJava.targetCompatibility == "1.9"
+        testCompileJava.sourceCompatibility == "1.9"
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -563,12 +562,12 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
     void "source and target compatibility of compile tasks default to release if set"() {
         given:
         project.pluginManager.apply(JavaPlugin)
-        def compileJava = project.tasks.named("compileJava", AbstractCompile).get()
-        def testCompileJava = project.tasks.named("compileTestJava", AbstractCompile).get()
+        def compileJava = project.tasks.named("compileJava", JavaCompile).get()
+        def testCompileJava = project.tasks.named("compileTestJava", JavaCompile).get()
 
         when:
-        compileJava.release.set(8)
-        testCompileJava.release.set(9)
+        compileJava.options.release.set(8)
+        testCompileJava.options.release.set(9)
 
         then:
         compileJava.targetCompatibility == "1.8"


### PR DESCRIPTION
This property, when used, is only leveraged by JavaCompile. It is mapped
to the javac release flag. It takes precedence over the source and
target compatibility.

This commit also improves the wiring of the target JVM version
attribute in resolvable configurations, which is now derived from
release.

This is mostly the work done previously by @jjohannes , adapted to the recent code changes.