### PR TITLE
Update tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,3 +1,3 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=3.4.2,3.5.3,3.6.3,4.0.0,4.1.0-beta01,4.2.0-alpha02
-nightly=4.2.0-20200614004801+0000
+latests=3.4.2,3.5.3,3.6.3,4.0.0,4.1.0-beta02,4.2.0-alpha02
+nightly=4.2.0-20200621004745+0000


### PR DESCRIPTION
from 4.1.0-beta01 to 4.1.0-beta02
bump 4.2 nightly
