### PR TITLE
Update gradle-module-metadata-latest-specification.md

### DIFF
--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -28,7 +28,7 @@ The file must be encoded using UTF-8.
 
 The file must contain a JSON object with the following values:
 
-- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"1.0"`
+- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"1.1"`
 - `component`: optional. Describes the identity of the component contained in the module.
 - `createdBy`: optional. Describes the producer of this metadata file and the contents of the module.
 - `variants`: optional. Describes the variants of the component packaged in the module, if any.


### PR DESCRIPTION
Specify formatVersion 1.1 instead of 1.0, which is what artifacts such as okio-2.6.0 (for example) use.


### Context
The specification seems to describe the wrong version number for its format, which might lead to bad switching logic for any systems consuming or producing this which adapt based on the format version. Also, real artifacts such as `okio` don't agree with the prior unchanged value.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- N/A Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- N/A Provide unit tests (under `<subproject>/src/test`) to verify logic
- N/A Update User Guide, DSL Reference, and Javadoc for public-facing changes
- N/A Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
