### PR TITLE
Don't delay encoding configuration cache fingerprint input files

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -196,7 +196,7 @@ class DefaultInstantExecution internal constructor(
     fun writeInstantExecutionState(stateFile: File) {
         service<ProjectStateRegistry>().withLenientState {
             withWriteContextFor(stateFile) {
-                InstantExecutionState(codecs, host, relevantProjectsRegistry).run {
+                instantExecutionState().run {
                     writeState()
                 }
             }
@@ -206,11 +206,15 @@ class DefaultInstantExecution internal constructor(
     private
     fun readInstantExecutionState(stateFile: File) {
         withReadContextFor(stateFile) {
-            InstantExecutionState(codecs, host, relevantProjectsRegistry).run {
+            instantExecutionState().run {
                 readState()
             }
         }
     }
+
+    private
+    fun instantExecutionState() =
+        InstantExecutionState(codecs(), host, relevantProjectsRegistry)
 
     private
     fun startCollectingCacheFingerprint() {
@@ -231,7 +235,7 @@ class DefaultInstantExecution internal constructor(
     private
     fun cacheFingerprintWriterContextFor(outputStream: OutputStream) =
         writerContextFor(outputStream).apply {
-            push(IsolateOwner.OwnerHost(host), codecs.userTypesCodec)
+            push(IsolateOwner.OwnerHost(host), codecs().userTypesCodec)
         }
 
     private
@@ -288,7 +292,7 @@ class DefaultInstantExecution internal constructor(
     fun writeContextFor(
         encoder: Encoder
     ) = DefaultWriteContext(
-        codecs.userTypesCodec,
+        codecs().userTypesCodec,
         encoder,
         scopeRegistryListener,
         logger,
@@ -296,8 +300,10 @@ class DefaultInstantExecution internal constructor(
     )
 
     private
-    fun readContextFor(decoder: KryoBackedDecoder) = DefaultReadContext(
-        codecs.userTypesCodec,
+    fun readContextFor(
+        decoder: KryoBackedDecoder
+    ) = DefaultReadContext(
+        codecs().userTypesCodec,
         decoder,
         service(),
         beanConstructors,
@@ -306,7 +312,7 @@ class DefaultInstantExecution internal constructor(
     )
 
     private
-    val codecs: Codecs by unsafeLazy {
+    fun codecs(): Codecs =
         Codecs(
             directoryFileTreeFactory = service(),
             fileCollectionFactory = service(),
@@ -335,11 +341,10 @@ class DefaultInstantExecution internal constructor(
             fileSystem = service(),
             fileFactory = service()
         )
-    }
 
     private
     inline fun <T : MutableIsolateContext, R> T.withHostIsolate(block: T.() -> R): R =
-        withIsolate(IsolateOwner.OwnerHost(host), codecs.userTypesCodec) {
+        withIsolate(IsolateOwner.OwnerHost(host), codecs().userTypesCodec) {
             block()
         }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/coroutines/RunToCompletion.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/coroutines/RunToCompletion.kt
@@ -29,9 +29,9 @@ internal
 fun <R> runToCompletion(block: suspend () -> R): R {
     var completion: Result<R>? = null
     block.startCoroutine(
-            Continuation(EmptyCoroutineContext) {
-                completion = it
-            }
+        Continuation(EmptyCoroutineContext) {
+            completion = it
+        }
     )
     return completion.let {
         require(it != null) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
@@ -70,9 +70,6 @@ class InstantExecutionCacheFingerprintWriter(
     val capturedFiles: MutableSet<File>
 
     private
-    val inputFiles = mutableListOf<InputFile>()
-
-    private
     val undeclaredSystemProperties = mutableSetOf<String>()
 
     private
@@ -102,9 +99,6 @@ class InstantExecutionCacheFingerprintWriter(
     fun close() {
         if (closestChangingValue != null) {
             write(closestChangingValue)
-        }
-        for (inputFile in inputFiles) {
-            write(inputFile)
         }
         write(null)
         writeContext.close()
@@ -183,7 +177,7 @@ class InstantExecutionCacheFingerprintWriter(
         if (!capturedFiles.add(file)) {
             return
         }
-        inputFiles.add(inputFile(file))
+        write(inputFile(file))
     }
 
     private


### PR DESCRIPTION
The code is simpler and leaner that way.

This required getting rid of the shared mutable `Codecs` state by using separate instances for the fingerprint and state writers.