### PR TITLE
Mark credentials as Optional in ivy and maven repositories

### DIFF
--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
@@ -30,6 +30,7 @@ import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublisher;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
@@ -44,12 +45,9 @@ import java.util.concurrent.Callable;
  */
 public class PublishToIvyRepository extends DefaultTask {
 
-    private static final Credentials NO_CREDENTIALS = new Credentials() {
-    };
-
     private IvyPublicationInternal publication;
     private IvyArtifactRepository repository;
-    private final Property<Credentials> credentials = getProject().getObjects().property(Credentials.class).convention(NO_CREDENTIALS);
+    private final Property<Credentials> credentials = getProject().getObjects().property(Credentials.class);
 
     public PublishToIvyRepository() {
 
@@ -118,6 +116,7 @@ public class PublishToIvyRepository extends DefaultTask {
     }
 
     @Input
+    @Optional
     Property<Credentials> getCredentials() {
         return credentials;
     }
@@ -129,7 +128,7 @@ public class PublishToIvyRepository extends DefaultTask {
      */
     public void setRepository(IvyArtifactRepository repository) {
         this.repository = repository;
-        this.credentials.set(((AuthenticationSupportedInternal) repository).getConfiguredCredentials().orElse(NO_CREDENTIALS));
+        this.credentials.set(((AuthenticationSupportedInternal) repository).getConfiguredCredentials());
     }
 
     @TaskAction

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -28,6 +28,7 @@ import org.gradle.api.publish.maven.internal.publisher.MavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.ValidatingMavenPublisher;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
 import org.gradle.internal.serialization.Cached;
@@ -48,10 +49,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
     private final Transient.Var<MavenArtifactRepository> repository = varOf();
     private final Cached<PublishSpec> spec = Cached.of(this::computeSpec);
 
-    private static final Credentials NO_CREDENTIALS = new Credentials() {
-    };
-
-    private final Property<Credentials> credentials = getProject().getObjects().property(Credentials.class).convention(NO_CREDENTIALS);
+    private final Property<Credentials> credentials = getProject().getObjects().property(Credentials.class);
 
     /**
      * The repository to publish to.
@@ -65,6 +63,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
     }
 
     @Input
+    @Optional
     Property<Credentials> getCredentials() {
         return credentials;
     }
@@ -76,7 +75,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
      */
     public void setRepository(MavenArtifactRepository repository) {
         this.repository.set(repository);
-        this.credentials.set(((AuthenticationSupportedInternal) repository).getConfiguredCredentials().orElse(NO_CREDENTIALS));
+        this.credentials.set(((AuthenticationSupportedInternal) repository).getConfiguredCredentials());
     }
 
     @TaskAction


### PR DESCRIPTION
As per review comments here https://github.com/gradle/gradle/pull/13107#pullrequestreview-437171964
It is possible to mark the credentials in repositories as Optional and avoid the NO_CREDENTIALS placeholders.