### PR TITLE
Use isolated gradle user home for DistributionIntegrationSpec

### DIFF
--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -69,6 +69,10 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         coreLibJarsCount + packagedPluginsJarCount + thirdPartyLibJarsCount
     }
 
+    def setup() {
+        executer.requireOwnGradleUserHomeDir().requireIsolatedDaemons()
+    }
+
     def "no duplicate entries"() {
         given:
         def entriesByPath = zipEntries.findAll { !it.name.contains('/META-INF/services/') }.groupBy { it.name }


### PR DESCRIPTION
We found issues when BinDistributionIntegrationSpec and AllDistributionIntegrationSpec
connecting to same deamon because they have same version numbers.

This PR fixes by use isolated user home for each test.

Will cherry-pick to `release`.