### PR TITLE
Replace `reentrant` codec by top-level trampoline

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -27,6 +27,7 @@ import org.gradle.instantexecution.fingerprint.InstantExecutionCacheFingerprintC
 import org.gradle.instantexecution.fingerprint.InvalidationReason
 import org.gradle.instantexecution.initialization.InstantExecutionStartParameter
 import org.gradle.instantexecution.problems.InstantExecutionProblems
+import org.gradle.instantexecution.serialization.BeanStateReaders
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
@@ -305,11 +306,15 @@ class DefaultInstantExecution internal constructor(
     ) = DefaultReadContext(
         codecs().userTypesCodec,
         decoder,
-        service(),
-        beanConstructors,
+        beanStateReaders,
         logger,
         problems
     )
+
+    private
+    val beanStateReaders by lazy {
+        BeanStateReaders(service(), beanConstructors)
+    }
 
     private
     fun codecs(): Codecs =

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
@@ -55,32 +55,49 @@ fun buildConsoleSummary(cacheAction: String, problems: List<PropertyProblem>, re
 
 
 private
-fun uniquePropertyProblems(problems: List<PropertyProblem>): Set<UniquePropertyProblem> =
-    problems.sortedBy { it.trace.sequence.toList().reversed().joinToString(".") }
-        .groupBy { UniquePropertyProblem(propertyDescriptionFor(it.trace), it.message, it.documentationSection?.anchor) }
-        .keys
+fun uniquePropertyProblems(problems: List<PropertyProblem>): Collection<UniquePropertyProblem> =
+    problems
+        .sortedBy(::uniquePropertyProblemSortingKey)
+        .groupBy { problem ->
+            UniquePropertyProblem(
+                propertyDescriptionFor(problem.trace),
+                problem.message,
+                problem.documentationSection?.anchor
+            )
+        }.keys
+
+
+private
+fun uniquePropertyProblemSortingKey(problem: PropertyProblem) =
+    StringBuilder().run {
+        problem.trace.sequence.toList().asReversed().forEach { trace ->
+            trace.run {
+                appendStringOf(trace)
+            }
+        }
+        toString()
+    }
 
 
 private
 fun buildSummaryHeader(
     cacheAction: String,
     totalProblemCount: Int,
-    uniquePropertyProblems: Set<UniquePropertyProblem>
-): String {
-    val result = StringBuilder()
-    result.append(totalProblemCount)
-    result.append(if (totalProblemCount == 1) " problem was found " else " problems were found ")
-    result.append(cacheAction)
-    result.append(" the configuration cache")
+    uniquePropertyProblems: Collection<UniquePropertyProblem>
+): String = StringBuilder().run {
+    append(totalProblemCount)
+    append(if (totalProblemCount == 1) " problem was found " else " problems were found ")
+    append(cacheAction)
+    append(" the configuration cache")
     val uniqueProblemCount = uniquePropertyProblems.size
     if (totalProblemCount != uniquePropertyProblems.size) {
-        result.append(", ")
-        result.append(uniqueProblemCount)
-        result.append(" of which ")
-        result.append(if (uniqueProblemCount == 1) "seems unique" else "seem unique")
+        append(", ")
+        append(uniqueProblemCount)
+        append(" of which ")
+        append(if (uniqueProblemCount == 1) "seems unique" else "seem unique")
     }
-    result.append(".")
-    return result.toString()
+    append(".")
+    toString()
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -63,12 +63,6 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
 
     fun getProject(path: String): ProjectInternal
 
-    /**
-     * When in immediate mode, [read] calls are NOT suspending.
-     * Useful for bridging with non-suspending serialization protocols such as [java.io.Serializable].
-     */
-    var immediateMode: Boolean // TODO:instant-execution prevent StackOverflowErrors when crossing protocols
-
     suspend fun read(): Any?
 
     fun readClass(): Class<*>
@@ -138,18 +132,6 @@ interface MutableIsolateContext {
     fun push(codec: Codec<Any?>)
     fun push(owner: IsolateOwner, codec: Codec<Any?>)
     fun pop()
-}
-
-
-internal
-inline fun <T : ReadContext, R> T.withImmediateMode(block: T.() -> R): R {
-    val immediateMode = this.immediateMode
-    try {
-        this.immediateMode = true
-        return block()
-    } finally {
-        this.immediateMode = immediateMode
-    }
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -48,11 +48,9 @@ class DefaultWriteContext(
     override val logger: Logger,
 
     private
-    val problemsListener: ProblemsListener,
+    val problemsListener: ProblemsListener
 
-    override var recursionScope: RecursiveFunctionScope<Any?, Unit>? = null
-
-) : AbstractIsolateContext<WriteIsolate>(codec), WriteContext, RecursiveContext<Any?, Unit>, Encoder by encoder, AutoCloseable {
+) : AbstractIsolateContext<WriteIsolate>(codec), WriteContext, Encoder by encoder, AutoCloseable {
 
     override val sharedIdentities = WriteIdentities()
 
@@ -187,11 +185,9 @@ class DefaultReadContext(
     override val logger: Logger,
 
     private
-    val problemsListener: ProblemsListener,
+    val problemsListener: ProblemsListener
 
-    override var recursionScope: RecursiveFunctionScope<Any?, Any?>? = null
-
-) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, RecursiveContext<Any?, Any?>, Decoder by decoder {
+) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, RecursiveContext, Decoder by decoder {
 
     override val sharedIdentities = ReadIdentities()
 
@@ -315,7 +311,7 @@ typealias ProjectProvider = (String) -> ProjectInternal
 
 
 internal
-abstract class AbstractIsolateContext<T>(codec: Codec<Any?>) : MutableIsolateContext {
+abstract class AbstractIsolateContext<T>(codec: Codec<Any?>) : MutableIsolateContext, RecursiveContext {
 
     private
     var currentIsolate: T? = null
@@ -324,6 +320,8 @@ abstract class AbstractIsolateContext<T>(codec: Codec<Any?>) : MutableIsolateCon
     var currentCodec = codec
 
     var trace: PropertyTrace = PropertyTrace.Gradle
+
+    override var recursionScope: RecursionScope? = null
 
     protected
     abstract fun newIsolate(owner: IsolateOwner): T

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -142,14 +142,23 @@ class DefaultRecursionScope(
         COROUTINE_SUSPENDED
     }
 
-        while (true) {
     fun runCallLoop(): Any? {
+        var iteration = 0
+        while (true) {
+            val k = this.k
             val result = this.result
-            val k = this.k // null means done
-                ?: return result.getOrThrow() // done -- final result
+            if (k == null) {
+                return result.getOrThrow()  // done -- final result
+            }
+            iteration += 1
+            if (iteration > 1_000_000) {
+                throw IllegalStateException("Too many iterations! Are we stuck? {value: $value, k: $k, result: $result}")
+            }
             // ~startCoroutineUninterceptedOrReturn
             val r = try {
                 function(value, k)
+            } catch (e: InterruptedException) {
+                throw e
             } catch (e: Throwable) {
                 k.resumeWithException(e)
                 continue

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("unchecked_cast")
+
 package org.gradle.instantexecution.serialization
 
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.startCoroutine
 
 
@@ -25,18 +32,130 @@ import kotlin.coroutines.startCoroutine
  */
 internal
 fun <T : ReadContext, R> T.runReadOperation(readOperation: suspend T.() -> R): R =
-    runToCompletion {
-        readOperation()
-    }
+    runRecursiveOperation(readOperation)
 
 
 /**
  * Runs the given [writeOperation] synchronously.
  */
 internal
-fun <T : WriteContext> T.runWriteOperation(writeOperation: suspend T.() -> Unit) {
-    runToCompletion {
-        writeOperation()
+fun <T : WriteContext, R> T.runWriteOperation(writeOperation: suspend T.() -> R) =
+    runRecursiveOperation(writeOperation)
+
+
+/**
+ * Runs the [recursiveOperation] on the current context [T].
+ *
+ * Implementation heavily inspired by [Deep recursion with coroutines](https://medium.com/@elizarov/deep-recursion-with-coroutines-7c53e15993e3).
+ */
+private
+fun <T, R> T.runRecursiveOperation(recursiveOperation: suspend T.() -> R): R {
+    when (this) {
+        is RecursiveContext<*, *> -> {
+            val recursiveContext = this as RecursiveContext<Any?, Any?>
+            val function: RecursiveFunction<Any?, Any?> = { value ->
+                recursiveContext.applyFunctionTo(value)
+            }
+            val scope = DefaultRecursiveFunctionScope<Any?, Any?>(function, null)
+            val previous = recursiveContext.recursionScope
+            try {
+                recursiveContext.recursionScope = scope
+                val operation = recursiveOperation as Function2<T, Continuation<Any?>, Any?>
+                return when (val result = operation.invoke(this, scope)) {
+                    COROUTINE_SUSPENDED -> scope.runCallLoop() as R
+                    else -> result as R
+                }
+            } finally {
+                recursiveContext.recursionScope = previous
+            }
+        }
+        else -> {
+            // support for custom context implementations used by tests
+            return runToCompletion {
+                recursiveOperation()
+            }
+        }
+    }
+}
+
+
+internal
+interface RecursiveContext<T, R> {
+
+    var recursionScope: RecursiveFunctionScope<T, R>?
+
+    suspend fun applyFunctionTo(value: T): R
+}
+
+
+internal
+sealed class RecursiveFunctionScope<T, R> {
+    abstract suspend fun recur(value: T): R
+}
+
+
+private
+typealias RecursiveFunction<T, R> = suspend (T) -> R
+
+
+private
+typealias UndecoratedRecursiveFunction = Function2<Any?, Continuation<Any?>?, Any?>
+
+
+private
+val UNDEFINED_RESULT = Result.success(COROUTINE_SUSPENDED)
+
+
+private
+class DefaultRecursiveFunctionScope<T, R>(
+    recursiveFunction: RecursiveFunction<T, R>,
+    value: T
+) : RecursiveFunctionScope<T, R>(), Continuation<R> {
+
+    private
+    var function: UndecoratedRecursiveFunction = recursiveFunction as UndecoratedRecursiveFunction
+
+    // Value to call function with
+    private
+    var value: Any? = value
+
+    // Continuation of the current call
+    private
+    var k: Continuation<Any?>? = this as Continuation<Any?>
+
+    // Completion result (completion of the whole call stack)
+    private
+    var result: Result<Any?> = UNDEFINED_RESULT
+
+    override val context: CoroutineContext
+        get() = EmptyCoroutineContext
+
+    override fun resumeWith(result: Result<R>) {
+        this.k = null
+        this.result = result
+    }
+
+    override suspend fun recur(value: T): R = suspendCoroutineUninterceptedOrReturn { k ->
+        this.k = k as Continuation<Any?>
+        this.value = value
+        COROUTINE_SUSPENDED
+    }
+
+    fun runCallLoop(): R {
+        while (true) {
+            val result = this.result
+            val k = this.k // null means done
+                ?: return (result as Result<R>).getOrThrow() // done -- final result
+            // ~startCoroutineUninterceptedOrReturn
+            val r = try {
+                function(value, k)
+            } catch (e: Throwable) {
+                k.resumeWithException(e)
+                continue
+            }
+            if (r !== COROUTINE_SUSPENDED)
+                k.resume(r as R)
+        }
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -143,22 +143,15 @@ class DefaultRecursionScope(
     }
 
     fun runCallLoop(): Any? {
-        var iteration = 0
         while (true) {
             val k = this.k
             val result = this.result
             if (k == null) {
-                return result.getOrThrow()  // done -- final result
-            }
-            iteration += 1
-            if (iteration > 1_000_000) {
-                throw IllegalStateException("Too many iterations! Are we stuck? {value: $value, k: $k, result: $result}")
+                return result.getOrThrow() // done -- final result
             }
             // ~startCoroutineUninterceptedOrReturn
             val r = try {
                 function(value, k)
-            } catch (e: InterruptedException) {
-                throw e
             } catch (e: Throwable) {
                 k.resumeWithException(e)
                 continue

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -145,11 +145,11 @@ class DefaultRecursionScope(
     fun runCallLoop(): Any? {
         while (true) {
             val k = this.k
-            val result = this.result
-            if (k == null) {
-                return result.getOrThrow() // done -- final result
+                ?: return result.getOrThrow() // done -- final result
+            if (Thread.interrupted()) {
+                k.resumeWithException(InterruptedException())
+                continue
             }
-            // ~startCoroutineUninterceptedOrReturn
             val r = try {
                 function(value, k)
             } catch (e: Throwable) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -93,9 +93,6 @@ class BeanPropertyReader(
 }
 
 
-/**
- * Reads a sequence of properties written with [writingProperties].
- */
 suspend fun ReadContext.readPropertyValue(kind: PropertyKind, name: String, action: (Any?) -> Unit) {
     withPropertyTrace(kind, name) {
         val value =
@@ -103,6 +100,8 @@ suspend fun ReadContext.readPropertyValue(kind: PropertyKind, name: String, acti
                 read().also {
                     logPropertyInfo("deserialize", it)
                 }
+            } catch (passThrough: InterruptedException) {
+                throw passThrough
             } catch (passThrough: IOException) {
                 throw passThrough
             } catch (passThrough: GradleException) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -69,6 +69,8 @@ suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: Prop
     withPropertyTrace(kind, name) {
         try {
             write(value)
+        } catch (passThrough: InterruptedException) {
+            throw passThrough
         } catch (passThrough: IOException) {
             throw passThrough
         } catch (passThrough: InstantExecutionProblemsException) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -42,10 +42,10 @@ val unsupportedFieldDeclaredTypes = listOf(
 internal
 fun relevantStateOf(beanType: Class<*>): List<RelevantField> =
     relevantTypeHierarchyOf(beanType)
-        .toList()
         .flatMap(Class<*>::relevantFields)
         .onEach(Field::makeAccessible)
         .map { RelevantField(it, unsupportedFieldTypeFor(it)) }
+        .toList()
 
 
 internal
@@ -107,8 +107,8 @@ val irrelevantDeclaringClasses = setOf(
 
 
 private
-val Class<*>.relevantFields: List<Field>
-    get() = declaredFields.toList()
+val Class<*>.relevantFields: Sequence<Field>
+    get() = declaredFields.asSequence()
         .filterNot { field ->
             Modifier.isStatic(field.modifiers)
                 || Modifier.isTransient(field.modifiers)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -54,7 +54,6 @@ import org.gradle.instantexecution.serialization.codecs.transform.Transformation
 import org.gradle.instantexecution.serialization.codecs.transform.TransformationStepCodec
 import org.gradle.instantexecution.serialization.codecs.transform.TransformedExternalArtifactSetCodec
 import org.gradle.instantexecution.serialization.ownerServiceCodec
-import org.gradle.instantexecution.serialization.reentrant
 import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
@@ -204,10 +203,7 @@ class Codecs(
         bind(unsupported<Externalizable>(NotYetImplementedJavaSerialization))
         bind(JavaObjectSerializationCodec())
 
-        // This protects the BeanCodec against StackOverflowErrors but
-        // we can still get them for the other codecs, for instance,
-        // with deeply nested Lists, deeply nested Maps, etc.
-        bind(reentrant(BeanCodec()))
+        bind(BeanCodec())
     }
 
     val internalTypesCodec = BindingsBackedCodec {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -32,7 +32,6 @@ import org.gradle.instantexecution.serialization.logPropertyProblem
 import org.gradle.instantexecution.serialization.readEnum
 import org.gradle.instantexecution.serialization.readNonNull
 import org.gradle.instantexecution.serialization.withBeanTrace
-import org.gradle.instantexecution.serialization.withImmediateMode
 import org.gradle.instantexecution.serialization.writeEnum
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
@@ -107,26 +106,22 @@ class JavaObjectSerializationCodec : EncodingProducer, Decoding {
         decodePreservingIdentity { id ->
             when (readEnum<Format>()) {
                 Format.WriteObject -> {
-                    withImmediateMode {
-                        decodingBeanWithId(id) { bean, beanType, beanStateReader ->
-                            val objectInputStream = objectInputStreamAdapterFor(bean, beanStateReader)
-                            val readObject = readObjectMethodHierarchyForDecoding(beanType)
-                            when {
-                                readObject.isNotEmpty() -> invokeAll(readObject, bean, objectInputStream)
-                                else -> objectInputStream.defaultReadObject()
-                            }
+                    decodingBeanWithId(id) { bean, beanType, beanStateReader ->
+                        val objectInputStream = objectInputStreamAdapterFor(bean, beanStateReader)
+                        val readObject = readObjectMethodHierarchyForDecoding(beanType)
+                        when {
+                            readObject.isNotEmpty() -> invokeAll(readObject, bean, objectInputStream)
+                            else -> objectInputStream.defaultReadObject()
                         }
                     }
                 }
                 Format.ReadObject -> {
-                    withImmediateMode {
-                        decodingBeanWithId(id) { bean, beanType, beanStateReader ->
-                            invokeAll(
-                                readObjectMethodHierarchyForDecoding(beanType),
-                                bean,
-                                objectInputStreamAdapterFor(bean, beanStateReader)
-                            )
-                        }
+                    decodingBeanWithId(id) { bean, beanType, beanStateReader ->
+                        invokeAll(
+                            readObjectMethodHierarchyForDecoding(beanType),
+                            bean,
+                            objectInputStreamAdapterFor(bean, beanStateReader)
+                        )
                     }
                 }
                 Format.WriteReplace -> {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/ObjectInputStreamAdapter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/ObjectInputStreamAdapter.kt
@@ -42,15 +42,22 @@ class ObjectInputStreamAdapter(
 
 ) : ObjectInputStream() {
 
-    override fun defaultReadObject() = beanStateReader.run {
-        readContext.runReadOperation {
-            readStateOf(bean)
+    override fun defaultReadObject() {
+        runReadOperation {
+            beanStateReader.run {
+                readStateOf(bean)
+            }
         }
     }
 
-    override fun readObjectOverride(): Any? = readContext.runReadOperation {
-        read()
-    }
+    override fun readObjectOverride(): Any? =
+        runReadOperation {
+            read()
+        }
+
+    private
+    fun runReadOperation(operation: suspend ReadContext.() -> Any?): Any? =
+        readContext.runReadOperation(operation)
 
     override fun readInt(): Int = readContext.readInt()
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
@@ -371,10 +371,6 @@ class InstantExecutionFingerprintCheckerTest {
         override fun getProject(path: String): ProjectInternal =
             undefined()
 
-        override var immediateMode: Boolean
-            get() = undefined()
-            set(_) {}
-
         override fun readClass(): Class<*> =
             undefined()
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -114,13 +114,13 @@ abstract class AbstractUserTypeCodecTest {
             }
         }
 
-    private
+    internal
     inline fun <R> MutableIsolateContext.withIsolateMock(codec: Codec<Any?>, block: () -> R): R =
         withIsolate(IsolateOwner.OwnerGradle(mock()), codec) {
             block()
         }
 
-    private
+    internal
     fun writeContextFor(encoder: Encoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
         DefaultWriteContext(
             codec = codec,

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -21,6 +21,7 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.problems.ProblemsListener
 import org.gradle.instantexecution.problems.PropertyProblem
+import org.gradle.instantexecution.serialization.BeanStateReaders
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
@@ -135,8 +136,10 @@ abstract class AbstractUserTypeCodecTest {
         DefaultReadContext(
             codec = codec,
             decoder = KryoBackedDecoder(inputStream),
-            instantiatorFactory = TestUtil.instantiatorFactory(),
-            constructors = BeanConstructors(TestCrossBuildInMemoryCacheFactory()),
+            beanStateReaders = BeanStateReaders(
+                instantiatorFactory = TestUtil.instantiatorFactory(),
+                constructors = BeanConstructors(TestCrossBuildInMemoryCacheFactory())
+            ),
             logger = mock(),
             problemsListener = mock()
         )

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/ContextsTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/ContextsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import com.nhaarman.mockitokotlin2.mock
+import org.gradle.instantexecution.serialization.runWriteOperation
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+import org.gradle.kotlin.dsl.support.useToRun
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+
+class ContextsTest : AbstractUserTypeCodecTest() {
+
+    @Test
+    fun `runWriteOperation can complete without recursion`() {
+        val codec = codecs().userTypesCodec
+        val result =
+            writeContextFor(KryoBackedEncoder(ByteArrayOutputStream()), codec, mock()).useToRun {
+                withIsolateMock(codec) {
+                    runWriteOperation {
+                        42
+                    }
+                }
+            }
+        assertThat(result, equalTo(42))
+    }
+}


### PR DESCRIPTION
This allows deep recursive calls across all codecs while improving performance and removing the stateful `reentrant` codec from `Codecs`.