### PR TITLE
Add `StartParameter.projectDir` to the configuration cache fingerprint

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -50,6 +50,12 @@ class InstantExecutionStartParameter(
     val recreateCache: Boolean
         get() = startParameter.isConfigurationCacheRecreateCache
 
+    /**
+     * See [StartParameter.getProjectDir].
+     */
+    val projectDirectory: File?
+        get() = startParameter.projectDir
+
     val currentDirectory: File
         get() = startParameter.currentDir
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.gradle.integtests;
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest;
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution;
 import org.gradle.integtests.fixtures.executer.ExecutionFailure;
 import org.gradle.test.fixtures.file.TestFile;
 import org.junit.Test;
@@ -300,7 +299,6 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     public void multiProjectBuildCanHaveSettingsFileAndRootBuildFileInSubDir() {
         TestFile buildFilesDir = getTestDirectory().file("root");
         TestFile settingsFile = buildFilesDir.file("settings.gradle");


### PR DESCRIPTION
To ensure relative task names are resolved correctly.