### PR TITLE
Add more supported Linux variants to file system watching documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -219,7 +219,7 @@ Gradle uses operating system features for watching the file system.
 It supports the feature on these operating systems:
 
 - Windows 10,
-- Linux (Ubuntu 16.04 or later),
+- Linux (Ubuntu 16.04 or later, CentOS 8 or later, Red Hat Enterprise Linux 8 or later, Amazon Linux 2),
 - macOS 10.14 (Mojave) or later.
 
 Watching the file system is an experimental feature and is disabled by default.


### PR DESCRIPTION
We are now testing on CentOS 8, which is the same as RHEL 8. We already have been testing on Amazon Linux 2.