### PR TITLE
Stop watching on macOs when a watched directory is symlinked

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingIntegrationTest.groovy
@@ -819,7 +819,7 @@ class FileSystemWatchingIntegrationTest extends AbstractIntegrationSpec implemen
         executer.beforeExecute {
             // Use `new File` here to avoid canonicalization of the path
             def symlinkedProjectDir = new File(symlink, "projectDir")
-            assert !symlinkedProjectDir.absolutePath.startsWith(actualProjectDir.absolutePath)
+            assert symlinkedProjectDir.absolutePath != actualProjectDir.absolutePath
             inDirectory(symlinkedProjectDir)
         }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingIntegrationTest.groovy
@@ -796,7 +796,7 @@ class FileSystemWatchingIntegrationTest extends AbstractIntegrationSpec implemen
     }
 
     @Requires(TestPrecondition.SYMLINKS)
-    def "file system watching works the project dir is symlinked"() {
+    def "file system watching works when the project dir is symlinked"() {
         def actualProjectDir = file("parent/projectDir")
         def symlink = file("symlinkedParent")
         symlink.createLink(file("parent"))

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/WatchingNotSupportedException.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/WatchingNotSupportedException.java
@@ -17,6 +17,10 @@
 package org.gradle.internal.watch;
 
 public class WatchingNotSupportedException extends RuntimeException {
+    public WatchingNotSupportedException(String message) {
+        super(message);
+    }
+
     public WatchingNotSupportedException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -26,6 +26,8 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.CANONICAL_PATH;
+
 public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<OsxFileEventFunctions> {
 
     public DarwinFileWatcherRegistryFactory() throws NativeIntegrationUnavailableException {
@@ -42,6 +44,6 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
 
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
-        return new HierarchicalFileWatcherUpdater(watcher);
+        return new HierarchicalFileWatcherUpdater(watcher, CANONICAL_PATH);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -21,12 +21,13 @@ import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions;
+import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.CANONICAL_PATH;
 
 public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<OsxFileEventFunctions> {
 
@@ -44,6 +45,22 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
 
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
-        return new HierarchicalFileWatcherUpdater(watcher, CANONICAL_PATH);
+        return new HierarchicalFileWatcherUpdater(watcher, DarwinFileWatcherRegistryFactory::validateLocationToWatch);
+    }
+
+    private static void validateLocationToWatch(File location) {
+        try {
+            String canonicalPath = location.getCanonicalPath();
+            String absolutePath = location.getAbsolutePath();
+            if (!canonicalPath.equals(absolutePath)) {
+                throw new WatchingNotSupportedException(String.format(
+                    "Unable to watch '%s' since itself or one of its parent is a symbolic link (canonical path: '%s')",
+                    absolutePath,
+                    canonicalPath
+                ));
+            }
+        } catch (IOException e) {
+            throw new WatchingNotSupportedException("Unable to watch '%s' since its canonical path can't be resolved: " + e.getMessage(), e);
+        }
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -22,11 +22,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
+import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Comparator;
@@ -69,9 +71,11 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private final Set<Path> watchedRootProjectDirectoriesFromPreviousBuild = new HashSet<>();
 
     private final FileWatcher watcher;
+    private final ReportedFileEventPath reportedFileEventPath;
 
-    public HierarchicalFileWatcherUpdater(FileWatcher watcher) {
+    public HierarchicalFileWatcherUpdater(FileWatcher watcher, ReportedFileEventPath reportedFileEventPath) {
         this.watcher = watcher;
+        this.reportedFileEventPath = reportedFileEventPath;
     }
 
     @Override
@@ -146,11 +150,31 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         if (!hierarchiesToStartWatching.isEmpty()) {
             watcher.startWatching(hierarchiesToStartWatching.stream()
                 .map(Path::toFile)
+                .peek(this::validateLocationToWatch)
                 .collect(Collectors.toList())
             );
             watchedHierarchies.addAll(hierarchiesToStartWatching);
         }
         LOGGER.info("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
+    }
+
+    private void validateLocationToWatch(File location) {
+        if (reportedFileEventPath == ReportedFileEventPath.ABSOLUTE_PATH) {
+            return;
+        }
+        try {
+            String canonicalPath = location.getCanonicalPath();
+            String absolutePath = location.getAbsolutePath();
+            if (!canonicalPath.equals(absolutePath)) {
+                throw new WatchingNotSupportedException(String.format(
+                    "Unable to watch '%s' since itself or one of its parent is a symbolic link (canonical path: '%s')",
+                    absolutePath,
+                    canonicalPath
+                ));
+            }
+        } catch (IOException e) {
+            throw new WatchingNotSupportedException("Unable to watch '%s' since its canonical path can't be resolved: " + e.getMessage(), e);
+        }
     }
 
     /**
@@ -176,5 +200,10 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
             })
             .forEach(hierarchies::add);
         return hierarchies;
+    }
+
+    public enum ReportedFileEventPath {
+        CANONICAL_PATH,
+        ABSOLUTE_PATH
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -25,7 +25,7 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 
 import java.util.concurrent.BlockingQueue;
 
-import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.ABSOLUTE_PATH;
+import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.FileSystemLocationToWatchValidator.NO_VALIDATION;
 
 public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<WindowsFileEventFunctions> {
     private static final int BUFFER_SIZE = 128 * 1024;
@@ -43,6 +43,6 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
 
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
-        return new HierarchicalFileWatcherUpdater(watcher, ABSOLUTE_PATH);
+        return new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -25,6 +25,8 @@ import org.gradle.internal.watch.registry.FileWatcherUpdater;
 
 import java.util.concurrent.BlockingQueue;
 
+import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.ABSOLUTE_PATH;
+
 public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<WindowsFileEventFunctions> {
     private static final int BUFFER_SIZE = 128 * 1024;
 
@@ -41,6 +43,6 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
 
     @Override
     protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher) {
-        return new HierarchicalFileWatcherUpdater(watcher);
+        return new HierarchicalFileWatcherUpdater(watcher, ABSOLUTE_PATH);
     }
 }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -26,13 +26,13 @@ import org.gradle.util.TestPrecondition
 
 import java.nio.file.Paths
 
-import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.ABSOLUTE_PATH
+import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.FileSystemLocationToWatchValidator.NO_VALIDATION
 
 class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
     FileWatcherUpdater createUpdater(FileWatcher watcher) {
-        new HierarchicalFileWatcherUpdater(watcher, ABSOLUTE_PATH)
+        new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION)
     }
 
     def "does not watch project root directory if no snapshot is inside"() {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -26,11 +26,13 @@ import org.gradle.util.TestPrecondition
 
 import java.nio.file.Paths
 
+import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.ReportedFileEventPath.ABSOLUTE_PATH
+
 class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
     FileWatcherUpdater createUpdater(FileWatcher watcher) {
-        new HierarchicalFileWatcherUpdater(watcher)
+        new HierarchicalFileWatcherUpdater(watcher, ABSOLUTE_PATH)
     }
 
     def "does not watch project root directory if no snapshot is inside"() {


### PR DESCRIPTION
The macOS native watcher reports the canonical path for watched paths. That means that we would not invalidate the right locations in the virtual file system on macOS.

Therefore, we disable file system watching when we try to watch a directory whose parent is a symlink.

Note that the project directory is canonicalized by Gradle, so the project directory can always be watched.