### PR TITLE
Fix PlayTestPlugin now that Test.classpath has no convention mapping

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestExecutionResult
 import org.gradle.play.integtest.fixtures.PlayMultiVersionApplicationIntegrationTest
-import spock.lang.Ignore
 
 abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplicationIntegrationTest {
 
@@ -57,7 +56,6 @@ abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplic
                 ":testPlayBinary")
     }
 
-    @Ignore("convention mapping / software model combination causing troubles")
     def "can run play app tests if java plugin is applied"() {
         when:
         buildFile << """

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
@@ -86,8 +86,6 @@ public class PlayTestPlugin extends RuleSource {
             tasks.create(testTaskName, Test.class, test -> {
                 test.setDescription("Runs " + WordUtils.uncapitalize(binary.getDisplayName() + "."));
 
-                test.setClasspath(testClassesDirs.plus(testCompileClasspath));
-
                 test.setTestClassesDirs(testClassesDirs);
                 test.setBinResultsDir(new File(binaryBuildDir, "results/" + testTaskName + "/bin"));
                 test.getReports().getJunitXml().setDestination(new File(binaryBuildDir, "reports/test/xml"));
@@ -95,6 +93,7 @@ public class PlayTestPlugin extends RuleSource {
                 test.dependsOn(testCompileTaskName);
                 test.setWorkingDir(projectIdentifier.getProjectDir());
             });
+            tasks.withType(Test.class).named(testTaskName, test -> test.setClasspath(testClassesDirs.plus(testCompileClasspath)));
             binary.getTasks().add(tasks.get(testTaskName));
         }
     }

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
@@ -70,6 +70,8 @@ class PlayTestPluginTest extends Specification {
         then:
         1 * taskModelMap.create("compileSomeBinaryTests", PlatformScalaCompile, _)
         1 * taskModelMap.create("testSomeBinary", Test, _)
+        1 * taskModelMap.withType(Test) >> taskModelMap
+        1 * taskModelMap.named("testSomeBinary", _)
         0 * taskModelMap.create(_)
         0 * taskModelMap.create(_, _, _)
         1 * taskModelMap.get('testSomeBinary')


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
