### PR TITLE
Introduce `ProviderFactory#zip`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -23,6 +23,7 @@ import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
 
 /**
  * A container object that provides a value of a specific type. The value can be retrieved using one of the query methods such as {@link #get()} or {@link #getOrNull()}.
@@ -152,4 +153,22 @@ public interface Provider<T> {
      */
     @Incubating
     Provider<T> forUseAtConfigurationTime();
+
+    /**
+     * Returns a provider which value will be computed by combining this provider value with another
+     * provider value using the supplied combiner function.
+     *
+     * If the supplied providers represents a task or the output of a task, the resulting provider
+     * will carry the dependency information.
+     *
+     * @param right the second provider to combine with
+     * @param combiner the combiner of values
+     * @param <B> the type of the second provider
+     * @param <R> the type of the result of the combiner
+     * @return a combined provider
+     *
+     * @since 6.6
+     */
+    @Incubating
+    <B, R> Provider<R> zip(Provider<B> right, BiFunction<T, B, R> combiner);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -252,5 +252,5 @@ public interface ProviderFactory {
      * @since 6.6
      */
     @Incubating
-    <A, B, R> Provider<R> zip(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner);
+    <A, B, R> Provider<R> zip(Provider<A> first, Provider<B> second, BiFunction<A, B, R> combiner);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -26,6 +26,7 @@ import org.gradle.api.file.FileContents;
 import org.gradle.api.file.RegularFile;
 
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
 
 /**
  * A factory for creating instances of {@link Provider}.
@@ -232,4 +233,24 @@ public interface ProviderFactory {
      */
     @Incubating
     <T extends Credentials> Provider<T> credentials(Class<T> credentialsType, Provider<String> identity);
+
+    /**
+     * Returns a provider which value will be computed by combining a provider value with another
+     * provider value using the supplied combiner function.
+     *
+     * If the supplied providers represents a task or the output of a task, the resulting provider
+     * will carry the dependency information.
+     *
+     * @param left the first provider to combine with
+     * @param right the second provider to combine with
+     * @param combiner the combiner of values
+     * @param <A> the type of the first provider
+     * @param <B> the type of the second provider
+     * @param <R> the type of the result of the combiner
+     * @return a combined provider
+     *
+     * @since 6.6
+     */
+    @Incubating
+    <A, B, R> Provider<R> zip(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner);
 }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
@@ -38,7 +38,7 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
                 String getText() {
                     text.get()
                 }
-                
+
                 void setText(Provider<String> text) {
                     this.text = text
                 }
@@ -79,7 +79,7 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
 
             public class MyTask extends DefaultTask {
                 private final Provider<String> text;
- 
+
                 @Inject
                 public MyTask(ProviderFactory providerFactory) {
                     text = providerFactory.provider(new Callable<String>() {
@@ -89,12 +89,12 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
                         }
                     });
                 }
-                
+
                 @Internal
                 public String getText() {
                     return text.get();
                 }
-                
+
                 @Internal
                 public Boolean getRenderText() {
                     return getProviderFactory().provider(new Callable<Boolean>() {
@@ -104,7 +104,7 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
                         }
                     }).get();
                 }
-                
+
                 @Inject
                 public ProviderFactory getProviderFactory() {
                     throw new UnsupportedOperationException();
@@ -130,5 +130,77 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         renderText << [false, true]
+    }
+
+    def "zip tracks task dependencies"() {
+        buildFile << """
+            tasks.register('myTask1', MyTask) {
+                text.set('Hello')
+            }
+            tasks.register('myTask2', MyTask) {
+                text.set('World')
+            }
+
+            tasks.register('combined', MyTask) {
+                text.set(providers.zip(
+                    tasks.named('myTask1').map { t -> t.text.get() },
+                    tasks.named('myTask2').map { t -> t.text.get() }) { h, w ->
+                    "\$h, \$w!"
+                })
+            }
+
+            class MyTask extends DefaultTask {
+                @Input
+                final Property<String> text = project.objects.property(String).convention('$DEFAULT_TEXT')
+
+                @TaskAction
+                void printText() {
+                    println text.get()
+                }
+            }
+        """
+
+        when:
+        succeeds 'combined'
+
+        then:
+        executedAndNotSkipped(':myTask1', ':myTask2', ':combined')
+        outputContains('Hello, World!')
+    }
+
+    def "can zip tasks directly"() {
+        buildFile << """
+            tasks.register('myTask1', MyTask) {
+                text.set('Hello')
+            }
+            tasks.register('myTask2', MyTask) {
+                text.set('World')
+            }
+
+            tasks.register('combined', MyTask) {
+                text.set(providers.zip(
+                    tasks.named('myTask1'),
+                    tasks.named('myTask2')) { h, w ->
+                    "\${h.text.get()}, \${w.text.get()}!"
+                })
+            }
+
+            class MyTask extends DefaultTask {
+                @Input
+                final Property<String> text = project.objects.property(String).convention('$DEFAULT_TEXT')
+
+                @TaskAction
+                void printText() {
+                    println text.get()
+                }
+            }
+        """
+
+        when:
+        succeeds 'combined'
+
+        then:
+        executedAndNotSkipped(':myTask1', ':myTask2', ':combined')
+        outputContains('Hello, World!')
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
@@ -34,9 +35,16 @@ class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
-        Value<? extends A> lv = left.calculateValue(consumer);
-        Value<? extends B> rv = right.calculateValue(consumer);
+        Value<? extends A> lv = assertHasValue(left.calculateValue(consumer), left);
+        Value<? extends B> rv = assertHasValue(right.calculateValue(consumer), right);
         return Value.of(combiner.apply(lv.get(), rv.get()));
+    }
+
+    private <T> Value<? extends T> assertHasValue(Value<? extends T> value, ProviderInternal<?> provider) {
+        if (value.isMissing()) {
+            throw new InvalidUserDataException("Provider has no value: " + provider);
+        }
+        return value;
     }
 
     @Nullable

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -34,6 +34,17 @@ class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
     }
 
     @Override
+    public ExecutionTimeValue<? extends R> calculateExecutionTimeValue() {
+        return isChangingValue(left) || isChangingValue(right)
+            ? ExecutionTimeValue.changingValue(this)
+            : super.calculateExecutionTimeValue();
+    }
+
+    private boolean isChangingValue(ProviderInternal<?> provider) {
+        return provider.calculateExecutionTimeValue().isChangingValue();
+    }
+
+    @Override
     protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
         Value<? extends A> lv = assertHasValue(left.calculateValue(consumer), left);
         Value<? extends B> rv = assertHasValue(right.calculateValue(consumer), right);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.provider.Provider;
+
+import javax.annotation.Nullable;
+import java.util.function.BiFunction;
+
+class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
+
+    private final BiFunction<A, B, R> combiner;
+    private final ProviderInternal<A> left;
+    private final ProviderInternal<B> right;
+
+    public BiProvider(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner) {
+        this.combiner = combiner;
+        this.left = Providers.internal(left);
+        this.right = Providers.internal(right);
+    }
+
+    @Override
+    protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
+        Value<? extends A> lv = left.calculateValue(consumer);
+        Value<? extends B> rv = right.calculateValue(consumer);
+        return Value.of(combiner.apply(lv.get(), rv.get()));
+    }
+
+    @Nullable
+    @Override
+    public Class<R> getType() {
+        // Could do a better job of inferring this
+        return null;
+    }
+
+    @Override
+    public ValueProducer getProducer() {
+        return new PlusProducer(left.getProducer(), right.getProducer());
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -35,6 +35,7 @@ import org.gradle.internal.event.ListenerManager;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
 
 public class DefaultProviderFactory implements ProviderFactory {
 
@@ -148,6 +149,11 @@ public class DefaultProviderFactory implements ProviderFactory {
     @Override
     public <T extends Credentials> Provider<T> credentials(Class<T> credentialsType, Provider<String> identity) {
         return credentialsProviderFactory.provide(credentialsType, identity);
+    }
+
+    @Override
+    public <A, B, R> Provider<R> zip(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner) {
+        return new BiProvider<>(left, right, combiner);
     }
 
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
+import java.util.function.BiFunction;
 
 public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDependencyContainer {
     /**
@@ -63,4 +64,8 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      * intermediate steps.
      */
     ExecutionTimeValue<? extends T> calculateExecutionTimeValue();
+
+    default <B, R> Provider<R> zip(Provider<B> right, BiFunction<T, B, R> combiner) {
+        return new BiProvider<>(this, right, combiner);
+    }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderAssertions.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderAssertions.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.Task
+
+trait ProviderAssertions {
+    void assertHasNoProducer(ProviderInternal<?> provider) {
+        def producer = provider.producer
+        assert !producer.known
+        producer.visitProducerTasks { assert false }
+        producer.visitContentProducerTasks { assert false }
+    }
+
+    void assertHasKnownProducer(ProviderInternal<?> provider) {
+        def producer = provider.producer
+        assert producer.known
+        producer.visitProducerTasks { assert false }
+        producer.visitContentProducerTasks { assert false }
+    }
+
+    void assertHasProducer(ProviderInternal<?> provider, Task task, Task... additional) {
+        def expected = [task] + (additional as List)
+
+        def producer = provider.producer
+        assert producer.known
+        def tasks = []
+        producer.visitProducerTasks { tasks.add(it) }
+        assert tasks == expected
+        tasks.clear()
+        producer.visitContentProducerTasks { tasks.add(it) }
+        assert tasks == expected
+    }
+}

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -16,14 +16,14 @@
 
 package org.gradle.api.internal.provider
 
-import org.gradle.api.Task
+
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Provider
 import org.gradle.internal.state.Managed
 import org.gradle.internal.state.ManagedFactory
 import spock.lang.Specification
 
-abstract class ProviderSpec<T> extends Specification {
+abstract class ProviderSpec<T> extends Specification implements ProviderAssertions {
     abstract Provider<T> providerWithValue(T value)
 
     abstract Provider<T> providerWithNoValue()
@@ -449,32 +449,5 @@ abstract class ProviderSpec<T> extends Specification {
                 throw new RuntimeException("broken!")
             }
         }
-    }
-
-    void assertHasNoProducer(ProviderInternal<?> provider) {
-        def producer = provider.producer
-        assert !producer.known
-        producer.visitProducerTasks { assert false }
-        producer.visitContentProducerTasks { assert false }
-    }
-
-    void assertHasKnownProducer(ProviderInternal<?> provider) {
-        def producer = provider.producer
-        assert producer.known
-        producer.visitProducerTasks { assert false }
-        producer.visitContentProducerTasks { assert false }
-    }
-
-    void assertHasProducer(ProviderInternal<?> provider, Task task, Task... additional) {
-        def expected = [task] + (additional as List)
-
-        def producer = provider.producer
-        assert producer.known
-        def tasks = []
-        producer.visitProducerTasks { tasks.add(it) }
-        assert tasks == expected
-        tasks.clear()
-        producer.visitContentProducerTasks { tasks.add(it) }
-        assert tasks == expected
     }
 }


### PR DESCRIPTION
This PR introduces a `zip` method which allows combining two providers into a new live provider. The dependencies of both providers are tracked (because the resulting provider _depends on_ both values).

See #12974
