### PR TITLE
Support default excludes with file system watching

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -99,7 +99,7 @@ public class PatternSpecFactory {
         DeprecationLogger
             .deprecateIndirectUsage("Changing default excludes during the build")
             .withContext(String.format("Default excludes changed from %s to %s.", sortedExcludesFromSettings, sortedNewExcludes))
-            .withAdvice("Configure default excludes in settings instead.")
+            .withAdvice("Configure default excludes in the settings script instead.")
             .willBeRemovedInGradle7()
             .withUserManual("working_with_files", "sec:change_ant_excludes")
             .nagUser();

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -82,8 +82,7 @@ public class PatternSpecFactory {
         String[] defaultExcludes = DirectoryScanner.getDefaultExcludes();
         if (defaultExcludeSpecCache.isEmpty()) {
             updateDefaultExcludeSpecCache(defaultExcludes);
-        }
-        if (!Arrays.equals(previousDefaultExcludes, defaultExcludes)) {
+        } else if (!Arrays.equals(previousDefaultExcludes, defaultExcludes)) {
             reportChangedDefaultExcludes(previousDefaultExcludes, defaultExcludes);
             updateDefaultExcludeSpecCache(defaultExcludes);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -95,7 +95,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -201,7 +200,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 @Override
                 public void settingsEvaluated(Settings settings) {
                     super.settingsEvaluated(settings);
-                    List<String> defaultExcludes = Arrays.asList(DirectoryScanner.getDefaultExcludes());
+                    String[] defaultExcludes = DirectoryScanner.getDefaultExcludes();
                     patternSpecFactory.setDefaultExcludesFromSettings(defaultExcludes);
                     PatternSpecFactory.INSTANCE.setDefaultExcludesFromSettings(defaultExcludes);
                 }
@@ -211,7 +210,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 public void afterStart(GradleInternal gradle) {
                     // Reset default excludes for each build
                     DirectoryScanner.resetDefaultExcludes();
-                    List<String> defaultExcludes = Arrays.asList(DirectoryScanner.getDefaultExcludes());
+                    String[] defaultExcludes = DirectoryScanner.getDefaultExcludes();
                     patternSpecFactory.setDefaultExcludesFromSettings(defaultExcludes);
                     PatternSpecFactory.INSTANCE.setDefaultExcludesFromSettings(defaultExcludes);
                 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -195,6 +195,17 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 DirectoryScanner.getDefaultExcludes()
             );
             listenerManager.addListener(new DefaultExcludesBuildListener(delegate));
+            listenerManager.addListener(new RootBuildLifecycleListener() {
+                @Override
+                public void afterStart(GradleInternal gradle) {
+                    // Reset default excludes for each build
+                    DirectoryScanner.resetDefaultExcludes();
+                }
+
+                @Override
+                public void beforeComplete(GradleInternal gradle) {
+                }
+            });
             WatchingAwareVirtualFileSystem watchingAwareVirtualFileSystem = determineWatcherRegistryFactory(OperatingSystem.current(), nativeCapabilities)
                 .<WatchingAwareVirtualFileSystem>map(watcherRegistryFactory -> new WatchingVirtualFileSystem(
                     watcherRegistryFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -201,7 +201,9 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 @Override
                 public void settingsEvaluated(Settings settings) {
                     super.settingsEvaluated(settings);
-                    patternSpecFactory.setDefaultExcludesFromSettings(Arrays.asList(DirectoryScanner.getDefaultExcludes()));
+                    List<String> defaultExcludes = Arrays.asList(DirectoryScanner.getDefaultExcludes());
+                    patternSpecFactory.setDefaultExcludesFromSettings(defaultExcludes);
+                    PatternSpecFactory.INSTANCE.setDefaultExcludesFromSettings(defaultExcludes);
                 }
             });
             listenerManager.addListener(new RootBuildLifecycleListener() {
@@ -209,7 +211,9 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 public void afterStart(GradleInternal gradle) {
                     // Reset default excludes for each build
                     DirectoryScanner.resetDefaultExcludes();
-                    patternSpecFactory.setDefaultExcludesFromSettings(null);
+                    List<String> defaultExcludes = Arrays.asList(DirectoryScanner.getDefaultExcludes());
+                    patternSpecFactory.setDefaultExcludesFromSettings(defaultExcludes);
+                    PatternSpecFactory.INSTANCE.setDefaultExcludesFromSettings(defaultExcludes);
                 }
 
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -19,7 +19,9 @@ package org.gradle.internal.service.scopes;
 import com.google.common.annotations.VisibleForTesting;
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.gradle.BuildAdapter;
 import org.gradle.StartParameter;
+import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
@@ -192,6 +194,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                 updateFunctionDecorator,
                 DirectoryScanner.getDefaultExcludes()
             );
+            listenerManager.addListener(new DefaultExcludesBuildListener(delegate));
             WatchingAwareVirtualFileSystem watchingAwareVirtualFileSystem = determineWatcherRegistryFactory(OperatingSystem.current(), nativeCapabilities)
                 .<WatchingAwareVirtualFileSystem>map(watcherRegistryFactory -> new WatchingVirtualFileSystem(
                     watcherRegistryFactory,
@@ -280,7 +283,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             VirtualFileSystem gradleUserHomeVirtualFileSystem
         ) {
             StartParameterInternal startParameterInternal = (StartParameterInternal) startParameter;
-            VirtualFileSystem buildSessionsScopedVirtualFileSystem = new DefaultVirtualFileSystem(
+            DefaultVirtualFileSystem buildSessionsScopedVirtualFileSystem = new DefaultVirtualFileSystem(
                 hasher,
                 stringInterner,
                 stat,
@@ -306,6 +309,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                     buildSessionsScopedVirtualFileSystem.invalidateAll();
                 }
             });
+            listenerManager.addListener(new DefaultExcludesBuildListener(buildSessionsScopedVirtualFileSystem));
             listenerManager.addListener(new OutputChangeListener() {
                 @Override
                 public void beforeOutputChange() {
@@ -366,6 +370,18 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
         CompileClasspathFingerprinter createCompileClasspathFingerprinter(ResourceSnapshotterCacheService resourceSnapshotterCacheService, FileCollectionSnapshotter fileCollectionSnapshotter, StringInterner stringInterner) {
             return new DefaultCompileClasspathFingerprinter(resourceSnapshotterCacheService, fileCollectionSnapshotter, stringInterner);
         }
+    }
 
+    private static class DefaultExcludesBuildListener extends BuildAdapter {
+        private final DefaultVirtualFileSystem virtualFileSystem;
+
+        public DefaultExcludesBuildListener(DefaultVirtualFileSystem virtualFileSystem) {
+            this.virtualFileSystem = virtualFileSystem;
+        }
+
+        @Override
+        public void settingsEvaluated(Settings settings) {
+            virtualFileSystem.updateDefaultExcludes(DirectoryScanner.getDefaultExcludes());
+        }
     }
 }

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -438,6 +438,7 @@ You can see more examples of supported patterns in the API docs for link:{javado
 
 By default, `fileTree()` returns a `FileTree` instance that applies some default exclusion patterns for convenience — the same defaults as Ant in fact. For the complete default exclusion list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
 
+[[sec:change_ant_excludes]]
 If those default exclusions prove problematic, you can workaround the issue by changing Ant's default excludes in settings:
 
 .Changing Ant default exclusions in settings

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -447,7 +447,15 @@ include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=cha
 include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]
 ====
 
+[NOTE]
+====
+Currently, Gradle's default excludes are configured via Ant's `DirectoryScanner` class.
+====
+
+[NOTE]
+====
 Gradle does not support changing default excludes during the execution phase.
+====
 
 You can do many of the same things with file trees that you can with file collections:
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -436,18 +436,18 @@ include::sample[dir="snippets/files/fileTrees/kotlin",files="build.gradle.kts[ta
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable]. Also, see the API documentation for `fileTree()` to see what types you can pass as the base directory.
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclusion patterns for convenience — the same defaults as Ant in fact. For the complete default exclusion list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — the same defaults as Ant in fact. For the complete default exclude list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
 
 [[sec:change_ant_excludes]]
-If those default exclusions prove problematic, you can workaround the issue by changing Ant's default excludes in settings:
+If those default excludes prove problematic, you can workaround the issue by changing the default excludes in settings:
 
-.Changing Ant default exclusions in settings
+.Changing default excludes in settings
 ====
 include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=change-default-exclusions]"]
 include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]
 ====
 
-Gradle does not support to change Ant's default excludes during task execution.
+Gradle does not support to change default excludes during task execution.
 
 You can do many of the same things with file trees that you can with file collections:
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -438,15 +438,15 @@ You can see more examples of supported patterns in the API docs for link:{javado
 
 By default, `fileTree()` returns a `FileTree` instance that applies some default exclusion patterns for convenience — the same defaults as Ant in fact. For the complete default exclusion list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
 
-If those default exclusions prove problematic, you can workaround the issue by using the {antManual}/Tasks/defaultexcludes.html[`defaultexcludes` Ant task], as demonstrated in this example:
+If those default exclusions prove problematic, you can workaround the issue by changing Ant's default excludes in settings:
 
-.Changing Ant default exclusions for a copy task
+.Changing Ant default exclusions in settings
 ====
-include::sample[dir="snippets/files/copy/groovy",files="build.gradle[tags=change-default-exclusions]"]
-include::sample[dir="snippets/files/copy/kotlin",files="build.gradle.kts[tags=change-default-exclusions]"]
+include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=change-default-exclusions]"]
+include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]
 ====
 
-In general, it's best to ensure that the default exclusions are reset whenever you change them as modifications are visible to the entire build. The above example is performing such a reset in its `doLast` action.
+Gradle does not support to change Ant's default excludes during task execution.
 
 You can do many of the same things with file trees that you can with file collections:
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -447,7 +447,7 @@ include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=cha
 include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]
 ====
 
-Gradle does not support changing default excludes during task execution.
+Gradle does not support changing default excludes during the execution phase.
 
 You can do many of the same things with file trees that you can with file collections:
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -438,10 +438,10 @@ You can see more examples of supported patterns in the API docs for link:{javado
 
 By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — the same defaults as Ant in fact. For the complete default exclude list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
 
-[[sec:change_ant_excludes]]
-If those default excludes prove problematic, you can workaround the issue by changing the default excludes in settings:
+[[sec:change_default_excludes]]
+If those default excludes prove problematic, you can workaround the issue by changing the default excludes in the settings script:
 
-.Changing default excludes in settings
+.Changing default excludes in the settings script
 ====
 include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=change-default-exclusions]"]
 include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -447,7 +447,7 @@ include::sample[dir="snippets/files/copy/groovy",files="settings.gradle[tags=cha
 include::sample[dir="snippets/files/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]
 ====
 
-Gradle does not support to change default excludes during task execution.
+Gradle does not support changing default excludes during task execution.
 
 You can do many of the same things with file trees that you can with file collections:
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -33,6 +33,22 @@ Some plugins will break with this new version of Gradle, for example because the
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_6.7]]
+== Upgrading from 6.6
+
+=== Potential breaking changes
+
+=== Deprecations
+
+==== Changing default excludes during task execution
+
+Gradle's file trees apply some default exclusion patterns for convenience — the same defaults as Ant in fact.
+See the <<working_with_files.adoc#sec:file_trees,user manual>> for more information.
+Sometimes, Ant's default exclusions prove problematic, for example when you want to include the `.gitignore` in an archive file.
+
+Changing Gradle's default excludes during task execution can lead to correctness problems with up-to-date checks, and is deprecated.
+You are only allowed to change Gradle's default excludes in settings, see the <<working_with_files.adoc#sec:change_ant_excludes,user manual>> for an example.
+
 [[changes_6.6]]
 == Upgrading from 6.5
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -40,13 +40,13 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Deprecations
 
-==== Changing default excludes during task execution
+==== Changing default excludes during the execution phase
 
 Gradle's file trees apply some default exclude patterns for convenience — the same defaults as Ant in fact.
 See the <<working_with_files.adoc#sec:file_trees,user manual>> for more information.
 Sometimes, Ant's default excludes prove problematic, for example when you want to include the `.gitignore` in an archive file.
 
-Changing Gradle's default excludes during task execution can lead to correctness problems with up-to-date checks, and is deprecated.
+Changing Gradle's default excludes during the execution phase can lead to correctness problems with up-to-date checks, and is deprecated.
 You are only allowed to change Gradle's default excludes in settings, see the <<working_with_files.adoc#sec:change_ant_excludes,user manual>> for an example.
 
 [[changes_6.6]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -42,9 +42,9 @@ Some plugins will break with this new version of Gradle, for example because the
 
 ==== Changing default excludes during task execution
 
-Gradle's file trees apply some default exclusion patterns for convenience — the same defaults as Ant in fact.
+Gradle's file trees apply some default exclude patterns for convenience — the same defaults as Ant in fact.
 See the <<working_with_files.adoc#sec:file_trees,user manual>> for more information.
-Sometimes, Ant's default exclusions prove problematic, for example when you want to include the `.gitignore` in an archive file.
+Sometimes, Ant's default excludes prove problematic, for example when you want to include the `.gitignore` in an archive file.
 
 Changing Gradle's default excludes during task execution can lead to correctness problems with up-to-date checks, and is deprecated.
 You are only allowed to change Gradle's default excludes in settings, see the <<working_with_files.adoc#sec:change_ant_excludes,user manual>> for an example.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -47,7 +47,7 @@ See the <<working_with_files.adoc#sec:file_trees,user manual>> for more informat
 Sometimes, Ant's default excludes prove problematic, for example when you want to include the `.gitignore` in an archive file.
 
 Changing Gradle's default excludes during the execution phase can lead to correctness problems with up-to-date checks, and is deprecated.
-You are only allowed to change Gradle's default excludes in settings, see the <<working_with_files.adoc#sec:change_ant_excludes,user manual>> for an example.
+You are only allowed to change Gradle's default excludes in the settings script, see the <<working_with_files.adoc#sec:change_default_excludes,user manual>> for an example.
 
 [[changes_6.6]]
 == Upgrading from 6.5

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -236,7 +236,6 @@ This enables watching the file system for all builds, unless explicitly disabled
 Limitations::
 We are working on removing the following limitations to make file system watching production ready.
 - If you have symlinks in your build, you won’t get the performance benefits for those locations (we plan to change this in the future).
-- Default excludes (ignoring files and directories like “CVS/”, “.DS_Store” etc.) cannot be configured when file system watching is enabled.
 - When multiple daemons are running, the idle ones can pick up the changes produced by the others and create large log files with lots of debug info about the changes.
 - On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
 

--- a/subprojects/docs/src/snippets/files/copy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/copy/groovy/build.gradle
@@ -270,20 +270,3 @@ task archiveDistAssets(type: Zip) {
     from 'distResources', webAssetPatterns
 }
 // end::shared-copy-patterns[]
-
-// tag::change-default-exclusions[]
-task forcedCopy (type: Copy) {
-    into "$buildDir/inPlaceApp"
-    from 'src/main/webapp'
-
-    doFirst {
-        ant.defaultexcludes remove: "**/.git"
-        ant.defaultexcludes remove: "**/.git/**"
-        ant.defaultexcludes remove: "**/*~"
-    }
-
-    doLast {
-        ant.defaultexcludes default: true
-    }
-}
-// end::change-default-exclusions[]

--- a/subprojects/docs/src/snippets/files/copy/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/files/copy/groovy/settings.gradle
@@ -1,1 +1,7 @@
+// tag::change-default-exclusions[]
+import org.apache.tools.ant.DirectoryScanner
+
+DirectoryScanner.removeDefaultExclude('**/.git')
+DirectoryScanner.removeDefaultExclude('**/.git/**')
+// end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/subprojects/docs/src/snippets/files/copy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/copy/kotlin/build.gradle.kts
@@ -271,24 +271,3 @@ tasks.register<Zip>("archiveDistAssets") {
     from("distResources", webAssetPatterns)
 }
 // end::shared-copy-patterns[]
-
-// tag::change-default-exclusions[]
-tasks.register<Copy>("forcedCopy") {
-    into("$buildDir/inPlaceApp")
-    from("src/main/webapp")
-
-    doFirst {
-        ant.withGroovyBuilder {
-            "defaultexcludes"("remove" to "**/.git")
-            "defaultexcludes"("remove" to "**/.git/**")
-            "defaultexcludes"("remove" to "**/*~")
-        }
-    }
-
-    doLast {
-        ant.withGroovyBuilder {
-            "defaultexcludes"("default" to true)
-        }
-    }
-}
-// end::change-default-exclusions[]

--- a/subprojects/docs/src/snippets/files/copy/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/files/copy/kotlin/settings.gradle.kts
@@ -1,1 +1,7 @@
+// tag::change-default-exclusions[]
+import org.apache.tools.ant.DirectoryScanner
+
+DirectoryScanner.removeDefaultExclude("**/.git")
+DirectoryScanner.removeDefaultExclude("**/.git/**")
+// end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -46,7 +46,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def watcher = Mock(FileWatcher)
-    def directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner())
+    def directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [])
     def decorator = new DelegatingDiffCapturingUpdateFunctionDecorator({ String path -> true})
     def root = DefaultSnapshotHierarchy.empty(CaseSensitivity.CASE_SENSITIVE)
 

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.vfs
+
+import org.apache.tools.ant.DirectoryScanner
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
+
+    private static final EXCLUDED_FILE_NAME = "my-excluded-file.txt"
+
+    def "default excludes defined in settings.gradle are used"() {
+        buildFile << """
+            task copyTask(type: Copy) {
+                from("input")
+                into("build/output")
+            }
+        """
+        settingsFile << """
+            ${DirectoryScanner.name}.addDefaultExclude('**/${EXCLUDED_FILE_NAME}')
+        """
+
+        def outputDir = file("build/output")
+        file("input/inputFile.txt").text = "input"
+        def excludedFile = file("input/${EXCLUDED_FILE_NAME}")
+        excludedFile.text = "initial"
+        def copyOfExcludedFile = outputDir.file(EXCLUDED_FILE_NAME)
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists()
+
+        when:
+        excludedFile.text = "changed"
+        run "copyTask"
+        then:
+        skipped(":copyTask")
+    }
+}

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -139,7 +139,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         executer.expectDocumentedDeprecationWarning("Changing default excludes during the build has been deprecated. " +
             "This is scheduled to be removed in Gradle 7.0. " +
             "Default excludes changed from ${defaultExcludesFromSettings} to ${defaultExcludesInTask}. " +
-            "Configure default excludes in settings instead. " +
+            "Configure default excludes in the settings script instead. " +
             "See https://docs.gradle.org/current/userguide/working_with_files.html#sec:change_ant_excludes for more details.")
         run "copyTask"
         then:

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.EnumSet;
 import java.util.List;
@@ -60,7 +61,7 @@ public class DirectorySnapshotter {
     private final Interner<String> stringInterner;
     private final DefaultExcludes defaultExcludes;
 
-    public DirectorySnapshotter(FileHasher hasher, Interner<String> stringInterner, String... defaultExcludes) {
+    public DirectorySnapshotter(FileHasher hasher, Interner<String> stringInterner, Collection<String> defaultExcludes) {
         this.hasher = hasher;
         this.stringInterner = stringInterner;
         this.defaultExcludes = new DefaultExcludes(defaultExcludes);
@@ -103,7 +104,7 @@ public class DirectorySnapshotter {
         private final ImmutableSet<String> excludedDirNames;
         private final Predicate<String> excludedFileNameSpec;
 
-        public DefaultExcludes(String[] defaultExcludes) {
+        public DefaultExcludes(Collection<String> defaultExcludes) {
             final List<String> excludeFiles = Lists.newArrayList();
             final List<String> excludeDirs = Lists.newArrayList();
             final List<Predicate<String>> excludeFileSpecs = Lists.newArrayList();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.vfs.impl;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Interner;
 import com.google.common.util.concurrent.Striped;
 import org.gradle.internal.file.FileMetadata;
@@ -49,7 +49,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
     private final Stat stat;
     private final SnapshotHierarchy.DiffCapturingUpdateFunctionDecorator updateFunctionDecorator;
     private final Interner<String> stringInterner;
-    private ImmutableSet<String> defaultExcludes;
+    private ImmutableList<String> defaultExcludes;
     private DirectorySnapshotter directorySnapshotter;
     private final FileHasher hasher;
     private final StripedProducerGuard<String> producingSnapshots = new StripedProducerGuard<>();
@@ -58,7 +58,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
         this.stringInterner = stringInterner;
         this.stat = stat;
         this.updateFunctionDecorator = updateFunctionDecorator;
-        this.defaultExcludes = ImmutableSet.copyOf(defaultExcludes);
+        this.defaultExcludes = ImmutableList.copyOf(defaultExcludes);
         this.directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, this.defaultExcludes);
         this.hasher = hasher;
         this.root = new AtomicSnapshotHierarchyReference(DefaultSnapshotHierarchy.empty(caseSensitivity));
@@ -213,7 +213,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
     }
 
     public synchronized void updateDefaultExcludes(String... newDefaultExcludesArgs) {
-        ImmutableSet<String> newDefaultExcludes = ImmutableSet.copyOf(newDefaultExcludesArgs);
+        ImmutableList<String> newDefaultExcludes = ImmutableList.copyOf(newDefaultExcludesArgs);
         if (!defaultExcludes.equals(newDefaultExcludes)) {
             defaultExcludes = newDefaultExcludes;
             directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, newDefaultExcludes);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.vfs.impl;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
 import com.google.common.util.concurrent.Striped;
 import org.gradle.internal.file.FileMetadata;
@@ -54,7 +55,7 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
     public DefaultVirtualFileSystem(FileHasher hasher, Interner<String> stringInterner, Stat stat, CaseSensitivity caseSensitivity, SnapshotHierarchy.DiffCapturingUpdateFunctionDecorator updateFunctionDecorator, String... defaultExcludes) {
         this.stat = stat;
         this.updateFunctionDecorator = updateFunctionDecorator;
-        this.directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, defaultExcludes);
+        this.directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, ImmutableSet.copyOf(defaultExcludes));
         this.hasher = hasher;
         this.root = new AtomicSnapshotHierarchyReference(DefaultSnapshotHierarchy.empty(caseSensitivity));
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultVirtualFileSystem.java
@@ -35,6 +35,8 @@ import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.snapshot.SnapshottingFilter;
 import org.gradle.internal.snapshot.impl.DirectorySnapshotter;
 import org.gradle.internal.snapshot.impl.FileSystemSnapshotFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Optional;
@@ -45,6 +47,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultVirtualFileSystem.class);
+
     private final AtomicSnapshotHierarchyReference root;
     private final Stat stat;
     private final SnapshotHierarchy.DiffCapturingUpdateFunctionDecorator updateFunctionDecorator;
@@ -212,9 +216,10 @@ public class DefaultVirtualFileSystem extends AbstractVirtualFileSystem {
         }
     }
 
-    public synchronized void updateDefaultExcludes(String... newDefaultExcludesArgs) {
+    public void updateDefaultExcludes(String... newDefaultExcludesArgs) {
         ImmutableList<String> newDefaultExcludes = ImmutableList.copyOf(newDefaultExcludesArgs);
         if (!defaultExcludes.equals(newDefaultExcludes)) {
+            LOGGER.debug("Default excludes changes from {} to {}", defaultExcludes, newDefaultExcludes);
             defaultExcludes = newDefaultExcludes;
             directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, newDefaultExcludes);
             invalidateAll();

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -75,7 +75,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
     }
 
     private static DirectorySnapshotter directorySnapshotter() {
-        new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner())
+        new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [])
     }
 
     private static List<FileVisitDetails> walkFiles(rootDir) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -48,7 +48,7 @@ class DirectorySnapshotterTest extends Specification {
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def fileHasher = new TestFileHasher()
-    def directorySnapshotter = new DirectorySnapshotter(fileHasher, new StringInterner())
+    def directorySnapshotter = new DirectorySnapshotter(fileHasher, new StringInterner(), [])
 
     def "should snapshot without filters"() {
         given:
@@ -259,7 +259,7 @@ class DirectorySnapshotterTest extends Specification {
     }
 
     def "default excludes are correctly parsed"() {
-        def defaultExcludes = new DirectorySnapshotter.DefaultExcludes(DirectoryScanner.getDefaultExcludes())
+        def defaultExcludes = new DirectorySnapshotter.DefaultExcludes(DirectoryScanner.getDefaultExcludes() as List)
 
         expect:
         DirectoryScanner.getDefaultExcludes() as Set == ['**/%*%', '**/.git/**', '**/SCCS', '**/.bzr', '**/.hg/**', '**/.bzrignore', '**/.git', '**/SCCS/**', '**/.hg', '**/.#*', '**/vssver.scc', '**/.bzr/**', '**/._*', '**/#*#', '**/*~', '**/CVS', '**/.hgtags', '**/.svn/**', '**/.hgignore', '**/.svn', '**/.gitignore', '**/.gitmodules', '**/.hgsubstate', '**/.gitattributes', '**/CVS/**', '**/.hgsub', '**/.DS_Store', '**/.cvsignore'] as Set

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -45,7 +45,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
 
     private static final SnapshotHierarchy EMPTY = DefaultSnapshotHierarchy.empty(CASE_SENSITIVE)
 
-    DirectorySnapshotter directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner())
+    DirectorySnapshotter directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [])
 
     def diffListener = new SnapshotHierarchy.NodeDiffListener() {
         @Override


### PR DESCRIPTION
This PR allows changing the default excludes in settings and have that picked up consistently during a build. Changes during a build are reported as deprecation warnings.

Fixes https://github.com/gradle/gradle/issues/13427.