### PR TITLE
Add support for dependency locking when the configuration cache is enabled

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -172,6 +172,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
+import org.gradle.internal.resource.local.FileResourceListener;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -566,8 +567,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer, dependencyLockingProvider);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager, PropertyFactory propertyFactory, FilePropertyFactory filePropertyFactory) {
-            DefaultDependencyLockingProvider dependencyLockingProvider = instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews, propertyFactory, filePropertyFactory);
+        DependencyLockingProvider createDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews, ListenerManager listenerManager, PropertyFactory propertyFactory, FilePropertyFactory filePropertyFactory) {
+            DefaultDependencyLockingProvider dependencyLockingProvider = new DefaultDependencyLockingProvider(fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews, propertyFactory, filePropertyFactory, listenerManager.getBroadcaster(FileResourceListener.class));
             if (startParameter.isWriteDependencyLocks() && featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)) {
                 listenerManager.addListener(new InternalBuildFinishedListener() {
                     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.provider.DefaultPropertyFactory
 import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
@@ -53,6 +54,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
     StartParameter startParameter = Mock()
     DomainObjectContext context = Mock()
     DependencySubstitutionRules dependencySubstitutionRules = Mock()
+    FileResourceListener listener = Mock()
     FeaturePreviews featurePreviews = new FeaturePreviews()
     PropertyFactory propertyFactory = new DefaultPropertyFactory(Stub(PropertyHost))
     FilePropertyFactory filePropertyFactory = TestFiles.filePropertyFactory()
@@ -123,6 +125,8 @@ empty=
         then:
         result.mustValidateLockState()
         result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.3'), newId(DefaultModuleIdentifier.newId('org', 'foo'), '1.0')] as Set
+
+        1 * listener.fileObserved(_)
 
         where:
         unique << [true, false]
@@ -272,7 +276,7 @@ empty=
     }
 
     private DefaultDependencyLockingProvider newProvider() {
-        new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews, propertyFactory, filePropertyFactory)
+        new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews, propertyFactory, filePropertyFactory, listener)
     }
 
     def writeLockFile(List<String> modules, boolean unique = true, String configuration = 'conf') {

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -883,11 +883,3 @@ Support for link:https://blog.gradle.org/introducing-source-dependencies[source 
 With the configuration cache enabled, no problem will be reported and the build will fail.
 
 See link:{gradle-issues}13506[gradle/gradle#13506].
-
-[[config_cache:not_yet_implemented:dependency_locking]]
-=== Dependency locking
-
-<<dependency_locking#dependency-locking, Locking dependency versions>> isn't supported yet.
-With the configuration cache enabled, no problem will be reported and dependency locks will be ignored.
-
-See link:{gradle-issues}13507[gradle/gradle#13507].

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSkipCacheIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSkipCacheIntegrationTest.groovy
@@ -16,10 +16,13 @@
 
 package org.gradle.instantexecution
 
+import spock.lang.Unroll
+
 
 class InstantExecutionSkipCacheIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    def "skip reading cached state on --refresh-dependencies"() {
+    @Unroll
+    def "skip reading cached state on #commandLine"() {
 
         def instantExecution = newInstantExecutionFixture()
 
@@ -65,11 +68,13 @@ class InstantExecutionSkipCacheIntegrationTest extends AbstractInstantExecutionI
         instantExecution.assertStateLoaded()
 
         when:
-        instantRun "myTask", "--refresh-dependencies"
+        def commandLineArgs = commandLine.split("\\s+")
+        executer.withArguments(commandLineArgs)
+        instantRun "myTask"
 
         then:
         outputContains("bar")
-        outputContains("Calculating task graph as configuration cache cannot be reused due to --refresh-dependencies")
+        outputContains("Calculating task graph as configuration cache cannot be reused due to ${commandLineArgs.first()}")
         instantExecution.assertStateStored()
 
         when:
@@ -78,5 +83,11 @@ class InstantExecutionSkipCacheIntegrationTest extends AbstractInstantExecutionI
         then:
         outputContains("bar")
         instantExecution.assertStateLoaded()
+
+        where:
+        commandLine              | _
+        "--refresh-dependencies" | _
+        "--write-locks"          | _
+        "--update-locks thing:*" | _
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -88,6 +88,20 @@ class DefaultInstantExecution internal constructor(
             )
             false
         }
+        startParameter.isWriteDependencyLocks -> {
+            logBootstrapSummary(
+                "Calculating task graph as configuration cache cannot be reused due to {}",
+                "--write-locks"
+            )
+            false
+        }
+        startParameter.isUpdateDependencyLocks -> {
+            logBootstrapSummary(
+                "Calculating task graph as configuration cache cannot be reused due to {}",
+                "--update-locks"
+            )
+            false
+        }
         else -> {
             val checkedFingerprint = cache.useForFingerprintCheck(
                 cacheKey.string,

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
@@ -43,8 +43,6 @@ class DefaultInstantExecutionProblemsListener internal constructor(
     private val problems: InstantExecutionProblems,
     private val userCodeApplicationContext: UserCodeApplicationContext
 ) : InstantExecutionProblemsListener {
-    private
-    val fileRepos = mutableSetOf<String>()
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
         onTaskExecutionAccessProblem(invocationDescription, task)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -62,6 +62,12 @@ class InstantExecutionStartParameter(
     val isRefreshDependencies
         get() = startParameter.isRefreshDependencies
 
+    val isWriteDependencyLocks
+        get() = startParameter.isWriteDependencyLocks && !isUpdateDependencyLocks
+
+    val isUpdateDependencyLocks
+        get() = startParameter.lockedDependenciesToUpdate.isNotEmpty()
+
     val requestedTaskNames: List<String> by unsafeLazy {
         startParameter.taskNames
     }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
@@ -23,8 +23,8 @@ import java.io.File;
 
 @EventScope(Scopes.Build)
 public interface FileResourceListener {
-    FileResourceListener NO_OP = file -> {
-    };
-
+    /**
+     * Called when a file system resource is accessed.
+     */
     void fileObserved(File file);
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
