### PR TITLE
Let configuration cache post build output display saved time

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -99,7 +99,7 @@ include::{snippetsPath}/configurationCache/noProblem/tests/load.out[]
 ...
 BUILD SUCCESSFUL in 50ms
 1 actionable task: 1 executed
-Configuration cache entry reused.
+Configuration cache entry reused, saving 150ms.
 ----
 
 If it succeeds on your build, congratulations, you can now try with more useful tasks.
@@ -373,7 +373,7 @@ Let's ignore the problems reported when storing the configuration cache, and run
 ❯ gradle --configuration-cache someTask -DsomeDestination=dest
 ...
 include::{snippetsPath}/configurationCache/problemsGroovy/tests/load.out[]
-Configuration cache entry reused.
+Configuration cache entry reused, saving 150ms.
 ----
 
 The build fails again, reporting the observed problems.
@@ -399,7 +399,7 @@ include::{snippetsPath}/configurationCache/problemsFixed/tests/store.out[]
 Configuration cache entry stored.
 ❯ gradle --configuration-cache someTask -DsomeDestination=dest
 include::{snippetsPath}/configurationCache/problemsFixed/tests/load.out[]
-Configuration cache entry reused.
+Configuration cache entry reused, saving 150ms.
 ----
 
 But, what if we change the value of the system property?
@@ -428,7 +428,7 @@ include::{snippetsPath}/configurationCache/problemsFixedReuse/tests/store.out[]
 Configuration cache entry stored.
 ❯ gradle --configuration-cache someTask -DsomeDestination=another
 include::{snippetsPath}/configurationCache/problemsFixedReuse/tests/load-another.out[]
-Configuration cache entry reused.
+Configuration cache entry reused, saving 150ms.
 ----
 
 We're now done with fixing the problems with this simple task.

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -43,13 +43,13 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         instantRun "help"
         def firstRunOutput = removeVfsLogOutput(result.normalizedOutput)
             .replaceAll(/Calculating task graph as no configuration cache is available for tasks: help\n/, '')
-            .replaceAll(/Configuration cache entry stored.\n/, '')
+            .replaceAll(/Configuration cache entry stored\.\n/, '')
 
         when:
         instantRun "help"
         def secondRunOutput = removeVfsLogOutput(result.normalizedOutput)
             .replaceAll(/Reusing configuration cache.\n/, '')
-            .replaceAll(/Configuration cache entry reused.\n/, '')
+            .replaceAll(/Configuration cache entry reused, saving .*\.\n/, '')
 
         then:
         firstRunOutput == secondRunOutput

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionProblemReportingIntegrationTest.groovy
@@ -199,7 +199,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
             withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
             problemsWithStackTraceCount = 0
         }
-        postBuildOutputContains("Configuration cache entry reused with 4 problems.")
+        postBuildOutputContains("Configuration cache entry reused with 4 problems")
 
         when:
         instantFails 'all'
@@ -214,7 +214,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
             withProblem("input property 'otherBrokenProperty' of ':problems': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
             problemsWithStackTraceCount = 0
         }
-        outputContains("Configuration cache entry reused with 4 problems.")
+        outputContains("Configuration cache entry reused with 4 problems")
     }
 
     def "configuration time problems are reported and fail the build by default only when configuration is executed and do not invalidate the cache"() {
@@ -247,7 +247,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':all')
         instantExecution.assertStateLoaded()
-        postBuildOutputContains("Configuration cache entry reused.")
+        postBuildOutputContains("Configuration cache entry reused")
         problems.assertResultHasProblems(result) {
             // TODO - should give some indication to the user that the build may not work correctly
         }
@@ -258,7 +258,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':all')
         instantExecution.assertStateLoaded()
-        postBuildOutputContains("Configuration cache entry reused.")
+        postBuildOutputContains("Configuration cache entry reused")
         problems.assertResultHasProblems(result) {
             // TODO - should fail and give some indication to the user why
         }
@@ -304,7 +304,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':all')
         instantExecution.assertStateLoaded()
-        postBuildOutputContains("Configuration cache entry reused with 2 problems.")
+        postBuildOutputContains("Configuration cache entry reused with 2 problems")
         problems.assertResultHasProblems(result) {
             // TODO - retain the location information
             withProblem("task `:anotherBroken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
@@ -317,7 +317,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':all')
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 2 problems.")
+        outputContains("Configuration cache entry reused with 2 problems")
         problems.assertFailureHasProblems(failure) {
             withProblem("task `:anotherBroken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
             withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
@@ -359,7 +359,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
 
         then:
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 1 problem.")
+        outputContains("Configuration cache entry reused with 1 problem")
         problems.assertResultHasProblems(result) {
             withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
         }
@@ -372,7 +372,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
 
         then:
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 1 problem.")
+        outputContains("Configuration cache entry reused with 1 problem")
         problems.assertFailureHasProblems(failure) {
             withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
         }
@@ -430,7 +430,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':problems', ':moreProblems', ':all')
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 4 problems.")
+        outputContains("Configuration cache entry reused with 4 problems")
         problems.assertFailureHasTooManyProblems(failure) {
             withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
             withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
@@ -446,7 +446,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':problems', ':moreProblems', ':all')
         instantExecution.assertStateLoaded()
-        postBuildOutputContains("Configuration cache entry reused with 4 problems.")
+        postBuildOutputContains("Configuration cache entry reused with 4 problems")
         problems.assertResultHasProblems(result) {
             withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
             withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
@@ -500,7 +500,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':problems', ':moreProblems', ':all')
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 4 problems.")
+        outputContains("Configuration cache entry reused with 4 problems")
         problems.assertFailureHasProblems(failure) {
             withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
             withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
@@ -516,7 +516,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         then:
         executed(':problems', ':moreProblems', ':all')
         instantExecution.assertStateLoaded()
-        outputContains("Configuration cache entry reused with 4 problems.")
+        outputContains("Configuration cache entry reused with 4 problems")
         problems.assertFailureHasProblems(failure) {
             withProblem("task `:moreProblems` of type `BrokenTask`: invocation of 'Task.project' at execution time is unsupported.")
             withProblem("field 'broken' from type 'BrokenTask': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
@@ -555,7 +555,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
         instantRunLenient("broken")
 
         then:
-        postBuildOutputContains("Configuration cache entry reused with 1 problem.")
+        postBuildOutputContains("Configuration cache entry reused with 1 problem")
         problems.assertResultHasProblems(result) {
             withProblem("input property 'p' of ':broken': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.")
             problemsWithStackTraceCount = 0
@@ -614,7 +614,7 @@ class InstantExecutionProblemReportingIntegrationTest extends AbstractInstantExe
 
         then:
         instantExecution.assertStateLoaded()
-        postBuildOutputContains("Configuration cache entry reused with 5 problems.")
+        postBuildOutputContains("Configuration cache entry reused with 5 problems")
 
         and:
         problems.assertResultHasProblems(result) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
@@ -53,16 +53,19 @@ class InstantExecutionState(
     private val relevantProjectsRegistry: RelevantProjectsRegistry
 ) {
 
-    suspend fun DefaultWriteContext.writeState() {
+    suspend fun DefaultWriteContext.writeState(cachedWorkDuration: Long) {
+        writeLong(cachedWorkDuration)
         encodeScheduledWork()
         writeInt(0x1ecac8e)
     }
 
-    suspend fun DefaultReadContext.readState() {
+    suspend fun DefaultReadContext.readState(): Long {
+        val savedTime = readLong()
         decodeScheduledWork()
         require(readInt() == 0x1ecac8e) {
             "corrupt state file"
         }
+        return savedTime
     }
 
     private


### PR DESCRIPTION
by capturing time elapsed configuring and storing it in the state

and by moving the responsibility for the post build output from `InstantExecutionProblems` to `DefaultInstantExecution`
