### PR TITLE
Don't cache `readResolve` methods when writing to the configuration cache

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCache.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCache.kt
@@ -35,9 +35,15 @@ class MethodCache(
         forClass(value.javaClass)
 
     fun forClass(type: Class<*>) = methodCache.computeIfAbsent(type) {
-        it.firstMatchingMethodOrNull(predicate)
+        it.firstAccessibleMatchingMethodOrNull(predicate)
     }
 }
+
+
+internal
+fun Class<*>.firstAccessibleMatchingMethodOrNull(predicate: Method.() -> Boolean): Method? =
+    firstMatchingMethodOrNull(predicate)
+        ?.apply { isAccessible = true }
 
 
 internal
@@ -45,4 +51,3 @@ fun Class<*>.firstMatchingMethodOrNull(predicate: Method.() -> Boolean): Method?
     ClassInspector.inspect(this)
         .allMethods
         .find(predicate)
-        ?.apply { isAccessible = true }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
@@ -93,8 +93,8 @@ class SerializableWriteObjectCodec : EncodingProducer, Decoding {
 
     private
     fun writeObjectMethodOf(type: Class<*>) = type
-        .takeIf { Serializable::class.java.isAssignableFrom(type) }
-        ?.firstMatchingMethodOrNull {
+        .takeIf { type.isSerializable() }
+        ?.firstAccessibleMatchingMethodOrNull {
             parameterCount == 1
                 && name == "writeObject"
                 && parameterTypes[0].isAssignableFrom(ObjectOutputStream::class.java)
@@ -315,6 +315,11 @@ class ObjectInputStreamAdapter(
     val inputStream: InputStream
         get() = readContext.inputStream
 }
+
+
+internal
+fun Class<*>.isSerializable() =
+    Serializable::class.java.isAssignableFrom(this)
 
 
 private


### PR DESCRIPTION
And definitely don't bother making them accessible.
