### PR TITLE
Disable file system watching when native services are not available

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/UnavailableFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/UnavailableFileWatcherRegistryFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.registry.impl;
+
+import org.gradle.internal.watch.registry.FileWatcherRegistry;
+import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
+
+public class UnavailableFileWatcherRegistryFactory implements FileWatcherRegistryFactory {
+    @Override
+    public FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler) {
+        throw new UnsupportedOperationException("File watching is not available for this operating system");
+    }
+}

--- a/subprojects/native/native.gradle.kts
+++ b/subprojects/native/native.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(project(":files"))
 
     implementation(project(":baseServices"))
+    implementation(project(":fileWatching"))
 
     implementation(library("nativePlatform"))
     implementation(library("slf4j_api"))


### PR DESCRIPTION
I tried to add an integration test, though I didn't manage to disable native services on the daemon :(