### PR TITLE
Let configuration cache decode `HashSet` as `LinkedHashSet`

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -268,7 +268,6 @@ class Codecs(
         bind(ImmutableListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)
-        bind(linkedHashSetCodec)
         bind(hashSetCodec)
         bind(treeSetCodec)
         bind(ImmutableSetCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
@@ -38,12 +38,11 @@ internal
 val linkedListCodec: Codec<LinkedList<Any?>> = collectionCodec { LinkedList<Any?>() }
 
 
+/**
+ * Decodes HashSet instances as LinkedHashSet to preserve original iteration order.
+ */
 internal
-val hashSetCodec: Codec<HashSet<Any?>> = collectionCodec { HashSet<Any?>(it) }
-
-
-internal
-val linkedHashSetCodec: Codec<LinkedHashSet<Any?>> = collectionCodec { LinkedHashSet<Any?>(it) }
+val hashSetCodec: Codec<HashSet<Any?>> = collectionCodec { LinkedHashSet<Any?>(it) }
 
 
 internal


### PR DESCRIPTION
To preserve original iteration order and fix flakiness of `TaskUpToDateIntegrationTest.hash set output files marks task up-to-date`.