### PR TITLE
BuildLayout should detect `master/settings.gradle` in current directory

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -15,13 +15,13 @@
  */
 package org.gradle.initialization.layout;
 
-import javax.annotation.Nullable;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 @UsedByScanPlugin
@@ -67,6 +67,9 @@ public class BuildLayoutFactory {
 
     BuildLayout getLayoutFor(File currentDir, File stopAt) {
         File settingsFile = findExistingSettingsFileIn(currentDir);
+        if (settingsFile == null) {
+            settingsFile = findExistingSettingsFileIn(new File(currentDir, "master"));
+        }
         if (settingsFile != null) {
             return layout(currentDir, settingsFile);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -216,6 +216,29 @@ class BuildLayoutFactoryTest extends Specification {
     }
 
     @Unroll
+    def "prefers the child 'master' directory over an ancestor directory with 'master' or a #settingsFilename file"() {
+        given:
+        def locator = buildLayoutFactoryFor()
+
+        and:
+        def currentDir = tmpDir.createDir("project")
+        def masterDir = currentDir.createDir("master")
+        def settingsFile = masterDir.createFile(settingsFilename)
+        def ancestorMasterDir = tmpDir.createDir("master")
+        ancestorMasterDir.createFile(settingsFilename)
+        tmpDir.createFile(settingsFilename)
+
+        expect:
+        def layout = locator.getLayoutFor(currentDir, true)
+        layout.rootDirectory == masterDir.parentFile
+        layout.settingsDir == masterDir
+        refersTo(layout, settingsFile)
+
+        where:
+        settingsFilename << TEST_CASES
+    }
+
+    @Unroll
     def "returns start directory when search upwards is disabled with a #settingsFilename file"() {
         given:
         def locator = buildLayoutFactoryFor()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -93,6 +93,25 @@ class BuildLayoutFactoryTest extends Specification {
     }
 
     @Unroll
+    def "looks for child directory called 'master' that it contains a #settingsFilename file"() {
+        given:
+        def locator = buildLayoutFactoryFor()
+
+        and:
+        def masterDir = tmpDir.createDir("master")
+        def settingsFile = masterDir.createFile(settingsFilename)
+
+        expect:
+        def layout = locator.getLayoutFor(tmpDir.testDirectory, true)
+        layout.rootDirectory == masterDir.parentFile
+        layout.settingsDir == masterDir
+        refersTo(layout, settingsFile)
+
+        where:
+        settingsFilename << TEST_CASES
+    }
+
+    @Unroll
     def "searches ancestors for a directory called 'master' that contains a #settingsFilename file"() {
         given:
         def locator = buildLayoutFactoryFor()


### PR DESCRIPTION
I saw that for example in `EclipseIntegrationTest` the `gradle.properties` from the `gradle/gradle` build is picked up instead of no project specific `gradle.properties` file.

I think the root cause is that for a layout like this:

```
rootProjectDir
   master
      settings.gradle
   project1
   project2
```

When running a build from the `rootProjectDir`, then Gradle doesn't currently pick up the `master/settings.gradle` file. It does pick it up when running from e.g. `project1`. I think this is an oversight.