### PR TITLE
Revert TestNG fixes for the configuration cache

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -90,6 +90,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'testng', '--dsl', scriptDsl.id)
@@ -134,6 +135,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*TestNG.*")
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', testFramework.id, '--package', 'my.app', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -89,6 +89,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'testng', '--dsl', scriptDsl.id)
@@ -137,6 +138,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*TestNG.*")
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', testFramework.id, '--package', 'my.lib', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -148,6 +148,7 @@ Root project 'webinar-parent'
 """
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "singleModule"() {
         when:
         run 'init'
@@ -183,6 +184,7 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         assert text.contains(publishingBlock)
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "singleModule with explicit project dir"() {
         setup:
         resources.maybeCopy('MavenConversionIntegrationTest/singleModule')
@@ -203,6 +205,7 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         failure.assertHasCause("There were failing tests.")
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def 'sourcesJar'() {
         when: 'build is initialized'
         run 'init'
@@ -244,6 +247,7 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         file('build/libs/util-2.5-tests.jar').exists()
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def 'javadocJar'() {
         when: 'build is initialized'
         run 'init'

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.console.jvm
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.ConcurrentTestUtil
@@ -46,6 +47,11 @@ abstract class AbstractConsoleJvmTestWorkerFunctionalTest extends AbstractIntegr
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(
+        because = "test-ng",
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "ConsoleTestNGTestWorkerFunctionalTest"
+    )
     def "shows test class execution #description test class name in work-in-progress area of console for single project build"() {
         given:
         buildFile << testableJavaProject(testDependency(), MAX_WORKERS)
@@ -74,6 +80,11 @@ abstract class AbstractConsoleJvmTestWorkerFunctionalTest extends AbstractIntegr
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(
+        because = "test-ng",
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "ConsoleTestNGTestWorkerFunctionalTest"
+    )
     def "shows test class execution #description test class name in work-in-progress area of console for multi-project build"() {
         given:
         settingsFile << "include 'project1', 'project2'"

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleTestNGUnsupportedTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleTestNGUnsupportedTestWorkerFunctionalTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.console.jvm
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -45,6 +46,7 @@ class ConsoleTestNGUnsupportedTestWorkerFunctionalTest extends AbstractIntegrati
         server.start()
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng", skip = ToBeFixedForInstantExecution.Skip.FAILS_TO_CLEANUP)
     def "omits parallel test execution if TestNG version does not emit class listener events"() {
         given:
         buildFile << testableJavaProject(TESTNG_DEPENDENCY, MAX_WORKERS)

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestExecutionResult
 import org.gradle.play.integtest.fixtures.PlayMultiVersionApplicationIntegrationTest
+import spock.lang.Ignore
 
 abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplicationIntegrationTest {
 
@@ -56,6 +57,7 @@ abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplic
                 ":testPlayBinary")
     }
 
+    @Ignore("convention mapping / software model combination causing troubles")
     def "can run play app tests if java plugin is applied"() {
         when:
         buildFile << """

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestExecutionResult
 import org.gradle.play.integtest.fixtures.PlayMultiVersionApplicationIntegrationTest
-import spock.lang.Ignore
 
 abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplicationIntegrationTest {
 
@@ -57,7 +56,6 @@ abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplic
                 ":testPlayBinary")
     }
 
-    @Ignore("convention mapping / software model combination causing troubles")
     def "can run play app tests if java plugin is applied"() {
         when:
         buildFile << """

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
@@ -86,6 +86,8 @@ public class PlayTestPlugin extends RuleSource {
             tasks.create(testTaskName, Test.class, test -> {
                 test.setDescription("Runs " + WordUtils.uncapitalize(binary.getDisplayName() + "."));
 
+                test.setClasspath(testClassesDirs.plus(testCompileClasspath));
+
                 test.setTestClassesDirs(testClassesDirs);
                 test.setBinResultsDir(new File(binaryBuildDir, "results/" + testTaskName + "/bin"));
                 test.getReports().getJunitXml().setDestination(new File(binaryBuildDir, "reports/test/xml"));
@@ -93,7 +95,6 @@ public class PlayTestPlugin extends RuleSource {
                 test.dependsOn(testCompileTaskName);
                 test.setWorkingDir(projectIdentifier.getProjectDir());
             });
-            tasks.withType(Test.class).named(testTaskName, test -> test.setClasspath(testClassesDirs.plus(testCompileClasspath)));
             binary.getTasks().add(tasks.get(testTaskName));
         }
     }

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
@@ -70,8 +70,6 @@ class PlayTestPluginTest extends Specification {
         then:
         1 * taskModelMap.create("compileSomeBinaryTests", PlatformScalaCompile, _)
         1 * taskModelMap.create("testSomeBinary", Test, _)
-        1 * taskModelMap.withType(Test) >> taskModelMap
-        1 * taskModelMap.named("testSomeBinary", _)
         0 * taskModelMap.create(_)
         0 * taskModelMap.create(_, _, _)
         1 * taskModelMap.get('testSomeBinary')

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -415,7 +415,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     private void configureTest(Project project, JavaPluginExtension javaPluginExtension, JavaPluginConvention pluginConvention) {
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.getConventionMapping().map("testClassesDirs", () -> sourceSetOf(pluginConvention, SourceSet.TEST_SOURCE_SET_NAME).getOutput().getClassesDirs());
-            test.setClasspath(sourceSetOf(pluginConvention, SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath());
+            test.getConventionMapping().map("classpath", () -> sourceSetOf(pluginConvention, SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath());
             test.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -440,7 +440,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         then:
         task instanceof org.gradle.api.tasks.testing.Test
         task dependsOn(JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME)
-        task.classpath.files == project.sourceSets.test.runtimeClasspath.files
+        task.classpath == project.sourceSets.test.runtimeClasspath
         task.testClassesDirs.contains(project.sourceSets.test.java.destinationDirectory.get().asFile)
         task.workingDir == project.projectDir
     }
@@ -453,7 +453,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task('customTest', type: org.gradle.api.tasks.testing.Test.class)
 
         then:
-        task.classpath.files == project.sourceSets.test.runtimeClasspath.files
+        task.classpath == project.sourceSets.test.runtimeClasspath
         task.testClassesDirs.contains(project.sourceSets.test.java.destinationDirectory.get().asFile)
         task.workingDir == project.projectDir
         task.reports.junitXml.destination == new File(project.testResultsDir, 'customTest')

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -86,7 +86,7 @@ class TestTest extends AbstractConventionTaskTest {
         expect:
         test.getTestFramework() instanceof JUnitTestFramework
         test.getTestClassesDirs() == null
-        test.getClasspath().files.isEmpty()
+        test.getClasspath() == null
         test.getReports().getJunitXml().getDestination() == null
         test.getReports().getHtml().getDestination() == null
         test.getIncludes().isEmpty()

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.samples.java
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
@@ -139,6 +140,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng-groups/groovy")
+    @ToBeFixedForInstantExecution
     def "can filter tests by TestNG group"() {
         given:
         executer.inDirectory(sample.dir)
@@ -216,6 +218,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng-preserveorder/groovy")
+    @ToBeFixedForInstantExecution
     def "can use the preserveOrder option with TestNG tests"() {
         given:
         executer.inDirectory(sample.dir)
@@ -239,6 +242,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng-groupbyinstances/groovy")
+    @ToBeFixedForInstantExecution
     def "can use the groupByInstances option with TestNG tests"() {
         given:
         executer.inDirectory(sample.dir)

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
@@ -50,6 +50,7 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertJunit(rootTestOp, operations)
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "emitsBuildOperationsForTestNgTests"() {
         given:
         executer.withRepositoryMirrors()
@@ -105,7 +106,7 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             task testng {
                 dependsOn gradle.includedBuild('testng').task(':test')
             }
-
+            
             task junit {
                 dependsOn gradle.includedBuild('junit').task(':test')
             }

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -44,7 +44,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         return testSuite
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can listen for test results"() {
         given:
         createPassingFailingTest()
@@ -102,7 +102,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         succeeds "verifyTestResultConventions"
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "test results show passing and failing tests"() {
         given:
         createPassingFailingTest()
@@ -122,7 +122,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "test results capture test output"() {
         Assume.assumeTrue(capturesTestOutput())
         given:
@@ -141,7 +141,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeTest').assertStderr(CoreMatchers.containsString("some error output"))
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "failing tests cause report url to be printed"() {
         given:
         createPassingFailingTest()
@@ -153,7 +153,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("There were failing tests. See the report at:")
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "lack of tests produce an empty report"() {
         given:
         createEmptyProject()
@@ -165,7 +165,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.assertNoTestClassesExecuted()
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "adding and removing tests remove old tests from reports"() {
         given:
         createPassingFailingTest()
@@ -177,7 +177,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.assertTestClassesExecuted('SomeTest', 'NewTest')
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "honors test case filter from --tests flag"() {
         given:
         createPassingFailingTest()
@@ -190,7 +190,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "honors test suite filter from --tests flag"() {
         given:
         createPassingFailingTest()
@@ -203,7 +203,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "reports when no matching methods found"() {
         given:
         createPassingFailingTest()
@@ -222,7 +222,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("No tests found for given includes: [${testSuite('SomeTest')}.missingMethod](filter.includeTestsMatching)")
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "task is out of date when --tests argument changes"() {
         given:
         createPassingFailingTest()
@@ -251,7 +251,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can select multiple tests from command line #scenario"() {
         given:
         createPassingFailingTest()
@@ -285,7 +285,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "XCTestTestFrameworkIntegrationTest")
+    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can deduplicate test filters when #scenario"() {
         given:
         createPassingFailingTest()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
@@ -65,6 +66,7 @@ class IncrementalTestIntegrationTest extends MultiVersionIntegrationSpec {
         succeeds('test').assertTasksNotSkipped()
     }
 
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def executesTestsWhenTestFrameworkChanges() {
         given:
         succeeds('test')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.testing
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
@@ -175,6 +176,7 @@ test.testLogging {
     }
 
     @Test
+    @ToBeFixedForInstantExecution(because = "test-ng")
     def "shows standard stream also for testNG"() {
         given:
         ignoreWhenJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing
 import org.apache.commons.lang.RandomStringUtils
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.gradle.util.Requires
@@ -185,6 +186,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2313")
     @Unroll
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*useTestNG.*")
     def "can clean test after extracting class file with #framework"() {
         when:
         ignoreWhenJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing.fixture
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.ConcurrentTestUtil
@@ -41,6 +42,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "all tests run with #description"() {
         given:
         buildFile.text = generator.initBuildFile()
@@ -68,6 +73,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "stop test execution with #description"() {
         given:
         buildFile.text = generator.initBuildFile()
@@ -94,6 +103,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "ensure fail fast with forkEvery #forkEvery, maxWorkers #maxWorkers, omittedTests #testOmitted"() {
         given:
         buildFile.text = generator.initBuildFile(maxWorkers, forkEvery)
@@ -125,6 +138,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
         2         | 2          | 5
     }
 
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "fail fast console output shows failure"() {
         given:
         buildFile.text = generator.initBuildFile()
@@ -144,6 +161,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
     }
 
     @IgnoreIf({ GradleContextualExecuter.isParallel() })
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "fail fast console output shows test class in work-in-progress"() {
         given:
         executer.withConsole(ConsoleOutput.Rich).withArguments('--parallel', "--max-workers=$DEFAULT_MAX_WORKERS")
@@ -166,6 +187,10 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
         gradleHandle.waitForFailure()
     }
 
+    @ToBeFixedForInstantExecution(
+        skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT,
+        bottomSpecs = "TestNGFailFastIntegrationTest"
+    )
     def "fail fast works with --tests filter"() {
         given:
         buildFile.text = generator.initBuildFile()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.testing.fixture
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -35,6 +36,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         """
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes single method from a test class"() {
         buildFile << """
             test {
@@ -72,6 +74,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         pattern << ['FooTest.pass', 'org.gradle.FooTest.pass']
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes multiple methods from a test class"() {
         buildFile << """
             test {
@@ -106,6 +109,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         result.testClass("FooTest").assertTestCount(2, 0, 0)
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes multiple methods from different classes"() {
         buildFile << """
             test {
@@ -147,6 +151,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "reports when no matching methods found"() {
         file("src/test/java/org/gradle/FooTest.java") << """
             package org.gradle;
@@ -170,6 +175,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         pattern << ['FooTest.missingMethod', 'org.gradle.FooTest.missingMethod']
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "adds import/export rules to report about no matching methods found"() {
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -188,6 +194,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         then: failure.assertHasCause("No tests found for given includes: [FooTest*](include rules) [NotImportant*](exclude rules) [FooTest.missingMethod](--tests filter)")
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "does not report when matching method has been filtered before via include/exclude"() { //current behavior, not necessarily desired
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -201,6 +208,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         succeeds("test", "--tests", 'FooTest.missingMethod')
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "task is out of date when --tests argument changes"() {
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -224,6 +232,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "can select multiple tests from commandline #scenario"() {
         given:
         file("src/test/java/Foo1Test.java") << """import $imports;
@@ -279,6 +288,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
 
     @Issue("https://github.com/gradle/gradle/issues/1571")
     @Unroll
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "option --tests filter in combined with #includeType"() {
         given:
         buildFile << """
@@ -304,6 +314,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         "filter.includePatterns"      | "filter { includePatterns = ['*ATest*', '*CTest*'] }"
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "invoking testNameIncludePatterns does not influence include/exclude filter"() {
         given:
         buildFile << """
@@ -324,6 +335,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         !output.contains('CTest!')
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "invoking filter.includePatterns not disable include/exclude filter"() {
         given:
         buildFile << """
@@ -344,6 +356,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         !output.contains('CTest!')
     }
 
+    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "can exclude tests"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.UsesSample
@@ -35,6 +36,7 @@ class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     @UsesSample('testing/testng-suitexmlbuilder')
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FAILS_TO_CLEANUP)
      void suiteXmlBuilder() {
         def testDir = sample.dir.file('groovy')
         executer.inDirectory(testDir).withTasks('clean', 'test').run()
@@ -47,6 +49,7 @@ class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     @UsesSample('testing/testng-java-passing')
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FAILS_TO_CLEANUP)
     void javaPassing() {
         def testDir = sample.dir.file('groovy')
         executer.inDirectory(testDir).withTasks('clean', 'test').run()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestMethodDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor
 import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER
@@ -40,50 +40,51 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
         TestNGCoverage.enableTestNG(buildFile, version)
 
         buildFile << """
-
+            import org.gradle.api.internal.tasks.testing.TestCompleteEvent
+            import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+            import org.gradle.api.internal.tasks.testing.TestStartEvent
+            import org.gradle.api.internal.tasks.testing.results.TestListenerInternal
+            import org.gradle.api.tasks.testing.TestOutputEvent
+            import org.gradle.api.tasks.testing.TestResult
+    
             test {
                 useTestNG()
-                addTestListener(new TestListener() {
-
-                    void beforeSuite(TestDescriptor d) {
-                        printEventInformation('$STARTED', d)
-                    }
-
-                    void afterSuite(TestDescriptor d, TestResult result) {
-                        printEventInformation('$FINISHED', d)
-                    }
-
-                    void beforeTest(TestDescriptor d) {
-                        printEventInformation('$STARTED', d)
-                    }
-
-                    void afterTest(TestDescriptor d, TestResult result) {
-                        printEventInformation('$FINISHED', d)
-                    }
-
-                    private void printEventInformation(String eventTypeDescription, TestDescriptor d) {
-                        def name = d.name
-                        def descriptor = d;
-                        while (descriptor.parent != null) {
-                            name = "\${descriptor.parent.name} > \$name"
-                            descriptor = descriptor.parent
-                        }
-                        println "\$eventTypeDescription event type \${d.descriptor.class.name} for \${name}"
-                    }
-                })
             }
+    
+            gradle.addListener(new TestListenerInternal() {
+                void started(TestDescriptorInternal d, TestStartEvent s) {
+                    printEventInformation('$STARTED', d)
+                }
+    
+                void completed(TestDescriptorInternal d, TestResult result, TestCompleteEvent cE) {
+                    printEventInformation('$FINISHED', d)
+                }
+    
+                private void printEventInformation(String eventTypeDescription, TestDescriptorInternal d) {
+                    def name = d.name
+                    def descriptor = d;
+                    while (descriptor.parent != null) {
+                        name = "\${descriptor.parent.name} > \$name"
+                        descriptor = descriptor.parent
+                    }
+                    println "\$eventTypeDescription event type \${d.descriptor.class.name} for \${name}"
+                }
+    
+                void output(TestDescriptorInternal descriptor, TestOutputEvent output) {
+                }
+            })
         """
     }
 
+    @ToBeFixedForInstantExecution
     def "test class events references correct suite as parent"() {
         given:
         def testNgSuite = file("src/test/resources/testng.xml")
 
         buildFile << """
             test {
-                def suiteFile = file("${(normaliseFileSeparators(testNgSuite.absolutePath))}")
                 useTestNG {
-                    suites suiteFile
+                    suites file("${(normaliseFileSeparators(testNgSuite.absolutePath))}")
                 }
             }
         """
@@ -137,7 +138,7 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
         containsEvent(FINISHED, DefaultTestSuiteDescriptor, 'TestSuite > FullTest')
     }
 
-    @ToBeFixedForInstantExecution(because = "build failed with multiple exceptions")
+    @ToBeFixedForInstantExecution
     def "synthesized events for broken configuration methods reference test class descriptors"() {
         given:
         file("src/test/java/org/company/TestWithBrokenSetupMethod.java") << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 // can make assumptions about order in which test methods of TestNGTest get executed
 // because the methods are chained with 'methodDependsOn'
@@ -80,6 +81,7 @@ class TestNGConsoleLoggingIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
+    @ToBeFixedForInstantExecution
     def "defaultLifecycleLogging"() {
         when:
         fails "test"
@@ -91,6 +93,7 @@ Gradle test > org.gradle.TestNGTest.badTest FAILED
         """)
     }
 
+    @ToBeFixedForInstantExecution
     def customQuietLogging() {
         when:
         executer.withStackTraceChecksDisabled()
@@ -112,6 +115,7 @@ Gradle suite FAILED
         """)
     }
 
+    @ToBeFixedForInstantExecution
     def "standardOutputLogging"() {
         given:
         buildFile.text = """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.AbstractJvmFailFastIntegrationSpec
 import org.hamcrest.CoreMatchers
 import spock.lang.Unroll
@@ -42,6 +43,7 @@ class TestNGFailFastIntegrationTest extends AbstractJvmFailFastIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.LONG_TIMEOUT)
     def "parallel #parallel execution with #threadCount threads, #maxWorkers workers fails fast"() {
         given:
         buildFile.text = generator.initBuildFile(maxWorkers)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestClassExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.TestResources
@@ -38,6 +39,7 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         """
     }
 
+    @ToBeFixedForInstantExecution
     def "skips tests after a config method failure by default"() {
         when:
         usingTestNG(NEWEST)
@@ -50,6 +52,7 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         testResults.assertTestSkipped("someTest")
     }
 
+    @ToBeFixedForInstantExecution
     def "can be configured to continue executing tests after a config method failure"() {
         when:
         usingTestNG(NEWEST)
@@ -67,6 +70,7 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         testResults.assertTestPassed("someTest")
     }
 
+    @ToBeFixedForInstantExecution
     def "informative error is shown when trying to use config failure policy and a version that does not support it"() {
         when:
         usingTestNG("5.12.1")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -18,6 +18,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.AbstractTestFilteringIntegrationTest
 import org.gradle.testing.fixture.TestNGCoverage
@@ -74,6 +75,7 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
     }
 
     @Issue("GRADLE-3112")
+    @ToBeFixedForInstantExecution
     def "suites can be filtered from the command-line"() {
         given:
         theUsualFiles()
@@ -92,6 +94,7 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
     }
 
     @Issue("GRADLE-3112")
+    @ToBeFixedForInstantExecution
     def "suites can be filtered from the build file"() {
         given:
         theUsualFiles()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -23,6 +24,7 @@ import org.gradle.testing.fixture.TestNGCoverage
 @TargetCoverage({TestNGCoverage.GROUP_BY_INSTANCES})
 public class TestNGGroupByInstancesIntegrationTest extends MultiVersionIntegrationSpec {
 
+    @ToBeFixedForInstantExecution
     def "run tests using groupByInstances"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 public class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
+    @ToBeFixedForInstantExecution
     def "run tests using TestNG version not supporting groupByInstances"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -34,6 +35,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         TestNGCoverage.enableTestNG(buildFile, version)
     }
 
+    @ToBeFixedForInstantExecution
     def "executes tests in correct environment"() {
         given:
         buildFile << """
@@ -45,15 +47,15 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         """.stripIndent()
         file('src/test/java/org/gradle/OkTest.java') << '''
             package org.gradle;
-
+            
             import static org.testng.Assert.*;
-
+            
             public class OkTest {
                 @org.testng.annotations.Test
                 public void ok() throws Exception {
                     // check working dir
                     assertEquals(System.getProperty("testDir"), System.getProperty("user.dir"));
-
+            
                     // check Gradle classes not visible
                     try {
                         getClass().getClassLoader().loadClass("org.gradle.api.Project");
@@ -61,16 +63,16 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
                     } catch (ClassNotFoundException e) {
                         // Expected
                     }
-
+            
                     // check context classloader
                     assertSame(getClass().getClassLoader(), Thread.currentThread().getContextClassLoader());
-
+            
                     // check sys properties
                     assertEquals("value", System.getProperty("testSysProperty"));
-
+            
                     // check env vars
                     assertEquals("value", System.getenv("TEST_ENV_VAR"));
-
+            
                     // check other environmental stuff
                     assertEquals("Test worker", Thread.currentThread().getName());
                     assertNull(System.getSecurityManager());
@@ -85,13 +87,14 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         new DefaultTestExecutionResult(testDirectory).testClass('org.gradle.OkTest').assertTestPassed('ok')
     }
 
+    @ToBeFixedForInstantExecution
     def "can listen for test results"() {
         given:
         buildFile << """
             test {
                 ignoreFailures = true
             }
-
+            
             ${testListener()}
         """.stripIndent()
         file('src/test/java/AppException.java') << 'public class AppException extends Exception {}'
@@ -99,13 +102,13 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             public class SomeTest {
                 @org.testng.annotations.Test
                 public void pass() {}
-
+            
                 @org.testng.annotations.Test
                 public void fail() { assert false; }
-
+            
                 @org.testng.annotations.Test
                 public void knownError() { throw new RuntimeException("message"); }
-
+            
                 @org.testng.annotations.Test
                 public void unknownError() throws AppException { throw new AppException(); }
             }
@@ -134,12 +137,13 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-1532")
+    @ToBeFixedForInstantExecution
     def "supports thread pool size"() {
         given:
         file('src/test/java/SomeTest.java') << '''
             import org.testng.Assert;
             import org.testng.annotations.Test;
-
+            
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(true); }
@@ -150,12 +154,13 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         succeeds 'test'
     }
 
+    @ToBeFixedForInstantExecution
     def "supports test groups"() {
         buildFile << """
             ext {
                 ngIncluded = "database"
                 ngExcluded = "slow"
-            }
+            }            
             test {
                 useTestNG {
                     includeGroups ngIncluded
@@ -166,14 +171,14 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/org/gradle/groups/SomeTest.java') << '''
             package org.gradle.groups;
             import org.testng.annotations.Test;
-
+            
             public class SomeTest {
                 @Test(groups = "web")
                 public void webTest() {}
-
+            
                 @Test(groups = "database")
                 public void databaseTest() {}
-
+            
                 @Test(groups = {"database", "slow"})
                 public void slowDatabaseTest() {}
             }
@@ -188,13 +193,14 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         result.testClass('org.gradle.groups.SomeTest').assertTestsExecuted("databaseTest")
     }
 
+    @ToBeFixedForInstantExecution
     def "supports test factory"() {
         given:
         file('src/test/java/org/gradle/factory/FactoryTest.java') << '''
             package org.gradle.factory;
             import org.testng.annotations.Test;
-
-            public class FactoryTest {
+            
+            public class FactoryTest {            
                 private final String name;
                 public FactoryTest(String name) { this.name = name; }
 
@@ -205,7 +211,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/org/gradle/factory/TestNGFactory.java') << '''
             package org.gradle.factory;
             import org.testng.annotations.Factory;
-
+            
             public class TestNGFactory {
                 @Factory
                 public Object[] factory() {
@@ -233,7 +239,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/SomeTest.java') << """
             import org.testng.Assert;
             import org.testng.annotations.Test;
-
+            
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(true); }
@@ -247,7 +253,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/SomeTest.java') << """
             import org.testng.Assert;
             import org.testng.annotations.Test;
-
+            
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(false); }
@@ -261,6 +267,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         result.assertTestsFailed()
     }
 
+    @ToBeFixedForInstantExecution
     def "tries to execute unparseable test classes"() {
         given:
         testDirectory.file('build/classes/java/test/com/example/Foo.class').text = "invalid class file"
@@ -277,25 +284,26 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/7878")
+    @ToBeFixedForInstantExecution
     def "can concurrently execute the same test class multiple times"() {
         given:
         file('src/test/java/TestNG7878.java') << """
             import org.testng.annotations.Factory;
             import org.testng.annotations.Test;
             import org.testng.Assert;
-
+            
             public class TestNG7878 {
                 @Factory
                 public static Object[] createTests() {
-                    return new Object[]{
-                            new TestNG7878(),
-                            new TestNG7878()
+                    return new Object[]{ 
+                            new TestNG7878(), 
+                            new TestNG7878() 
                     };
                 }
-
+            
                 @Test
                 public void runFirst() {}
-
+                
                 @Test(dependsOnMethods = "runFirst")
                 public void testGet2() {
                     Assert.assertEquals(true, true);
@@ -316,7 +324,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         return '''
             def listener = new TestListenerImpl()
             test {
-                addTestListener(listener)
+                addTestListener(listener)                
             }
             class TestListenerImpl implements TestListener {
                 void beforeSuite(TestDescriptor suite) { println "START [$suite] [$suite.name]" }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGJdkNavigationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGJdkNavigationIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
 import spock.lang.Issue
@@ -27,6 +28,7 @@ class TestNGJdkNavigationIntegrationTest extends AbstractSampleIntegrationTest {
     @Rule
     final TestResources resources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForInstantExecution
     def shouldNotNavigateToJdkClasses() {
         when:
         succeeds('test')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
@@ -80,6 +81,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
         """
     }
 
+    @ToBeFixedForInstantExecution
     def "attaches events to correct test descriptors of a suite"() {
         buildFile << "test.useTestNG { suites 'suite.xml' }"
 
@@ -115,6 +117,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
         assertTestClassExecutionResultReport(classReport)
     }
 
+    @ToBeFixedForInstantExecution
     def "attaches output events to correct test descriptors"() {
         when: succeeds "test"
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -18,6 +18,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -63,6 +64,7 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-3190")
+    @ToBeFixedForInstantExecution
     def "runs with multiple parallel threads"() {
         given:
         createTests(200, 20)
@@ -77,6 +79,7 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4457")
+    @ToBeFixedForInstantExecution
     def "can persist configurations in xml"() {
         given:
         createTests(3, 3)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -23,6 +24,7 @@ import org.gradle.testing.fixture.TestNGCoverage
 @TargetCoverage({TestNGCoverage.PRESERVE_ORDER})
 public class TestNGPreserveOrderIntegrationTest extends MultiVersionIntegrationSpec {
 
+    @ToBeFixedForInstantExecution
     def "run tests using preserveOrder"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 public class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
+    @ToBeFixedForInstantExecution
     def "run tests using TestNG version not supporting preserveOrder"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import spock.lang.Unroll
@@ -25,6 +26,7 @@ public class TestNGProducesOldReportsIntegrationTest extends AbstractIntegration
         executer.noExtraLogging()
     }
 
+    @ToBeFixedForInstantExecution
     def "always produces the new xml reports"() {
         given:
         file("src/test/java/org/MixedMethodsTest.java") << """package org;
@@ -60,6 +62,7 @@ test {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     "can generate the old xml reports"() {
         given:
         file("src/test/java/org/SomeTest.java") << """package org;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
@@ -36,6 +37,7 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-2841")
+    @ToBeFixedForInstantExecution
     def "captures output from logging frameworks"() {
         buildFile << """
             dependencies { implementation "org.slf4j:slf4j-simple:1.7.10", "org.slf4j:slf4j-api:1.7.10" }
@@ -70,6 +72,7 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-2841")
+    @ToBeFixedForInstantExecution
     def "captures logging from System streams referenced from static initializer"() {
         file("src/test/java/FooTest.java") << """
             import org.testng.annotations.*;
@@ -94,6 +97,7 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
         testResult.testClass("FooTest").assertTestCaseStderr("foo", is("err output from test\n"))
     }
 
+    @ToBeFixedForInstantExecution
     def "test can generate output from multiple threads"() {
         file("src/test/java/OkTest.java") << """
 import java.util.logging.Logger;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
@@ -26,6 +27,7 @@ import static org.hamcrest.CoreMatchers.startsWith
 class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("GRADLE-1710")
+    @ToBeFixedForInstantExecution
     def "reports suite fatal failure"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -18,6 +18,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -56,6 +57,7 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
         outputContains 'Property from task again: test'
     }
 
+    @ToBeFixedForInstantExecution
     def "methodMissing propagates failures"() {
         buildFile << """
     apply plugin: 'java'
@@ -86,6 +88,7 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-3020")
+    @ToBeFixedForInstantExecution
     def "can specify test suite by string"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.AbstractTestFrameworkIntegrationTest
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
@@ -77,6 +78,7 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3545")
+    @ToBeFixedForInstantExecution
     def "can run tests with ignored test class"() {
         given:
         file("src/test/java/DisabledTest.java") << """
@@ -95,6 +97,7 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3545")
+    @ToBeFixedForInstantExecution
     def "can run tests with ignored test methods"() {
         given:
         file("src/test/java/DisabledTest.java") << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -45,6 +46,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @Issue('https://github.com/gradle/gradle/issues/4924')
+    @ToBeFixedForInstantExecution
     def 'test task is up-to-date when #property is changed because it should not impact output'() {
         given:
         TestNGCoverage.enableTestNG(buildFile)
@@ -88,6 +90,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @Issue('https://github.com/gradle/gradle/issues/4924')
+    @ToBeFixedForInstantExecution
     def "re-executes test when #property is changed"() {
         given:
         TestNGCoverage.enableTestNG(buildFile)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
@@ -45,6 +45,7 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         setupTestCases()
     }
 
+    @ToBeFixedForInstantExecution
     def "produces JUnit xml results - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); $mode.config")
@@ -56,6 +57,7 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         mode << modes
     }
 
+    @ToBeFixedForInstantExecution
     def "produces JUnit xml results when running tests in parallel - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); maxParallelForks 2; $mode.config")
@@ -67,6 +69,7 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         mode << modes
     }
 
+    @ToBeFixedForInstantExecution
     def "produces JUnit xml results with aggressive forking - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); forkEvery 1; $mode.config")

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestClassLoaderFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestClassLoaderFactory.java
@@ -16,33 +16,27 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.initialization.ClassLoaderIds;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classpath.DefaultClassPath;
 
-import javax.inject.Inject;
-
 public class TestClassLoaderFactory implements Factory<ClassLoader> {
-
     private final ClassLoaderCache classLoaderCache;
-    private final String testTaskPath;
-    private final FileCollection testTaskClasspath;
+    private final Test testTask;
+    private ClassLoader testClassLoader;
 
-    @Inject
-    public TestClassLoaderFactory(
-        ClassLoaderCache classLoaderCache,
-        String testTaskPath,
-        FileCollection testTaskClasspath
-    ) {
+    public TestClassLoaderFactory(ClassLoaderCache classLoaderCache, Test testTask) {
         this.classLoaderCache = classLoaderCache;
-        this.testTaskPath = testTaskPath;
-        this.testTaskClasspath = testTaskClasspath;
+        this.testTask = testTask;
     }
 
     @Override
     public ClassLoader create() {
-        return classLoaderCache.get(ClassLoaderIds.testTaskClasspath(testTaskPath), DefaultClassPath.of(testTaskClasspath), null, null);
+        if (testClassLoader == null) {
+            testClassLoader = classLoaderCache.get(ClassLoaderIds.testTaskClasspath(testTask.getPath()), DefaultClassPath.of(testTask.getClasspath()), null, null);
+        }
+        return testClassLoader;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.testing.testng;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.testing.TestClassLoaderFactory;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
@@ -27,13 +27,12 @@ import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.ClassFileExtractionManager;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.testng.TestNGOptions;
-import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
@@ -47,22 +46,17 @@ import java.util.concurrent.Callable;
 public class TestNGTestFramework implements TestFramework {
     private final TestNGOptions options;
     private final TestNGDetector detector;
+    private final Test testTask;
     private final DefaultTestFilter filter;
-    private final ObjectFactory objects;
-    private final String testTaskPath;
-    private final FileCollection testTaskClasspath;
-    private final Factory<File> testTaskTemporaryDir;
-    private transient ClassLoader testClassLoader;
+    private final TestClassLoaderFactory classLoaderFactory;
 
-    public TestNGTestFramework(final Test testTask, DefaultTestFilter filter, ObjectFactory objects) {
+    public TestNGTestFramework(final Test testTask, DefaultTestFilter filter, Instantiator instantiator, ClassLoaderCache classLoaderCache) {
+        this.testTask = testTask;
         this.filter = filter;
-        this.objects = objects;
-        this.testTaskPath = testTask.getPath();
-        this.testTaskClasspath = testTask.getClasspath();
-        this.testTaskTemporaryDir = testTask.getTemporaryDirFactory();
-        options = objects.newInstance(TestNGOptions.class, testTask.getProject().getProjectDir());
+        options = instantiator.newInstance(TestNGOptions.class, testTask.getProject().getProjectDir());
         conventionMapOutputDirectory(options, testTask.getReports().getHtml());
         detector = new TestNGDetector(new ClassFileExtractionManager(testTask.getTemporaryDirFactory()));
+        classLoaderFactory = new TestClassLoaderFactory(classLoaderCache, testTask);
     }
 
     private static void conventionMapOutputDirectory(TestNGOptions options, final DirectoryReport html) {
@@ -79,7 +73,7 @@ public class TestNGTestFramework implements TestFramework {
         verifyConfigFailurePolicy();
         verifyPreserveOrder();
         verifyGroupByInstances();
-        List<File> suiteFiles = options.getSuites(testTaskTemporaryDir.create());
+        List<File> suiteFiles = options.getSuites(testTask.getTemporaryDir());
         TestNGSpec spec = new TestNGSpec(options, filter);
         return new TestClassProcessorFactoryImpl(this.options.getOutputDirectory(), spec, suiteFiles);
     }
@@ -112,16 +106,8 @@ public class TestNGTestFramework implements TestFramework {
     }
 
     private Class<?> createTestNg() {
-        if (testClassLoader == null) {
-            TestClassLoaderFactory factory = objects.newInstance(
-                TestClassLoaderFactory.class,
-                testTaskPath,
-                testTaskClasspath
-            );
-            testClassLoader = factory.create();
-        }
         try {
-            return testClassLoader.loadClass("org.testng.TestNG");
+            return classLoaderFactory.create().loadClass("org.testng.TestNG");
         } catch (ClassNotFoundException e) {
             throw new GradleException("Could not load TestNG.", e);
         }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -23,7 +23,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NonNullApi;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
@@ -63,7 +62,6 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
@@ -152,7 +150,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
 
     private FileCollection testClassesDirs;
     private final PatternFilterable patternSet;
-    private final ConfigurableFileCollection classpath;
+    private FileCollection classpath;
     private TestFramework testFramework;
     private boolean scanForTestClasses = true;
     private long forkEvery;
@@ -161,7 +159,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
 
     public Test() {
         patternSet = getPatternSetFactory().create();
-        classpath = getObjectFactory().fileCollection();
         forkOptions = getForkOptionsFactory().newDecoratedJavaForkOptions();
         forkOptions.setEnableAssertions(true);
         modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
@@ -177,14 +174,9 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         throw new UnsupportedOperationException();
     }
 
-    @Internal
-    @Deprecated
+    @Inject
     protected ClassLoaderCache getClassLoaderCache() {
-        DeprecationLogger.deprecateMethod(Test.class, "getClassLoaderCache()")
-            .willBeRemovedInGradle7()
-            .undocumented()
-            .nagUser();
-        return getServices().get(ClassLoaderCache.class);
+        throw new UnsupportedOperationException();
     }
 
     @Inject
@@ -994,7 +986,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @since 3.5
      */
     public void useTestNG(Action<? super TestNGOptions> testFrameworkConfigure) {
-        useTestFramework(new TestNGTestFramework(this, (DefaultTestFilter) getFilter(), getObjectFactory()), testFrameworkConfigure);
+        useTestFramework(new TestNGTestFramework(this, (DefaultTestFilter) getFilter(), getInstantiator(), getClassLoaderCache()), testFrameworkConfigure);
     }
 
     /**
@@ -1006,7 +998,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     }
 
     public void setClasspath(FileCollection classpath) {
-        this.classpath.setFrom(classpath);
+        this.classpath = classpath;
     }
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -31,7 +31,6 @@ import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.StringWriter;
@@ -81,7 +80,6 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     private final File projectDir;
 
-    @Inject
     public TestNGOptions(File projectDir) {
         this.projectDir = projectDir;
     }
@@ -175,7 +173,7 @@ public class TestNGOptions extends TestFrameworkOptions {
             return suiteXmlBuilder.getMetaClass().invokeMethod(suiteXmlBuilder, name, args);
         }
 
-        throw new MissingMethodException(name, getClass(), (Object[]) args);
+        throw new MissingMethodException(name, getClass(), (Object[])args);
     }
 
     /**

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.api.internal.tasks.testing.testng
 
 
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.testng.TestNGOptions
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.TestUtil
@@ -29,7 +30,7 @@ import spock.lang.Specification
 
 public class TestNGTestFrameworkTest extends Specification {
 
-    @Shared ObjectFactory objects = TestUtil.objectFactory()
+    @Shared Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
 
     private project = ProjectBuilder.builder().build()
     Test testTask = TestUtil.createTask(Test, project)
@@ -45,7 +46,7 @@ public class TestNGTestFrameworkTest extends Specification {
 
         then:
         processor instanceof TestNGTestClassProcessor
-        framework.testTaskPath == testTask.path
+        framework.testTask == testTask
         framework.detector
     }
 
@@ -60,6 +61,6 @@ public class TestNGTestFrameworkTest extends Specification {
     }
 
     TestNGTestFramework createFramework() {
-        new TestNGTestFramework(testTask, new DefaultTestFilter(), objects)
+        new TestNGTestFramework(testTask, new DefaultTestFilter(), instantiator, Stub(ClassLoaderCache))
     }
 }


### PR DESCRIPTION
The change to make Test.classpath a final file collection broke some use cases.

See e.g. https://e.grdev.net/s/sp5weeumy3j74/failure

This needs to be revisited.