### PR TITLE
Remove public modifier from Groovy Plugin Gradle init templates

### DIFF
--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/Plugin.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/Plugin.groovy.template
@@ -8,8 +8,8 @@ import org.gradle.api.Plugin
 /**
  * A simple 'hello world' plugin.
  */
-public class ${className.javaIdentifier} implements Plugin<Project> {
-    public void apply(Project project) {
+class ${className.javaIdentifier} implements Plugin<Project> {
+    void apply(Project project) {
         // Register a task
         project.tasks.register("greeting") {
             doLast {

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
@@ -8,7 +8,7 @@ import org.gradle.testkit.runner.GradleRunner
 /**
  * A simple functional test for the '${pluginId.value}' plugin.
  */
-public class ${className.javaIdentifier} extends Specification {
+class ${className.javaIdentifier} extends Specification {
     def "can run task"() {
         given:
         def projectDir = new File("build/functionalTest")

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginTest.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginTest.groovy.template
@@ -9,7 +9,7 @@ import spock.lang.Specification
 /**
  * A simple unit test for the '${pluginId.value}' plugin.
  */
-public class ${className.javaIdentifier} extends Specification {
+class ${className.javaIdentifier} extends Specification {
     def "plugin registers task"() {
         given:
         def project = ProjectBuilder.builder().build()


### PR DESCRIPTION
This small PR addresses some non idiomatic generated groovy code when generating a groovy based gradle plugin project via `gradle init`.

### Context
When running `gradle init` for generating a groovy based plugin, the generated groovy classes contain non required public modifier for the class and some methods.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
