### PR TITLE
Allow undeclared read of VM bitness system properties

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -266,6 +266,8 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
             "file.separator",
             "path.separator",
             "line.separator",
+            "sun.arch.data.model",
+            "com.ibm.vm.bitmode",
             "user.name",
             "user.home"
             // Not java.io.tmpdir and user.dir at this stage

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemPropertyAccessListener.kt
@@ -55,6 +55,8 @@ val allowedProperties = setOf(
     "file.separator",
     "path.separator",
     "line.separator",
+    "sun.arch.data.model",
+    "com.ibm.vm.bitmode",
     "user.name",
     "user.home",
     "java.runtime.version"


### PR DESCRIPTION
These two properties are used by plugins and libraries to infer the bitness of the current VM.

This was found in the wild in the protobuf gradle plugin and in the kotlin-android gradle plugin.
