### PR TITLE
Fix NPE when System.getProperty() is called from Groovy DSL build script with null default value

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -141,6 +141,13 @@ public class Instrumented {
         return obj;
     }
 
+    private static String convertToString(Object arg) {
+        if (arg instanceof CharSequence) {
+            return ((CharSequence) arg).toString();
+        }
+        return (String) arg;
+    }
+
     public interface Listener {
         /**
          * @param consumer The name of the class that is reading the property value
@@ -432,7 +439,7 @@ public class Instrumented {
         @Override
         public Object call(Object receiver, Object arg1, Object arg2) throws Throwable {
             if (receiver.equals(System.class)) {
-                return systemProperty(arg1.toString(), arg2.toString(), array.owner.getName());
+                return systemProperty(arg1.toString(), convertToString(arg2), array.owner.getName());
             } else {
                 return super.call(receiver, arg1, arg2);
             }


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
