### PR TITLE
Enable Kotlin DSL tests with file system watching

### DIFF
--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -17,13 +17,11 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.integtests.fixtures.ToBeFixedForFileSystemWatching
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.util.TestPrecondition
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
@@ -32,10 +30,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 
-@ToBeFixedForFileSystemWatching(
-    because = "https://github.com/gradle/gradle/issues/12184",
-    failsOnlyIf = TestPrecondition.WINDOWS
-)
 @RunWith(Parameterized::class)
 class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -1,24 +1,18 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.integtests.fixtures.ToBeFixedForFileSystemWatching
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.util.TestPrecondition
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
 
-@ToBeFixedForFileSystemWatching(
-    because = "https://github.com/gradle/gradle/issues/12184",
-    failsOnlyIf = TestPrecondition.WINDOWS
-)
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class KotlinDslPluginTest : AbstractPluginTest() {
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
@@ -16,18 +16,12 @@
 
 package org.gradle.kotlin.dsl.plugins.precompiled
 
-import org.gradle.integtests.fixtures.ToBeFixedForFileSystemWatching
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
-import org.gradle.util.TestPrecondition
 
 import org.junit.Before
 
 
-@ToBeFixedForFileSystemWatching(
-    because = "https://github.com/gradle/gradle/issues/12184",
-    failsOnlyIf = TestPrecondition.WINDOWS
-)
 open class AbstractPrecompiledScriptPluginTest : AbstractPluginTest() {
 
     @Before


### PR DESCRIPTION
If CI passes, we are good now.

Fixes #12184