### PR TITLE
Make `NestedInputIntegrationTest` compatible with the configuration cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -232,7 +232,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date", iterationMatchers = ".*inputProperty.*")
     def "re-configuring #change in nested bean after the task started executing has no effect"() {
         def fixture = new NestedBeanTestFixture()
         fixture.prepareInputFiles()
@@ -265,7 +264,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date", iterationMatchers = ".*from firstBean to null.*")
     def "re-configuring a nested bean from #from to #to after the task started executing has no effect"() {
         def fixture = new NestedBeanTestFixture()
         fixture.prepareInputFiles()
@@ -406,10 +404,10 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 }
             }
 
-            def firstString = project.findProperty('firstInput')
+            def firstString = providers.gradleProperty('firstInput').forUseAtConfigurationTime().orNull
             def firstBean = new NestedBean(firstInput: firstString, firstOutputFile: file("${firstOutputFile}"), firstInputFile: file("${firstInputFile}"))
 
-            def secondString = project.findProperty('secondInput')
+            def secondString = providers.gradleProperty('secondInput').forUseAtConfigurationTime().orNull
             def secondBean = new OtherNestedBean(secondInput: secondString, secondOutputFile: file("${secondOutputFile}"), secondInputFile: file("${secondInputFile}"))
 
             task taskWithNestedProperty(type: TaskWithNestedProperty) {
@@ -508,7 +506,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         succeeds "myTask"
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "changes to nested bean implementation are detected"() {
         buildFile << """
             class TaskWithNestedInput extends DefaultTask {
@@ -534,7 +531,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 input
             }
 
-            boolean useOther = project.findProperty('useOther')
+            boolean useOther = providers.gradleProperty('useOther').forUseAtConfigurationTime().present
 
             task myTask(type: TaskWithNestedInput) {
                 outputFile = file('build/output.txt')
@@ -583,7 +580,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         failure.assertHasCause('Null is not allowed as nested property \'beans.$1\'')
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "nested iterable beans can be iterables themselves"() {
         buildFile << nestedBeanWithStringInput()
         buildFile << """
@@ -600,7 +596,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 }
             }
 
-            def inputString = project.findProperty('input') ?: 'input'
+            def inputString = providers.gradleProperty('input').forUseAtConfigurationTime().orNull ?: 'input'
 
             task myTask(type: TaskWithNestedIterable) {
                 outputFile = file('build/output.txt')
@@ -672,12 +668,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         succeeds "myTask"
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "nested Provider is unpacked"() {
         buildFile << taskWithNestedInput()
         buildFile << nestedBeanWithStringInput()
         buildFile << """
-            myTask.nested = provider { new NestedBean(project.property('input')) }
+            myTask.nested = provider { new NestedBean(providers.gradleProperty('input').forUseAtConfigurationTime().get()) }
         """
 
         def myTask = ':myTask'
@@ -698,12 +693,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         output.contains "Value of input property 'nested.input' has changed for task ':myTask'"
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "input changes for task with named nested beans"() {
         buildFile << taskWithNestedInput()
         buildFile << namedBeanClass()
         buildFile << """
-            myTask.nested = [new NamedBean(project.property('namedName'), 'value1'), new NamedBean('name', 'value2')]
+            myTask.nested = [new NamedBean(providers.gradleProperty('namedName').forUseAtConfigurationTime().get(), 'value1'), new NamedBean('name', 'value2')]
         """
         def taskPath = ':myTask'
 
@@ -725,12 +719,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         output.contains("Input property 'nested.name1\$0' has been removed for task ':myTask'")
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "input changes for task with nested map"() {
         buildFile << taskWithNestedInput()
         buildFile << nestedBeanWithStringInput()
         buildFile << """
-            myTask.nested = [(project.property('key')): new NestedBean('value1'), key2: new NestedBean('value2')]
+            myTask.nested = [(providers.gradleProperty('key').forUseAtConfigurationTime().get()): new NestedBean('value1'), key2: new NestedBean('value2')]
         """
         def taskPath = ':myTask'
 
@@ -778,7 +771,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             "  Non-cacheable inputs: property 'bean' was loaded with an unknown classloader (class 'NestedBean')."
     }
 
-    @ToBeFixedForInstantExecution(because = "ClassNotFoundException: NestedBean")
+    @ToBeFixedForInstantExecution(because = "uses custom GroovyClassLoader")
     def "task with nested bean loaded with custom classloader is never up-to-date"() {
         file("input.txt").text = "data"
         buildFile << taskWithNestedBeanFromCustomClassLoader()
@@ -795,7 +788,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         output.contains "Implementation of input property 'bean' has changed for task ':customTask'"
     }
 
-    @ToBeFixedForInstantExecution(because = "task wrongly up-to-date")
     def "changes to nested domain object container are tracked"() {
         buildFile << taskWithNestedInput()
         buildFile << """
@@ -814,7 +806,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             def domainObjectCollection = objects.domainObjectContainer(Bean)
             myTask.nested = domainObjectCollection
 
-            domainObjectCollection.create('first') { prop = project.property('value') }
+            domainObjectCollection.create('first') { prop = providers.gradleProperty('value').forUseAtConfigurationTime().get() }
             domainObjectCollection.create('second') { prop = '2' }
         """
 


### PR DESCRIPTION
By replacing `project.property(...)` and `project.findProperty(...)` by the equivalent `providers.gradleProperty(...)` patterns.