### PR TITLE
Support file system repositories when the configuration cache is enabled

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.classpath
 
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.test.fixtures.file.TestFile
@@ -44,7 +43,6 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
     }
 
     @Unroll("jars on buildscript classpath can change (loopNumber: #loopNumber)")
-    @ToBeFixedForInstantExecution(because = "changing flatDir buildscript repository")
     def "jars on buildscript classpath can change"() {
         given:
         buildFile << '''
@@ -164,7 +162,6 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         succeeds("checkUrlConnectionCaching")
     }
 
-    @ToBeFixedForInstantExecution(because = "changing flatDir buildscript repository")
     def "jars with resources on buildscript classpath can change"() {
         given:
         buildFile << '''

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class IvyFileRepoResolveIntegrationTest extends AbstractDependencyResolutionTest {
-    @ToBeFixedForInstantExecution
     void "does not cache local artifacts or metadata"() {
         given:
         def repo = ivyRepo()
@@ -63,7 +62,6 @@ task retrieve(type: Sync) {
         file('libs/projectB-9-beta.jar').assertIsCopyOf(moduleB.jarFile)
     }
 
-    @ToBeFixedForInstantExecution
     void "does not cache resolution of dynamic versions or changing modules"() {
         def repo = ivyRepo()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
 class IvyModuleResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
-    @ToBeFixedForInstantExecution
     def "wildcard on LHS of configuration mapping includes all public configurations of target module"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class MavenFileRepoResolveIntegrationTest extends AbstractDependencyResolutionTest {
-    @ToBeFixedForInstantExecution
     void "can resolve snapshots uncached from local Maven repository"() {
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT')
@@ -57,7 +56,6 @@ task retrieve(type: Sync) {
         buildDir.file('projectB-9.1.jar').assertIsCopyOf(moduleB.artifactFile)
     }
 
-    @ToBeFixedForInstantExecution
     void "does not cache artifacts and metadata from local Maven repository"() {
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2')

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -33,8 +33,8 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryDisabler;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryDisabler;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashCodec;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryDisabler;
@@ -160,6 +160,7 @@ import org.gradle.internal.resource.cached.ExternalResourceFileStore;
 import org.gradle.internal.resource.cached.TwoStageByUrlCachedExternalResourceIndex;
 import org.gradle.internal.resource.cached.TwoStageExternalResourceFileStore;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
+import org.gradle.internal.resource.local.FileResourceListener;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.resource.local.ivy.LocallyAvailableResourceFinderFactory;
@@ -430,8 +431,7 @@ class DependencyManagementBuildScopeServices {
         return finderFactory.create();
     }
 
-    RepositoryTransportFactory createRepositoryTransportFactory(StartParameter startParameter,
-                                                                ProgressLoggerFactory progressLoggerFactory,
+    RepositoryTransportFactory createRepositoryTransportFactory(ProgressLoggerFactory progressLoggerFactory,
                                                                 TemporaryFileProvider temporaryFileProvider,
                                                                 FileStoreAndIndexProvider fileStoreAndIndexProvider,
                                                                 BuildCommencedTimeProvider buildCommencedTimeProvider,
@@ -441,7 +441,8 @@ class DependencyManagementBuildScopeServices {
                                                                 ProducerGuard<ExternalResourceName> producerGuard,
                                                                 FileResourceRepository fileResourceRepository,
                                                                 ChecksumService checksumService,
-                                                                StartParameterResolutionOverride startParameterResolutionOverride) {
+                                                                StartParameterResolutionOverride startParameterResolutionOverride,
+                                                                ListenerManager listenerManager) {
         return artifactCachesProvider.withWritableCache((md, manager) -> new RepositoryTransportFactory(
             resourceConnectorFactories,
             progressLoggerFactory,
@@ -453,7 +454,8 @@ class DependencyManagementBuildScopeServices {
             startParameterResolutionOverride,
             producerGuard,
             fileResourceRepository,
-            checksumService));
+            checksumService,
+            listenerManager.getBroadcaster(FileResourceListener.class)));
     }
 
     RepositoryDisabler createRepositoryDisabler() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -489,7 +489,6 @@ class DependencyManagementBuildScopeServices {
                                               ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                               RepositoryDisabler repositoryBlacklister,
                                               VersionParser versionParser,
-                                              InstantiatorFactory instantiatorFactory,
                                               ListenerManager listenerManager) {
         return new ResolveIvyFactory(
             moduleRepositoryCacheProvider,
@@ -500,7 +499,6 @@ class DependencyManagementBuildScopeServices {
             moduleIdentifierFactory,
             repositoryBlacklister,
             versionParser,
-            instantiatorFactory,
             listenerManager.getBroadcaster(ChangingValueDependencyResolutionListener.class)
         );
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ChangingValueDependencyResolutionListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ChangingValueDependencyResolutionListener.java
@@ -27,6 +27,16 @@ import org.gradle.internal.service.scopes.Scopes;
  */
 @EventScope(Scopes.Build)
 public interface ChangingValueDependencyResolutionListener {
+    ChangingValueDependencyResolutionListener NO_OP = new ChangingValueDependencyResolutionListener() {
+        @Override
+        public void onDynamicVersionSelection(ModuleComponentSelector requested, Expiry expiry) {
+        }
+
+        @Override
+        public void onChangingModuleResolve(ModuleComponentIdentifier moduleId, Expiry expiry) {
+        }
+    };
+
     /**
      * Called when a dynamic version is selected using the set of candidate versions queried from a repository.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -44,7 +44,6 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ModuleSources;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -68,7 +67,6 @@ public class ResolveIvyFactory {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final RepositoryDisabler repositoryBlacklister;
     private final VersionParser versionParser;
-    private final InstantiatorFactory instantiatorFactory;
 
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final ChangingValueDependencyResolutionListener listener;
@@ -81,7 +79,6 @@ public class ResolveIvyFactory {
                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                              RepositoryDisabler repositoryBlacklister,
                              VersionParser versionParser,
-                             InstantiatorFactory instantiatorFactory,
                              ChangingValueDependencyResolutionListener listener) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
@@ -90,7 +87,6 @@ public class ResolveIvyFactory {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.repositoryBlacklister = repositoryBlacklister;
         this.versionParser = versionParser;
-        this.instantiatorFactory = instantiatorFactory;
         this.dependencyVerificationOverride = dependencyVerificationOverride;
         this.listener = listener;
     }
@@ -123,7 +119,7 @@ public class ResolveIvyFactory {
 
             ModuleComponentRepository moduleComponentRepository = baseRepository;
             if (baseRepository.isLocal()) {
-                moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getInMemoryOnlyCaches(), cachePolicy, timeProvider, componentMetadataProcessor, listener);
+                moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getInMemoryOnlyCaches(), cachePolicy, timeProvider, componentMetadataProcessor, ChangingValueDependencyResolutionListener.NO_OP);
                 moduleComponentRepository = new LocalModuleComponentRepository(moduleComponentRepository);
             } else {
                 moduleComponentRepository = startParameterResolutionOverride.overrideModuleVersionRepository(moduleComponentRepository);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -130,7 +130,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     @Override
     public FlatDirectoryArtifactRepository createFlatDirRepository() {
-        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, ivyMetadataFactory, instantiatorFactory, objectFactory, checksumService);
+        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, ivyMetadataFactory, instantiatorFactory, objectFactory, checksumService);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.repositories.descriptor.FlatDirRepositoryDescriptor;
@@ -64,7 +63,6 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
     private final RepositoryTransportFactory transportFactory;
     private final LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder;
     private final FileStore<ModuleComponentArtifactIdentifier> artifactFileStore;
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final IvyMutableModuleMetadataFactory metadataFactory;
     private final InstantiatorFactory instantiatorFactory;
     private final ChecksumService checksumService;
@@ -73,7 +71,6 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
                                             RepositoryTransportFactory transportFactory,
                                             LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                                             FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
-                                            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                             IvyMutableModuleMetadataFactory metadataFactory,
                                             InstantiatorFactory instantiatorFactory,
                                             ObjectFactory objectFactory,
@@ -83,7 +80,6 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
         this.transportFactory = transportFactory;
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;
         this.artifactFileStore = artifactFileStore;
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.metadataFactory = metadataFactory;
         this.instantiatorFactory = instantiatorFactory;
         this.checksumService = checksumService;
@@ -158,7 +154,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
 
         RepositoryTransport transport = transportFactory.createFileTransport(getName());
         Instantiator injector = createInjectorForMetadataSuppliers(transport, instantiatorFactory, null, null);
-        IvyResolver resolver = new IvyResolver(getName(), transport, locallyAvailableResourceFinder, false, artifactFileStore, moduleIdentifierFactory, null, null, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector, checksumService);
+        IvyResolver resolver = new IvyResolver(getName(), transport, locallyAvailableResourceFinder, false, artifactFileStore, null, null, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector, checksumService);
         for (File root : dirs) {
             resolver.addArtifactLocation(root.toURI(), "/[artifact]-[revision](-[classifier]).[ext]");
             resolver.addArtifactLocation(root.toURI(), "/[artifact](-[classifier]).[ext]");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -104,7 +104,8 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     private final ChecksumService checksumService;
     private final IvyMetadataSources metadataSources = new IvyMetadataSources();
 
-    public DefaultIvyArtifactRepository(FileResolver fileResolver, RepositoryTransportFactory transportFactory,
+    public DefaultIvyArtifactRepository(FileResolver fileResolver,
+                                        RepositoryTransportFactory transportFactory,
                                         LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                                         FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                         FileStore<String> externalResourcesFileStore,
@@ -233,7 +234,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         Instantiator injector = createInjectorForMetadataSuppliers(transport, instantiatorFactory, getUrl(), externalResourcesFileStore);
         InstantiatingAction<ComponentMetadataSupplierDetails> supplierFactory = createComponentMetadataSupplierFactory(injector, isolatableFactory);
         InstantiatingAction<ComponentMetadataListerDetails> listerFactory = createComponentMetadataVersionLister(injector, isolatableFactory);
-        return new IvyResolver(getName(), transport, locallyAvailableResourceFinder, metaDataProvider.dynamicResolve, artifactFileStore, moduleIdentifierFactory, supplierFactory, listerFactory, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector, checksumService);
+        return new IvyResolver(getName(), transport, locallyAvailableResourceFinder, metaDataProvider.dynamicResolve, artifactFileStore, supplierFactory, listerFactory, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector, checksumService);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -100,7 +100,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final MavenMetadataSources metadataSources = new MavenMetadataSources();
     private final InstantiatorFactory instantiatorFactory;
 
-    public DefaultMavenArtifactRepository(FileResolver fileResolver, RepositoryTransportFactory transportFactory,
+    public DefaultMavenArtifactRepository(FileResolver fileResolver,
+                                          RepositoryTransportFactory transportFactory,
                                           LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                                           InstantiatorFactory instantiatorFactory,
                                           FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
@@ -121,7 +122,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     public DefaultMavenArtifactRepository(Transformer<String, MavenArtifactRepository> describer,
-                                          FileResolver fileResolver, RepositoryTransportFactory transportFactory,
+                                          FileResolver fileResolver,
+                                          RepositoryTransportFactory transportFactory,
                                           LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                                           InstantiatorFactory instantiatorFactory,
                                           FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -17,13 +17,11 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.internal.hash.ChecksumService;
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenLocalPomMetadataSource;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenPomMetadataSource;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenLocalPomMetadataSource;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMetadataArtifactProvider;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
@@ -35,6 +33,8 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.hash.ChecksumService;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult;
@@ -83,7 +83,9 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
             MavenMetadataArtifactProvider.INSTANCE,
             mavenMetadataLoader,
             null,
-            null, injector, checksumService);
+            null,
+            injector,
+            checksumService);
         for (URI repoUrl : getArtifactUrls()) {
             resolver.addArtifactLocation(repoUrl);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.ComponentMetadataListerDetails;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadataSources;
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider;
@@ -52,7 +51,6 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
                        LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                        boolean dynamicResolve,
                        FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
-                       ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                        @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
                        @Nullable InstantiatingAction<ComponentMetadataListerDetails> componentMetadataVersionListerFactory,
                        ImmutableMetadataSources repositoryContentFilter,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
@@ -24,6 +24,7 @@ import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
+import org.gradle.internal.resource.local.FileResourceListener;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 import org.gradle.internal.resource.local.LocallyAvailableResourceCandidates;
@@ -39,11 +40,11 @@ public class FileTransport extends AbstractRepositoryTransport {
     private final FileResourceRepository repository;
     private final FileCacheAwareExternalResourceAccessor resourceAccessor;
 
-    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard, ChecksumService checksumService) {
+    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard, ChecksumService checksumService, FileResourceListener listener) {
         super(name);
         this.repository = repository;
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
-        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, repository, checksumService));
+        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, repository, checksumService), listener);
     }
 
     @Override
@@ -63,15 +64,18 @@ public class FileTransport extends AbstractRepositoryTransport {
 
     private class FileCacheAwareExternalResourceAccessor implements CacheAwareExternalResourceAccessor {
         private final CacheAwareExternalResourceAccessor delegate;
+        private final FileResourceListener listener;
 
-        FileCacheAwareExternalResourceAccessor(CacheAwareExternalResourceAccessor delegate) {
+        FileCacheAwareExternalResourceAccessor(CacheAwareExternalResourceAccessor delegate, FileResourceListener listener) {
             this.delegate = delegate;
+            this.listener = listener;
         }
 
         @Nullable
         @Override
         public LocallyAvailableExternalResource getResource(ExternalResourceName source, @Nullable String baseName, ResourceFileStore fileStore, @Nullable LocallyAvailableResourceCandidates additionalCandidates) throws IOException {
             LocallyAvailableExternalResource resource = repository.resource(source);
+            listener.fileObserved(resource.getFile());
             if (!resource.getFile().exists()) {
                 return null;
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
+
 import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadataSources
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolver
@@ -60,9 +60,11 @@ class DependencyResolverIdentifierTest extends Specification {
 
     def patterns(ExternalResourceResolver resolver, Field field, List<String> patterns) {
         field.accessible = true
-        field.set(resolver, patterns.collect { p -> Mock(ResourcePattern) {
-            getPattern() >> p
-        }})
+        field.set(resolver, patterns.collect { p ->
+            Mock(ResourcePattern) {
+                getPattern() >> p
+            }
+        })
     }
 
     def id(ExternalResourceResolver resolver) {
@@ -70,12 +72,12 @@ class DependencyResolverIdentifierTest extends Specification {
     }
 
     def resolver() {
-        return new TestResolver("repo", false, Stub(ExternalResourceRepository), Stub(CacheAwareExternalResourceAccessor), Stub(LocallyAvailableResourceFinder), Stub(FileStore), Stub(ImmutableModuleIdentifierFactory), Stub(ImmutableMetadataSources), Stub(MetadataArtifactProvider))
+        return new TestResolver("repo", false, Stub(ExternalResourceRepository), Stub(CacheAwareExternalResourceAccessor), Stub(LocallyAvailableResourceFinder), Stub(FileStore), Stub(ImmutableMetadataSources), Stub(MetadataArtifactProvider))
     }
 
     static class TestResolver extends ExternalResourceResolver {
 
-        protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder locallyAvailableResourceFinder, FileStore artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
+        protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder locallyAvailableResourceFinder, FileStore artifactFileStore, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
             super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null, TestUtil.checksumService)
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -47,7 +47,6 @@ import org.gradle.api.internal.properties.GradleProperties
 import org.gradle.internal.Factory
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
@@ -62,7 +61,8 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class ResolveIvyFactoryTest extends Specification {
-    @Subject ResolveIvyFactory resolveIvyFactory
+    @Subject
+    ResolveIvyFactory resolveIvyFactory
     ModuleVersionsCache moduleVersionsCache
     ModuleMetadataCache moduleMetaDataCache
     ModuleArtifactsCache moduleArtifactsCache
@@ -74,7 +74,6 @@ class ResolveIvyFactoryTest extends Specification {
     ImmutableModuleIdentifierFactory moduleIdentifierFactory
     RepositoryDisabler repositoryBlacklister
     VersionParser versionParser
-    InstantiatorFactory instantiatorFactory
     BuildOperationExecutor buildOperationExecutor
     ChangingValueDependencyResolutionListener listener
 
@@ -94,14 +93,13 @@ class ResolveIvyFactoryTest extends Specification {
         versionComparator = Mock(VersionComparator)
         repositoryBlacklister = Mock(RepositoryDisabler)
         versionParser = new VersionParser()
-        instantiatorFactory = Mock()
         buildOperationExecutor = Mock()
         listener = Mock()
 
-        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor, TestUtil.checksumService, Mock(SignatureVerificationServiceFactory), new DocumentationRegistry(), buildCommencedTimeProvider, (Factory<GradleProperties>) Mock(Factory)), buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory, listener)
+        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor, TestUtil.checksumService, Mock(SignatureVerificationServiceFactory), new DocumentationRegistry(), buildCommencedTimeProvider, (Factory<GradleProperties>) Mock(Factory)), buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, listener)
     }
 
-    def "returns an empty resolver when no repositories are configured" () {
+    def "returns an empty resolver when no repositories are configured"() {
         when:
         def resolver = resolveIvyFactory.create("test", Stub(ResolutionStrategyInternal), Collections.emptyList(), Stub(ComponentMetadataProcessorFactory), ImmutableAttributes.EMPTY, Stub(AttributesSchemaInternal), AttributeTestUtil.attributesFactory(), Stub(ComponentMetadataSupplierRuleExecutor))
 
@@ -109,7 +107,7 @@ class ResolveIvyFactoryTest extends Specification {
         resolver instanceof NoRepositoriesResolver
     }
 
-    def "sets parent resolver with different selection rules when repository is external" () {
+    def "sets parent resolver with different selection rules when repository is external"() {
         def componentSelectionRules = Stub(ComponentSelectionRulesInternal)
 
         def resolutionStrategy = Stub(ResolutionStrategyInternal) {
@@ -164,7 +162,7 @@ class ResolveIvyFactoryTest extends Specification {
                 TestUtil.checksumService
             ]
         ) {
-            appendId(_) >> { }
+            appendId(_) >> {}
             getLocalAccess() >> Stub(ModuleComponentRepositoryAccess)
             getRemoteAccess() >> Stub(ModuleComponentRepositoryAccess)
             isM2compatible() >> true

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -40,10 +39,9 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final RepositoryTransportFactory transportFactory = Mock()
     final LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder = Mock()
     final DefaultArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
-    final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
-    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory), TestUtil.checksumService)
+    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory), TestUtil.checksumService)
 
     def "creates a repository with multiple root directories"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultArtifactMetadataSource
 import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadataSources
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
@@ -55,13 +54,12 @@ class ExternalResourceResolverTest extends Specification {
     CacheAwareExternalResourceAccessor resourceAccessor = Stub()
     LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder = Mock()
     FileStore<ModuleComponentArtifactIdentifier> fileStore = Stub()
-    ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
     ExternalResourceArtifactResolver artifactResolver = Mock()
     ImmutableMetadataSources metadataSources = Mock()
     ExternalResourceResolver resolver
 
     def setup() {
-        resolver = new TestResolver(name, true, repository, resourceAccessor, locallyAvailableResourceFinder, fileStore, moduleIdentifierFactory, metadataSources, Stub(MetadataArtifactProvider))
+        resolver = new TestResolver(name, true, repository, resourceAccessor, locallyAvailableResourceFinder, fileStore, metadataSources, Stub(MetadataArtifactProvider))
         resolver.artifactResolver = artifactResolver
     }
 
@@ -147,7 +145,7 @@ class ExternalResourceResolverTest extends Specification {
 
         then:
         1 * metadataSources.sources() >> ImmutableList.of(new DefaultArtifactMetadataSource(Mock(MutableModuleMetadataFactory)))
-        1 * artifactResolver.artifactExists({ it.componentId.is(id) && it.name.type == 'jar'}, _)
+        1 * artifactResolver.artifactExists({ it.componentId.is(id) && it.name.type == 'jar' }, _)
         1 * metadataResult.missing()
         0 * _
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -190,7 +190,6 @@ class IvyResolverTest extends Specification {
                 Stub(LocallyAvailableResourceFinder),
                 false,
                 Stub(FileStore),
-                moduleIdentifierFactory,
                 supplier,
                 lister,
                 metadataSources,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadataSources;
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider;
@@ -38,7 +37,7 @@ import org.gradle.util.TestUtil;
 public class TestResolver extends ExternalResourceResolver<ModuleComponentResolveMetadata> {
     ExternalResourceArtifactResolver artifactResolver;
 
-    protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, FileStore<ModuleComponentArtifactIdentifier> artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
+    protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, FileStore<ModuleComponentArtifactIdentifier> artifactFileStore, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
         super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null, TestUtil.getChecksumService());
     }
 
@@ -88,5 +87,6 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
         };
     }
 
-    interface MutableTestResolveMetadata extends MutableModuleComponentResolveMetadata {}
+    interface MutableTestResolveMetadata extends MutableModuleComponentResolveMetadata {
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.authentication.Authentication
 import org.gradle.cache.internal.ProducerGuard
 import org.gradle.internal.authentication.AbstractAuthentication
 import org.gradle.internal.resource.connector.ResourceConnectorFactory
+import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.transport.ResourceConnectorRepositoryTransport
 import org.gradle.internal.verifier.HttpRedirectVerifier
@@ -46,7 +47,7 @@ class RepositoryTransportFactoryTest extends Specification {
         connectorFactory2.getSupportedAuthentication() >> ([] as Set)
         List<ResourceConnectorFactory> resourceConnectorFactories = Lists.newArrayList(connectorFactory1, connectorFactory2)
         StartParameterResolutionOverride override = new StartParameterResolutionOverride(new StartParameter(), Mock(File))
-        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override, producerGuard, Mock(FileResourceRepository), TestUtil.checksumService)
+        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override, producerGuard, Mock(FileResourceRepository), TestUtil.checksumService, Stub(FileResourceListener))
     }
 
     RepositoryTransport createTransport(String scheme, String name, Collection<Authentication> authentications) {

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -176,7 +176,7 @@ org.gradle.unsafe.configuration-cache.max-problems=5
 
 The configuration cache is automatically invalidated when inputs to the configuration phase change.
 However, certain inputs are not tracked yet, so you may have to manually invalidate the configuration cache when untracked inputs to the configuration phase change.
-This can happen if you <<configuration_cache#config_cache:usage:ignore_problems,ignored problems>>, or when your build uses a <<config_cache:not_yet_implemented:file_system_repositories,file system repository>> and dependencies in this repository have changed for example.
+This can happen if you <<configuration_cache#config_cache:usage:ignore_problems,ignored problems>>.
 See the <<configuration_cache#config_cache:requirements>> and <<configuration_cache#config_cache:not_yet_implemented>> sections below for more information.
 
 The configuration cache state is stored on disk in a directory named `.gradle/configuration-cache` in the root directory of the Gradle build in use.
@@ -891,17 +891,3 @@ See link:{gradle-issues}13506[gradle/gradle#13506].
 With the configuration cache enabled, no problem will be reported and dependency locks will be ignored.
 
 See link:{gradle-issues}13507[gradle/gradle#13507].
-
-[[config_cache:not_yet_implemented:file_system_repositories]]
-=== File system repositories
-
-Repositories on local file systems are not supported yet.
-With the configuration cache enabled, no problem will be reported and changes to the filesystem in the repositories won't be detected.
-
-This includes:
-
-* <<declaring_repositories#sec:declaring_custom_repository,Maven or Ivy repositories>> with `file://` URLs,
-* <<declaring_repositories#sub:maven_local,`mavenLocal()`>>,
-* and <<declaring_repositories#sub:flat_dir_resolver,flat directory repositories>>.
-
-See link:{gradle-issues}13509[gradle/gradle#13509].

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionFeaturesIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.instantexecution
 
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.junit.Rule
+import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
 
@@ -289,5 +291,231 @@ class InstantExecutionDependencyResolutionFeaturesIntegrationTest extends Abstra
         fixture.assertStateStored()
         outputContains("Calculating task graph as configuration cache cannot be reused because cached artifact information for thing:lib:1.3 has expired.")
         outputContains("result = [lib-1.3.jar]")
+    }
+
+    // This documents current behaviour, rather than desired behaviour. The contents of the artifact does not affect the contents of the task graph and so should not be treated as an input
+    @Unroll
+    def "reports changes to artifact in #repo.displayName"() {
+        repo.setup(this)
+        taskTypeLogsInputFileCollectionContent()
+        buildFile << """
+            configurations {
+                resolve1
+                resolve2
+            }
+            dependencies {
+                resolve1 'thing:lib1:2.1'
+                resolve2 'thing:lib1:2.1'
+            }
+
+            task resolve1(type: ShowFilesTask) {
+                inFiles.from(configurations.resolve1)
+            }
+            task resolve2(type: ShowFilesTask) {
+                inFiles.from(configurations.resolve2)
+            }
+        """
+        def fixture = newInstantExecutionFixture()
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateStored()
+        outputContains("result = [lib1-2.1.jar]")
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateLoaded()
+        outputContains("result = [lib1-2.1.jar]")
+
+        when:
+        repo.publishWithDifferentArtifactContent(this)
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateStored()
+        outputContains("Calculating task graph as configuration cache cannot be reused because file '${repo.pomLocation}' has changed.")
+        outputContains("result = [lib1-2.1.jar]")
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateLoaded()
+        outputContains("result = [lib1-2.1.jar]")
+
+        where:
+        repo                 | _
+        new MavenFileRepo()  | _
+        new MavenLocalRepo() | _
+    }
+
+    @Unroll
+    def "reports changes to metadata in #repo.displayName"() {
+        repo.setup(this)
+        taskTypeLogsInputFileCollectionContent()
+        buildFile << """
+            configurations {
+                resolve1
+                resolve2
+            }
+            dependencies {
+                resolve1 'thing:lib1:2.1'
+                resolve2 'thing:lib1:2.1'
+            }
+
+            task resolve1(type: ShowFilesTask) {
+                inFiles.from(configurations.resolve1)
+            }
+            task resolve2(type: ShowFilesTask) {
+                inFiles.from(configurations.resolve2)
+            }
+        """
+        def fixture = newInstantExecutionFixture()
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateStored()
+        outputContains("result = [lib1-2.1.jar]")
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateLoaded()
+        outputContains("result = [lib1-2.1.jar]")
+
+        when:
+        repo.publishWithDifferentDependencies(this)
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateStored()
+        outputContains("Calculating task graph as configuration cache cannot be reused because file '${repo.pomLocation}' has changed.")
+        outputContains("result = [lib1-2.1.jar, lib2-4.0.jar]")
+
+        when:
+        instantRun("resolve1", "resolve2")
+
+        then:
+        fixture.assertStateLoaded()
+        outputContains("result = [lib1-2.1.jar, lib2-4.0.jar]")
+
+        where:
+        repo                 | _
+        new MavenFileRepo()  | _
+        new MavenLocalRepo() | _
+    }
+
+    abstract class FileRepoSetup {
+        abstract String getDisplayName()
+
+        abstract String getProblemDisplayName()
+
+        abstract String getPomLocation()
+
+        abstract void setup(AbstractIntegrationSpec owner)
+
+        abstract void publishWithDifferentArtifactContent(AbstractIntegrationSpec owner)
+
+        abstract void publishWithDifferentDependencies(AbstractIntegrationSpec owner)
+    }
+
+    class MavenFileRepo extends FileRepoSetup {
+        @Override
+        String getDisplayName() {
+            return "Maven file repository"
+        }
+
+        @Override
+        String getProblemDisplayName() {
+            return 'maven'
+        }
+
+        @Override
+        String getPomLocation() {
+            return 'maven-repo/thing/lib1/2.1/lib1-2.1.pom'
+        }
+
+        @Override
+        void setup(AbstractIntegrationSpec owner) {
+            owner.with {
+                mavenRepo.module("thing", "lib1", "2.1").publish()
+                buildFile << """
+                    repositories {
+                        maven {
+                            url = '${mavenRepo.uri}'
+                        }
+                    }
+                """
+            }
+        }
+
+        @Override
+        void publishWithDifferentArtifactContent(AbstractIntegrationSpec owner) {
+            owner.with {
+                mavenRepo.module("thing", "lib1", "2.1").publishWithChangedContent()
+            }
+        }
+
+        @Override
+        void publishWithDifferentDependencies(AbstractIntegrationSpec owner) {
+            owner.with {
+                def dep = mavenRepo.module("thing", "lib2", "4.0").publish()
+                mavenRepo.module("thing", "lib1", "2.1").dependsOn(dep).publish()
+            }
+        }
+    }
+
+    class MavenLocalRepo extends FileRepoSetup {
+        @Override
+        String getDisplayName() {
+            return "Maven local repository"
+        }
+
+        @Override
+        String getProblemDisplayName() {
+            return 'MavenLocal'
+        }
+
+        @Override
+        String getPomLocation() {
+            return 'maven_home/.m2/repository/thing/lib1/2.1/lib1-2.1.pom'
+        }
+
+        @Override
+        void setup(AbstractIntegrationSpec owner) {
+            owner.with {
+                m2.execute(executer)
+                m2.mavenRepo().module("thing", "lib1", "2.1").publish()
+                buildFile << """
+                    repositories {
+                        mavenLocal()
+                    }
+                """
+            }
+        }
+
+        @Override
+        void publishWithDifferentArtifactContent(AbstractIntegrationSpec owner) {
+            owner.with {
+                m2.execute(executer)
+                m2.mavenRepo().module("thing", "lib1", "2.1").publishWithChangedContent()
+            }
+        }
+
+        @Override
+        void publishWithDifferentDependencies(AbstractIntegrationSpec owner) {
+            owner.with {
+                m2.execute(executer)
+                def dep = m2.mavenRepo().module("thing", "lib2", "4.0").publish()
+                m2.mavenRepo().module("thing", "lib1", "2.1").dependsOn(dep).publish()
+            }
+        }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
@@ -30,6 +30,8 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.internal.vfs.VirtualFileSystem
 import org.gradle.util.BuildCommencedTimeProvider
 import org.gradle.util.GFileUtils
@@ -41,6 +43,7 @@ import java.io.OutputStream
 /**
  * Coordinates the writing and reading of the instant execution cache fingerprint.
  */
+@ServiceScope(Scopes.Build)
 internal
 class InstantExecutionCacheFingerprintController internal constructor(
     private val startParameter: InstantExecutionStartParameter,

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
@@ -41,6 +41,8 @@ class DefaultInstantExecutionProblemsListener internal constructor(
     private val problems: InstantExecutionProblems,
     private val userCodeApplicationContext: UserCodeApplicationContext
 ) : InstantExecutionProblemsListener {
+    private
+    val fileRepos = mutableSetOf<String>()
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
         onTaskExecutionAccessProblem(invocationDescription, task)

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.local;
+
+import org.gradle.internal.service.scopes.EventScope;
+import org.gradle.internal.service.scopes.Scopes;
+
+import java.io.File;
+
+@EventScope(Scopes.Build)
+public interface FileResourceListener {
+    FileResourceListener NO_OP = file -> {
+    };
+
+    void fileObserved(File file);
+}


### PR DESCRIPTION
# Context

Add some initial support for file system repositories when the configuration cache is enabled. Each file referenced from a file system repository during dependency resolution is recorded as an input to the configuration cache entry. While this means that the entry will not be reused when metadata for a local module changes, it also means that the cache entry is unnecessarily discarded when an artifact changes. This can be improved later.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
