### PR TITLE
Allow specifying a source encoding for the jacoco report tasks

### DIFF
--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation(project(":platformBase"))
     implementation(project(":testingBase"))
     implementation(project(":testingJvm"))
+    implementation(project(":languageJvm"))
+    implementation(project(":languageJava"))
     implementation(project(":plugins"))
     implementation(project(":reporting"))
 

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -283,6 +283,38 @@ public class ThingTest {
         htmlReport().numberOfClasses() == 2000
     }
 
+    @ToBeFixedForInstantExecution
+    def "allows specifying an encoding"() {
+        given:
+        buildFile << """
+            jacocoTestReport {
+                sourceEncoding = 'UTF-8'
+            }
+            """
+
+        when:
+        succeeds('test', 'jacocoTestReport')
+
+        then:
+        htmlReport().exists()
+    }
+
+    @ToBeFixedForInstantExecution
+    def "specified encoding is actually used"() {
+        given:
+        buildFile << """
+            jacocoTestReport {
+                sourceEncoding = 'THIS_ENCODING_DOES_NOT_EXIST'
+            }
+            """
+
+        when:
+        fails('test', 'jacocoTestReport')
+
+        then:
+        failure.hasErrorOutput("java.io.UnsupportedEncodingException")
+    }
+
     private JacocoReportFixture htmlReport(String basedir = "${REPORTING_BASE}/jacoco/test/html") {
         return new JacocoReportFixture(file(basedir))
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AbstractAntJacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AbstractAntJacocoReport.java
@@ -51,7 +51,7 @@ public abstract class AbstractAntJacocoReport<T> {
 
     protected void invokeJacocoReport(final GroovyObjectSupport antBuilder, final String projectName,
                      final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                     final FileCollection executionData, final T t) {
+                     final String encoding, final FileCollection executionData, final T t) {
         final Map<String, Object> emptyArgs = Collections.emptyMap();
         antBuilder.invokeMethod("jacocoReport", new Object[]{Collections.emptyMap(), new Closure<Object>(this, this) {
             @SuppressWarnings("UnusedDeclaration")
@@ -71,7 +71,8 @@ public abstract class AbstractAntJacocoReport<T> {
                                 return null;
                             }
                         }});
-                        antBuilder.invokeMethod("sourcefiles", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                        final Map<String, Object> sourcefileArgs = Collections.singletonMap("encoding", encoding);
+                        antBuilder.invokeMethod("sourcefiles", new Object[]{sourcefileArgs, new Closure<Object>(this, this) {
                             public Object doCall(Object ignore) {
                                 allSourcesDirs.addToAntBuilder(antBuilder, "resources");
                                 return null;

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
@@ -51,14 +51,14 @@ public class AntJacocoCheck extends AbstractAntJacocoReport<JacocoViolationRules
 
     public JacocoCheckResult execute(FileCollection classpath, final String projectName,
                                      final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                                     final FileCollection executionData, final JacocoViolationRulesContainer violationRules) {
+                                     final String encoding, final FileCollection executionData, final JacocoViolationRulesContainer violationRules) {
         final JacocoCheckResult jacocoCheckResult = new JacocoCheckResult();
 
         configureAntReportTask(classpath, new Action<GroovyObjectSupport>() {
             @Override
             public void execute(GroovyObjectSupport antBuilder) {
                 try {
-                    invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, executionData, violationRules);
+                    invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, encoding, executionData, violationRules);
                 } catch (Exception e) {
                     String violations = getViolations(antBuilder);
                     jacocoCheckResult.setSuccess(false);

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
@@ -31,11 +31,11 @@ public class AntJacocoReport extends AbstractAntJacocoReport<JacocoReportsContai
 
     public void execute(FileCollection classpath, final String projectName,
                         final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                        final FileCollection executionData, final JacocoReportsContainer reports) {
+                        final String encoding, final FileCollection executionData, final JacocoReportsContainer reports) {
         configureAntReportTask(classpath, new Action<GroovyObjectSupport>() {
             @Override
             public void execute(GroovyObjectSupport antBuilder) {
-                invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, executionData, reports);
+                invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, encoding, executionData, reports);
             }
         });
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoCoverageVerification.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoCoverageVerification.java
@@ -78,6 +78,7 @@ public class JacocoCoverageVerification extends JacocoReportBase {
                 getProject().getName(),
                 getAllClassDirs().filter(fileExistsSpec),
                 getAllSourceDirs().filter(fileExistsSpec),
+                getSourceEncoding().get(),
                 getExecutionData(),
                 getViolationRules()
         );

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
@@ -95,6 +95,7 @@ public class JacocoReport extends JacocoReportBase implements Reporting<JacocoRe
             projectName.get(),
             getAllClassDirs().filter(fileExistsSpec),
             getAllSourceDirs().filter(fileExistsSpec),
+            getSourceEncoding().get(),
             getExecutionData(),
             getReports()
         );

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -24,7 +24,9 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
+import org.gradle.api.provider.Property;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -37,6 +39,7 @@ import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -53,6 +56,7 @@ public abstract class JacocoReportBase extends JacocoBase {
     private final ConfigurableFileCollection classDirectories = getProject().files();
     private final ConfigurableFileCollection additionalClassDirs = getProject().files();
     private final ConfigurableFileCollection additionalSourceDirs = getProject().files();
+    private final Property<String> sourceEncoding = getProject().getObjects().property(String.class).value(Charset.defaultCharset().name());
 
     public JacocoReportBase() {
         onlyIf(new Spec<Task>() {
@@ -133,6 +137,15 @@ public abstract class JacocoReportBase extends JacocoBase {
     @InputFiles
     public ConfigurableFileCollection getAdditionalSourceDirs() {
         return additionalSourceDirs;
+    }
+
+    /**
+     * The character encoding of the source files.
+     */
+    @Optional
+    @Input
+    public Property<String> getSourceEncoding() {
+        return sourceEncoding;
     }
 
     /**

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -25,6 +25,8 @@ import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Unroll
 
+import java.nio.charset.Charset
+
 class JacocoPluginSpec extends AbstractProjectBuilderSpec {
     def setup() {
         project.apply plugin: 'jacoco'
@@ -108,5 +110,29 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
         jacocoTestCoverageVerificationTask.group == LifecycleBasePlugin.VERIFICATION_GROUP
         jacocoTestReportTask.description == 'Generates code coverage report for the test task.'
         jacocoTestCoverageVerificationTask.description == 'Verifies code coverage metrics based on specified rules for the test task.'
+    }
+
+    def "declares task property values for sourceEncoding, with default value if compileJava does not have an encoding"() {
+        given:
+        project.apply plugin: 'java'
+
+        expect:
+        def jacocoTestReportTask = project.tasks.getByName('jacocoTestReport')
+        def jacocoTestCoverageVerificationTask = project.tasks.getByName('jacocoTestCoverageVerification')
+        jacocoTestReportTask.sourceEncoding.get() == Charset.defaultCharset().name()
+        jacocoTestCoverageVerificationTask.sourceEncoding.get() == Charset.defaultCharset().name()
+    }
+
+    def "declares task property values for sourceEncoding, with value specified for compileJava"() {
+        given:
+        project.apply plugin: 'java'
+        def compileJavaTask = project.tasks.getByName('compileJava')
+        compileJavaTask.options.encoding = "SOME_ENCODING"
+
+        expect:
+        def jacocoTestReportTask = project.tasks.getByName('jacocoTestReport')
+        def jacocoTestCoverageVerificationTask = project.tasks.getByName('jacocoTestCoverageVerification')
+        jacocoTestReportTask.sourceEncoding.get() == "SOME_ENCODING"
+        jacocoTestCoverageVerificationTask.sourceEncoding.get() == "SOME_ENCODING"
     }
 }


### PR DESCRIPTION
Use the encoding of the compileJava task by default (if specified), or the default encoding if not specified

Issue #13666

Signed-off-by: Jean-Baptiste Nizet <jb@ninja-squad.com>

<!--- The issue this PR addresses -->
Fixes #13666

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

I have several questions/doubts about the code I've submitted in this PR:

1. I'm not sure if something needs to be done regarding the documentation, other than specifying a javadoc comment on the new sourceEncoding property. Please tell if something should be done
2. I used the name `sourceEncoding`, as suggested in the issue, but I don't know if it's the most appropriate name
3. I thought it was a good idea to use the same encoding as the compileJava task that compiles the same files that jacoco needs to read. That has forced me to add a dependency to the `languageJava` project. But I was surprised to see that this wasn't sufficient for the code to compile. Indeed, JavaCompile extends AbstractCompile, which is in the languageJvm project. Shouldn't languageJava have an `api` dependency on `languageJvm` then, rather than an `implementation` dependency?
4. I chose to use the default charset as the default value of the `sourceEncoding` property of the task, because I tend to prefer having a valid value rather than null, and because I think two developers using a different default charset should not share the cached output of the task, since the output depends on the charset. But the JavaCompile task seems to set the encoding to null by default instead. So I'm not sure if I made the right choice.
5. I put the `sourceEncoding` property in the `JacocoReportBase` class, because that's where the sourceDirectories and additionalSourceDirs also are, and because the source files are passed to the ant tasks in both Jacoco tasks (JacocoReport and JacocoCoverageVerification). But, when I tried to add an integration test for the JacocoCoverageVerification task to check that the encoding was used, the test failed: it seems this task doesn't read the source files at all. So I'm a bit confused. 