### PR TITLE
Further fixes for artifact transforms with configuration cache enabled

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -41,6 +41,27 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         outputContains("build dir 2: " + testDirectory.file("output"))
     }
 
+    def "can apply convention to build dir"() {
+        buildFile << """
+            println "build dir: " + project.buildDir
+            layout.buildDirectory.convention(layout.projectDirectory.dir("out"))
+            println "build dir 2: " + project.buildDir
+            layout.buildDirectory = layout.projectDirectory.dir("target")
+            println "build dir 3: " + project.buildDir
+            layout.buildDirectory.convention(layout.projectDirectory.dir("out"))
+            println "build dir 4: " + project.buildDir
+"""
+
+        when:
+        run()
+
+        then:
+        outputContains("build dir: " + testDirectory.file("build"))
+        outputContains("build dir 2: " + testDirectory.file("out"))
+        outputContains("build dir 3: " + testDirectory.file("target"))
+        outputContains("build dir 4: " + testDirectory.file("target"))
+    }
+
     def "layout is available for injection"() {
         buildFile << """
             import javax.inject.Inject

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1238,7 +1238,6 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         useParameterObject << [true, false]
     }
 
-    @ToBeFixedForInstantExecution(because = "cannot decode isolated transform parameters")
     def "transform is supplied with a different output directory when parameters change"() {
         given:
         // Use another script to define the value, so that transform implementation does not change when the value is changed

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -847,7 +847,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         outputContains("result = [b-dir.green, c-dir.green]")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "changes to files in local file repositories are ignored for transforms")
     def "can attach @PathSensitive(NONE) to input artifact property for external artifact"() {
         setupBuildWithColorTransformAction()
         def lib1 = mavenRepo.module("group1", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
@@ -867,11 +867,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             dependencies {
-                if (project.hasProperty('externalCoords')) {
-                    implementation project.externalCoords
-                } else {
-                    implementation 'group1:lib:1.0'
-                }
+                implementation providers.gradleProperty('externalCoords').forUseAtConfigurationTime().orElse('group1:lib:1.0')
                 implementation 'group2:lib2:1.0'
             }
 
@@ -935,7 +931,6 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can attach @PathSensitive(#sensitivity) to input artifact property for external artifact"() {
         setupBuildWithColorTransformAction()
         def lib1 = withColorVariants(mavenRepo.module("group1", "lib", "1.0")).publish()
@@ -955,11 +950,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             dependencies {
-                if (project.hasProperty('externalCoords')) {
-                    implementation project.externalCoords
-                } else {
-                    implementation 'group1:lib:1.0'
-                }
+                implementation providers.gradleProperty('externalCoords').forUseAtConfigurationTime().orElse('group1:lib:1.0')
                 implementation 'group2:lib2:1.0'
             }
 
@@ -1018,7 +1009,6 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "honors content changes with @#annotation on input artifact property with project artifact file when not caching"() {
         settingsFile << "include 'a', 'b', 'c'"
         setupBuildWithColorTransformAction {
@@ -1119,7 +1109,6 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "honors @#annotation on input artifact property with project artifact file when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
         setupBuildWithColorTransformAction {
@@ -1220,7 +1209,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         annotation << ["Classpath", "CompileClasspath"]
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "classpath normalization configuration is not serialized")
     def "honors runtime classpath normalization for input artifact"() {
         settingsFile << "include 'a', 'b', 'c'"
         setupBuildWithColorTransformAction {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -412,7 +412,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution(because = "PublishArtifactLocalArtifactMetadata instances are used as their own id and when serialized as an id drags in unnecessary and unserializable state")
     def "does not apply transform to variants with requested implicit format attribute"() {
         given:
         buildFile << """
@@ -462,7 +461,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution(because = "PublishArtifactLocalArtifactMetadata instances are used as their own id, as above")
     def "does not apply transforms to artifacts from local projects matching requested format attribute"() {
         given:
         buildFile << """
@@ -2084,7 +2082,6 @@ Found the following transforms:
         outputContains("ids: [out-foo.txt (test:test:1.3), out-bar.txt (test:test:1.3)]")
     }
 
-    @ToBeFixedForInstantExecution(because = "PublishArtifactLocalArtifactMetadata instances are used as their own id, as above")
     def "transform runs only once even when variant is consumed from multiple projects"() {
         given:
         settingsFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -35,7 +35,7 @@ import javax.inject.Inject
 
 def artifactType = Attribute.of('artifactType', String)
 
-class Counter implements Serializable {    
+class Counter implements Serializable {
     private int count = 0;
 
     public int increment() {
@@ -78,7 +78,7 @@ class Resolve extends Copy {
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "transform parameters are isolated when writing to the cache rather than at execution time")
     def "serialized mutable class is isolated during artifact transformation"() {
         mavenRepo.module("test", "test", "1.3").publish()
         mavenRepo.module("test", "test2", "2.3").publish()
@@ -98,7 +98,7 @@ class Resolve extends Copy {
                 CountRecorder() {
                     println "Creating CountRecorder"
                 }
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     def output = outputs.file(input.name + ".txt")
@@ -119,16 +119,16 @@ class Resolve extends Copy {
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
-            
+
             configurations {
                 compile
             }
-            
+
             dependencies {
                 compile 'test:test:1.3'
                 compile 'test:test2:2.3'
             }
-            
+
             dependencies {
                 registerTransform(CountRecorder) {
                     from.attribute(artifactType, 'jar')
@@ -164,7 +164,7 @@ class Resolve extends Copy {
                 artifactTypeAttribute = 'firstCount'
                 into "\${buildDir}/libs1"
             }
-            
+
             task resolveSecond(type: Resolve) {
                 artifactTypeAttribute = 'secondCount'
                 into "\${buildDir}/libs2"
@@ -174,7 +174,7 @@ class Resolve extends Copy {
                 artifactTypeAttribute = 'thirdCount'
                 into "\${buildDir}/libs3"
             }
-            
+
             task resolve dependsOn 'resolveFirst', 'resolveSecond', 'resolveThird'
         """
 
@@ -214,13 +214,13 @@ class Resolve extends Copy {
 
             public class CountRecorder extends ArtifactTransform {
                 private final Counter counter;
-                
+
                 @Inject
                 public CountRecorder(Counter counter) {
                     this.counter = counter
                     println "Creating CountRecorder"
                 }
-                
+
                 List<File> transform(File input) {
                     assert outputDirectory.directory && outputDirectory.list().length == 0
                     def output = new File(outputDirectory, input.name + ".txt")
@@ -241,16 +241,16 @@ class Resolve extends Copy {
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
-            
+
             configurations {
                 compile
             }
-            
+
             dependencies {
                 compile 'test:test:1.3'
                 compile 'test:test2:2.3'
             }
-            
+
             dependencies {
                 registerTransform {
                     from.attribute(artifactType, 'jar')
@@ -275,7 +275,7 @@ class Resolve extends Copy {
                 artifactTypeAttribute = 'firstCount'
                 into "\${buildDir}/libs1"
             }
-            
+
             task increment {
                 doFirst {
                     // Just to show that incrementing the counter doesn't matter.
@@ -292,7 +292,7 @@ class Resolve extends Copy {
                 artifactTypeAttribute = 'thirdCount'
                 into "\${buildDir}/libs3"
             }
-            
+
             task resolve dependsOn 'resolveFirst', 'increment', 'resolveSecond', 'resolveThird'
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -212,7 +212,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         outputContains("Transforming c.jar to c.jar.txt")
     }
 
-    @ToBeFixedForInstantExecution(because = "external dependencies are transformed eagerly and file dependencies are transformed lazily")
+    @ToBeFixedForInstantExecution(because = "external dependencies are transformed eagerly and file dependencies are transformed lazily", skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT)
     def "transformations are applied in parallel for a mix of external and file dependency artifacts"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -333,7 +333,6 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         outputContains("Transforming b.jar to b.jar.txt")
     }
 
-    @ToBeFixedForInstantExecution
     def "failures are collected from transformations applied parallel"() {
         given:
         buildFile << """
@@ -370,7 +369,6 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         failure.assertHasCause("Failed to transform bad-c.jar to match attributes {artifactType=size}")
     }
 
-    @ToBeFixedForInstantExecution
     def "only one transformer execution per workspace"() {
 
         settingsFile << """
@@ -419,7 +417,6 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         handle.waitForFinish()
     }
 
-    @ToBeFixedForInstantExecution
     def "only one process can run immutable transforms at the same time"() {
         given:
         List<BuildTestFile> builds = (1..3).collect { idx ->
@@ -438,9 +435,10 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                         }.artifacts
                         inputs.files(artifacts.artifactFiles)
 
+                        def projectName = project.name
                         doLast {
-                            ${server.callFromBuildUsingExpression('"resolveStarted_" + project.name')}
-                            assert artifacts.artifactFiles.collect { it.name } == [project.name + '.jar.txt']
+                            ${server.callFromBuildUsingExpression('"resolveStarted_" + projectName')}
+                            assert artifacts.artifactFiles.collect { it.name } == [projectName + '.jar.txt']
                         }
                     }
                 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -84,11 +84,7 @@ project(':common') {
 
 project(':lib') {
     dependencies {
-        if (rootProject.hasProperty("useOldDependencyVersion")) {
-            implementation 'org.slf4j:slf4j-api:1.7.24'
-        } else {
-            implementation 'org.slf4j:slf4j-api:1.7.25'
-        }
+        implementation providers.gradleProperty('useOldDependencyVersion').forUseAtConfigurationTime().map { 'org.slf4j:slf4j-api:1.7.24' }.orElse('org.slf4j:slf4j-api:1.7.25')
         implementation project(':common')
     }
 }
@@ -292,7 +288,6 @@ project(':common') {
         )
     }
 
-    @ToBeFixedForInstantExecution
     def "transform with changed set of dependencies are re-executed"() {
         given:
         setupBuildWithSingleStep()
@@ -331,7 +326,6 @@ project(':common') {
         assertTransformationsExecuted()
     }
 
-    @ToBeFixedForInstantExecution
     def "transform with changed project file dependencies content or path are re-executed"() {
         given:
         setupBuildWithSingleStep()
@@ -407,7 +401,6 @@ project(':common') {
         assertTransformationsExecuted()
     }
 
-    @ToBeFixedForInstantExecution
     def "can attach @PathSensitive(NONE) to dependencies property"() {
         given:
         setupBuildWithNoSteps()
@@ -503,7 +496,6 @@ abstract class NoneTransform implements TransformAction<TransformParameters.None
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can attach @#classpathAnnotation.simpleName to dependencies property"() {
         given:
         setupBuildWithNoSteps {
@@ -661,7 +653,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         assert libTransformWithNewSlf4j < app2Resolve
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "treating file collection visit failures as a configuration cache problem adds an additional failure to the build summary")
     def "transform does not execute when dependencies cannot be found"() {
         given:
         mavenHttpRepo.module("unknown", "not-found", "4.3").allowAll().assertNotPublished()
@@ -685,7 +677,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         failure.assertThatCause(CoreMatchers.containsString("Could not find unknown:not-found:4.3"))
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "treating file collection visit failures as a configuration cache problem adds an additional failure to the build summary")
     def "transform does not execute when dependencies cannot be downloaded"() {
         given:
         def cantBeDownloaded = withColorVariants(mavenHttpRepo.module("test", "cant-be-downloaded", "4.3")).publish()
@@ -722,7 +714,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         )
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "treating file collection visit failures as a configuration cache problem adds an additional failure to the build summary")
     def "transform does not execute when dependencies cannot be transformed"() {
         given:
         setupBuildWithFirstStepThatDoesNotUseDependencies()
@@ -749,7 +741,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         )
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "external dependencies are transformed eagerly")
     def "transform does not execute when dependencies cannot be built"() {
         given:
         setupBuildWithTwoSteps()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -265,7 +265,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "included build is used but not detected by problem reporting")
     def "transform can receive a file collection containing substituted external dependencies as parameter"() {
         file("tools/settings.gradle") << """
             include 'tool-a', 'tool-b'
@@ -461,7 +461,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "file collection containing a String provider is not serialized correctly")
     def "can use input path sensitivity #pathSensitivity for parameter object"() {
         settingsFile << """
                 include 'a', 'b', 'c'
@@ -469,7 +469,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         setupBuildWithTransformFileInputs("@PathSensitive(PathSensitivity.$pathSensitivity) @InputFiles")
         buildFile << """
             allprojects {
-                ext.inputFiles = files(rootProject.file(project.property('fileName')))
+                ext.inputFiles = rootProject.files(providers.gradleProperty('fileName'))
             }
 
             project(':a') {
@@ -516,7 +516,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         PathSensitivity.ABSOLUTE  | [['first/input', 'foo'], ['first/input', 'foo'], ['third/input', 'foo']]
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "classpath normalization configuration is not serialized")
     def "can use classpath normalization for parameter object"() {
         settingsFile << """
                 include 'a', 'b', 'c'

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -209,11 +209,31 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
             "os.version",
             "os.arch",
             "java.version",
-            "java.vm.version",
+            "java.version.date",
+            "java.vendor",
+            "java.vendor.url",
+            "java.vendor.version",
             "java.specification.version",
+            "java.specification.vendor",
+            "java.specification.name",
+            "java.vm.version",
+            "java.vm.specification.version",
+            "java.vm.specification.vendor",
+            "java.vm.specification.name",
+            "java.vm.version",
+            "java.vm.vendor",
+            "java.vm.name",
+            "java.class.version",
+            "java.home",
+            "java.class.path",
+            "java.library.path",
+            "java.compiler",
+            "file.separator",
+            "path.separator",
             "line.separator",
             "user.name",
             "user.home"
+            // Not java.io.tmpdir and user.dir at this stage
         ]
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
@@ -33,13 +33,32 @@ val whitelistedProperties = setOf(
     "os.version",
     "os.arch",
     "java.version",
-    "java.vm.version",
-    "java.runtime.version",
+    "java.version.date",
+    "java.vendor",
+    "java.vendor.url",
+    "java.vendor.version",
     "java.specification.version",
+    "java.specification.vendor",
+    "java.specification.name",
+    "java.vm.version",
+    "java.vm.specification.version",
+    "java.vm.specification.vendor",
+    "java.vm.specification.name",
+    "java.vm.version",
+    "java.vm.vendor",
+    "java.vm.name",
+    "java.class.version",
     "java.home",
+    "java.class.path",
+    "java.library.path",
+    "java.compiler",
+    "file.separator",
+    "path.separator",
     "line.separator",
     "user.name",
-    "user.home"
+    "user.home",
+    "java.runtime.version"
+    // Not java.io.tmpdir and user.dir at this stage
 )
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -147,6 +147,7 @@ class Codecs(
 
         bind(IsolatedManagedValueCodec(managedFactoryRegistry))
         bind(IsolatedImmutableManagedValueCodec(managedFactoryRegistry))
+        bind(IsolatedSerializedValueSnapshotCodec)
         bind(IsolatedArrayCodec)
         bind(IsolatedSetCodec)
         bind(IsolatedListCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -139,6 +139,7 @@ class Codecs(
         bind(DefaultTransformerCodec(buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
         bind(LegacyTransformerCodec(actionScheme))
         bind(ResolvableArtifactCodec)
+        bind(PublishArtifactLocalArtifactMetadataCodec)
 
         bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PublishArtifactLocalArtifactMetadataCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PublishArtifactLocalArtifactMetadataCodec.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readFile
+import org.gradle.instantexecution.serialization.writeFile
+import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata
+import org.gradle.internal.component.model.IvyArtifactName
+
+
+/**
+ * This class exists because PublishArtifactLocalArtifactMetadata is used as its own id, and so when serialized as an id causes
+ * a lot of unnecessary and unserializable state to be dragged in.
+ *
+ * A better change would be to split an immutable id type out of PublishArtifactLocalArtifactMetadata (or reuse one of the existing
+ * implementations). However, the Eclipse tooling model builder assumes that the id and metadata objects are the same and also that
+ * the metadata object provides access to the backing PublishArtifact. This makes the better change too large to undertake at this point,
+ * so for now just use some custom serialization that also makes assumptions and improve the Eclipse tooling model builder later.
+ */
+object PublishArtifactLocalArtifactMetadataCodec : Codec<PublishArtifactLocalArtifactMetadata> {
+    override suspend fun WriteContext.encode(value: PublishArtifactLocalArtifactMetadata) {
+        write(value.componentIdentifier)
+        write(value.name)
+        writeFile(value.file)
+    }
+
+    override suspend fun ReadContext.decode(): PublishArtifactLocalArtifactMetadata? {
+        val componentId = read() as ComponentIdentifier
+        val ivyName = read() as IvyArtifactName
+        val file = readFile()
+        return PublishArtifactLocalArtifactMetadata(componentId, DefaultPublishArtifact(ivyName.name, ivyName.extension, ivyName.type, ivyName.classifier, null, file))
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ResolvableArtifactCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ResolvableArtifactCodec.kt
@@ -24,9 +24,10 @@ import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readFile
+import org.gradle.instantexecution.serialization.writeFile
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.component.model.DefaultIvyArtifactName
-import java.io.File
 
 
 object ResolvableArtifactCodec : Codec<ResolvableArtifact> {
@@ -39,7 +40,7 @@ object ResolvableArtifactCodec : Codec<ResolvableArtifact> {
             throw UnsupportedOperationException("Don't know how to serialize for ${value.javaClass.name}.")
         }
         // Write the source artifact
-        writeString(value.file.absolutePath)
+        writeFile(value.file)
         writeString(value.artifactName.name)
         writeString(value.artifactName.type)
         writeNullableString(value.artifactName.extension)
@@ -50,7 +51,7 @@ object ResolvableArtifactCodec : Codec<ResolvableArtifact> {
     }
 
     override suspend fun ReadContext.decode(): ResolvableArtifact {
-        val file = File(readString())
+        val file = readFile()
         val artifactName = DefaultIvyArtifactName(readString(), readString(), readNullableString(), readNullableString())
         val componentId = componentIdSerializer.read(this)
         return PreResolvedResolvableArtifact(null, artifactName, ComponentFileArtifactIdentifier(componentId, file.name), file, TaskDependencyContainer.EMPTY)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -53,6 +53,7 @@ import org.gradle.api.publish.Publication
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskDependency
 import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.kotlin.dsl.*
 import java.io.FileDescriptor
@@ -89,6 +90,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<Settings>())
     bind(unsupported<Project>())
     bind(unsupported<TaskContainer>())
+    bind(unsupported<TaskDependency>())
     bind(unsupported<SourceSetContainer>())
     bind(unsupported<SourceSet>())
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedSerializedValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedSerializedValueSnapshot.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 public class IsolatedSerializedValueSnapshot extends SerializedValueSnapshot implements Isolatable<Object> {
     private final Class<?> originalClass;
 
-    public IsolatedSerializedValueSnapshot(HashCode implementationHash, byte[] serializedValue, Class<?> originalClass) {
+    public IsolatedSerializedValueSnapshot(@Nullable HashCode implementationHash, byte[] serializedValue, Class<?> originalClass) {
         super(implementationHash, serializedValue);
         this.originalClass = originalClass;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/SerializedValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/SerializedValueSnapshot.java
@@ -24,6 +24,7 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.internal.snapshot.ValueSnapshottingException;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 
@@ -34,11 +35,12 @@ public class SerializedValueSnapshot implements ValueSnapshot {
     private final HashCode implementationHash;
     private final byte[] serializedValue;
 
-    public SerializedValueSnapshot(HashCode implementationHash, byte[] serializedValue) {
+    public SerializedValueSnapshot(@Nullable HashCode implementationHash, byte[] serializedValue) {
         this.implementationHash = implementationHash;
         this.serializedValue = serializedValue;
     }
 
+    @Nullable
     public HashCode getImplementationHash() {
         return implementationHash;
     }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
@@ -234,11 +234,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
         skipped(":signCustomFile")
     }
 
-    @ToBeFixedForInstantExecution(
-        bottomSpecs = [
-            "SigningTasksWithGpgCmdIntegrationSpec"
-        ]
-    )
+    @ToBeFixedForInstantExecution
     def "up-to-date when order of signed files changes"() {
         given:
         def inputFile1 = file("input1.txt") << "foo"


### PR DESCRIPTION

### Context

Fix some issues in serializing artifact transform parameters and the elements of `ArtifactCollection` when transforms are applied to project outputs.

Fix some artifact transform tests to use configuration cache friendly APIs.

Attach a description to the remaining `@ToBeFixedForInstantExecution` annotations on artifact transform tests.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
