### PR TITLE
Enforce EdgeState invariant

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -67,6 +67,7 @@ class EdgeState implements DependencyGraphEdge {
 
     private ResolvedVariantResult resolvedVariant;
     private boolean unattached;
+    private boolean used;
 
     EdgeState(NodeState from, DependencyState dependencyState, ExcludeSpec transitiveExclusions, ResolveState resolveState) {
         this.from = from;
@@ -182,15 +183,26 @@ class EdgeState implements DependencyGraphEdge {
         targetNodeSelectionFailure = new ModuleVersionResolveException(dependencyState.getRequested(), err);
     }
 
-    public void restart(boolean checkUnattached) {
+
+    public void restart() {
         if (from.isSelected()) {
-            removeFromTargetConfigurations();
-            // We now have corner cases that can lead to this restart not succeeding
-            if (checkUnattached && !isUnattached()) {
-                selector.getTargetModule().addUnattachedDependency(this);
-            }
-            attachToTargetConfigurations();
+            restartInternal(false);
         }
+    }
+
+    public void restartConnected(boolean checkUnattached) {
+        if (from.isSelected() && isUsed()) {
+            restartInternal(checkUnattached);
+        }
+    }
+
+    private void restartInternal(boolean checkUnattached) {
+        removeFromTargetConfigurations();
+        // We now have corner cases that can lead to this restart not succeeding
+        if (checkUnattached && !isUnattached()) {
+            selector.getTargetModule().addUnattachedDependency(this);
+        }
+        attachToTargetConfigurations();
     }
 
     @Override
@@ -446,5 +458,23 @@ class EdgeState implements DependencyGraphEdge {
 
     public boolean isUnattached() {
         return unattached;
+    }
+
+    void markUsed() {
+        this.used = true;
+    }
+
+    void markUnused() {
+        this.used = false;
+    }
+
+    /**
+     * Indicates whether the edge is currently listed as outgoing in a node.
+     * It can be either a full edge or an edge to a virtual platform.
+     *
+     * @return true if used, false otherwise
+     */
+    boolean isUsed() {
+        return used;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -262,10 +262,10 @@ class ModuleResolveState implements CandidateModule {
     private void restartUnattachedDependencies() {
         if (unattachedDependencies.size() == 1) {
             EdgeState singleDependency = unattachedDependencies.get(0);
-            singleDependency.restart(false);
+            singleDependency.restart();
         } else {
             for (EdgeState dependency : new ArrayList<>(unattachedDependencies)) {
-                dependency.restart(false);
+                dependency.restart();
             }
         }
     }


### PR DESCRIPTION
An EdgeState can only be added as an incoming edge if it is properly
tracked as an outgoing edge in the node it originates from.
Before these changes there was a code path were an edge could be added
as incoming while it was no longer outgoing.

Draft PR to get the changes through CI while crafting an integration test.