### PR TITLE
Stabilize Shutdown API tests and improve implementation

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r65/ToolingApiShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r65/ToolingApiShutdownCrossVersionSpec.groovy
@@ -200,6 +200,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         build.forTasks('hang').withCancellationToken(cancellation.token()).run(resultHandler)
         sync.waitForAllPendingCalls(resultHandler)
         cancellation.cancel()
+        Thread.sleep(200) // The daemon seems to drop messages arriving the same time
         connector.disconnect()
         resultHandler.finished()
 
@@ -229,6 +230,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         build.forTasks('hang').withCancellationToken(cancellation.token()).run(resultHandler)
         sync.waitForAllPendingCalls(resultHandler)
         connector.disconnect()
+        Thread.sleep(200) // The daemon seems to drop messages arriving the same time
         cancellation.cancel()
         resultHandler.finished()
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r65/ToolingApiShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r65/ToolingApiShutdownCrossVersionSpec.groovy
@@ -25,9 +25,12 @@ import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.eclipse.EclipseProject
-import spock.lang.Ignore
+import spock.lang.Retry
+import spock.lang.Timeout
 import spock.util.concurrent.PollingConditions
 
+@Timeout(60)
+@Retry(count = 3)
 @ToolingApiVersion(">=6.5")
 class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
 
@@ -41,7 +44,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     @TargetGradleVersion(">=6.5")
     def "disconnect during build stops daemon"() {
         setup:
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -68,10 +71,9 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     }
 
     @TargetGradleVersion(">=6.5")
-    @Ignore('https://github.com/gradle/gradle-private/issues/3107')
     def "disconnect during tooling model query stops daemon"() {
         setup:
-        buildFile << """
+        buildFile.text = """
             apply plugin: 'eclipse'
             eclipse {
                 project {
@@ -104,7 +106,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     @TargetGradleVersion(">=6.5")
     def "disconnect stops multiple daemons"() {
         setup:
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -140,7 +142,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     }
 
     def "disconnect cancels the current build"() {
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -177,9 +179,8 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         assertNoRunningDaemons()
     }
 
-    @Ignore
     def "can call disconnect after the build was cancelled"() {
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -209,7 +210,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     }
 
     def "can call cancel after disconnect"() {
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -239,7 +240,7 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
     }
 
     def "can call close after disconnect"() {
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}
@@ -266,9 +267,8 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         resultHandler.assertFailedWith(BuildCancelledException)
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3107')
     def "can call disconnect after project connection closed"() {
-        buildFile << """
+        buildFile.text = """
             task myTask {
                 doLast {
                     println "myTask"
@@ -288,9 +288,8 @@ class ToolingApiShutdownCrossVersionSpec extends CancellationSpec {
         noExceptionThrown()
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3107')
     def "can call disconnect before project connection closed"() {
-        buildFile << """
+        buildFile.text = """
             task hang {
                 doLast {
                     ${server.callFromBuild("waiting")}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
@@ -90,7 +90,7 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     }
 
     private void requestCancellation() {
-        if (cancellationToken != null) {
+        if (cancellationToken != null && !cancellationToken.isCancellationRequested()) {
             cancellationToken.cancel();
         }
     }


### PR DESCRIPTION
The tests have now timeouts and they simulate real-life use cases better (cancellation and disconnect does not happen at the same exact time). Besides the shutdown API implementation no longer cancels the current build if cancellation is already requested.