### PR TITLE
Disable instrumentation of injected build logic when a Java agent is used

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
@@ -65,7 +65,7 @@ public class DependencyClassPathProvider implements ClassPathProvider {
 
     private ClassPath initGradleApi() {
         ClassPath classpath = ClassPath.EMPTY;
-        for (String moduleName : Arrays.asList("gradle-worker-processes", "gradle-launcher", "gradle-workers", "gradle-dependency-management", "gradle-plugin-use", "gradle-tooling-api")) {
+        for (String moduleName : Arrays.asList("gradle-worker-processes", "gradle-launcher", "gradle-workers", "gradle-dependency-management", "gradle-plugin-use", "gradle-tooling-api", "gradle-instant-execution")) {
             classpath = classpath.plus(moduleRegistry.getModule(moduleName).getAllRequiredModulesClasspath());
         }
         for (Module pluginModule : pluginModuleRegistry.getApiModules()) {

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -48,7 +48,7 @@ public class ProjectBuilder {
     private File gradleUserHomeDir;
     private String name = "test";
     private Project parent;
-    private ProjectBuilderImpl impl = new ProjectBuilderImpl();
+    private final ProjectBuilderImpl impl = new ProjectBuilderImpl();
 
     /**
      * An instance should only be created via the {@link #builder()}.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyClassPathProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyClassPathProviderTest.groovy
@@ -32,7 +32,7 @@ class DependencyClassPathProviderTest extends Specification {
         def classpath = provider.findClassPath("GRADLE_API")
 
         then:
-        classpath.asFiles.collect{it.name} == ["gradle-worker-processes-runtime", "gradle-launcher-runtime", "gradle-cli-runtime", "gradle-workers-runtime", "gradle-dependency-management-runtime", "gradle-plugin-use-runtime", "gradle-tooling-api-runtime", "plugin1-runtime", "plugin2-runtime"]
+        classpath.asFiles.collect{it.name} == ["gradle-worker-processes-runtime", "gradle-launcher-runtime", "gradle-cli-runtime", "gradle-workers-runtime", "gradle-dependency-management-runtime", "gradle-plugin-use-runtime", "gradle-tooling-api-runtime", "gradle-instant-execution-runtime", "plugin1-runtime", "plugin2-runtime"]
 
         and:
         1 * moduleRegistry.getModule("gradle-worker-processes") >> module("gradle-worker-processes")
@@ -41,6 +41,7 @@ class DependencyClassPathProviderTest extends Specification {
         1 * moduleRegistry.getModule("gradle-dependency-management") >> module("gradle-dependency-management")
         1 * moduleRegistry.getModule("gradle-plugin-use") >> module("gradle-plugin-use")
         1 * moduleRegistry.getModule("gradle-tooling-api") >> module("gradle-tooling-api")
+        1 * moduleRegistry.getModule("gradle-instant-execution") >> module("gradle-instant-execution")
         1 * pluginModuleRegistry.getApiModules() >> ([module("plugin1"), module("plugin2")] as LinkedHashSet)
     }
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -891,6 +891,10 @@ With the configuration cache enabled, no problem will be reported and the build 
 
 See link:{gradle-issues}13506[gradle/gradle#13506].
 
+[[config_cache:not_yet_implemented:testkit_build_with_java_agent]]
+=== Using a Java agent for builds started using TestKit
+
+
 [[config_cache:not_yet_implemented:java_serialization]]
 === Java Object Serialization
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -892,8 +892,9 @@ With the configuration cache enabled, no problem will be reported and the build 
 See link:{gradle-issues}13506[gradle/gradle#13506].
 
 [[config_cache:not_yet_implemented:testkit_build_with_java_agent]]
-=== Using a Java agent for builds started using TestKit
+=== Using a Java agent with builds run using TestKit
 
+When running builds using <<test_kit#test_kit, TestKit>>, the configuration cache can interfere with Java agents, such as the Jacoco agent, that are applied to these builds.
 
 [[config_cache:not_yet_implemented:java_serialization]]
 === Java Object Serialization

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(project(":publish"))
     implementation(project(":resources"))
     implementation(project(":snapshots"))
+    implementation(project(":pluginUse"))
 
     // TODO - move the isolatable serializer to model-core to live with the isolatable infrastructure
     implementation(project(":workers"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTestkitIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTestkitIntegrationTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+@Requires(TestPrecondition.NOT_WINDOWS)
+class InstantExecutionTestkitIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    def "reports when a TestKit build runs with a Java agent and configuration caching enabled"() {
+        def builder = artifactBuilder()
+        builder.sourceFile("TestAgent.java") << """
+            public class TestAgent {
+                public static void premain(String p1, java.lang.instrument.Instrumentation p2) {
+                }
+            }
+        """
+        builder.manifestAttributes("Premain-Class": "TestAgent")
+        def agentJar = file("agent.jar")
+        builder.buildJar(agentJar)
+        buildFile << """
+        """
+        settingsFile << """
+        """
+
+        when:
+        def runner = GradleRunner.create()
+        runner.withJvmArguments("-javaagent:${agentJar}")
+        if (!GradleContextualExecuter.embedded) {
+            runner.withGradleInstallation(buildContext.gradleHomeDir)
+        }
+        runner.withArguments("--configuration-cache")
+        runner.forwardOutput()
+        runner.withProjectDir(testDirectory)
+        def result = runner.buildAndFail()
+        def output = result.output
+
+        then:
+        output.contains("- Gradle runtime: support for using a Java agent with TestKit builds is not yet implemented with the configuration cache.")
+
+        when:
+        runner = GradleRunner.create()
+        runner.withJvmArguments("-javaagent:${agentJar}")
+        if (!GradleContextualExecuter.embedded) {
+            runner.withGradleInstallation(buildContext.gradleHomeDir)
+        }
+        runner.forwardOutput()
+        runner.withProjectDir(testDirectory)
+        result = runner.build()
+        output = result.output
+
+        then:
+        !output.contains("configuration cache")
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -236,7 +236,7 @@ class InstantExecutionHost internal constructor(
         fun applyAutoPluginRequestsTo(settingsInternal: SettingsInternal) {
             service<PluginRequestApplicator>().applyPlugins(
                 autoAppliedPluginRequestsFor(settingsInternal),
-                settingsInternal.buildscript as ScriptHandlerInternal?,
+                settingsInternal.buildscript as ScriptHandlerInternal,
                 settingsInternal.pluginManager,
                 settingsInternal.classLoaderScope
             )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -19,6 +19,7 @@ package org.gradle.instantexecution
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.configuration.internal.UserCodeApplicationContext
 import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprintController
+import org.gradle.instantexecution.initialization.DefaultInjectedClasspathInstrumentationStrategy
 import org.gradle.instantexecution.initialization.DefaultInstantExecutionProblemsListener
 import org.gradle.instantexecution.initialization.InstantExecutionProblemsListener
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
@@ -44,6 +45,7 @@ class InstantExecutionServices : AbstractPluginServiceRegistry() {
         registration.run {
             add(BuildTreeListenerManager::class.java)
             add(InstantExecutionStartParameter::class.java)
+            add(DefaultInjectedClasspathInstrumentationStrategy::class.java)
             add(InstantExecutionCacheKey::class.java)
             add(InstantExecutionReport::class.java)
             add(InstantExecutionProblems::class.java)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionState.kt
@@ -117,7 +117,7 @@ class InstantExecutionState(
     private
     suspend fun DefaultReadContext.readGradleState(gradle: GradleInternal) {
         withGradleIsolate(gradle) {
-            readIncludedBuilds()
+            readChildBuilds()
             readBuildCacheConfiguration(gradle)
             readBuildEventListenerSubscriptions()
             readBuildOutputCleanupRegistrations()
@@ -154,7 +154,7 @@ class InstantExecutionState(
     }
 
     private
-    suspend fun DefaultReadContext.readIncludedBuilds() {
+    suspend fun DefaultReadContext.readChildBuilds() {
         if (readBoolean()) {
             logNotImplemented(
                 feature = "included builds",

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/DefaultInjectedClasspathInstrumentationStrategy.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/DefaultInjectedClasspathInstrumentationStrategy.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.initialization
+
+import org.gradle.instantexecution.problems.DocumentationSection
+import org.gradle.instantexecution.problems.InstantExecutionProblems
+import org.gradle.instantexecution.problems.PropertyProblem
+import org.gradle.instantexecution.problems.PropertyTrace
+import org.gradle.instantexecution.problems.StructuredMessage
+import org.gradle.internal.classpath.CachedClasspathTransformer
+import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathInstrumentationStrategy
+import java.lang.management.ManagementFactory
+
+
+class DefaultInjectedClasspathInstrumentationStrategy(private val startParameter: InstantExecutionStartParameter, private val problems: InstantExecutionProblems) : InjectedClasspathInstrumentationStrategy {
+    override fun getTransform(): CachedClasspathTransformer.StandardTransform {
+        val isAgentPresent = ManagementFactory.getRuntimeMXBean().inputArguments.find { it.startsWith("-javaagent:") } != null
+        return if (!startParameter.isEnabled && isAgentPresent) {
+            // Currently, the build logic instrumentation can interfere with Java agents, such as Jacoco
+            // For now, disable the instrumentation
+            CachedClasspathTransformer.StandardTransform.None
+        } else if (isAgentPresent) {
+            problems.onProblem(PropertyProblem(
+                PropertyTrace.Gradle,
+                StructuredMessage.build { text("support for using a Java agent with TestKit builds is not yet implemented with the configuration cache.") },
+                null,
+                DocumentationSection.NotYetImplementedTestKitJavaAgent
+            ))
+            CachedClasspathTransformer.StandardTransform.BuildLogic
+        } else {
+            CachedClasspathTransformer.StandardTransform.BuildLogic
+        }
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/PropertyProblem.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/PropertyProblem.kt
@@ -37,6 +37,7 @@ enum class DocumentationSection(val anchor: String) {
     NotYetImplementedCompositeBuilds("config_cache:not_yet_implemented:composite_builds"),
     NotYetImplementedSourceDependencies("config_cache:not_yet_implemented:source_dependencies"),
     NotYetImplementedJavaSerialization("config_cache:not_yet_implemented:java_serialization"),
+    NotYetImplementedTestKitJavaAgent("config_cache:not_yet_implemented:testkit_build_with_java_agent"),
     RequirementsBuildListeners("config_cache:requirements:build_listeners"),
     RequirementsDisallowedTypes("config_cache:requirements:disallowed_types"),
     RequirementsTaskAccess("config_cache:requirements:task_access"),

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
@@ -50,6 +50,7 @@ import org.gradle.plugin.use.internal.PluginDependencyResolutionServices;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
 import org.gradle.plugin.use.internal.PluginResolverFactory;
 import org.gradle.plugin.use.resolve.internal.PluginResolverContributor;
+import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathInstrumentationStrategy;
 import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathPluginResolver;
 
 import java.util.List;
@@ -101,8 +102,9 @@ public class PluginUsePluginServiceRegistry extends AbstractPluginServiceRegistr
         }
 
         InjectedClasspathPluginResolver createInjectedClassPathPluginResolver(ClassLoaderScopeRegistry classLoaderScopeRegistry, PluginInspector pluginInspector,
-                                                                              InjectedPluginClasspath injectedPluginClasspath, CachedClasspathTransformer classpathTransformer) {
-            return new InjectedClasspathPluginResolver(classLoaderScopeRegistry.getCoreAndPluginsScope(), classpathTransformer, pluginInspector, injectedPluginClasspath.getClasspath());
+                                                                              InjectedPluginClasspath injectedPluginClasspath, CachedClasspathTransformer classpathTransformer,
+                                                                              InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
+            return new InjectedClasspathPluginResolver(classLoaderScopeRegistry.getCoreAndPluginsScope(), classpathTransformer, pluginInspector, injectedPluginClasspath.getClasspath(), instrumentationStrategy);
         }
 
         PluginResolutionStrategyInternal createPluginResolutionStrategy(Instantiator instantiator, ListenerManager listenerManager) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathInstrumentationStrategy.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathInstrumentationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.test.fixtures.file.TestFile;
+package org.gradle.plugin.use.resolve.service.internal;
 
-import java.io.File;
-import java.util.Map;
+import org.gradle.internal.classpath.CachedClasspathTransformer;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
-public interface ArtifactBuilder {
-    TestFile sourceFile(String path);
-
-    TestFile resourceFile(String path);
-
-    void manifestAttributes(Map<String, String> attributes);
-
-    void buildJar(File jarFile);
+@ServiceScope(Scopes.BuildTree)
+public interface InjectedClasspathInstrumentationStrategy {
+    CachedClasspathTransformer.StandardTransform getTransform();
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathPluginResolver.java
@@ -36,16 +36,14 @@ import org.gradle.plugin.use.resolve.internal.PluginResolver;
 
 import java.io.File;
 
-import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic;
-
 public class InjectedClasspathPluginResolver implements PluginResolver {
 
     private final ClassPath injectedClasspath;
     private final PluginRegistry pluginRegistry;
 
-    public InjectedClasspathPluginResolver(ClassLoaderScope parentScope, CachedClasspathTransformer classpathTransformer, PluginInspector pluginInspector, ClassPath injectedClasspath) {
+    public InjectedClasspathPluginResolver(ClassLoaderScope parentScope, CachedClasspathTransformer classpathTransformer, PluginInspector pluginInspector, ClassPath injectedClasspath, InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
         this.injectedClasspath = injectedClasspath;
-        ClassPath cachedClassPath = classpathTransformer.transform(injectedClasspath, BuildLogic);
+        ClassPath cachedClassPath = classpathTransformer.transform(injectedClasspath, instrumentationStrategy.getTransform());
         this.pluginRegistry = new DefaultPluginRegistry(pluginInspector,
             parentScope.createChild("injected-plugin")
                 .local(cachedClassPath)


### PR DESCRIPTION

### Context

This is a short term workaround to allow Jacoco to be used along with TestKit to gather coverage of the plugins under test. 

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
