### PR TITLE
Init git repo in integration tests

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
@@ -115,6 +115,7 @@ class IsolatedAntBuilderMemoryLeakIntegrationTest extends AbstractIntegrationSpe
     @ToBeFixedForInstantExecution
     void "does not fail with a PermGen space error or a missing method exception"() {
         given:
+        initGitDir()
         buildFile << """
 buildscript {
   repositories {

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(library("jackson_databind"))
     implementation(library("ivy"))
     implementation(library("ant"))
+    implementation(library("jgit"))
     testLibraries("sshd").forEach {
         // we depend on both the platform and the library
         implementation(it)

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -60,7 +60,9 @@ dependencies {
     implementation(library("jackson_databind"))
     implementation(library("ivy"))
     implementation(library("ant"))
-    implementation(library("jgit"))
+    implementation(library("jgit")) {
+        because("Some tests require a git reportitory - see AbstractIntegrationSpec.initGitDir(")
+    }
     testLibraries("sshd").forEach {
         // we depend on both the platform and the library
         implementation(it)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures
 
+import org.eclipse.jgit.api.Git
 import org.gradle.api.Action
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.build.BuildTestFixture
@@ -109,6 +110,18 @@ class AbstractIntegrationSpec extends Specification {
 
     GradleExecuter createExecuter() {
         new GradleContextualExecuter(distribution, temporaryFolder, getBuildContext())
+    }
+
+    /**
+     * Some integration tests need to run git commands in test directory,
+     * but distributed-test-remote-executor has no .git directory so we init a "dummy .git dir".
+     */
+    void initGitDir() {
+        Git.init().setDirectory(testDirectory).call().withCloseable { Git git ->
+            testDirectory.file('initial-commit').createNewFile()
+            git.add().addFilepattern("initial-commit").call()
+            git.commit().setMessage("Initial commit").call()
+        }
     }
 
     TestFile getBuildFile() {


### PR DESCRIPTION
Some integration tests need to run git commands in test directory,
but distributed-test-remote-executor has no .git directory so we init a "dummy" .git dir.
