### PR TITLE
Improve configuration cache support for Java serialization

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
@@ -204,17 +204,17 @@ class RecordingObjectOutputStream(
 
     override fun close() = Unit
 
-    override fun reset() = TODO("reset")
+    override fun reset() = unsupported("ObjectOutputStream.reset")
 
-    override fun writeFields() = TODO("writeFields")
+    override fun writeFields() = unsupported("ObjectOutputStream.writeFields")
 
-    override fun putFields(): PutField = TODO("putFields")
+    override fun putFields(): PutField = unsupported("ObjectOutputStream.putFields")
 
-    override fun writeChars(str: String) = TODO("writeChars")
+    override fun writeChars(str: String) = unsupported("ObjectOutputStream.writeChars")
 
-    override fun writeUnshared(obj: Any?) = TODO("writeUnshared")
+    override fun writeBytes(str: String) = unsupported("ObjectOutputStream.writeBytes")
 
-    override fun writeBytes(str: String) = TODO("writeBytes")
+    override fun writeUnshared(obj: Any?) = unsupported("ObjectOutputStream.writeUnshared")
 }
 
 
@@ -252,9 +252,23 @@ class ObjectInputStreamAdapter(
 
     override fun mark(readlimit: Int) = inputStream.mark(readlimit)
 
+    override fun reset() = inputStream.reset()
+
     override fun read(): Int = inputStream.read()
 
     override fun readChar(): Char = readContext.readInt().toChar()
+
+    override fun readUnsignedByte(): Int = readByte().let {
+        require(it >= 0)
+        it.toInt()
+    }
+
+    override fun readByte(): Byte = readContext.readByte()
+
+    override fun readUnsignedShort(): Int = readShort().let {
+        require(it >= 0)
+        it.toInt()
+    }
 
     override fun readShort(): Short = readContext.readShort()
 
@@ -281,31 +295,28 @@ class ObjectInputStreamAdapter(
 
     override fun skipBytes(len: Int): Int = inputStream.skip(len.toLong()).toInt()
 
-    override fun read(buf: ByteArray, off: Int, len: Int): Int = TODO("read")
+    override fun read(buf: ByteArray, off: Int, len: Int): Int = inputStream.read(buf, off, len)
 
-    override fun readLine(): String = TODO("readLine")
+    override fun readLine(): String = unsupported("ObjectInputStream.readLine")
 
-    override fun readByte(): Byte = TODO("readByte")
+    override fun readFully(buf: ByteArray) = unsupported("ObjectInputStream.readFully")
 
-    override fun readFully(buf: ByteArray) = TODO("readFully")
+    override fun readFully(buf: ByteArray, off: Int, len: Int) = unsupported("ObjectInputStream.readFully")
 
-    override fun readFully(buf: ByteArray, off: Int, len: Int) = TODO("readFully")
+    override fun readUnshared(): Any = unsupported("ObjectInputStream.readUnshared")
 
-    override fun readUnshared(): Any = TODO("readUnshared")
+    override fun readFields(): GetField = unsupported("ObjectInputStream.readFields")
 
-    override fun readUnsignedShort(): Int = TODO("readUnsignedShort")
+    override fun transferTo(out: OutputStream): Long = unsupported("ObjectInputStream.transferTo")
 
-    override fun readUnsignedByte(): Int = TODO("readUnsignedByte")
-
-    override fun readFields(): GetField = TODO("readFields")
-
-    override fun transferTo(out: OutputStream): Long = TODO("transferTo")
-
-    override fun readAllBytes(): ByteArray = TODO("readAllBytes")
-
-    override fun reset() = TODO("reset")
+    override fun readAllBytes(): ByteArray = unsupported("ObjectInputStream.readAllBytes")
 
     private
     val inputStream: InputStream
         get() = readContext.inputStream
 }
+
+
+private
+fun unsupported(feature: String): Nothing =
+    throw UnsupportedOperationException("'$feature' is not supported by the Gradle configuration cache.")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteReplaceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteReplaceCodec.kt
@@ -114,10 +114,11 @@ class SerializableWriteReplaceCodec : EncodingProducer, Decoding {
     private
     suspend fun ReadContext.decodeBean(): Any {
         val beanType = readClass()
-        val beanReader = beanStateReaderFor(beanType)
-        return beanReader.run {
-            newBean(false).also {
-                readStateOf(it)
+        return withBeanTrace(beanType) {
+            beanStateReaderFor(beanType).run {
+                newBean(false).also {
+                    readStateOf(it)
+                }
             }
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteReplaceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteReplaceCodec.kt
@@ -60,8 +60,8 @@ class SerializableWriteReplaceCodec : EncodingProducer, Decoding {
         decodePreservingIdentity { id ->
             readResolve(
                 when (readEnum<Format>()) {
+                    Format.Inline -> decodeBean()
                     Format.Replaced -> readNonNull()
-                    Format.Bean -> decodeBean()
                 }
             ).also { bean ->
                 isolate.identities.putInstance(id, bean)
@@ -70,7 +70,7 @@ class SerializableWriteReplaceCodec : EncodingProducer, Decoding {
 
     private
     enum class Format {
-        Bean,
+        Inline,
         Replaced
     }
 
@@ -80,7 +80,7 @@ class SerializableWriteReplaceCodec : EncodingProducer, Decoding {
             encodePreservingIdentityOf(value) {
                 val replacement = writeReplace.invoke(value)
                 if (replacement === value) {
-                    writeEnum(Format.Bean)
+                    writeEnum(Format.Inline)
                     encodeBean(value)
                 } else {
                     writeEnum(Format.Replaced)
@@ -94,7 +94,7 @@ class SerializableWriteReplaceCodec : EncodingProducer, Decoding {
     inner class ReadResolveEncoding : Encoding {
         override suspend fun WriteContext.encode(value: Any) {
             encodePreservingIdentityOf(value) {
-                writeEnum(Format.Bean)
+                writeEnum(Format.Inline)
                 encodeBean(value)
             }
         }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableBeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableBeanCodecTest.kt
@@ -55,42 +55,54 @@ class SerializableBeanCodecTest : AbstractUserTypeCodecTest() {
 
         val (decodedSerializable, decodedBean) = decodedGraph
 
-        assertThat(
-            "defaultWriteObject / defaultReadObject handles non-transient fields",
-            decodedSerializable.value,
-            equalTo(serializable.value)
-        )
+        decodedSerializable.apply {
+            assertThat(
+                "defaultWriteObject / defaultReadObject handles non-transient fields",
+                value,
+                equalTo(serializable.value)
+            )
 
-        assertThat(
-            decodedSerializable.transientShort,
-            equalTo(SerializableWriteObjectBean.EXPECTED_SHORT)
-        )
+            assertThat(
+                transientByte,
+                equalTo(SerializableWriteObjectBean.EXPECTED_BYTE)
+            )
 
-        assertThat(
-            decodedSerializable.transientInt,
-            equalTo(SerializableWriteObjectBean.EXPECTED_INT)
-        )
+            assertThat(
+                transientShort,
+                equalTo(SerializableWriteObjectBean.EXPECTED_SHORT)
+            )
 
-        assertThat(
-            decodedSerializable.transientString,
-            equalTo(SerializableWriteObjectBean.EXPECTED_STRING)
-        )
+            assertThat(
+                transientInt,
+                equalTo(SerializableWriteObjectBean.EXPECTED_INT)
+            )
 
-        assertThat(
-            decodedSerializable.transientFloat,
-            equalTo(SerializableWriteObjectBean.EXPECTED_FLOAT)
-        )
+            assertThat(
+                transientLong,
+                equalTo(SerializableWriteObjectBean.EXPECTED_LONG)
+            )
 
-        assertThat(
-            decodedSerializable.transientDouble,
-            equalTo(SerializableWriteObjectBean.EXPECTED_DOUBLE)
-        )
+            assertThat(
+                transientString,
+                equalTo(SerializableWriteObjectBean.EXPECTED_STRING)
+            )
 
-        assertThat(
-            "preserves identities across protocols",
-            decodedSerializable.value,
-            sameInstance(decodedBean)
-        )
+            assertThat(
+                transientFloat,
+                equalTo(SerializableWriteObjectBean.EXPECTED_FLOAT)
+            )
+
+            assertThat(
+                transientDouble,
+                equalTo(SerializableWriteObjectBean.EXPECTED_DOUBLE)
+            )
+
+            assertThat(
+                "preserves identities across protocols",
+                value,
+                sameInstance(decodedBean)
+            )
+        }
     }
 
     @Test
@@ -266,7 +278,11 @@ class SerializableBeanCodecTest : AbstractUserTypeCodecTest() {
 
             const val EXPECTED_SHORT: Short = Short.MAX_VALUE
 
+            const val EXPECTED_BYTE: Byte = 42
+
             const val EXPECTED_INT: Int = 42
+
+            const val EXPECTED_LONG: Long = 42L
 
             const val EXPECTED_STRING: String = "42"
 
@@ -276,10 +292,16 @@ class SerializableBeanCodecTest : AbstractUserTypeCodecTest() {
         }
 
         @Transient
+        var transientByte: Byte? = null
+
+        @Transient
         var transientShort: Short? = null
 
         @Transient
         var transientInt: Int? = null
+
+        @Transient
+        var transientLong: Long? = null
 
         @Transient
         var transientString: String? = null
@@ -294,8 +316,10 @@ class SerializableBeanCodecTest : AbstractUserTypeCodecTest() {
         fun writeObject(objectOutputStream: ObjectOutputStream) {
             objectOutputStream.run {
                 defaultWriteObject()
+                writeByte(EXPECTED_BYTE.toInt())
                 writeShort(EXPECTED_SHORT.toInt())
                 writeInt(EXPECTED_INT)
+                writeLong(EXPECTED_LONG)
                 writeUTF(EXPECTED_STRING)
                 writeFloat(EXPECTED_FLOAT)
                 writeDouble(EXPECTED_DOUBLE)
@@ -305,8 +329,10 @@ class SerializableBeanCodecTest : AbstractUserTypeCodecTest() {
         private
         fun readObject(objectInputStream: ObjectInputStream) {
             objectInputStream.defaultReadObject()
+            transientByte = objectInputStream.readByte()
             transientShort = objectInputStream.readShort()
             transientInt = objectInputStream.readInt()
+            transientLong = objectInputStream.readLong()
             transientString = objectInputStream.readUTF()
             transientFloat = objectInputStream.readFloat()
             transientDouble = objectInputStream.readDouble()


### PR DESCRIPTION
- allow `writeReplace` to return `this`
- handle serializable objects with only a `readResolve` method