### PR TITLE
Re-enable https tests for JDK11+

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -23,8 +23,6 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.matchers.UserAgentMatcher
 import org.gradle.util.GUtil
 import org.gradle.util.GradleVersion
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -111,8 +109,6 @@ class HttpScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
         succeeds()
     }
 
-    // Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-    @Requires(TestPrecondition.JDK11_OR_EARLIER)
     def "can apply script via https"() {
         applyTrustStore()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -21,8 +21,6 @@ import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.GUtil
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 @TestReproducibleArchives
@@ -142,8 +140,6 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksSkipped(":uriText")
     }
 
-    // Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-    @Requires(TestPrecondition.JDK11_OR_EARLIER)
     def "uri backed text resource over https"() {
         given:
         def uuid = UUID.randomUUID()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
@@ -28,8 +28,7 @@ import spock.lang.Unroll
 
 import static org.gradle.util.Matchers.containsText
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
     @Rule TestResources resources = new TestResources(temporaryFolder)
     TestKeyStore keyStore

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
@@ -21,13 +21,10 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.AuthScheme
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Unroll
 
 import static org.gradle.util.Matchers.containsText
-
 
 abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
     @Rule TestResources resources = new TestResources(temporaryFolder)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
@@ -19,12 +19,9 @@ package org.gradle.integtests.resolve.http
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 class HttpsProxyResolveIntegrationTest extends AbstractProxyResolveIntegrationTest {
     @Override
     MavenHttpRepository getRepo() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.junit.Rule
 
-
 class HttpsProxyResolveIntegrationTest extends AbstractProxyResolveIntegrationTest {
     @Override
     MavenHttpRepository getRepo() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpRedirectResolveIntegrationTest.groovy
@@ -18,13 +18,9 @@ package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
 class HttpsToHttpRedirectResolveIntegrationTest extends AbstractRedirectResolveIntegrationTest {
 
     @Rule TestResources resources = new TestResources(temporaryFolder)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
@@ -22,8 +22,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 class HttpsToHttpsRedirectResolveIntegrationTest extends AbstractRedirectResolveIntegrationTest {
 
     @Rule TestResources resources = new TestResources(temporaryFolder)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
@@ -18,10 +18,7 @@ package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
-
 
 class HttpsToHttpsRedirectResolveIntegrationTest extends AbstractRedirectResolveIntegrationTest {
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
@@ -20,10 +20,7 @@ import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
-
 
 class IvyHttpsLegacyPublishIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest {
     TestKeyStore keyStore

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
@@ -24,8 +24,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 class IvyHttpsLegacyPublishIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest {
     TestKeyStore keyStore
     @Rule RepositoryHttpServer server = new RepositoryHttpServer(temporaryFolder)

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
@@ -23,12 +23,9 @@ import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 class IvyPublishHttpsIntegTest extends AbstractIvyPublishIntegTest {
     TestKeyStore keyStore
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
 import org.junit.Rule
 
-
 class IvyPublishHttpsIntegTest extends AbstractIvyPublishIntegTest {
     TestKeyStore keyStore
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
@@ -26,8 +26,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
-// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
-@Requires(TestPrecondition.JDK11_OR_EARLIER)
+
 class MavenPublishHttpsIntegTest extends AbstractMavenPublishIntegTest {
     TestKeyStore keyStore
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
@@ -22,10 +22,7 @@ import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
-
 
 class MavenPublishHttpsIntegTest extends AbstractMavenPublishIntegTest {
     TestKeyStore keyStore


### PR DESCRIPTION
They were disabled because of a bug in JDK12 https://bugs.openjdk.java.net/browse/JDK-8219658
This bug is marked as fixed in JDK13. We no longer run tests against JDK12 and JDK13 wich have reached their end of life. The tests pass on current latest JDK14.

