### PR TITLE
Don't rely on the artifact's existence to decide whether it should be published

### DIFF
--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIdentifierValidationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIdentifierValidationIntegTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.encoding.Identifier
 import spock.lang.Unroll
@@ -28,7 +27,6 @@ class MavenPublishIdentifierValidationIntegTest extends AbstractMavenPublishInte
     def artifactId = 'valid_artifact.name'
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can publish with version and description containing #identifier characters"() {
         given:
         def version = identifier.safeForFileName().decorate("version")
@@ -71,7 +69,6 @@ class MavenPublishIdentifierValidationIntegTest extends AbstractMavenPublishInte
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can publish artifacts with version, extension and classifier containing #identifier characters"() {
         given:
         file("content-file") << "some content"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -105,8 +105,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         [apiMapping, runtimeMapping] << ([
-                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -192,8 +192,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         [apiMapping, runtimeMapping] << ([
-                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -274,8 +274,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         config << [
-                "fromResolutionOf('extra')",
-                "fromResolutionOf(project.configurations.extra)"
+            "fromResolutionOf('extra')",
+            "fromResolutionOf(project.configurations.extra)"
         ]
     }
 
@@ -363,8 +363,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         [apiMapping, runtimeMapping] << ([
-                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')")],
-                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')")]
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')")]
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -538,7 +538,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
             }
 
             $substitution
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -548,7 +548,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
                             ${runtimeUsingUsage()}
                         }
                     }
-            
+
                 }
             }
         """)
@@ -573,7 +573,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         substitution << [
-                """
+            """
             dependencies {
                 modules {
                     module("org:foo") {
@@ -590,7 +590,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
                 }
             }
             """,
-                """
+            """
             configurations.all {
                 resolutionStrategy.dependencySubstitution {
                     substitute(module('org:foo')).with(module('org:baz:1.0'))
@@ -615,7 +615,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
                     substitute(module('org:foo')) with(project(':lib'))
                 }
             }
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -625,14 +625,14 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
                             ${runtimeUsingUsage()}
                         }
                     }
-            
+
                 }
             }
         """)
 
         file("lib/build.gradle") << """
             apply plugin: 'java-library'
-            
+
             group = 'com.acme'
             version = '1.45'
         """
@@ -681,7 +681,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
                 // use for resolving
                 maven { url "${mavenRepo.uri}" }
             }
-            
+
             publishing {
                 repositories {
                     // used for publishing

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.api.attributes.Category
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenJavaModule
 import spock.lang.Unroll
@@ -26,7 +25,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     MavenJavaModule javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
 
     @Unroll("can publish java-library with dependencies (#apiMapping, #runtimeMapping)")
-    @ToBeFixedForInstantExecution
     def "can publish java-library with dependencies (runtime last)"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
@@ -113,7 +111,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     }
 
     @Unroll("can publish java-library with dependencies (#runtimeMapping, #apiMapping)")
-    @ToBeFixedForInstantExecution
     def "can publish java-library with dependencies (runtime first)"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
@@ -207,7 +204,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
      * or when the component is not a Java library and we don't have a default.
      */
     @Unroll("can publish resolved versions from a different configuration (#config)")
-    @ToBeFixedForInstantExecution
     def "can publish resolved versions from a different configuration"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
@@ -284,7 +280,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     }
 
     @Unroll("can publish resolved versions from dependency constraints (#apiMapping, #runtimeMapping)")
-    @ToBeFixedForInstantExecution
     def "can publish resolved versions from dependency constraints"() {
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
@@ -373,7 +368,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         ].combinations() + [[allVariants(), noop()]])
     }
 
-    @ToBeFixedForInstantExecution
     def "dependency constraints which are unresolved are published as is"() {
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
@@ -450,7 +444,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     }
 
     // This test documents the existing behavior, not necessarily the best one
-    @ToBeFixedForInstantExecution
     def "import scope makes use of runtime classpath"() {
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata()
@@ -529,7 +522,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     // substitution rule (via a plugin for example) that you are not aware of.
     // Ideally we should warn when such things happen (linting).
     @Unroll
-    @ToBeFixedForInstantExecution
     def "substituted dependencies are also substituted in the generated POM file"() {
         javaLibrary(mavenRepo.module("org", "foo", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org", "bar", "1.0"))
@@ -608,7 +600,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         ]
     }
 
-    @ToBeFixedForInstantExecution
     def "can substitute with a project dependency"() {
         given:
         settingsFile << """

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -32,7 +32,6 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("maven-publish/quickstart")
-    @ToBeFixedForInstantExecution
     def "quickstart publish with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)
@@ -84,7 +83,6 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("maven-publish/javaProject")
-    @ToBeFixedForInstantExecution
     def "publish java project with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)
@@ -113,7 +111,6 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("maven-publish/multiple-publications")
-    @ToBeFixedForInstantExecution
     def "multiple publications with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)
@@ -146,7 +143,9 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("maven-publish/conditional-publishing")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(
+        iterationMatchers = ".* kotlin dsl"
+    )
     def "conditional publishing with #dsl dsl"() {
         using m2
 
@@ -270,7 +269,6 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("maven-publish/distribution")
-    @ToBeFixedForInstantExecution
     def "publishes distribution archives with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -77,7 +77,6 @@ import org.gradle.api.publish.maven.internal.dependencies.DefaultMavenDependency
 import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MutableMavenProjectIdentity;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -126,12 +126,6 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         }
         return left.compareTo(right);
     };
-    private static final Spec<MavenArtifact> PUBLISHED_ARTIFACTS = artifact -> {
-        if (!((PublicationArtifactInternal) artifact).shouldBePublished()) {
-            return false;
-        }
-        return artifact.getFile().exists();
-    };
 
     @VisibleForTesting
     public static final String INCOMPATIBLE_FEATURE = " contains dependencies that will produce a pom file that cannot be consumed by a Maven client.";
@@ -673,11 +667,11 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             ));
     }
 
-    private MavenArtifact normalizedArtifactFor(MavenArtifact pomArtifact) {
+    private MavenArtifact normalizedArtifactFor(MavenArtifact artifact) {
         // TODO: introduce something like a NormalizedMavenArtifact to capture the required MavenArtifact
         //  information and only that instead of having MavenArtifact references in
         //  MavenNormalizedPublication
-        return new SerializableMavenArtifact(pomArtifact);
+        return new SerializableMavenArtifact(artifact);
     }
 
     private DomainObjectSet<MavenArtifact> artifactsToBePublished() {
@@ -687,7 +681,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                 new DomainObjectCollection<?>[]{mainArtifacts, metadataArtifacts, derivedArtifacts}
             )
         ).matching(element -> {
-            if (!PUBLISHED_ARTIFACTS.isSatisfiedBy(element)) {
+            if (!((PublicationArtifactInternal) element).shouldBePublished()) {
                 return false;
             }
             if (moduleMetadataArtifact == element) {

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -134,13 +134,11 @@ class DefaultMavenPublicationTest extends Specification {
         }
         notationParser.parseNotation("artifact") >> mavenArtifact
         mavenArtifact.extension >> "ext"
-        mavenArtifact.file >> artifactFile
         def attachedMavenArtifact = Mock(MavenTestArtifact) {
             shouldBePublished() >> true
         }
         notationParser.parseNotation("attached") >> attachedMavenArtifact
         attachedMavenArtifact.extension >> "jar"
-        attachedMavenArtifact.file >> artifactFile
 
         and:
         def publication = createPublication()
@@ -160,7 +158,6 @@ class DefaultMavenPublicationTest extends Specification {
         }
         notationParser.parseNotation("artifact") >> mavenArtifact
         mavenArtifact.extension >> "ext"
-        mavenArtifact.file >> artifactFile
 
         and:
         def publication = createPublication()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
@@ -56,7 +56,7 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
         file("unzip/TestProject-custom/someFile").assertIsFile()
     }
 
-    @ToBeFixedForInstantExecution(because = "publishing")
+    @ToBeFixedForInstantExecution(because = "uploadArchives")
     def "can publish distribution"() {
         when:
         buildFile << """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.java.fixtures
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.GradleModuleMetadata
 import org.gradle.test.fixtures.file.TestFile
@@ -257,7 +256,6 @@ hamcrest-core-1.3.jar
         )
     }
 
-    @ToBeFixedForInstantExecution(because = "publishing")
     def "can publish test fixtures"() {
         buildFile << """
             apply plugin: 'maven-publish'
@@ -314,7 +312,6 @@ hamcrest-core-1.3.jar
         }
     }
 
-    @ToBeFixedForInstantExecution(because = "publishing")
     def "can deactivate test fixture publishing"() {
         buildFile << """
             apply plugin: 'maven-publish'

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -86,9 +86,9 @@ public class JavaPlatformPlugin implements Plugin<Project> {
         }
     };
     private static final String DISALLOW_DEPENDENCIES = "Adding dependencies to platforms is not allowed by default.\n" +
-            "Most likely you want to add constraints instead.\n" +
-            "If you did this intentionally, you need to configure the platform extension to allow dependencies:\n    javaPlatform.allowDependencies()\n" +
-            "Found dependencies in the '%s' configuration.";
+        "Most likely you want to add constraints instead.\n" +
+        "If you did this intentionally, you need to configure the platform extension to allow dependencies:\n    javaPlatform.allowDependencies()\n" +
+        "Found dependencies in the '%s' configuration.";
 
     private final SoftwareComponentFactory softwareComponentFactory;
 
@@ -101,8 +101,10 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     public void apply(Project project) {
         if (project.getPluginManager().hasPlugin("java")) {
             // This already throws when creating `apiElements` so be eager to have a clear error message
-            throw new IllegalStateException("The \"java-platform\" plugin cannot be applied together with the \"java\" (or \"java-library\") plugin. " +
-                "A project is either a platform or a library but cannot be both at the same time.");
+            throw new IllegalStateException(
+                "The \"java-platform\" plugin cannot be applied together with the \"java\" (or \"java-library\") plugin. " +
+                    "A project is either a platform or a library but cannot be both at the same time."
+            );
         }
         project.getPluginManager().apply(BasePlugin.class);
         createConfigurations(project);

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomExternalTaskIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomExternalTaskIntegrationTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.integtests.samples
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
 import spock.lang.Unroll
 
 class SamplesCustomExternalTaskIntegrationTest extends AbstractSampleIntegrationTest {
-    @Rule public final Sample sample = new Sample(temporaryFolder)
+    @Rule
+    public final Sample sample = new Sample(temporaryFolder)
 
     @Unroll
     @UsesSample("base/customExternalTask")
@@ -42,7 +42,6 @@ class SamplesCustomExternalTaskIntegrationTest extends AbstractSampleIntegration
         dsl << ['groovy', 'kotlin']
     }
 
-    @ToBeFixedForInstantExecution
     @Unroll
     @UsesSample("base/customExternalTask")
     def "can publish and use task implementations for #dsl dsl"() {

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
@@ -42,7 +42,9 @@ class SamplesCustomPluginIntegrationTest extends AbstractSampleIntegrationTest {
         dsl << ['groovy', 'kotlin']
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(
+        iterationMatchers = ".* for javaGradlePlugin producer .*"
+    )
     @Unroll
     @UsesSample("plugins/customPlugin")
     def "can publish and use plugin and test implementations for #producerName producer and #dsl dsl"() {


### PR DESCRIPTION
For compatibility with the configuration cache, the publication specs are computed and filtered before the execution of tasks thus before artifacts have been produced.