### PR TITLE
Revert "Use Stat in FileTimeStampInspector"

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.RootBuildLifecycleListener;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -31,8 +30,8 @@ import java.io.File;
  */
 @ServiceScope(Scopes.BuildSession)
 public class BuildSessionScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
-    public BuildSessionScopeFileTimeStampInspector(File workDir, Stat stat) {
-        super(workDir, stat);
+    public BuildSessionScopeFileTimeStampInspector(File workDir) {
+        super(workDir);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.initialization.RootBuildLifecycleListener;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -42,8 +41,8 @@ public class GradleUserHomeScopeFileTimeStampInspector extends FileTimeStampInsp
     private long currentTimestamp;
     private final Set<String> filesWithCurrentTimestamp = new HashSet<>();
 
-    public GradleUserHomeScopeFileTimeStampInspector(CacheScopeMapping cacheScopeMapping, Stat stat) {
-        super(cacheScopeMapping.getBaseDirectory(null, "file-changes", VersionStrategy.CachePerVersion), stat);
+    public GradleUserHomeScopeFileTimeStampInspector(CacheScopeMapping cacheScopeMapping) {
+        super(cacheScopeMapping.getBaseDirectory(null, "file-changes", VersionStrategy.CachePerVersion));
     }
 
     public void attach(CachingFileHasher fileHasher) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -54,7 +54,6 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.featurelifecycle.DeprecatedUsageBuildOperationProgressBroadcaster;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.filewatch.PendingChangesManager;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
@@ -138,9 +137,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new ProjectCacheDir(cacheDir, progressLoggerFactory, deleter);
     }
 
-    BuildSessionScopeFileTimeStampInspector createFileTimeStampInspector(ProjectCacheDir projectCacheDir, CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager, Stat stat) {
+    BuildSessionScopeFileTimeStampInspector createFileTimeStampInspector(ProjectCacheDir projectCacheDir, CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager) {
         File workDir = cacheScopeMapping.getBaseDirectory(projectCacheDir.getDir(), "fileChanges", VersionStrategy.CachePerVersion);
-        BuildSessionScopeFileTimeStampInspector timeStampInspector = new BuildSessionScopeFileTimeStampInspector(workDir, stat);
+        BuildSessionScopeFileTimeStampInspector timeStampInspector = new BuildSessionScopeFileTimeStampInspector(workDir);
         listenerManager.addListener(timeStampInspector);
         return timeStampInspector;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -61,7 +61,6 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.execution.timeout.impl.DefaultTimeoutHandler;
 import org.gradle.internal.file.FileAccessTimeJournal;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.jvm.JavaModuleDetector;
@@ -109,8 +108,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return parent.createChild(Scopes.UserHome);
     }
 
-    GradleUserHomeScopeFileTimeStampInspector createFileTimestampInspector(CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager, Stat stat) {
-        GradleUserHomeScopeFileTimeStampInspector timeStampInspector = new GradleUserHomeScopeFileTimeStampInspector(cacheScopeMapping, stat);
+    GradleUserHomeScopeFileTimeStampInspector createFileTimestampInspector(CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager) {
+        GradleUserHomeScopeFileTimeStampInspector timeStampInspector = new GradleUserHomeScopeFileTimeStampInspector(cacheScopeMapping);
         listenerManager.addListener(timeStampInspector);
         return timeStampInspector;
     }


### PR DESCRIPTION
Seems like using `Stat` causes some changes to go unnoticed: https://builds.gradle.org/buildConfiguration/Gradle_Check_Instant_20_bucket24/36213362

So when using instant execution, test like `JavaSourceIncrementalCompilationIntegrationTest.recompiles class when constant from inner class is changed` start to fail.

This reverts commit 27c82421ed222d69808f980e2112ca94308d0f41.