### PR TITLE
Disable file system watching when native integration is disabled

### DIFF
--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/NativeCapabilities.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/NativeCapabilities.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration;
+
+public interface NativeCapabilities {
+    boolean isNativeIntegrationAvailable();
+}

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -31,6 +31,7 @@ import org.gradle.api.JavaVersion;
 import org.gradle.internal.Cast;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.nativeintegration.NativeCapabilities;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.console.ConsoleDetector;
 import org.gradle.internal.nativeintegration.console.FallbackConsoleDetector;
@@ -288,6 +289,15 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
         }
 
         return new FallbackFileMetadataAccessor();
+    }
+
+    protected NativeCapabilities createNativeCapabilities() {
+        return new NativeCapabilities() {
+            @Override
+            public boolean isNativeIntegrationAvailable() {
+                return useNativeIntegrations;
+            }
+        };
     }
 
     private <T> T notAvailable(Class<T> type) {


### PR DESCRIPTION
I tried to add an integration test, though I didn't manage to disable native services on the daemon :(