### PR TITLE
Consider `BiProvider` as changing if either `left` or `right` is

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -34,6 +34,17 @@ class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
     }
 
     @Override
+    public ExecutionTimeValue<? extends R> calculateExecutionTimeValue() {
+        return isChangingValue(left) || isChangingValue(right)
+            ? ExecutionTimeValue.changingValue(this)
+            : super.calculateExecutionTimeValue();
+    }
+
+    private boolean isChangingValue(ProviderInternal<?> provider) {
+        return provider.calculateExecutionTimeValue().isChangingValue();
+    }
+
+    @Override
     protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
         Value<? extends A> lv = assertHasValue(left.calculateValue(consumer), left);
         Value<? extends B> rv = assertHasValue(right.calculateValue(consumer), right);


### PR DESCRIPTION
So it is stored to the configuration cache as a spec rather than a value.