### PR TITLE
Fix @ToBeFixedForInstantExecution skip condition

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionExtension.groovy
@@ -29,7 +29,7 @@ import java.lang.reflect.Field
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Predicate
 
-import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecution.Skip.FLAKY
+import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecution.Skip.DO_NOT_SKIP
 
 class ToBeFixedForInstantExecutionExtension extends AbstractAnnotationDrivenExtension<ToBeFixedForInstantExecution> {
 
@@ -44,7 +44,7 @@ class ToBeFixedForInstantExecutionExtension extends AbstractAnnotationDrivenExte
             return
         }
 
-        if (annotation.skip() == FLAKY) {
+        if (annotation.skip() != DO_NOT_SKIP) {
             feature.skipped = true
             return
         }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -122,7 +122,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         gradle.waitForFinish()
     }
 
-    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FAILS_TO_CLEANUP)
+    @ToBeFixedForInstantExecution(because = "composite builds", skip = ToBeFixedForInstantExecution.Skip.FAILS_TO_CLEANUP)
     def "shows progress bar and percent phase completion with included build"() {
         settingsFile << """
             ${server.callFromBuild('settings')}


### PR DESCRIPTION
This PR restores the behaviour of `@ToBeFixedForInstantExecution` for skipping tests.
This is a follow up for https://github.com/gradle/gradle/pull/13542/files#r448147109
