### PR TITLE
Capture `Jar` manifest generator in the configuration cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -75,6 +75,7 @@ import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.SharedResource;
 import org.gradle.internal.scripts.ScriptOrigin;
+import org.gradle.internal.serialization.Cached;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 import org.gradle.util.ConfigureUtil;
@@ -94,6 +95,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.factory;
 import static org.gradle.util.GUtil.uncheckedCall;
 
 /**
@@ -607,12 +609,9 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     // note: this method is on TaskInternal
     @Override
     public Factory<File> getTemporaryDirFactory() {
-        return new Factory<File>() {
-            @Override
-            public File create() {
-                return getTemporaryDir();
-            }
-        };
+        // Cached during serialization so it can be isolated from this task
+        final Cached<File> temporaryDir = Cached.of(this::getTemporaryDir);
+        return factory(temporaryDir::get);
     }
 
     private InputChangesAwareTaskAction convertClosureToAction(Closure actionClosure, String actionName) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.lambdas;
 
 import org.gradle.api.Action;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.Factory;
 
 import java.io.Serializable;
 
@@ -36,6 +37,10 @@ public class SerializableLambdas {
         return action;
     }
 
+    public static <T> Factory<T> factory(SerializableFactory<T> factory) {
+        return factory;
+    }
+
     /**
      * A {@link Serializable} version of {@link Spec}.
      */
@@ -46,6 +51,12 @@ public class SerializableLambdas {
      * A {@link Serializable} version of {@link Action}.
      */
     public interface SerializableAction<T> extends Action<T>, Serializable {
+    }
+
+    /**
+     * A {@link Serializable} version of {@link Factory}.
+     */
+    public interface SerializableFactory<T> extends Factory<T>, Serializable {
     }
 
     private SerializableLambdas() {

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -103,10 +103,11 @@ public class Ear extends Jar {
                 //  on each run.
                 //  See https://github.com/gradle/instant-execution/issues/168
                 Cached<byte[]> cachedDescriptor = cachedContentsOf(descriptor);
+                final OutputChangeListener outputChangeListener = outputChangeListener();
                 return fileCollectionFactory().generated(
                     getTemporaryDirFactory(),
                     descriptorFileName,
-                    file -> outputChangeListener().beforeOutputChange(singleton(file.getAbsolutePath())),
+                    file -> outputChangeListener.beforeOutputChange(singleton(file.getAbsolutePath())),
                     outputStream -> {
                         try {
                             outputStream.write(cachedDescriptor.get());

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -74,12 +74,11 @@ public class Ear extends Jar {
             (Callable<String>) () -> GUtil.elvis(getLibDirName(), DEFAULT_LIB_DIR_NAME)
         );
         getMainSpec().appendCachingSafeCopyAction(details -> {
-                if (generateDeploymentDescriptor.get()) {
-                    checkIfShouldGenerateDeploymentDescriptor(details);
-                    recordTopLevelModules(details);
-                }
+            if (generateDeploymentDescriptor.get()) {
+                checkIfShouldGenerateDeploymentDescriptor(details);
+                recordTopLevelModules(details);
             }
-        );
+        });
 
         // create our own metaInf which runs after mainSpec's files
         // this allows us to generate the deployment descriptor after recording all modules it contains

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -32,7 +32,9 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.execution.OutputChangeListener;
+import org.gradle.internal.serialization.Cached;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.EarModule;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
@@ -43,11 +45,13 @@ import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.util.Collections;
 import java.util.concurrent.Callable;
 
+import static java.util.Collections.singleton;
 import static org.gradle.plugins.ear.EarPlugin.DEFAULT_LIB_DIR_NAME;
 
 /**
@@ -70,7 +74,7 @@ public class Ear extends Jar {
             (Callable<String>) () -> GUtil.elvis(getLibDirName(), DEFAULT_LIB_DIR_NAME)
         );
         getMainSpec().appendCachingSafeCopyAction(details -> {
-                if(generateDeploymentDescriptor.get()) {
+                if (generateDeploymentDescriptor.get()) {
                     checkIfShouldGenerateDeploymentDescriptor(details);
                     recordTopLevelModules(details);
                 }
@@ -81,8 +85,6 @@ public class Ear extends Jar {
         // this allows us to generate the deployment descriptor after recording all modules it contains
         CopySpecInternal metaInf = (CopySpecInternal) getMainSpec().addChild().into("META-INF");
         CopySpecInternal descriptorChild = metaInf.addChild();
-        OutputChangeListener outputChangeListener = getServices().get(OutputChangeListener.class);
-        FileCollectionFactory fileCollectionFactory = getServices().get(FileCollectionFactory.class);
         descriptorChild.from((Callable<FileTree>) () -> {
             final DeploymentDescriptor descriptor = getDeploymentDescriptor();
 
@@ -95,16 +97,44 @@ public class Ear extends Jar {
                 if (descriptorFileName.contains("/") || descriptorFileName.contains(File.separator)) {
                     throw new InvalidUserDataException("Deployment descriptor file name must be a simple name but was " + descriptorFileName);
                 }
-                return fileCollectionFactory.generated(
+
+                // TODO: Consider capturing the `descriptor` as a spec
+                //  so any captured manifest attribute providers are re-evaluated
+                //  on each run.
+                //  See https://github.com/gradle/instant-execution/issues/168
+                Cached<byte[]> cachedDescriptor = cachedContentsOf(descriptor);
+                return fileCollectionFactory().generated(
                     getTemporaryDirFactory(),
                     descriptorFileName,
-                    file -> outputChangeListener.beforeOutputChange(Collections.singleton(file.getAbsolutePath())),
-                    outputStream -> descriptor.writeTo(new OutputStreamWriter(outputStream))
+                    file -> outputChangeListener().beforeOutputChange(singleton(file.getAbsolutePath())),
+                    outputStream -> {
+                        try {
+                            outputStream.write(cachedDescriptor.get());
+                        } catch (IOException e) {
+                            throw UncheckedException.throwAsUncheckedException(e);
+                        }
+                    }
                 );
             }
 
             return null;
         });
+    }
+
+    private Cached<byte[]> cachedContentsOf(DeploymentDescriptor descriptor) {
+        return Cached.of(() -> {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            descriptor.writeTo(new OutputStreamWriter(bytes));
+            return bytes.toByteArray();
+        });
+    }
+
+    private FileCollectionFactory fileCollectionFactory() {
+        return getServices().get(FileCollectionFactory.class);
+    }
+
+    private OutputChangeListener outputChangeListener() {
+        return getServices().get(OutputChangeListener.class);
     }
 
     private void recordTopLevelModules(FileCopyDetails details) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -55,6 +55,25 @@ public class GeneratedSingletonFileTree implements FileSystemMirroringFileTree, 
         this.fileSystem = fileSystem;
     }
 
+    public Spec toSpec() {
+        return new Spec(tmpDirSource, fileName, fileGenerationListener, contentWriter);
+    }
+
+    public static class Spec {
+
+        public final Factory<File> tmpDir;
+        public final String fileName;
+        public final Action<File> fileGenerationListener;
+        public final Action<OutputStream> contentGenerator;
+
+        public Spec(Factory<File> tmpDir, String fileName, Action<File> fileGenerationListener, Action<OutputStream> contentGenerator) {
+            this.tmpDir = tmpDir;
+            this.fileName = fileName;
+            this.fileGenerationListener = fileGenerationListener;
+            this.contentGenerator = contentGenerator;
+        }
+    }
+
     private File getTmpDir() {
         return tmpDirSource.create();
     }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -37,21 +37,24 @@ afterEvaluate {
 dependencies {
     implementation(project(":baseServices"))
     implementation(project(":baseServicesGroovy"))
-    implementation(project(":messaging"))
-    implementation(project(":logging"))
-    implementation(project(":coreApi"))
     implementation(project(":core"))
-    implementation(project(":resources"))
-    implementation(project(":snapshots"))
-    implementation(project(":modelCore"))
-    implementation(project(":fileCollections"))
+    implementation(project(":coreApi"))
     implementation(project(":dependencyManagement"))
+    implementation(project(":execution"))
+    implementation(project(":fileCollections"))
+    implementation(project(":kotlinDsl"))
+    implementation(project(":logging"))
+    implementation(project(":messaging"))
+    implementation(project(":modelCore"))
     implementation(project(":persistentCache"))
     implementation(project(":plugins"))
     implementation(project(":publish"))
-    implementation(project(":kotlinDsl"))
+    implementation(project(":resources"))
+    implementation(project(":snapshots"))
+
     // TODO - move the isolatable serializer to model-core to live with the isolatable infrastructure
     implementation(project(":workers"))
+
     // TODO - it might be good to allow projects to contribute state to save and restore, rather than have this project know about everything
     implementation(project(":toolingApi"))
     implementation(project(":buildEvents"))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -51,6 +51,7 @@ import org.gradle.instantexecution.serialization.ownerServiceCodec
 import org.gradle.instantexecution.serialization.reentrant
 import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.isolation.IsolatableFactory
@@ -180,6 +181,7 @@ class Codecs(
         bind(ownerServiceCodec<BuildRequestMetaData>())
         bind(ownerServiceCodec<ListenerManager>())
         bind(ownerServiceCodec<TemporaryFileProvider>())
+        bind(ownerServiceCodec<OutputChangeListener>())
         bind(ServicesCodec())
 
         bind(ProxyCodec)

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -74,15 +74,15 @@ public class Jar extends Zip {
     }
 
     private ManifestInternal computeManifest() {
-        Manifest manifest1 = getManifest();
-        if (manifest1 == null) {
-            manifest1 = new DefaultManifest(null);
+        Manifest manifest = getManifest();
+        if (manifest == null) {
+            manifest = new DefaultManifest(null);
         }
         ManifestInternal manifestInternal;
-        if (manifest1 instanceof ManifestInternal) {
-            manifestInternal = (ManifestInternal) manifest1;
+        if (manifest instanceof ManifestInternal) {
+            manifestInternal = (ManifestInternal) manifest;
         } else {
-            manifestInternal = new CustomManifestInternalWrapper(manifest1);
+            manifestInternal = new CustomManifestInternalWrapper(manifest);
         }
         manifestInternal.setContentCharset(manifestContentCharset);
         return manifestInternal;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -63,31 +62,24 @@ public class WarPlugin implements Plugin<Project> {
         final WarPluginConvention pluginConvention = new DefaultWarPluginConvention(project);
         project.getConvention().getPlugins().put("war", pluginConvention);
 
-        project.getTasks().withType(War.class).configureEach(new Action<War>() {
-            @Override
-            public void execute(War task) {
-                task.from((Callable) () -> pluginConvention.getWebAppDir());
-                task.dependsOn((Callable) () -> project.getConvention()
-                    .getPlugin(JavaPluginConvention.class)
-                    .getSourceSets()
-                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                    .getRuntimeClasspath());
-                task.classpath((Callable) () -> {
-                    FileCollection runtimeClasspath = project.getConvention().getPlugin(JavaPluginConvention.class)
-                            .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
-                    Configuration providedRuntime = project.getConfigurations().getByName(
-                            PROVIDED_RUNTIME_CONFIGURATION_NAME);
-                    return runtimeClasspath.minus(providedRuntime);
-                });
-            }
+        project.getTasks().withType(War.class).configureEach(task -> {
+            task.from((Callable) () -> pluginConvention.getWebAppDir());
+            task.dependsOn((Callable) () -> project.getConvention()
+                .getPlugin(JavaPluginConvention.class)
+                .getSourceSets()
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                .getRuntimeClasspath());
+            task.classpath((Callable) () -> {
+                FileCollection runtimeClasspath = project.getConvention().getPlugin(JavaPluginConvention.class)
+                    .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+                Configuration providedRuntime = project.getConfigurations().getByName(PROVIDED_RUNTIME_CONFIGURATION_NAME);
+                return runtimeClasspath.minus(providedRuntime);
+            });
         });
 
-        TaskProvider<War> war = project.getTasks().register(WAR_TASK_NAME, War.class, new Action<War>() {
-            @Override
-            public void execute(War war) {
-                war.setDescription("Generates a war archive with all the compiled classes, the web-app content and the libraries.");
-                war.setGroup(BasePlugin.BUILD_GROUP);
-            }
+        TaskProvider<War> war = project.getTasks().register(WAR_TASK_NAME, War.class, warTask -> {
+            warTask.setDescription("Generates a war archive with all the compiled classes, the web-app content and the libraries.");
+            warTask.setGroup(BasePlugin.BUILD_GROUP);
         });
 
         PublishArtifact warArtifact = new LazyPublishArtifact(war);
@@ -98,10 +90,10 @@ public class WarPlugin implements Plugin<Project> {
 
     public void configureConfigurations(ConfigurationContainer configurationContainer) {
         Configuration provideCompileConfiguration = configurationContainer.create(PROVIDED_COMPILE_CONFIGURATION_NAME).setVisible(false).
-                setDescription("Additional compile classpath for libraries that should not be part of the WAR archive.");
+            setDescription("Additional compile classpath for libraries that should not be part of the WAR archive.");
         Configuration provideRuntimeConfiguration = configurationContainer.create(PROVIDED_RUNTIME_CONFIGURATION_NAME).setVisible(false).
-                extendsFrom(provideCompileConfiguration).
-                setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
+            extendsFrom(provideCompileConfiguration).
+            setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
         configurationContainer.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME).extendsFrom(provideCompileConfiguration);
         configurationContainer.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
+
 /**
  * Assembles a WAR archive.
  */
@@ -47,7 +49,6 @@ public class War extends Jar {
     private FileCollection classpath;
     private final DefaultCopySpec webInf;
 
-
     public War() {
         getArchiveExtension().set(WAR_EXTENSION);
         setMetadataCharset("UTF-8");
@@ -56,11 +57,11 @@ public class War extends Jar {
         webInf = (DefaultCopySpec) getRootSpec().addChildBeforeSpec(getMainSpec()).into("WEB-INF");
         webInf.into("classes", spec -> spec.from((Callable<Iterable<File>>) () -> {
             FileCollection classpath = getClasspath();
-            return classpath != null ? classpath.filter(File::isDirectory) : Collections.<File>emptyList();
+            return classpath != null ? classpath.filter(spec(File::isDirectory)) : Collections.<File>emptyList();
         }));
         webInf.into("lib", spec -> spec.from((Callable<Iterable<File>>) () -> {
             FileCollection classpath = getClasspath();
-            return classpath != null ? classpath.filter(File::isFile) : Collections.<File>emptyList();
+            return classpath != null ? classpath.filter(spec(File::isFile)) : Collections.<File>emptyList();
         }));
 
         CopySpecInternal renameSpec = webInf.addChild();


### PR DESCRIPTION
So the generated manifest reflects changes to any captured provider values.