### PR TITLE
Shorten test dir name

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
 import org.gradle.util.Requires
 
 import static org.gradle.util.TestPrecondition.JDK14_OR_EARLIER
 
 @Requires(JDK14_OR_EARLIER)
+@TestDir("IEJIT")
 class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
     def "can use jacoco"() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -47,7 +47,9 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
 
     protected AbstractTestDirectoryProvider(TestFile root, Class<?> testClass) {
         this.root = root;
-        this.className = testClass.getSimpleName();
+        this.className = testClass.getAnnotation(TestDir.class) == null
+            ? testClass.getSimpleName()
+            : testClass.getAnnotation(TestDir.class).value();
     }
 
     @Override
@@ -135,8 +137,8 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
         }
         if (prefix == null) {
             String safeMethodName = methodName.replaceAll("[^\\w]", "_");
-            if (safeMethodName.length() > 30) {
-                safeMethodName = safeMethodName.substring(0, 19) + "..." + safeMethodName.substring(safeMethodName.length() - 9);
+            if (safeMethodName.length() > 20) {
+                safeMethodName = safeMethodName.substring(0, 9) + "..." + safeMethodName.substring(safeMethodName.length() - 9);
             }
             prefix = String.format("%s/%s", className, safeMethodName);
         }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDir.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDir.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.file;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the tmp test directory name for the test files. Previously we used class name as
+ * tmp test files directory but that might cause issues on Windows due to Windows path length
+ * limitation. When test class is marked with this annotation, its value will be used to
+ * create tmp test file directories (usually acronym of original class name).
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestDir {
+    String value();
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
 
 import static org.gradle.util.BinaryDiffUtils.levenshteinDistance
 import static org.gradle.util.BinaryDiffUtils.toHexStrings
 
+@TestDir("JTRIT")
 class JacocoTestRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedContainersDslTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedContainersDslTest.kt
@@ -67,17 +67,17 @@ class NamedContainersDslTest : AbstractDslTest() {
                 val bar: Configuration = getByName("bar") {
                     extendsFrom(foo)
                 }
-    
+
                 val bazar: Configuration = create("bazar")
                 val cathedral: Configuration = create("cathedral") {
                     extendsFrom(bazar)
                 }
-    
+
                 val cabin: NamedDomainObjectProvider<Configuration> = named("cabin")
                 val castle: NamedDomainObjectProvider<Configuration> = named("castle") {
                     extendsFrom(cabin.get())
                 }
-    
+
                 val valley: NamedDomainObjectProvider<Configuration> = register("valley")
                 val hill: NamedDomainObjectProvider<Configuration> = register("hill") {
                     extendsFrom(valley.get())

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
@@ -22,10 +22,12 @@ import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.MixedLanguageHelloWorldApp
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+@TestDir('ALIBIT')
 @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
 class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/c/CPreCompiledHeaderSourcesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/c/CPreCompiledHeaderSourcesIntegrationTest.groovy
@@ -20,9 +20,11 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.language.AbstractNativePreCompiledHeaderIntegrationTest
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+@TestDir("CPCHSIT")
 class CPreCompiledHeaderSourcesIntegrationTest extends AbstractNativePreCompiledHeaderIntegrationTest {
     @Requires(TestPrecondition.MAC_OS_X)
     @ToBeFixedForInstantExecution

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
@@ -21,8 +21,10 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraryAndOptionalFeature
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.maven.MavenFileRepository
 
+@TestDir("CLWBLPIT")
 class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
     @ToBeFixedForInstantExecution
@@ -35,7 +37,7 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
         buildFile << """
             apply plugin: 'cpp-library'
             apply plugin: 'maven-publish'
-            
+
             group = 'some.group'
             version = '1.2'
             library {
@@ -165,13 +167,13 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
         producer.file("build.gradle") << """
             apply plugin: 'cpp-library'
             apply plugin: 'maven-publish'
-            
+
             group = 'some.group'
             version = '1.2'
             publishing {
                 repositories { maven { url '${repoDir.toURI()}' } }
             }
-            
+
             library {
                 linkage = [Linkage.STATIC, Linkage.SHARED]
                 binaries.configureEach {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
@@ -21,8 +21,10 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraryAndOptionalFeature
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.maven.MavenFileRepository
 
+@TestDir('CLWSLPIT')
 class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
     @ToBeFixedForInstantExecution
@@ -35,7 +37,7 @@ class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractInsta
         buildFile << """
             apply plugin: 'cpp-library'
             apply plugin: 'maven-publish'
-            
+
             group = 'some.group'
             version = '1.2'
             library {
@@ -138,13 +140,13 @@ class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractInsta
         producer.file("build.gradle") << """
             apply plugin: 'cpp-library'
             apply plugin: 'maven-publish'
-            
+
             group = 'some.group'
             version = '1.2'
             publishing {
                 repositories { maven { url '${repoDir.toURI()}' } }
             }
-            
+
             library {
                 linkage = [Linkage.STATIC]
                 binaries.configureEach {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppPreCompiledHeaderSourcesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppPreCompiledHeaderSourcesIntegrationTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.language.AbstractNativePreCompiledHeaderIntegrationTest
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+@TestDir("CPCHSIT")
 class CppPreCompiledHeaderSourcesIntegrationTest extends AbstractNativePreCompiledHeaderIntegrationTest implements DirectoryBuildCacheFixture {
 
     @Override

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -21,11 +21,13 @@ import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.launcher.daemon.client.DaemonDisappearedException
 import org.gradle.launcher.daemon.logging.DaemonMessages
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
+@TestDir('PCHIT')
 class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
     @Rule BlockingHttpServer server = new BlockingHttpServer()
 

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.Sample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -30,6 +31,7 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_3
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32_AND_64
 import static org.junit.Assume.assumeTrue
 
+@TestDir("NPSIT")
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     @Rule public final Sample cppLib = sample(testDirectoryProvider, 'cpp-lib')

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -19,10 +19,12 @@ package org.gradle.api.reporting.plugins
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
+import org.gradle.test.fixtures.file.TestDir
 import org.gradle.test.fixtures.file.TestFile
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
+@TestDir("BDPIT")
 class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
     def setup() {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithBothLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithBothLibraryLinkageIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.nativeplatform.test.cpp
 
 import org.gradle.nativeplatform.fixtures.app.CppLibWithSimpleUnitTest
 import org.gradle.nativeplatform.fixtures.app.SourceElement
+import org.gradle.test.fixtures.file.TestDir
 
+@TestDir('CUTCWBLLIT')
 class CppUnitTestComponentWithBothLibraryLinkageIntegrationTest extends AbstractCppUnitTestComponentWithTestedComponentIntegrationTest {
     @Override
     protected void makeSingleProject() {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.nativeplatform.test.cpp
 
 import org.gradle.nativeplatform.fixtures.app.CppLibWithSimpleUnitTest
 import org.gradle.nativeplatform.fixtures.app.SourceElement
+import org.gradle.test.fixtures.file.TestDir
 
+@TestDir("CUTCWSLLIT")
 class CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest extends AbstractCppUnitTestComponentWithTestedComponentIntegrationTest {
     @Override
     protected void makeSingleProject() {


### PR DESCRIPTION
Previously we create tmp test directory based on test class/method names. This caused very long path which might break on Windows. Even though we enabled long path support on Windows, some native tool/JDK8 still complains long path:

https://bugs.openjdk.java.net/browse/JDK-8188122

The idea of this PR is to introduce an annotation `@TestDir` to declare a shorten test dir name, but still allow users to search the name to quickly locate the test class.