### PR TITLE
Eclipse API for unresolved dependencies

### DIFF
--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -168,7 +168,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 383 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 400 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Plugins
         assertIsGradleJar(contentsDir.file("lib/plugins/gradle-dependency-management-${baseVersion}.jar"))

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r67
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+@ToolingApiVersion('>=6.7')
+@TargetGradleVersion(">=6.7")
+class ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec extends ToolingApiSpecification {
+
+    def setup() {
+        def mavenRepo = new MavenFileRepository(file('maven-repo'))
+        mavenRepo.module('org.example', 'lib', '1.0').publish()
+
+        settingsFile << 'rootProject.name = "root"'
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            repositories {
+                maven {
+                    url '${mavenRepo.uri}'
+                }
+            }
+            dependencies {
+                implementation 'org.example:lib:1.0'
+                implementation 'org.example:does not exist:1.0'
+            }
+        """
+    }
+
+
+    @TargetGradleVersion("<6.7")
+    def "Older Gradle versions mark all dependencies as resolved"() {
+        when:
+        def project = loadToolingModel(EclipseProject)
+        def allDependencies = project.classpath
+
+        then:
+        allDependencies.size() == 2
+        !allDependencies[0].resolved
+        allDependencies[0].attemptedSelector == null
+        !allDependencies[1].resolved
+        allDependencies[1].attemptedSelector == null
+    }
+
+    def "Client can distinguish resolved and unresolved dependencies"() {
+        when:
+        def project = loadToolingModel(EclipseProject)
+        def allDependencies = project.classpath
+        def resolvedDependencies = project.classpath.findAll { it.resolved }
+        def unresolvedDependencies = project.classpath.findAll { !it.resolved }
+
+        then:
+        allDependencies.size() == 2
+
+        and:
+        resolvedDependencies.size() == 1
+        resolvedDependencies[0].resolved
+        resolvedDependencies[0].attemptedSelector == null
+
+        and:
+        unresolvedDependencies.size() == 1
+        !unresolvedDependencies[0].resolved
+        unresolvedDependencies[0].attemptedSelector == 'org.example:does not exist:1.0'
+    }
+}

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
@@ -81,6 +81,6 @@ class ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec extends Tooli
         and:
         unresolvedDependencies.size() == 1
         !unresolvedDependencies[0].resolved
-        unresolvedDependencies[0].attemptedSelector == 'org.example:does not exist:1.0'
+        unresolvedDependencies[0].attemptedSelector.displayName == 'org.example:does not exist:1.0'
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r67/ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec.groovy
@@ -57,9 +57,9 @@ class ToolingApiEclipseModelUnresolvedDependenciesCrossVersionSpec extends Tooli
 
         then:
         allDependencies.size() == 2
-        !allDependencies[0].resolved
+        allDependencies[0].resolved
         allDependencies[0].attemptedSelector == null
-        !allDependencies[1].resolved
+        allDependencies[1].resolved
         allDependencies[1].attemptedSelector == null
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse.model;
+
+/**
+ * A library that turned out to be unresolved.
+ */
+public class UnresolvedLibrary extends Library {
+    public UnresolvedLibrary(FileReference library) {
+        super(library);
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
@@ -20,7 +20,21 @@ package org.gradle.plugins.ide.eclipse.model;
  * A library that turned out to be unresolved.
  */
 public class UnresolvedLibrary extends Library {
+
+    /**
+     * The attempted selector reported by the related UnresolvedDependencyResult
+     */
+    private String attemptedSelector;
+
     public UnresolvedLibrary(FileReference library) {
         super(library);
+    }
+
+    public String getAttemptedSelector() {
+        return attemptedSelector;
+    }
+
+    public void setAttemptedSelector(String attemptedSelector) {
+        this.attemptedSelector = attemptedSelector;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/UnresolvedLibrary.java
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide.eclipse.model;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ComponentSelector;
 
 /**
  * A library that turned out to be unresolved.
@@ -26,7 +27,7 @@ import org.gradle.api.Incubating;
 @Incubating
 public class UnresolvedLibrary extends Library {
 
-    private String attemptedSelector;
+    private ComponentSelector attemptedSelector;
 
     public UnresolvedLibrary(FileReference library) {
         super(library);
@@ -35,11 +36,11 @@ public class UnresolvedLibrary extends Library {
     /**
      * The attempted selector reported by the related UnresolvedDependencyResult
      */
-    public String getAttemptedSelector() {
+    public ComponentSelector getAttemptedSelector() {
         return attemptedSelector;
     }
 
-    public void setAttemptedSelector(String attemptedSelector) {
+    public void setAttemptedSelector(ComponentSelector attemptedSelector) {
         this.attemptedSelector = attemptedSelector;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -148,7 +148,9 @@ public class EclipseDependenciesCreator {
         @Override
         public void visitUnresolvedDependency(UnresolvedDependencyResult unresolvedDependency) {
             File unresolvedFile = unresolvedIdeDependencyHandler.asFile(unresolvedDependency, project.getProjectDir());
-            files.add(createLibraryEntry(unresolvedFile, null, null, classpath, null, pathToSourceSets, false, false, true));
+            UnresolvedLibrary unresolvedLib = (UnresolvedLibrary) createLibraryEntry(unresolvedFile, null, null, classpath, null, pathToSourceSets, false, false, true);
+            unresolvedLib.setAttemptedSelector(unresolvedDependency.getAttempted().getDisplayName());
+            files.add(unresolvedLib);
             unresolvedIdeDependencyHandler.log(unresolvedDependency);
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -149,7 +149,7 @@ public class EclipseDependenciesCreator {
         public void visitUnresolvedDependency(UnresolvedDependencyResult unresolvedDependency) {
             File unresolvedFile = unresolvedIdeDependencyHandler.asFile(unresolvedDependency, project.getProjectDir());
             UnresolvedLibrary unresolvedLib = (UnresolvedLibrary) createUnresolvedLibraryEntry(unresolvedFile, classpath, pathToSourceSets, false, false);
-            unresolvedLib.setAttemptedSelector(unresolvedDependency.getAttempted().getDisplayName());
+            unresolvedLib.setAttemptedSelector(unresolvedDependency.getAttempted());
             files.add(unresolvedLib);
             unresolvedIdeDependencyHandler.log(unresolvedDependency);
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -265,8 +265,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 if(entry instanceof UnresolvedLibrary) {
                     UnresolvedLibrary unresolvedLibrary = (UnresolvedLibrary)entry;
                     dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), true, unresolvedLibrary.getAttemptedSelector(), createAttributes(library), createAccessRules(library));
-                }
-                else{
+                } else {
                     dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
                 }
                 classpathElements.getExternalDependencies().add(dependency);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -261,7 +261,14 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 final File file = library.getLibrary().getFile();
                 final File source = library.getSourcePath() == null ? null : library.getSourcePath().getFile();
                 final File javadoc = library.getJavadocPath() == null ? null : library.getJavadocPath().getFile();
-                DefaultEclipseExternalDependency dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), (library instanceof UnresolvedLibrary), createAttributes(library), createAccessRules(library));
+                final DefaultEclipseExternalDependency dependency;
+                if(entry instanceof UnresolvedLibrary) {
+                    UnresolvedLibrary unresolvedLibrary = (UnresolvedLibrary)entry;
+                    dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), true, unresolvedLibrary.getAttemptedSelector(), createAttributes(library), createAccessRules(library));
+                }
+                else{
+                    dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
+                }
                 classpathElements.getExternalDependencies().add(dependency);
             } else if (entry instanceof ProjectDependency) {
                 final ProjectDependency projectDependency = (ProjectDependency) entry;
@@ -271,7 +278,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 if (!isProjectOpen) {
                     final File source = projectDependency.getPublicationSourcePath() == null ? null : projectDependency.getPublicationSourcePath().getFile();
                     final File javadoc = projectDependency.getPublicationJavadocPath() == null ? null : projectDependency.getPublicationJavadocPath().getFile();
-                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), false, createAttributes(projectDependency), createAccessRules(projectDependency)));
+                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
                     classpathElements.getBuildDependencies().add(projectDependency.getBuildDependencies());
                 } else {
                     projectDependencyMap.put(path, new DefaultEclipseProjectDependency(path, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -47,6 +47,7 @@ import org.gradle.plugins.ide.eclipse.model.Link;
 import org.gradle.plugins.ide.eclipse.model.Output;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
+import org.gradle.plugins.ide.eclipse.model.UnresolvedLibrary;
 import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider;
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultAccessRule;
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultClasspathAttribute;
@@ -260,7 +261,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 final File file = library.getLibrary().getFile();
                 final File source = library.getSourcePath() == null ? null : library.getSourcePath().getFile();
                 final File javadoc = library.getJavadocPath() == null ? null : library.getJavadocPath().getFile();
-                DefaultEclipseExternalDependency dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
+                DefaultEclipseExternalDependency dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), (library instanceof UnresolvedLibrary), createAttributes(library), createAccessRules(library));
                 classpathElements.getExternalDependencies().add(dependency);
             } else if (entry instanceof ProjectDependency) {
                 final ProjectDependency projectDependency = (ProjectDependency) entry;
@@ -270,7 +271,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 if (!isProjectOpen) {
                     final File source = projectDependency.getPublicationSourcePath() == null ? null : projectDependency.getPublicationSourcePath().getFile();
                     final File javadoc = projectDependency.getPublicationJavadocPath() == null ? null : projectDependency.getPublicationJavadocPath().getFile();
-                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
+                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), false, createAttributes(projectDependency), createAccessRules(projectDependency)));
                     classpathElements.getBuildDependencies().add(projectDependency.getBuildDependencies());
                 } else {
                     projectDependencyMap.put(path, new DefaultEclipseProjectDependency(path, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -261,12 +261,12 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 final File file = library.getLibrary().getFile();
                 final File source = library.getSourcePath() == null ? null : library.getSourcePath().getFile();
                 final File javadoc = library.getJavadocPath() == null ? null : library.getJavadocPath().getFile();
-                final DefaultEclipseExternalDependency dependency;
-                if(entry instanceof UnresolvedLibrary) {
-                    UnresolvedLibrary unresolvedLibrary = (UnresolvedLibrary)entry;
-                    dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), true, unresolvedLibrary.getAttemptedSelector(), createAttributes(library), createAccessRules(library));
+                DefaultEclipseExternalDependency dependency;
+                if (entry instanceof UnresolvedLibrary) {
+                    UnresolvedLibrary unresolvedLibrary = (UnresolvedLibrary) entry;
+                    dependency = DefaultEclipseExternalDependency.createUnresolved(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library), unresolvedLibrary.getAttemptedSelector());
                 } else {
-                    dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
+                    dependency = DefaultEclipseExternalDependency.createResolved(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
                 }
                 classpathElements.getExternalDependencies().add(dependency);
             } else if (entry instanceof ProjectDependency) {
@@ -277,7 +277,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 if (!isProjectOpen) {
                     final File source = projectDependency.getPublicationSourcePath() == null ? null : projectDependency.getPublicationSourcePath().getFile();
                     final File javadoc = projectDependency.getPublicationJavadocPath() == null ? null : projectDependency.getPublicationJavadocPath().getFile();
-                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
+                    classpathElements.getExternalDependencies().add(DefaultEclipseExternalDependency.createResolved(projectDependency.getPublication().getFile(), javadoc, source, null, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
                     classpathElements.getBuildDependencies().add(projectDependency.getBuildDependencies());
                 } else {
                     projectDependencyMap.put(path, new DefaultEclipseProjectDependency(path, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -264,7 +264,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
                 DefaultEclipseExternalDependency dependency;
                 if (entry instanceof UnresolvedLibrary) {
                     UnresolvedLibrary unresolvedLibrary = (UnresolvedLibrary) entry;
-                    dependency = DefaultEclipseExternalDependency.createUnresolved(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library), unresolvedLibrary.getAttemptedSelector());
+                    dependency = DefaultEclipseExternalDependency.createUnresolved(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library), unresolvedLibrary.getAttemptedSelector().getDisplayName());
                 } else {
                     dependency = DefaultEclipseExternalDependency.createResolved(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
                 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseComponentSelector.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseComponentSelector.java
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.consumer.converters;
+package org.gradle.plugins.ide.internal.tooling.eclipse;
 
-import org.gradle.tooling.model.ComponentSelector;
-import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
+import java.io.Serializable;
 
-/**
- * This is used for compatibility with clients <6.7
- */
-public class EclipseExternalDependencyUnresolvedMixin {
+public class DefaultEclipseComponentSelector implements Serializable {
 
-    public EclipseExternalDependencyUnresolvedMixin(EclipseExternalDependency dependency) {
+    private final String displayName;
+
+    DefaultEclipseComponentSelector(String displayName) {
+        this.displayName = displayName;
     }
 
-    public boolean isResolved() {
-        return true;
-    }
-
-    public ComponentSelector getAttemptedSelector() {
-        return null;
+    public String getDisplayName() {
+        return displayName;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
@@ -28,19 +28,32 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
     private final File javadoc;
     private final File source;
 
-    private boolean isUnresolved;
+    private final boolean isUnresolved;
+    private final String attemptedSelector;
 
     private final ModuleVersionIdentifier identifier;
     private final GradleModuleVersion moduleVersion;
 
-    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, boolean unresolved, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
+    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
         super(exported, attributes, accessRules);
         this.file = file;
         this.javadoc = javadoc;
         this.source = source;
         this.identifier = identifier;
-        this.isUnresolved = unresolved;
         this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
+        this.isUnresolved = false;
+        this.attemptedSelector = null;
+    }
+
+    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, boolean unresolved, String attemptedSelector, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
+        super(exported, attributes, accessRules);
+        this.file = file;
+        this.javadoc = javadoc;
+        this.source = source;
+        this.identifier = identifier;
+        this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
+        this.isUnresolved = unresolved;
+        this.attemptedSelector = attemptedSelector;
     }
 
     public File getFile() {
@@ -65,4 +78,7 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         return moduleVersion;
     }
 
+    public String getAttemptedSelector() {
+        return attemptedSelector;
+    }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
@@ -28,15 +28,18 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
     private final File javadoc;
     private final File source;
 
+    private boolean isUnresolved;
+
     private final ModuleVersionIdentifier identifier;
     private final GradleModuleVersion moduleVersion;
 
-    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
+    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, boolean unresolved, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
         super(exported, attributes, accessRules);
         this.file = file;
         this.javadoc = javadoc;
         this.source = source;
         this.identifier = identifier;
+        this.isUnresolved = unresolved;
         this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
     }
 
@@ -51,6 +54,8 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
     public File getSource() {
         return source;
     }
+
+    public boolean isUnresolved() { return isUnresolved; }
 
     public ModuleVersionIdentifier getModuleVersionIdentifier() {
         return identifier;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
@@ -68,7 +68,9 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         return source;
     }
 
-    public boolean isUnresolved() { return isUnresolved; }
+    public boolean isUnresolved() {
+        return isUnresolved;
+    }
 
     public ModuleVersionIdentifier getModuleVersionIdentifier() {
         return identifier;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
@@ -28,31 +28,20 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
     private final File javadoc;
     private final File source;
 
-    private final boolean isUnresolved;
-    private final String attemptedSelector;
-
     private final ModuleVersionIdentifier identifier;
     private final GradleModuleVersion moduleVersion;
 
-    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
-        super(exported, attributes, accessRules);
-        this.file = file;
-        this.javadoc = javadoc;
-        this.source = source;
-        this.identifier = identifier;
-        this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
-        this.isUnresolved = false;
-        this.attemptedSelector = null;
-    }
+    private final boolean resolved;
+    private final String attemptedSelector;
 
-    public DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, boolean unresolved, String attemptedSelector, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
+    private DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules, boolean resolved, String attemptedSelector) {
         super(exported, attributes, accessRules);
         this.file = file;
         this.javadoc = javadoc;
         this.source = source;
         this.identifier = identifier;
         this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
-        this.isUnresolved = unresolved;
+        this.resolved = resolved;
         this.attemptedSelector = attemptedSelector;
     }
 
@@ -68,10 +57,6 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         return source;
     }
 
-    public boolean isUnresolved() {
-        return isUnresolved;
-    }
-
     public ModuleVersionIdentifier getModuleVersionIdentifier() {
         return identifier;
     }
@@ -80,7 +65,20 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         return moduleVersion;
     }
 
+    public boolean isResolved() {
+        return resolved;
+    }
+
     public String getAttemptedSelector() {
         return attemptedSelector;
     }
+
+    public static DefaultEclipseExternalDependency createResolved(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules) {
+        return new DefaultEclipseExternalDependency(file, javadoc, source, identifier, exported, attributes, accessRules, true, null);
+    }
+
+    public static DefaultEclipseExternalDependency createUnresolved(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules, String attemptedSelector) {
+        return new DefaultEclipseExternalDependency(file, javadoc, source, identifier, exported, attributes, accessRules, false, attemptedSelector);
+    }
+
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseExternalDependency.java
@@ -32,7 +32,7 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
     private final GradleModuleVersion moduleVersion;
 
     private final boolean resolved;
-    private final String attemptedSelector;
+    private final DefaultEclipseComponentSelector attemptedSelector;
 
     private DefaultEclipseExternalDependency(File file, File javadoc, File source, ModuleVersionIdentifier identifier, boolean exported, List<DefaultClasspathAttribute> attributes, List<DefaultAccessRule> accessRules, boolean resolved, String attemptedSelector) {
         super(exported, attributes, accessRules);
@@ -40,9 +40,9 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         this.javadoc = javadoc;
         this.source = source;
         this.identifier = identifier;
-        this.moduleVersion = (identifier == null)? null : new DefaultGradleModuleVersion(identifier);
+        this.moduleVersion = (identifier == null) ? null : new DefaultGradleModuleVersion(identifier);
         this.resolved = resolved;
-        this.attemptedSelector = attemptedSelector;
+        this.attemptedSelector = (attemptedSelector == null) ? null : new DefaultEclipseComponentSelector(attemptedSelector);
     }
 
     public File getFile() {
@@ -69,7 +69,7 @@ public class DefaultEclipseExternalDependency extends DefaultEclipseDependency i
         return resolved;
     }
 
-    public String getAttemptedSelector() {
+    public DefaultEclipseComponentSelector getAttemptedSelector() {
         return attemptedSelector;
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -43,12 +43,14 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
     Project child1
     Project child2
     Project child3
+    Project child4
 
     def setup() {
         project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
         child3 = ProjectBuilder.builder().withName("child3").withParent(project).build()
+        child4 = ProjectBuilder.builder().withName("child4").withParent(project).build()
         new File(project.projectDir, "settings.gradle") << """
             rootProject.name = 'test'
         """
@@ -56,8 +58,8 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         def libsDir = new File(project.projectDir, "libs")
         libsDir.mkdirs()
         new File(libsDir, "test-1.0.jar").createNewFile()
-        [project, child1, child2, child3].each { it.pluginManager.apply(EclipsePlugin) }
-        [child1, child2, child3].each {
+        [project, child1, child2, child3, child4].each { it.pluginManager.apply(EclipsePlugin) }
+        [child1, child2, child3, child4].each {
             it.plugins.apply(JavaPlugin)
             it.repositories.flatDir {
                 dirs libsDir
@@ -87,6 +89,11 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
                 entries += [customDependency]
             }
         }
+        child4.dependencies {
+            implementation child1.dependencies.project(path: ":child1")
+            implementation "unresolved:dependency:10.0"
+            implementation "fakegroup:test:1.0"
+        }
     }
 
     def "project dependencies are mapped to eclipse model"() {
@@ -103,6 +110,20 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         eclipseChild2.classpath.collect { it.file.name } == ["test-1.0.jar"]
     }
 
+    def "unresolved dependencies are marked as such"(){
+        setup:
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", project)
+
+        then:
+        DefaultEclipseProject eclipseChild4 = eclipseModel.children.find { it.name == 'child4' }
+        def unresolvedRefs = eclipseChild4.classpath.findAll { it.isUnresolved() }
+        unresolvedRefs.size == 1
+        unresolvedRefs[0].file.name.contains("unresolved dependency")
+    }
+
     def "project dependencies are mapped to eclipse model with supplied runtime"() {
         setup:
         def eclipseRuntime = eclipseRuntime([gradleProject(child1), gradleProject(child2)])
@@ -117,7 +138,6 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         // verify we inherit the transitive dependency
         eclipseChild2.classpath.collect { it.file.name } == ["test-1.0.jar"]
     }
-
 
     def "project dependency is replaced when project is closed"() {
         setup:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -91,8 +91,10 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         }
         child4.dependencies {
             implementation child1.dependencies.project(path: ":child1")
-            implementation "unresolved:dependency:10.0"
+            implementation "inexistent:dependency:10.0"
             implementation "fakegroup:test:1.0"
+            implementation "notreal:depen dency:s p a c e s"
+
         }
     }
 
@@ -120,8 +122,8 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         then:
         DefaultEclipseProject eclipseChild4 = eclipseModel.children.find { it.name == 'child4' }
         def unresolvedRefs = eclipseChild4.classpath.findAll { it.isUnresolved() }
-        unresolvedRefs.size == 1
-        unresolvedRefs[0].file.name.contains("unresolved dependency")
+        unresolvedRefs.size == 2
+        unresolvedRefs.stream().allMatch {ur -> (ur.file.name.contains("unresolved dependency")) }
     }
 
     def "project dependencies are mapped to eclipse model with supplied runtime"() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -94,7 +94,6 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
             implementation "inexistent:dependency:10.0"
             implementation "fakegroup:test:1.0"
             implementation "notreal:depen dency:s p a c e s"
-
         }
     }
 
@@ -187,7 +186,6 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         eclipseChild3.classpath[0].source.name == 'customJar-sources.jar'
         eclipseChild3.classpath[0].javadoc.name == 'customJar-javadoc.jar'
     }
-
 
     private def createEclipseModelBuilder() {
         def gradleProjectBuilder = new GradleProjectBuilder()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -120,7 +120,7 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
 
         then:
         DefaultEclipseProject eclipseChild4 = eclipseModel.children.find { it.name == 'child4' }
-        def unresolvedRefs = eclipseChild4.classpath.findAll { it.isUnresolved() }
+        def unresolvedRefs = eclipseChild4.classpath.findAll { !it.resolved }
         unresolvedRefs.size == 2
         unresolvedRefs.stream().allMatch { ref -> ref.file.name.contains("unresolved dependency") }
     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -111,7 +111,7 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         eclipseChild2.classpath.collect { it.file.name } == ["test-1.0.jar"]
     }
 
-    def "unresolved dependencies are marked as such"(){
+    def "unresolved dependencies are marked as such"() {
         setup:
         def modelBuilder = createEclipseModelBuilder()
 
@@ -122,7 +122,7 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         DefaultEclipseProject eclipseChild4 = eclipseModel.children.find { it.name == 'child4' }
         def unresolvedRefs = eclipseChild4.classpath.findAll { it.isUnresolved() }
         unresolvedRefs.size == 2
-        unresolvedRefs.stream().allMatch {ur -> (ur.file.name.contains("unresolved dependency")) }
+        unresolvedRefs.stream().allMatch { ref -> ref.file.name.contains("unresolved dependency") }
     }
 
     def "project dependencies are mapped to eclipse model with supplied runtime"() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.consumer.connection;
 
 import org.gradle.tooling.internal.adapter.ViewBuilder;
 import org.gradle.tooling.internal.consumer.converters.BasicGradleProjectIdentifierMixin;
+import org.gradle.tooling.internal.consumer.converters.EclipseExternalDependencyUnresolvedMixin;
 import org.gradle.tooling.internal.consumer.converters.EclipseProjectHasAutoBuildMixin;
 import org.gradle.tooling.internal.consumer.converters.FixedBuildIdentifierProvider;
 import org.gradle.tooling.internal.consumer.converters.GradleProjectIdentifierMixin;
@@ -27,6 +28,7 @@ import org.gradle.tooling.internal.consumer.converters.IncludedBuildsMixin;
 import org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters;
 import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.model.GradleProject;
+import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
 import org.gradle.tooling.model.eclipse.EclipseProject;
 import org.gradle.tooling.model.gradle.BasicGradleProject;
 import org.gradle.tooling.model.gradle.GradleBuild;
@@ -49,6 +51,7 @@ public class HasCompatibilityMapping {
         viewBuilder.mixInTo(IdeaDependency.class, IdeaModuleDependencyTargetNameMixin.class);
         viewBuilder.mixInTo(GradleBuild.class, IncludedBuildsMixin.class);
         viewBuilder.mixInTo(EclipseProject.class, EclipseProjectHasAutoBuildMixin.class);
+        viewBuilder.mixInTo(EclipseExternalDependency.class, EclipseExternalDependencyUnresolvedMixin.class);
         return viewBuilder;
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/EclipseExternalDependencyUnresolvedMixin.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/EclipseExternalDependencyUnresolvedMixin.java
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.plugins.ide.eclipse.model;
+package org.gradle.tooling.internal.consumer.converters;
 
-import org.gradle.api.Incubating;
+import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
 
 /**
- * A library that turned out to be unresolved.
- *
- * @since 6.7
+ * This is used for compatibility with clients <6.7
  */
-@Incubating
-public class UnresolvedLibrary extends Library {
+public class EclipseExternalDependencyUnresolvedMixin {
 
-    private String attemptedSelector;
-
-    public UnresolvedLibrary(FileReference library) {
-        super(library);
+    public EclipseExternalDependencyUnresolvedMixin(EclipseExternalDependency dependency) {
     }
 
-    /**
-     * The attempted selector reported by the related UnresolvedDependencyResult
-     */
+    public boolean isResolved() {
+        return false;
+    }
+
     public String getAttemptedSelector() {
-        return attemptedSelector;
-    }
-
-    public void setAttemptedSelector(String attemptedSelector) {
-        this.attemptedSelector = attemptedSelector;
+        return null;
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/EclipseExternalDependencyUnresolvedMixin.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/EclipseExternalDependencyUnresolvedMixin.java
@@ -27,7 +27,7 @@ public class EclipseExternalDependencyUnresolvedMixin {
     }
 
     public boolean isResolved() {
-        return false;
+        return true;
     }
 
     public String getAttemptedSelector() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ComponentSelector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ComponentSelector.java
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.consumer.converters;
+package org.gradle.tooling.model;
 
-import org.gradle.tooling.model.ComponentSelector;
-import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
+import org.gradle.api.Incubating;
 
 /**
- * This is used for compatibility with clients <6.7
+ * Represents a component selector. Used for displaying unresolved dependency warnings in the IDE.
+ *
+ * @since 6.7
  */
-public class EclipseExternalDependencyUnresolvedMixin {
+@Incubating
+public interface ComponentSelector {
 
-    public EclipseExternalDependencyUnresolvedMixin(EclipseExternalDependency dependency) {
-    }
-
-    public boolean isResolved() {
-        return true;
-    }
-
-    public ComponentSelector getAttemptedSelector() {
-        return null;
-    }
+    /**
+     * Returns a human-readable display name for this selector.
+     */
+    String getDisplayName();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
@@ -15,7 +15,10 @@
  */
 package org.gradle.tooling.model.eclipse;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.model.ExternalDependency;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents an Eclipse-specific external artifact dependency.
@@ -24,4 +27,22 @@ import org.gradle.tooling.model.ExternalDependency;
  */
 public interface EclipseExternalDependency extends ExternalDependency, EclipseClasspathEntry {
 
+    /**
+     * Returns {@code true} if the current instance represents a resolved dependency.
+     *
+     * @since 6.7
+     */
+    @Incubating
+    boolean isResolved();
+
+    /**
+     * Returns the coordinates of the artifact that Gradle was not able to resolve.
+     * <p>
+     * Returns {@code null} for resolved dependencies (i.e. when {@link #isResolved()} returns true).
+     *
+     * @since 6.7
+     */
+    @Nullable
+    @Incubating
+    String getAttemptedSelector();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
@@ -16,6 +16,7 @@
 package org.gradle.tooling.model.eclipse;
 
 import org.gradle.api.Incubating;
+import org.gradle.tooling.model.ComponentSelector;
 import org.gradle.tooling.model.ExternalDependency;
 
 import javax.annotation.Nullable;
@@ -48,5 +49,5 @@ public interface EclipseExternalDependency extends ExternalDependency, EclipseCl
      */
     @Nullable
     @Incubating
-    String getAttemptedSelector();
+    ComponentSelector getAttemptedSelector();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
@@ -29,6 +29,8 @@ public interface EclipseExternalDependency extends ExternalDependency, EclipseCl
 
     /**
      * Returns {@code true} if the current instance represents a resolved dependency.
+     * <p>
+     * If the target Gradle version is older than 6.7 then this method will always return {@code true}.
      *
      * @since 6.7
      */
@@ -39,6 +41,8 @@ public interface EclipseExternalDependency extends ExternalDependency, EclipseCl
      * Returns the coordinates of the artifact that Gradle was not able to resolve.
      * <p>
      * Returns {@code null} for resolved dependencies (i.e. when {@link #isResolved()} returns true).
+     * <p>
+     * If the target Gradle version is older than 6.7 then this method will always return {@code null}.
      *
      * @since 6.7
      */


### PR DESCRIPTION
Signed-off-by: Leonardo Jr <leonardobsjr@yahoo.com.br>

<!--- The issue this PR addresses -->
Fixes  #7733 

### Context
<!--- Why do you believe many users will benefit from this change? -->
The way that Gradle reports unresolved dependencies is through a file with "unreleased dependency" on the name. Because of this, Buildship has to rely on parsing the file name to pinpoint the dependency problems. What i want is to create a better way for gradle to pass unresolved dependencies information to buildship.

<!--- Link to relevant issues or forum discussions here -->

https://github.com/eclipse/buildship/issues/263
https://github.com/eclipse/buildship/issues/999

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
