### PR TITLE
Support more notations for `MavenPublication#artifact()`

### DIFF
--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
@@ -19,17 +19,24 @@ package org.gradle.api.publish.maven.internal.artifact
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.tasks.DefaultTaskDependency
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenArtifact
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
-public class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuilderSpec {
+class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuilderSpec {
     Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     def task = Mock(Task)
     def dependencies = ImmutableSet.of(task)
@@ -158,4 +165,101 @@ public class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuild
         "some-file.zip"                | "zip"
         "some-file-1.2-classifier.zip" | "zip"
     }
+
+    def "creates lazy MavenArtifact for Provider<AbstractArchiveTask> notation"() {
+        def task = Mock(AbstractArchiveTask)
+        def taskProvider = Mock(TestTaskProvider)
+        def fileProvider = Mock(Provider)
+        def file = Mock(RegularFile)
+
+        when:
+        def artifact = parser.parseNotation(taskProvider)
+
+        then:
+        0 * taskProvider._
+
+        when:
+        artifact.file
+
+        then:
+        1 * taskProvider.get() >> task
+        1 * task.getArchiveFile() >> fileProvider
+        1 * fileProvider.get() >> file
+        1 * file.getAsFile()
+        0 * _
+    }
+
+    def "creates lazy MavenArtifact for Provider<Task> notation when task has a single output file"() {
+        def task = Mock(Task)
+        def taskProvider = Mock(TestTaskProvider)
+        def outputs = Mock(TaskOutputsInternal)
+        def fileCollection = Mock(FileCollection)
+
+        when:
+        def artifact = parser.parseNotation(taskProvider)
+
+        then:
+        0 * taskProvider._
+
+        when:
+        artifact.file
+
+        then:
+        1 * taskProvider.get() >> task
+        1 * task.getOutputs() >> outputs
+        1 * outputs.getFiles() >> fileCollection
+        1 * fileCollection.getSingleFile() >> Stub(File)
+        0 * _
+    }
+
+    def "fails resolving lazy MavenArtifact for Provider<Task> notation when task has a multiple output files"() {
+        def task = Mock(Task)
+        def taskProvider = Mock(TestTaskProvider)
+        def outputs = Mock(TaskOutputsInternal)
+        def fileCollection = Mock(FileCollection)
+
+        when:
+        def artifact = parser.parseNotation(taskProvider)
+
+        then:
+        0 * taskProvider._
+
+        when:
+        1 * taskProvider.get() >> task
+        1 * task.getOutputs() >> outputs
+        1 * outputs.getFiles() >> fileCollection
+        1 * fileCollection.getSingleFile() >> {
+            throw new RuntimeException("more than one file")
+        }
+        artifact.file
+
+        then:
+        RuntimeException e = thrown()
+        e.message == "more than one file"
+    }
+
+    def "creates lazy MavenArtifact for Provider<RegularFile> notation"() {
+        def provider = Mock(ProviderInternal)
+        def file = Stub(File) {
+            getName() >> 'picard.txt'
+        }
+        def regularFile = Mock(RegularFile)
+
+        when:
+        def artifact = parser.parseNotation(provider)
+
+        then:
+        0 * provider._
+
+        when:
+        1 * provider.get() >> regularFile
+        1 * regularFile.getAsFile() >> file
+        artifact.file
+
+        then:
+        0 * _
+    }
+
+    interface TestTaskProvider<T extends Task> extends TaskProvider<T>, ProviderInternal {}
+
 }


### PR DESCRIPTION
Currently, there's no good way for a user to have a lazy artifact
provider, even if the producer is lazy (e.g, a `TaskProvider` or
a `Provider<RegularFile>`.

This commit fixes that by supporting more notations in the converter
and automatically using `LazyPublishArtifact` when a provider is
supplied.

The lazy publish artifact now also supports more, in particular it
can accept any task as long as it provides a _single_ output file.

Fixes #7958
