### PR TITLE
Improve fixtures around platform dependencies

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -536,9 +536,13 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                 attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
             }.publish()
         def moduleA = mavenHttpRepo.module("org.test", "b", "1.9").withModuleMetadata().withVariant("runtime") {
-            dependsOn("org.test", "platform", "1.9", null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+            dependsOn("org.test", "platform", "1.9") {
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }
         }.withVariant("api") {
-            dependsOn("org.test", "platform", "1.9", null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+            dependsOn("org.test", "platform", "1.9") {
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }
         }.publish()
 
         when:
@@ -661,7 +665,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             }.publish()
         def depC = mavenHttpRepo.module('org.test', 'depC', '1.0').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('org.test', 'platform', '1.0', null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                dependsOn('org.test', 'platform', '1.0') {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
             }.publish()
         def depB = mavenHttpRepo.module('org.test', 'depB', '1.0').dependsOn([exclusions: [[module: 'excluded']]], depC).publish()
         def depF = mavenHttpRepo.module('org.test', 'depF', '1.0').dependsOn(depC).publish()
@@ -736,17 +742,23 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             }.publish()
         def depA = mavenHttpRepo.module('org.test', 'depA', '1.0').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('org.test', 'platform', '1.0', null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                dependsOn('org.test', 'platform', '1.0') {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
                 dependsOn('org.test', 'depB', '1.0')
             }.publish()
         def depA11 = mavenHttpRepo.module('org.test', 'depA', '1.1').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('org.test', 'platform', '1.0', null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                dependsOn('org.test', 'platform', '1.0') {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
                 dependsOn('org.test', 'depB', '1.0')
             }.publish()
         def depB = mavenHttpRepo.module('org.test', 'depB', '1.0').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('org.test', 'platform', '1.0', null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                dependsOn('org.test', 'platform', '1.0') {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
             }.publish()
 
         def otherPlatform10 = mavenHttpRepo.module('org.test', 'otherPlatform', '1.0').withModuleMetadata().withoutDefaultVariants()
@@ -781,7 +793,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             }.publish()
         def depE = mavenHttpRepo.module('org.test', 'depE', '1.0').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('org.test', 'otherPlatform', '1.1', null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                dependsOn('org.test', 'otherPlatform', '1.1') {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
             }.publish()
         def depD = mavenHttpRepo.module('org.test', 'depD', '1.0').dependsOn(depE).publish()
         def depC = mavenHttpRepo.module('org.test', 'depC', '1.0').dependsOn(depD).publish()
@@ -879,14 +893,12 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.0') {
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                    endorseStrictVersions = true
                 }
             }.publish()
         def depA11 = mavenHttpRepo.module('org.test', 'depA', '1.1').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.1') {
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                    endorseStrictVersions = true
                 }
             }.publish()
 
@@ -894,8 +906,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.1') {
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                    endorseStrictVersions = true
-                }//, null, [(Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM])
+                }
                 dependsOn('org.test', 'depA', '1.1')
             }.publish()
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.test.fixtures.gradle
 
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
+import org.gradle.api.attributes.Category
 
 @CompileStatic
 @EqualsAndHashCode
@@ -57,6 +58,29 @@ class DependencySpec {
             def parts = requestedCapability.split(':')
             this.requestedCapabilities << new CapabilitySpec(parts[0], parts[1], parts.size() > 2 ? parts[2] : null)
         }
+    }
+
+    DependencySpec(String g, String m, String v, String reason, Map<String, Object> attributes) {
+        group = g
+        module = m
+        version = v
+        this.reason = reason
+        this.attributes = attributes
+        if (!attributes?.isEmpty()) {
+            def category = attributes[Category.CATEGORY_ATTRIBUTE.name]
+            if (category == Category.REGULAR_PLATFORM || category == Category.ENFORCED_PLATFORM) {
+                this.endorseStrictVersions = true
+            }
+        }
+        rejects = []
+    }
+
+    DependencySpec(String g, String m, String v) {
+        group = g
+        module = m
+        version = v
+        attributes = [:]
+        rejects = []
     }
 
     DependencySpec attribute(String name, Object value) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -53,11 +53,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, reason, attributes, null, null)
+        dependencies << new DependencySpec(group, module, version, reason, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, [:], null, null)
+        def spec = new DependencySpec(group, module, version)
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()


### PR DESCRIPTION
In the dependency management code, when you specify that a dependency is
against a platform, it automatically sets the endorseStrictVersion flag.
This behaviour was not reflected in the test fixtures for creating
external dependencies.