### PR TITLE
Fix for constraints that are reactivated

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -16,9 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -438,7 +438,7 @@ public class NodeState implements DependencyGraphNode {
 
     private void registerActivatingConstraint(DependencyState dependencyState) {
         if (potentiallyActivatedConstraints == null) {
-            potentiallyActivatedConstraints = ArrayListMultimap.create();
+            potentiallyActivatedConstraints = LinkedHashMultimap.create();
         }
         potentiallyActivatedConstraints.put(dependencyState.getModuleIdentifier(), dependencyState);
     }
@@ -1165,7 +1165,7 @@ public class NodeState implements DependencyGraphNode {
     void makePending(EdgeState edgeState) {
         outgoingEdges.remove(edgeState);
         edgeState.getSelector().release();
-        registerActivatingConstraint(edgeState.getDependencyState());
+//        registerActivatingConstraint(edgeState.getDependencyState());
     }
 
     ImmutableAttributes desugar(ImmutableAttributes attributes) {


### PR DESCRIPTION
Prior to this fix the same dependency state could lead to duplicate
outgoing edges which would cause an issue when the node targeted was
removed because it was deselected.
The code now uses a datastructure that will perform the de duplication
and it no longer registers entries in some code paths.