### PR TITLE
Gracefully handle when file-events library can't be loaded

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -183,6 +183,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 DirectoryScanner.getDefaultExcludes()
             );
             WatchingAwareVirtualFileSystem watchingAwareVirtualFileSystem = determineWatcherRegistryFactory(OperatingSystem.current())
+                .filter(FileWatcherRegistryFactory::isAvailable)
                 .<WatchingAwareVirtualFileSystem>map(watcherRegistryFactory -> new WatchingVirtualFileSystem(
                     watcherRegistryFactory,
                     delegate,

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistryFactory.java
@@ -21,4 +21,11 @@ public interface FileWatcherRegistryFactory {
      * Create the file watcher registry.
      */
     FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler);
+
+    /**
+     * Whether file-system watching is available for the current operating system.
+     *
+     * E.g. some older Linux variants are not supported.
+     */
+    boolean isAvailable();
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistryFactory.java
@@ -21,11 +21,4 @@ public interface FileWatcherRegistryFactory {
      * Create the file watcher registry.
      */
     FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler);
-
-    /**
-     * Whether file-system watching is available for the current operating system.
-     *
-     * E.g. some older Linux variants are not supported.
-     */
-    boolean isAvailable();
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
@@ -16,17 +16,21 @@
 
 package org.gradle.internal.watch.registry.impl;
 
+import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 public abstract class AbstractFileWatcherRegistryFactory implements FileWatcherRegistryFactory {
     private static final int FILE_EVENT_QUEUE_SIZE = 4096;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFileWatcherRegistryFactory.class);
 
     @Override
     public FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler) {
@@ -46,7 +50,25 @@ public abstract class AbstractFileWatcherRegistryFactory implements FileWatcherR
         }
     }
 
+    @Override
+    public boolean isAvailable() {
+        try {
+            init();
+            return true;
+        } catch (NativeIntegrationUnavailableException e) {
+            LOGGER.info("Native file-system watching is not available for the current operating system", e);
+            return false;
+        }
+    }
+
     protected abstract FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException;
 
     protected abstract FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher);
+
+    /**
+     * Initializes the native parts of file-system watching.
+     *
+     * @throws NativeIntegrationUnavailableException if the native parts of file-system watching are not availabe on the current operating system. E.g. some older Linux variants are not supported.
+     */
+    protected abstract void init() throws NativeIntegrationUnavailableException;
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -26,11 +26,15 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory {
+public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<OsxFileEventFunctions> {
+
+    public DarwinFileWatcherRegistryFactory() throws NativeIntegrationUnavailableException {
+        super(Native.get(OsxFileEventFunctions.class));
+    }
+
     @Override
     protected FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException {
-        return Native.get(OsxFileEventFunctions.class)
-            .newWatcher(fileEvents)
+        return fileEventFunctions.newWatcher(fileEvents)
             // TODO Figure out a good value for this
             .withLatency(20, TimeUnit.MICROSECONDS)
             .start();
@@ -39,10 +43,5 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new HierarchicalFileWatcherUpdater(watcher);
-    }
-
-    @Override
-    public void init() throws NativeIntegrationUnavailableException {
-        Native.get(OsxFileEventFunctions.class);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.Native;
+import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions;
@@ -38,5 +39,10 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new HierarchicalFileWatcherUpdater(watcher);
+    }
+
+    @Override
+    public void init() throws NativeIntegrationUnavailableException {
+        Native.get(OsxFileEventFunctions.class);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.Native;
+import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.LinuxFileEventFunctions;
@@ -35,5 +36,10 @@ public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistry
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new NonHierarchicalFileWatcherUpdater(watcher);
+    }
+
+    @Override
+    public void init() throws NativeIntegrationUnavailableException {
+        Native.get(LinuxFileEventFunctions.class);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
@@ -25,21 +25,20 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 
 import java.util.concurrent.BlockingQueue;
 
-public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory {
+public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<LinuxFileEventFunctions> {
+
+    public LinuxFileWatcherRegistryFactory() throws NativeIntegrationUnavailableException {
+        super(Native.get(LinuxFileEventFunctions.class));
+    }
+
     @Override
     protected FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException {
-        return Native.get(LinuxFileEventFunctions.class)
-            .newWatcher(fileEvents)
+        return fileEventFunctions.newWatcher(fileEvents)
             .start();
     }
 
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new NonHierarchicalFileWatcherUpdater(watcher);
-    }
-
-    @Override
-    public void init() throws NativeIntegrationUnavailableException {
-        Native.get(LinuxFileEventFunctions.class);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.Native;
+import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.WindowsFileEventFunctions;
@@ -38,5 +39,10 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new HierarchicalFileWatcherUpdater(watcher);
+    }
+
+    @Override
+    public void init() throws NativeIntegrationUnavailableException {
+        Native.get(WindowsFileEventFunctions.class);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -25,13 +25,16 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 
 import java.util.concurrent.BlockingQueue;
 
-public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory {
+public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<WindowsFileEventFunctions> {
     private static final int BUFFER_SIZE = 128 * 1024;
+
+    public WindowsFileWatcherRegistryFactory() throws NativeIntegrationUnavailableException {
+        super(Native.get(WindowsFileEventFunctions.class));
+    }
 
     @Override
     protected FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException {
-        return Native.get(WindowsFileEventFunctions.class)
-            .newWatcher(fileEvents)
+        return fileEventFunctions.newWatcher(fileEvents)
             .withBufferSize(BUFFER_SIZE)
             .start();
     }
@@ -39,10 +42,5 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
         return new HierarchicalFileWatcherUpdater(watcher);
-    }
-
-    @Override
-    public void init() throws NativeIntegrationUnavailableException {
-        Native.get(WindowsFileEventFunctions.class);
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
@@ -26,12 +26,15 @@ import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
+import org.gradle.internal.nativeintegration.services.NativeServices
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.ToolingApiGradleExecutor
 import org.gradle.util.Requires
+import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestPrecondition
+import org.junit.Rule
 
 @Requires(TestPrecondition.NOT_WINDOWS)
 class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
@@ -42,6 +45,11 @@ class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends Abst
     String getLocation() {
         return "plugin 'sneaky'"
     }
+
+    @Rule
+    SetSystemProperties setSystemProperties = new SetSystemProperties(
+        (NativeServices.NATIVE_DIR_OVERRIDE): buildContext.nativeServicesDir.absolutePath
+    )
 
     @Override
     GradleExecuter createExecuter() {


### PR DESCRIPTION
We now try to load the native file-system
watching integration on daemon startup and
log the failure if it can't be loaded.

See #13396.