### PR TITLE
Use BuildActionRunner for file system watching bookkeeping

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -199,9 +199,6 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                     sectionId -> documentationRegistry.getDocumentationFor("gradle_daemon", sectionId)
                 ))
                 .orElse(new NonWatchingVirtualFileSystem(delegate));
-            listenerManager.addListener(new VirtualFileSystemBuildLifecycleListener(
-                watchingAwareVirtualFileSystem
-            ));
             listenerManager.addListener((BuildAddedListener) buildState ->
                 watchingAwareVirtualFileSystem.buildRootDirectoryAdded(buildState.getBuildRootDir())
             );

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.vfs.RoutingVirtualFileSystem
 import org.gradle.internal.vfs.VirtualFileSystem
-import org.gradle.internal.watch.vfs.WatchingAwareVirtualFileSystem
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -70,29 +69,5 @@ class VirtualFileSystemServicesTest extends Specification {
 
         where:
         watchFsEnabled << [true, false]
-    }
-
-    def "global virtual file system is informed about watching the file system being #watchFsEnabledString"() {
-        _ * startParameter.getSystemPropertiesArgs() >> [:]
-        _ * startParameter.getCurrentDir() >> new File("current/dir").absoluteFile
-        _ * gradle.getStartParameter() >> startParameter
-        _ * startParameter.isWatchFileSystem() >> watchFsEnabled
-        def virtualFileSystem = Mock(WatchingAwareVirtualFileSystem)
-
-        def buildLifecycleListener = new VirtualFileSystemBuildLifecycleListener(virtualFileSystem)
-
-        when:
-        buildLifecycleListener.afterStart(gradle)
-        then:
-        1 * virtualFileSystem.afterBuildStarted(watchFsEnabled)
-
-        when:
-        buildLifecycleListener.beforeComplete(gradle)
-        then:
-        1 * virtualFileSystem.beforeBuildFinished(watchFsEnabled)
-
-        where:
-        watchFsEnabled << [true, false]
-        watchFsEnabledString = watchFsEnabled ? "enabled" : "disabled"
     }
 }

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -57,9 +57,9 @@ class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec
         output.contains("projects evaluated")
         output.matches("""(?s).*
 BUILD SUCCESSFUL in [ \\dms]+
-1 actionable task: 1 executed
+1 actionable task: 1 executed.*
 failure is null: true
-.*""")
+\$""")
     }
 
     def "can observe failed build after completion of user logic and build outcome is reported"() {
@@ -82,15 +82,14 @@ failure is null: true
         then:
         outputContains("projects evaluated")
         output.matches("""(?s).*
-1 actionable task: 1 executed
+1 actionable task: 1 executed.*
 failure message: Execution failed for task ':t'.
-.*""")
+\$""")
 
         errorOutput.contains("projects evaluated")
         result.error.matches("""(?s)projects evaluated
 
-FAILURE: Build failed with an exception.
-.*
+FAILURE: Build failed with an exception\\..*
 BUILD FAILED in [ \\dms]+
 notified
 \$""")
@@ -123,9 +122,9 @@ notified
 
         then:
         output.matches("""(?s).*
-1 actionable task: 1 executed
+1 actionable task: 1 executed.*
 failure message: broken
-.*""")
+\$""")
     }
 
     def "can only register one listener"() {

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(project(":jvmServices"))
     implementation(project(":buildEvents"))
     implementation(project(":toolingApi"))
+    implementation(project(":fileWatching"))
 
     implementation(library("groovy")) // for 'ReleaseInfo.getVersion()'
     implementation(library("slf4j_api"))

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionStatisticsReporter;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
@@ -32,7 +33,6 @@ import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import java.util.List;
 
@@ -40,9 +40,9 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
     private final BuildActionRunner delegate;
     private final StyledTextOutputFactory styledTextOutputFactory;
 
-    public BuildOutcomeReportingBuildActionRunner(BuildActionRunner delegate, StyledTextOutputFactory styledTextOutputFactory) {
-        this.delegate = delegate;
+    public BuildOutcomeReportingBuildActionRunner(StyledTextOutputFactory styledTextOutputFactory, BuildActionRunner delegate) {
         this.styledTextOutputFactory = styledTextOutputFactory;
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
@@ -61,18 +61,18 @@ public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildA
     private final StyledTextOutput logger;
 
     public ContinuousBuildActionExecuter(
-        BuildActionExecuter<BuildActionParameters> delegate,
         FileSystemChangeWaiterFactory changeWaiterFactory,
         TaskInputsListeners inputsListeners,
         StyledTextOutputFactory styledTextOutputFactory,
-        ExecutorFactory executorFactory
+        ExecutorFactory executorFactory,
+        BuildActionExecuter<BuildActionParameters> delegate
     ) {
-        this.delegate = delegate;
         this.inputsListeners = inputsListeners;
         this.operatingSystem = OperatingSystem.current();
         this.executorFactory = executorFactory;
         this.changeWaiterFactory = changeWaiterFactory;
         this.logger = styledTextOutputFactory.create(ContinuousBuildActionExecuter.class, LogLevel.QUIET);
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -55,13 +55,13 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         }
     }
 
-    private void dropVirtualFileSystemIfRequested(StartParameterInternal startParameter, WatchingAwareVirtualFileSystem virtualFileSystem) {
+    private static void dropVirtualFileSystemIfRequested(StartParameterInternal startParameter, WatchingAwareVirtualFileSystem virtualFileSystem) {
         if (VirtualFileSystemServices.isDropVfs(startParameter)) {
             virtualFileSystem.invalidateAll();
         }
     }
 
-    private void logMessageForDeprecatedVfsRetentionProperty(StartParameterInternal startParameter) {
+    private static void logMessageForDeprecatedVfsRetentionProperty(StartParameterInternal startParameter) {
         if (VirtualFileSystemServices.isDeprecatedVfsRetentionPropertyPresent(startParameter)) {
             @SuppressWarnings("deprecation")
             String deprecatedVfsRetentionEnabledProperty = VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -14,27 +14,54 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.service.scopes;
+package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
-import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.invocation.BuildAction;
+import org.gradle.internal.invocation.BuildActionRunner;
+import org.gradle.internal.invocation.BuildController;
+import org.gradle.internal.service.scopes.VirtualFileSystemServices;
 import org.gradle.internal.watch.vfs.WatchingAwareVirtualFileSystem;
 import org.gradle.util.IncubationLogger;
 
-class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListener {
+public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
+    private final BuildActionRunner delegate;
 
-    private final WatchingAwareVirtualFileSystem virtualFileSystem;
-
-    public VirtualFileSystemBuildLifecycleListener(WatchingAwareVirtualFileSystem virtualFileSystem) {
-        this.virtualFileSystem = virtualFileSystem;
+    public FileSystemWatchingBuildActionRunner(BuildActionRunner delegate) {
+        this.delegate = delegate;
     }
 
     @Override
-    public void afterStart(GradleInternal gradle) {
+    public Result run(BuildAction action, BuildController buildController) {
+        GradleInternal gradle = buildController.getGradle();
         StartParameterInternal startParameter = (StartParameterInternal) gradle.getStartParameter();
+        WatchingAwareVirtualFileSystem virtualFileSystem = gradle.getServices().get(WatchingAwareVirtualFileSystem.class);
+
+        boolean watchFileSystem = startParameter.isWatchFileSystem();
+
+        logMessageForDeprecatedVfsRetentionProperty(startParameter);
+        if (watchFileSystem) {
+            IncubationLogger.incubatingFeatureUsed("Watching the file system");
+            dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
+        }
+        virtualFileSystem.afterBuildStarted(watchFileSystem);
+        try {
+            return delegate.run(action, buildController);
+        } finally {
+            virtualFileSystem.beforeBuildFinished(watchFileSystem);
+        }
+    }
+
+    private void dropVirtualFileSystemIfRequested(StartParameterInternal startParameter, WatchingAwareVirtualFileSystem virtualFileSystem) {
+        if (VirtualFileSystemServices.isDropVfs(startParameter)) {
+            virtualFileSystem.invalidateAll();
+        }
+    }
+
+    private void logMessageForDeprecatedVfsRetentionProperty(StartParameterInternal startParameter) {
         if (VirtualFileSystemServices.isDeprecatedVfsRetentionPropertyPresent(startParameter)) {
             @SuppressWarnings("deprecation")
             String deprecatedVfsRetentionEnabledProperty = VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY;
@@ -44,18 +71,5 @@ class VirtualFileSystemBuildLifecycleListener implements RootBuildLifecycleListe
                 .withUserManual("gradle_daemon")
                 .nagUser();
         }
-        boolean watchFileSystem = startParameter.isWatchFileSystem();
-        if (watchFileSystem) {
-            IncubationLogger.incubatingFeatureUsed("Watching the file system");
-            if (VirtualFileSystemServices.isDropVfs(startParameter)) {
-                virtualFileSystem.invalidateAll();
-            }
-        }
-        virtualFileSystem.afterBuildStarted(watchFileSystem);
-    }
-
-    @Override
-    public void beforeComplete(GradleInternal gradle) {
-        virtualFileSystem.beforeBuildFinished(((StartParameterInternal) gradle.getStartParameter()).isWatchFileSystem());
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -85,10 +85,11 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                 new InProcessBuildActionExecuter(
                 new RunAsBuildOperationBuildActionRunner(
                 new BuildCompletionNotifyingBuildActionRunner(
+                new FileSystemWatchingBuildActionRunner(
                 new ValidatingBuildActionRunner(
                 new BuildOutcomeReportingBuildActionRunner(styledTextOutputFactory,
                 new ChainingBuildActionRunner(buildActionRunners
-            ))))))))))))));
+            )))))))))))))));
             // @formatter:on
         }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -72,32 +72,24 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                           GradleUserHomeScopeServiceRegistry userHomeServiceRegistry,
                                           FileSystemChangeWaiterFactory fileSystemChangeWaiterFactory
         ) {
-            return new SetupLoggingActionExecuter(
-                new SessionFailureReportingActionExecuter(
-                    new StartParamsValidatingActionExecuter(
-                        new GradleThreadBuildActionExecuter(
-                            new SessionScopeBuildActionExecuter(
-                                new SubscribableBuildActionExecuter(
-                                    new ContinuousBuildActionExecuter(
-                                        new BuildTreeScopeBuildActionExecuter(
-                                            new InProcessBuildActionExecuter(
-                                                new RunAsBuildOperationBuildActionRunner(
-                                                    new BuildCompletionNotifyingBuildActionRunner(
-                                                        new ValidatingBuildActionRunner(
-                                                            new BuildOutcomeReportingBuildActionRunner(
-                                                                new ChainingBuildActionRunner(buildActionRunners),
-                                                                styledTextOutputFactory)))))),
-                                        fileSystemChangeWaiterFactory,
-                                        inputsListeners,
-                                        styledTextOutputFactory,
-                                        executorFactory),
-                                    listenerManager,
-                                    buildOperationListenerManager,
-                                    registrations),
-                                userHomeServiceRegistry))),
-                    styledTextOutputFactory,
-                    Time.clock()),
-                loggingManager);
+            // @formatter:off
+            return
+                new SetupLoggingActionExecuter(loggingManager,
+                new SessionFailureReportingActionExecuter(styledTextOutputFactory, Time.clock(),
+                new StartParamsValidatingActionExecuter(
+                new GradleThreadBuildActionExecuter(
+                new SessionScopeBuildActionExecuter(userHomeServiceRegistry,
+                new SubscribableBuildActionExecuter(listenerManager, buildOperationListenerManager, registrations,
+                new ContinuousBuildActionExecuter(fileSystemChangeWaiterFactory, inputsListeners, styledTextOutputFactory, executorFactory,
+                new BuildTreeScopeBuildActionExecuter(
+                new InProcessBuildActionExecuter(
+                new RunAsBuildOperationBuildActionRunner(
+                new BuildCompletionNotifyingBuildActionRunner(
+                new ValidatingBuildActionRunner(
+                new BuildOutcomeReportingBuildActionRunner(styledTextOutputFactory,
+                new ChainingBuildActionRunner(buildActionRunners
+            ))))))))))))));
+            // @formatter:on
         }
 
         FileSystemChangeWaiterFactory createFileSystemChangeWaiterFactory(FileWatcherFactory fileWatcherFactory) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
@@ -44,10 +44,10 @@ public class SessionFailureReportingActionExecuter implements BuildActionExecute
     private final StyledTextOutputFactory styledTextOutputFactory;
     private final Clock clock;
 
-    public SessionFailureReportingActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, StyledTextOutputFactory styledTextOutputFactory, Clock clock) {
-        this.delegate = delegate;
+    public SessionFailureReportingActionExecuter(StyledTextOutputFactory styledTextOutputFactory, Clock clock, BuildActionExecuter<BuildActionParameters> delegate) {
         this.styledTextOutputFactory = styledTextOutputFactory;
         this.clock = clock;
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionScopeBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionScopeBuildActionExecuter.java
@@ -39,9 +39,9 @@ public class SessionScopeBuildActionExecuter implements BuildActionExecuter<Buil
     private final BuildActionExecuter<BuildActionParameters> delegate;
     private final GradleUserHomeScopeServiceRegistry userHomeServiceRegistry;
 
-    public SessionScopeBuildActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, GradleUserHomeScopeServiceRegistry userHomeServiceRegistry) {
-        this.delegate = delegate;
+    public SessionScopeBuildActionExecuter(GradleUserHomeScopeServiceRegistry userHomeServiceRegistry, BuildActionExecuter<BuildActionParameters> delegate) {
         this.userHomeServiceRegistry = userHomeServiceRegistry;
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -33,9 +33,9 @@ public class SetupLoggingActionExecuter implements BuildExecuter {
     private final BuildActionExecuter<BuildActionParameters> delegate;
     private final LoggingManagerInternal loggingManager;
 
-    public SetupLoggingActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, LoggingManagerInternal loggingManager) {
-        this.delegate = delegate;
+    public SetupLoggingActionExecuter(LoggingManagerInternal loggingManager, BuildActionExecuter<BuildActionParameters> delegate) {
         this.loggingManager = loggingManager;
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuter.java
@@ -18,9 +18,9 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.initialization.BuildRequestContext;
-import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.build.event.BuildEventSubscriptions;
 import org.gradle.internal.build.event.BuildEventListenerFactory;
+import org.gradle.internal.build.event.BuildEventSubscriptions;
+import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
@@ -42,11 +42,11 @@ public class SubscribableBuildActionExecuter implements BuildActionExecuter<Buil
     private final List<Object> listeners = new ArrayList<Object>();
     private final List<? extends BuildEventListenerFactory> registrations;
 
-    public SubscribableBuildActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, ListenerManager listenerManager, BuildOperationListenerManager buildOperationListenerManager, List<? extends BuildEventListenerFactory> registrations) {
-        this.delegate = delegate;
+    public SubscribableBuildActionExecuter(ListenerManager listenerManager, BuildOperationListenerManager buildOperationListenerManager, List<? extends BuildEventListenerFactory> registrations, BuildActionExecuter<BuildActionParameters> delegate) {
         this.listenerManager = listenerManager;
         this.buildOperationListenerManager = buildOperationListenerManager;
         this.registrations = registrations;
+        this.delegate = delegate;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuter.java
@@ -39,7 +39,7 @@ public class SubscribableBuildActionExecuter implements BuildActionExecuter<Buil
     private final BuildActionExecuter<BuildActionParameters> delegate;
     private final ListenerManager listenerManager;
     private final BuildOperationListenerManager buildOperationListenerManager;
-    private final List<Object> listeners = new ArrayList<Object>();
+    private final List<Object> listeners = new ArrayList<>();
     private final List<? extends BuildEventListenerFactory> registrations;
 
     public SubscribableBuildActionExecuter(ListenerManager listenerManager, BuildOperationListenerManager buildOperationListenerManager, List<? extends BuildEventListenerFactory> registrations, BuildActionExecuter<BuildActionParameters> delegate) {

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
@@ -160,6 +160,6 @@ class ContinuousBuildActionExecuterTest extends ConcurrentSpec {
     }
 
     private ContinuousBuildActionExecuter executer() {
-        new ContinuousBuildActionExecuter(delegate, waiterFactory, inputsListeners, new TestStyledTextOutputFactory(), executorFactory)
+        new ContinuousBuildActionExecuter(waiterFactory, inputsListeners, new TestStyledTextOutputFactory(), executorFactory, delegate)
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.StartParameterInternal
+import org.gradle.internal.invocation.BuildAction
+import org.gradle.internal.invocation.BuildActionRunner
+import org.gradle.internal.invocation.BuildController
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.watch.vfs.WatchingAwareVirtualFileSystem
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class FileSystemWatchingBuildActionRunnerTest extends Specification {
+
+    def virtualFileSystem = Mock(WatchingAwareVirtualFileSystem)
+    def startParameter = Mock(StartParameterInternal)
+    def buildController = Stub(BuildController) {
+        getGradle() >> Stub(GradleInternal) {
+            getStartParameter() >> startParameter
+            getServices() >> Stub(ServiceRegistry) {
+                get(WatchingAwareVirtualFileSystem) >> virtualFileSystem
+            }
+        }
+    }
+    def delegate = Mock(BuildActionRunner)
+    def buildAction = Mock(BuildAction)
+
+    def "watching virtual file system is informed about watching the file system being #watchFsEnabledString"() {
+        _ * startParameter.getSystemPropertiesArgs() >> [:]
+        _ * startParameter.isWatchFileSystem() >> watchFsEnabled
+
+        def runner = new FileSystemWatchingBuildActionRunner(delegate)
+
+        when:
+        runner.run(buildAction, buildController)
+        then:
+        1 * virtualFileSystem.afterBuildStarted(watchFsEnabled)
+
+        then:
+        1 * delegate.run(buildAction, buildController)
+
+        then:
+        1 * virtualFileSystem.beforeBuildFinished(watchFsEnabled)
+
+        where:
+        watchFsEnabled << [true, false]
+        watchFsEnabledString = watchFsEnabled ? "enabled" : "disabled"
+    }
+}

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuterSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuterSpec.groovy
@@ -18,9 +18,9 @@ package org.gradle.tooling.internal.provider
 
 import org.gradle.initialization.BuildEventConsumer
 import org.gradle.initialization.BuildRequestContext
-import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.build.event.BuildEventSubscriptions
 import org.gradle.internal.build.event.BuildEventListenerFactory
+import org.gradle.internal.build.event.BuildEventSubscriptions
+import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationListener
 import org.gradle.internal.operations.BuildOperationListenerManager
 import org.gradle.internal.service.ServiceRegistry
@@ -52,7 +52,7 @@ class SubscribableBuildActionExecuterSpec extends Specification {
             createListeners(_, consumer) >> [listener1, listener2]
         }
 
-        def runner = new SubscribableBuildActionExecuter(delegate, listenerManager, buildOperationListenerManager, [registration])
+        def runner = new SubscribableBuildActionExecuter(listenerManager, buildOperationListenerManager, [registration], delegate)
 
         when:
         runner.execute(buildAction, buildRequestContext, buildActionParameters, serviceRegistry)


### PR DESCRIPTION
Instead of using a  `RootBuildLifecycleListener`.

This fixes two problems:
- Show the messages in build scans. 
- Consistently enable/disable file system watching during  a single build. #13309

Fixes #13309.
Fixes gradle/gradle-private#3131.