### PR TITLE
Introduce `@InternalApi`

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -177,6 +177,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.InternalApi",
+            "member": "Class org.gradle.api.InternalApi",
+            "acceptation": "This interface will not be incubating",
+            "changes": [
+                "Interface has been added"
+            ]
         }
     ]
 }

--- a/subprojects/base-annotations/src/main/java/org/gradle/api/InternalApi.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/api/InternalApi.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a package or a type as internal API.
+ * Internal APIs are not visible in the Gradle API jar.
+ *
+ * If a package is annotated with {@link InternalApi}, then
+ * all subpackages are automatically internal.
+ *
+ * @since 6.6
+ */
+@Target({ElementType.TYPE, ElementType.PACKAGE})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InternalApi {
+}

--- a/subprojects/base-annotations/src/main/java/org/gradle/api/InternalApi.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/api/InternalApi.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * If a package is annotated with {@link InternalApi}, then
  * all subpackages are automatically internal.
  *
- * @since 6.6
+ * @since 7.0
  */
 @Target({ElementType.TYPE, ElementType.PACKAGE})
 @Documented

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/InternalApiGroovyScriptCompilationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/InternalApiGroovyScriptCompilationIntegrationTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class InternalApiGroovyScriptCompilationIntegrationTest extends AbstractIntegrationSpec {
+    @Unroll
+    def "doesn't compile Groovy script if it uses an internal API"() {
+        buildFile << """
+            $statement
+        """
+
+        when:
+        fails 'help'
+
+        then:
+        failure.assertHasErrorOutput("Use of an Gradle internal API is not allowed")
+
+        where:
+        statement << [
+            'import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencyArtifactSelector',
+            'println(org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencyArtifactSelector)'
+        ]
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -39,9 +39,19 @@ import java.util.Comparator;
 @ServiceScope(Scopes.UserHome.class)
 public class ClasspathWalker {
     private final Stat stat;
+    private final Comparator<File> fileComparator;
 
     public ClasspathWalker(Stat stat) {
+        this(stat, Comparator.comparing(File::getName));
+    }
+
+    private ClasspathWalker(Stat stat, Comparator<File> comparator) {
         this.stat = stat;
+        this.fileComparator = comparator;
+    }
+
+    public ClasspathWalker withFileOrder(Comparator<File> comparator) {
+        return new ClasspathWalker(stat, comparator);
     }
 
     /**
@@ -66,7 +76,7 @@ public class ClasspathWalker {
         File[] files = dir.listFiles();
 
         // Apply a consistent order, regardless of file system ordering
-        Arrays.sort(files, Comparator.comparing(File::getName));
+        Arrays.sort(files, fileComparator);
 
         for (File file : files) {
             FileMetadata fileMetadata = stat.stat(file);

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -39,19 +39,9 @@ import java.util.Comparator;
 @ServiceScope(Scopes.UserHome.class)
 public class ClasspathWalker {
     private final Stat stat;
-    private final Comparator<File> fileComparator;
 
     public ClasspathWalker(Stat stat) {
-        this(stat, Comparator.comparing(File::getName));
-    }
-
-    private ClasspathWalker(Stat stat, Comparator<File> comparator) {
         this.stat = stat;
-        this.fileComparator = comparator;
-    }
-
-    public ClasspathWalker withFileOrder(Comparator<File> comparator) {
-        return new ClasspathWalker(stat, comparator);
     }
 
     /**
@@ -76,7 +66,7 @@ public class ClasspathWalker {
         File[] files = dir.listFiles();
 
         // Apply a consistent order, regardless of file system ordering
-        Arrays.sort(files, fileComparator);
+        Arrays.sort(files, Comparator.comparing(File::getName));
 
         for (File file : files) {
             FileMetadata fileMetadata = stat.stat(file);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultArtifactSelectionDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultArtifactSelectionDetails.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.gradle.api.InternalApi;
 import org.gradle.api.artifacts.DependencyArtifactSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@InternalApi
 public class DefaultArtifactSelectionDetails implements ArtifactSelectionDetailsInternal {
 
     private final DefaultDependencySubstitution owner;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyArtifactSelector.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution;
 
+import org.gradle.api.InternalApi;
 import org.gradle.api.artifacts.DependencyArtifactSelector;
 
 import javax.annotation.Nullable;
 
+@InternalApi
 public class DefaultDependencyArtifactSelector implements DependencyArtifactSelector {
     private final String type;
     private final String extension;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution;
 
 import org.gradle.api.Action;
+import org.gradle.api.InternalApi;
 import org.gradle.api.artifacts.ArtifactSelectionDetails;
 import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.DependencySubstitution;
@@ -509,6 +510,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         }
     }
 
+    @InternalApi
     public static class DefaultVariantSelectionDetails implements VariantSelectionDetails {
         private final ImmutableAttributesFactory attributesFactory;
         private final ObjectFactory objectFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
@@ -119,6 +119,10 @@ class ImplementationDependencyRelocator extends Remapper {
         return null;
     }
 
+    public boolean includeClass(String className) {
+        return false;
+    }
+
     public static class ClassLiteralRemapping {
         private final String literal;
         private final String literalReplacement;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/package-info.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/package-info.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@NonNullApi
 @InternalApi
-package org.gradle.api.internal.std;
+package org.gradle.internal.management;
 
 import org.gradle.api.InternalApi;
-import org.gradle.api.NonNullApi;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -136,35 +136,37 @@ org.gradle.api.internal.tasks.CompileServices
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         contents[0] == outputJar
+        def actualEntries = []
         handleAsJarFile(outputJar) { JarFile file ->
             List<JarEntry> entries = file.entries() as List
-            assert entries*.name == [
-                'org/',
-                'org/gradle/',
-                'org/gradle/MyClass.class',
-                'org/gradle/MySecondClass.class',
-                'net/',
-                'net/rubygrapefruit/',
-                'net/rubygrapefruit/platform/',
-                'net/rubygrapefruit/platform/osx-i386/',
-                'net/rubygrapefruit/platform/osx-i386/libnative-platform.dylib',
-                'org/gradle/reporting/',
-                'org/gradle/reporting/report.js',
-                'org/joda/',
-                'org/joda/time/',
-                'org/joda/time/tz/',
-                'org/joda/time/tz/data/',
-                'org/joda/time/tz/data/Africa/',
-                'org/joda/time/tz/data/Africa/Abidjan',
-                'org/gradle/MyAClass.class',
-                'org/gradle/MyBClass.class',
-                'org/gradle/MyFirstClass.class',
-                'META-INF/',
-                'META-INF/services/',
-                'META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry',
-                'META-INF/services/org.gradle.internal.other.Service',
-                'META-INF/.gradle-runtime-shaded']
+            actualEntries = entries*.name
         }
+        actualEntries == [
+            'org/',
+            'org/gradle/',
+            'org/gradle/MyClass.class',
+            'org/gradle/MySecondClass.class',
+            'net/',
+            'net/rubygrapefruit/',
+            'net/rubygrapefruit/platform/',
+            'net/rubygrapefruit/platform/osx-i386/',
+            'net/rubygrapefruit/platform/osx-i386/libnative-platform.dylib',
+            'org/gradle/reporting/',
+            'org/gradle/reporting/report.js',
+            'org/joda/',
+            'org/joda/time/',
+            'org/joda/time/tz/',
+            'org/joda/time/tz/data/',
+            'org/joda/time/tz/data/Africa/',
+            'org/joda/time/tz/data/Africa/Abidjan',
+            'org/gradle/MyAClass.class',
+            'org/gradle/MyBClass.class',
+            'org/gradle/MyFirstClass.class',
+            'META-INF/',
+            'META-INF/services/',
+            'META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry',
+            'META-INF/services/org.gradle.internal.other.Service',
+            'META-INF/.gradle-runtime-shaded']
         outputJar.md5Hash == "55b2497496d71392a4fa9010352aaf38"
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/package-info.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/package-info.java
@@ -20,6 +20,8 @@
  * @see org.gradle.api.plugins.catalog.VersionCatalogPlugin
  */
 @NonNullApi
+@InternalApi
 package org.gradle.api.plugins.catalog.internal;
 
+import org.gradle.api.InternalApi;
 import org.gradle.api.NonNullApi;


### PR DESCRIPTION
If a package is annotated with `@InternalApi`, this package and
all the subpackages it contains are not exposed in the Gradle API
jar.

Similarly, if a class within a non-annotated package is itself
annotated with `@InternalApi`, then it's not visible in the
Gradle API jar.

This approach lets us introduce new internal APIs which are
truly invisible to users, without relying on Java modules.

For now, because we only care about the Gradle API jar, it
means that the internal APIs are not visible in `buildSrc`,
but they are effectively usable in build scripts.

See #13501
