### PR TITLE
De-incubate new version of 'dependencies.constraints { }' (Kotlin DSL)

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Action
-import org.gradle.api.Incubating
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -57,7 +56,6 @@ private constructor(
      *
      * @since 6.3
      */
-    @Incubating
     fun constraints(configureAction: DependencyConstraintHandlerScope.() -> Unit) {
         super.constraints { t -> configureAction(DependencyConstraintHandlerScope.of(t)) }
     }


### PR DESCRIPTION
See: https://github.com/gradle/gradle/pull/12098
