### PR TITLE
Simplify task properties validation plugin script

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/task-properties-validation.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/task-properties-validation.gradle.kts
@@ -22,25 +22,15 @@ plugins {
 val validateTaskName = "validatePlugins"
 val reportFileName = "task-properties/report.txt"
 
-afterEvaluate {
-    // This is in an after evaluate block to defer the decision until after the `java-gradle-plugin` may have been applied, so as to not collide with it
-    // It would be better to use some convention plugins instead, that apply a fixes set of plugins (including this one)
-    if (plugins.hasPlugin("java-base")) {
-        val validateTask = if (plugins.hasPlugin("java-gradle-plugin")) {
-            tasks.named<ValidatePlugins>(validateTaskName)
-        } else {
-            tasks.register<ValidatePlugins>(validateTaskName)
-        }
-        validateTask {
-            configureValidateTask()
-        }
-        tasks.named("codeQuality") {
-            dependsOn(validateTask)
-        }
-        tasks.withType<Test>().configureEach {
-            shouldRunAfter(validateTask)
-        }
-    }
+val validateTask = tasks.register<ValidatePlugins>(validateTaskName)
+validateTask {
+    configureValidateTask()
+}
+tasks.named("codeQuality") {
+    dependsOn(validateTask)
+}
+tasks.withType<Test>().configureEach {
+    shouldRunAfter(validateTask)
 }
 
 fun ValidatePlugins.configureValidateTask() {
@@ -48,6 +38,5 @@ fun ValidatePlugins.configureValidateTask() {
     classes.from(main.output)
     classpath.from(main.runtimeClasspath)
     outputFile.set(project.reporting.baseDirectory.file(reportFileName))
-    failOnWarning.set(true)
     enableStricterValidation.set(true)
 }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/task-properties-validation.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/task-properties-validation.gradle.kts
@@ -22,18 +22,7 @@ plugins {
 val validateTaskName = "validatePlugins"
 val reportFileName = "task-properties/report.txt"
 
-val validateTask = tasks.register<ValidatePlugins>(validateTaskName)
-validateTask {
-    configureValidateTask()
-}
-tasks.named("codeQuality") {
-    dependsOn(validateTask)
-}
-tasks.withType<Test>().configureEach {
-    shouldRunAfter(validateTask)
-}
-
-fun ValidatePlugins.configureValidateTask() {
+tasks.register<ValidatePlugins>(validateTaskName) {
     val main = project.sourceSets.main.get()
     classes.from(main.output)
     classpath.from(main.runtimeClasspath)

--- a/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/shaded-jar.gradle.kts
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/shaded-jar.gradle.kts
@@ -88,19 +88,15 @@ fun Project.registerTransforms(shadedJarExtension: ShadedJarExtension) {
     }
 }
 
-fun createConfigurationToShade(): Configuration {
-    val configurationName = "jarsToShade"
-    afterEvaluate {
-        dependencies.add(configurationName, project)
-    }
-
-    return configurations.create(configurationName) {
+fun createConfigurationToShade() = configurations.create("jarsToShade") {
         attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
         attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         isCanBeResolved = true
         isCanBeConsumed = false
+        withDependencies {
+            this.add(project.dependencies.create(project))
+        }
     }
-}
 
 fun addShadedJarTask(shadedJarExtension: ShadedJarExtension): TaskProvider<ShadedJar> {
     val configurationToShade = shadedJarExtension.shadedConfiguration

--- a/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-bundle.gradle.kts
+++ b/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-bundle.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 
 extensions.create<PluginPublishExtension>("pluginPublish", gradlePlugin, pluginBundle)
 
-tasks.withType<ValidatePlugins>() {
+tasks.validatePlugins.configure {
     enableStricterValidation.set(true)
 }
 

--- a/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-bundle.gradle.kts
+++ b/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-bundle.gradle.kts
@@ -27,6 +27,10 @@ plugins {
 
 extensions.create<PluginPublishExtension>("pluginPublish", gradlePlugin, pluginBundle)
 
+tasks.withType<ValidatePlugins>() {
+    enableStricterValidation.set(true)
+}
+
 // Remove gradleApi() and gradleTestKit() as we want to compile/run against Gradle modules
 // TODO consider splitting `java-gradle-plugin` to provide only what's necessary here
 afterEvaluate {

--- a/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
+++ b/buildSrc/subprojects/publishing/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
@@ -66,13 +66,13 @@ fun Project.failEarlyIfCredentialsAreNotSet(publish: Task) {
     }
 }
 
-val Project.artifactoryUserName
+val artifactoryUserName
     get() = findProperty("artifactoryUserName") as String?
 
-val Project.artifactoryUserPassword
+val artifactoryUserPassword
     get() = findProperty("artifactoryUserPassword") as String?
 
-fun Project.publishNormalizedToLocalRepository() {
+fun publishNormalizedToLocalRepository() {
     val localRepository = layout.buildDirectory.dir("repo")
     val baseName = moduleIdentity.baseName
 
@@ -91,10 +91,10 @@ fun Project.publishNormalizedToLocalRepository() {
             }
         }
     }
-    project.tasks.named("publishLocalPublicationToRemoteRepository") {
+    tasks.named("publishLocalPublicationToRemoteRepository") {
         enabled = false // don't publish normalized local version to remote repository when using 'publish' lifecycle task
     }
-    project.tasks.named("publishGradleDistributionPublicationToLocalRepository") {
+    tasks.named("publishGradleDistributionPublicationToLocalRepository") {
         enabled = false // this should not be used so we disable it to avoid confusion when using 'publish' lifecycle task
     }
     val localPublish = project.tasks.named("publishLocalPublicationToLocalRepository") {
@@ -124,7 +124,7 @@ fun Project.publishNormalizedToLocalRepository() {
     }
 
     // For local consumption by tests
-    project.configurations.create("localLibsRepositoryElements") {
+    configurations.create("localLibsRepositoryElements") {
         attributes {
             attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution-module.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution-module.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gradlebuild.distribution
+package gradlebuild
 
+// Common configuration for everything that belongs to the Gradle distribution
 plugins {
-    id("gradlebuild.distribution-module")
-    id("gradlebuild.distribution.implementation")
+    id("gradlebuild.java-library")
+    id("gradlebuild.api-parameter-names-index")
+    id("gradlebuild.task-properties-validation")
 }

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/api-java.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/api-java.gradle.kts
@@ -16,7 +16,6 @@
 package gradlebuild.distribution
 
 plugins {
-    id("gradlebuild.java-library")
+    id("gradlebuild.distribution-module")
     id("gradlebuild.distribution.api")
-    id("gradlebuild.api-parameter-names-index")
 }

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/api-kotlin.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/api-kotlin.gradle.kts
@@ -17,6 +17,6 @@ package gradlebuild.distribution
 
 plugins {
     id("gradlebuild.kotlin-library")
+    id("gradlebuild.distribution-module")
     id("gradlebuild.distribution.api")
-    id("gradlebuild.api-parameter-names-index")
 }

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/implementation-kotlin.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/distribution/implementation-kotlin.gradle.kts
@@ -17,6 +17,6 @@ package gradlebuild.distribution
 
 plugins {
     id("gradlebuild.kotlin-library")
+    id("gradlebuild.distribution-module")
     id("gradlebuild.distribution.implementation")
-    id("gradlebuild.api-parameter-names-index")
 }

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
@@ -15,8 +15,6 @@
  */
 package gradlebuild
 
-import org.gradle.kotlin.dsl.*
-
 plugins {
     `java-library`
     id("gradlebuild.dependency-modules")
@@ -28,7 +26,6 @@ plugins {
     id("gradlebuild.test-fixtures")
     id("gradlebuild.distribution-testing")
     id("gradlebuild.incubation-report")
-    id("gradlebuild.task-properties-validation")
     id("gradlebuild.strict-compile")
     id("gradlebuild.classycle")
     id("gradlebuild.integration-tests")

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -82,7 +82,7 @@ fun Project.configureCodenarc(codeQualityConfigDir: File) {
 
 
 fun Project.configureCodeQualityTasks() {
-    val codeQualityTasks = tasks.matching { it is CodeNarc || it is Checkstyle || it.name == "classycle" }
+    val codeQualityTasks = tasks.matching { it is CodeNarc || it is Checkstyle || it.name == "classycle" || it is ValidatePlugins }
     tasks.register("codeQuality").configure {
         dependsOn(codeQualityTasks)
     }


### PR DESCRIPTION
This simplifies the script. Some setup is no longer needed now that the Gradle distribution setup is cleaner. This also removes the need to use afterEvaluate in the script.

This problem was discovered: https://github.com/gradle/gradle/issues/13678 (it exists with and without the changes in this PR)