### PR TITLE
Fix a stack overflow when a filtered mutable file collection is added to itself

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
@@ -26,6 +26,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.gradle.api.internal.file.AbstractFileTree.fileVisitorFrom;
 import static org.gradle.util.ConfigureUtil.configure;
@@ -54,7 +55,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
 
     @Override
     public FileTree matching(final Closure filterConfigClosure) {
-        return new FilteredFileTree(this, () -> {
+        return new FilteredFileTree(this, patternSetFactory, () -> {
             // For backwards compatibility, run the closure each time the file tree contents are queried
             return configure(filterConfigClosure, patternSetFactory.create());
         });
@@ -62,7 +63,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
 
     @Override
     public FileTree matching(final Action<? super PatternFilterable> filterConfigAction) {
-        return new FilteredFileTree(this, () -> {
+        return new FilteredFileTree(this, patternSetFactory, () -> {
             // For backwards compatibility, run the action each time the file tree contents are queried
             PatternSet patternSet = patternSetFactory.create();
             filterConfigAction.execute(patternSet);
@@ -72,7 +73,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
 
     @Override
     public FileTreeInternal matching(final PatternFilterable patterns) {
-        return new FilteredFileTree(this, () -> {
+        return new FilteredFileTree(this, patternSetFactory, () -> {
             if (patterns instanceof PatternSet) {
                 return (PatternSet) patterns;
             }
@@ -106,5 +107,10 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
     @Override
     public FileTreeInternal getAsFileTree() {
         return this;
+    }
+
+    @Override
+    public void visitContentsAsFileTrees(Consumer<FileTreeInternal> visitor) {
+        visitChildren(child -> visitor.accept((FileTreeInternal) child));
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -258,6 +258,10 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         }
 
         @Override
+        public void visitContentsAsFileTrees(Consumer<FileTreeInternal> visitor) {
+        }
+
+        @Override
         protected void visitContents(FileCollectionStructureVisitor visitor) {
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileTreeInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileTreeInternal.java
@@ -19,7 +19,13 @@ package org.gradle.api.internal.file;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.util.PatternFilterable;
 
+import java.util.function.Consumer;
+
 public interface FileTreeInternal extends FileTree, FileCollectionInternal {
+    String getDisplayName();
+
+    void visitContentsAsFileTrees(Consumer<FileTreeInternal> visitor);
+
     @Override
     FileTreeInternal matching(PatternFilterable patterns);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class FilteredFileCollection extends AbstractFileCollection {
-    private final AbstractFileCollection collection;
+    private final FileCollectionInternal collection;
     private final Spec<? super File> filterSpec;
 
     public FilteredFileCollection(AbstractFileCollection collection, Spec<? super File> filterSpec) {
@@ -46,7 +46,7 @@ public class FilteredFileCollection extends AbstractFileCollection {
         return new FilteredFileCollection(newCollection, filterSpec);
     }
 
-    public AbstractFileCollection getCollection() {
+    public FileCollectionInternal getCollection() {
         return collection;
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileCollection.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class FilteredFileCollection extends AbstractFileCollection {
     private final AbstractFileCollection collection;
@@ -34,6 +35,15 @@ public class FilteredFileCollection extends AbstractFileCollection {
         super(collection.patternSetFactory);
         this.collection = collection;
         this.filterSpec = filterSpec;
+    }
+
+    @Override
+    public FileCollectionInternal replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier) {
+        AbstractFileCollection newCollection = (AbstractFileCollection) collection.replace(original, supplier);
+        if (newCollection == collection) {
+            return this;
+        }
+        return new FilteredFileCollection(newCollection, filterSpec);
     }
 
     public AbstractFileCollection getCollection() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
@@ -19,16 +19,17 @@ package org.gradle.api.internal.file;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class FilteredFileTree extends CompositeFileTree implements FileCollectionInternal.Source {
-    private final CompositeFileTree tree;
+    private final FileTreeInternal tree;
     private final Supplier<? extends PatternSet> patternSupplier;
 
-    public FilteredFileTree(CompositeFileTree tree, Supplier<? extends PatternSet> patternSupplier) {
-        super(tree.patternSetFactory);
+    public FilteredFileTree(FileTreeInternal tree, Factory<PatternSet> patternSetFactory, Supplier<? extends PatternSet> patternSupplier) {
+        super(patternSetFactory);
         this.tree = tree;
         this.patternSupplier = patternSupplier;
     }
@@ -38,7 +39,7 @@ public class FilteredFileTree extends CompositeFileTree implements FileCollectio
         return tree.getDisplayName();
     }
 
-    public CompositeFileTree getTree() {
+    public FileTreeInternal getTree() {
         return tree;
     }
 
@@ -53,7 +54,7 @@ public class FilteredFileTree extends CompositeFileTree implements FileCollectio
     protected void visitChildren(Consumer<FileCollectionInternal> visitor) {
         // For backwards compatibility, need to calculate the patterns on each query
         PatternFilterable patterns = getPatterns();
-        tree.visitChildren(child -> visitor.accept(((FileTreeInternal) child).matching(patterns)));
+        tree.visitContentsAsFileTrees(child -> visitor.accept(child.matching(patterns)));
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
@@ -47,20 +47,18 @@ public class UnionFileCollection extends CompositeFileCollection {
 
     @Override
     public FileCollectionInternal replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier) {
-        for (FileCollectionInternal files : source) {
-            if (files == original) {
-                ImmutableSet.Builder<FileCollectionInternal> newSource = ImmutableSet.builderWithExpectedSize(source.size());
-                for (FileCollectionInternal candidate : source) {
-                    if (candidate == original) {
-                        newSource.add(supplier.get());
-                    } else {
-                        newSource.add(candidate);
-                    }
-                }
-                return new UnionFileCollection(newSource.build());
-            }
+        ImmutableSet.Builder<FileCollectionInternal> newSource = ImmutableSet.builderWithExpectedSize(source.size());
+        boolean hasChanges = false;
+        for (FileCollectionInternal candidate : source) {
+            FileCollectionInternal newCollection = candidate.replace(original, supplier);
+            hasChanges |= newCollection != candidate;
+            newSource.add(newCollection);
         }
-        return this;
+        if (hasChanges) {
+            return new UnionFileCollection(newSource.build());
+        } else {
+            return this;
+        }
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -156,14 +156,14 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     @Override
     public void setFrom(Object... paths) {
         if (assertMutable()) {
-            value = value.setFrom(resolver, patternSetFactory, paths);
+            value = value.setFrom(this, resolver, patternSetFactory, dependencyFactory, host, paths);
         }
     }
 
     @Override
     public ConfigurableFileCollection from(Object... paths) {
         if (assertMutable()) {
-            value = value.plus(resolver, patternSetFactory, paths);
+            value = value.plus(this, resolver, patternSetFactory, dependencyFactory, host, paths);
         }
         return this;
     }
@@ -279,9 +279,9 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
         ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Iterable<?> path);
 
-        ValueCollector setFrom(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object[] paths);
+        ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object[] paths);
 
-        ValueCollector plus(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object... paths);
+        ValueCollector plus(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object... paths);
 
         @Nullable
         List<Object> replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier);
@@ -307,13 +307,13 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public ValueCollector setFrom(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object[] paths) {
+        public ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object[] paths) {
             return new UnresolvedItemsCollector(resolver, patternSetFactory, paths);
         }
 
         @Override
-        public ValueCollector plus(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object... paths) {
-            return setFrom(resolver, patternSetFactory, paths);
+        public ValueCollector plus(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object... paths) {
+            return setFrom(owner, resolver, patternSetFactory, taskDependencyFactory, propertyHost, paths);
         }
 
         @Nullable
@@ -362,6 +362,30 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         public ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Iterable<?> path) {
             ImmutableSet<Object> oldItems = ImmutableSet.copyOf(items);
             items.clear();
+            addItem(owner, resolver, patternSetFactory, taskDependencyFactory, propertyHost, path, oldItems);
+            return this;
+        }
+
+        @Override
+        public ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object[] paths) {
+            ImmutableSet<Object> oldItems = ImmutableSet.copyOf(items);
+            items.clear();
+            for (Object path : paths) {
+                addItem(owner, resolver, patternSetFactory, taskDependencyFactory, propertyHost, path, oldItems);
+            }
+            return this;
+        }
+
+        @Override
+        public ValueCollector plus(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object... paths) {
+            ImmutableSet<Object> oldItems = ImmutableSet.copyOf(items);
+            for (Object path : paths) {
+                addItem(owner, resolver, patternSetFactory, taskDependencyFactory, propertyHost, path, oldItems);
+            }
+            return this;
+        }
+
+        private void addItem(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object path, ImmutableSet<Object> oldItems) {
             // Unpack to deal with DSL syntax: collection += someFiles
             if (path instanceof FileCollectionInternal) {
                 path = ((FileCollectionInternal) path).replace(owner, () -> {
@@ -371,39 +395,27 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
                 });
             }
             items.add(path);
-            return this;
-        }
-
-        @Override
-        public ValueCollector setFrom(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object[] paths) {
-            items.clear();
-            Collections.addAll(items, paths);
-            return this;
-        }
-
-        @Override
-        public ValueCollector plus(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object... paths) {
-            Collections.addAll(items, paths);
-            return this;
         }
 
         @Nullable
         @Override
         public List<Object> replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier) {
-            for (Object item : items) {
-                if (item == original) {
-                    ImmutableList.Builder<Object> builder = ImmutableList.builderWithExpectedSize(items.size());
-                    for (Object candidate : items) {
-                        if (candidate instanceof FileCollectionInternal) {
-                            builder.add(((FileCollectionInternal) candidate).replace(original, supplier));
-                        } else {
-                            builder.add(candidate);
-                        }
-                    }
-                    return builder.build();
+            ImmutableList.Builder<Object> builder = ImmutableList.builderWithExpectedSize(items.size());
+            boolean hasChanges = false;
+            for (Object candidate : items) {
+                if (candidate instanceof FileCollectionInternal) {
+                    FileCollectionInternal newCollection = ((FileCollectionInternal) candidate).replace(original, supplier);
+                    hasChanges |= newCollection != candidate;
+                    builder.add(newCollection);
+                } else {
+                    builder.add(candidate);
                 }
             }
-            return null;
+            if (hasChanges) {
+                return builder.build();
+            } else {
+                return null;
+            }
         }
     }
 
@@ -432,12 +444,12 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public ValueCollector setFrom(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object[] paths) {
+        public ValueCollector setFrom(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object[] paths) {
             throw new UnsupportedOperationException("Should not be called");
         }
 
         @Override
-        public ValueCollector plus(PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, Object... paths) {
+        public ValueCollector plus(DefaultConfigurableFileCollection owner, PathToFileResolver resolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost, Object... paths) {
             throw new UnsupportedOperationException("Should not be called");
         }
 
@@ -496,7 +508,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         @Override
         public boolean add(Object o) {
             if (assertMutable() && !delegate().contains(o)) {
-                value = value.plus(resolver, patternSetFactory, o);
+                value = value.plus(DefaultConfigurableFileCollection.this, resolver, patternSetFactory, dependencyFactory, host, o);
                 return true;
             } else {
                 return false;

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 
 import java.io.File;
+import java.util.function.Consumer;
 
 /**
  * Adapts a {@link MinimalFileTree} into a full {@link FileTree} implementation.
@@ -85,6 +86,11 @@ public class FileTreeAdapter extends AbstractFileTree {
     public FileTree visit(FileVisitor visitor) {
         tree.visit(visitor);
         return this;
+    }
+
+    @Override
+    public void visitContentsAsFileTrees(Consumer<FileTreeInternal> visitor) {
+        visitor.accept(this);
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ListBackedFileSet.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ListBackedFileSet.java
@@ -27,12 +27,8 @@ import java.util.Set;
 public class ListBackedFileSet implements MinimalFileSet {
     private final ImmutableSet<File> files;
 
-    public ListBackedFileSet(File... files) {
-        this.files = ImmutableSet.copyOf(files);
-    }
-
-    public ListBackedFileSet(Iterable<File> files) {
-        this.files = ImmutableSet.copyOf(files);
+    public ListBackedFileSet(ImmutableSet<File> files) {
+        this.files = files;
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/UnpackingVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/UnpackingVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file.collections;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryTree;
@@ -101,7 +102,7 @@ public class UnpackingVisitor {
     }
 
     private void visitSingleFile(Object element) {
-        visitor.accept(new FileCollectionAdapter(new ListBackedFileSet(resolver.resolve(element)), patternSetFactory));
+        visitor.accept(new FileCollectionAdapter(new ListBackedFileSet(ImmutableSet.of(resolver.resolve(element))), patternSetFactory));
     }
 
     private static class BuildableElementFileCollection extends CompositeFileCollection {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.util.PatternFilterable
 import spock.lang.Specification
 
+import java.util.function.Consumer
+
 class AbstractFileTreeTest extends Specification {
     def isEmptyWhenVisitsNoFiles() {
         def tree = new TestFileTree([])
@@ -132,6 +134,11 @@ class AbstractFileTreeTest extends Specification {
         @Override
         FileTreeInternal matching(PatternFilterable patterns) {
             return new FilteredTestFileTree(patterns: patterns)
+        }
+
+        @Override
+        void visitContentsAsFileTrees(Consumer<FileTreeInternal> visitor) {
+            visitor.accept(this)
         }
 
         FileTree visit(FileVisitor visitor) {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
@@ -142,8 +142,8 @@ class CompositeFileCollectionTest extends Specification {
     def "getAsFiletrees() returns union of file trees"() {
         def dir1 = tmpDir.createDir("dir1")
         def dir2 = tmpDir.createDir("dir2")
-        def source1 = Mock(AbstractFileTree)
-        def source2 = Mock(AbstractFileTree)
+        def source1 = Mock(FileTreeInternal)
+        def source2 = Mock(FileTreeInternal)
         def collection = new TestCompositeFileCollection(source1, source2)
 
         when:
@@ -154,10 +154,10 @@ class CompositeFileCollectionTest extends Specification {
         trees[0].dir == dir1
         trees[1].dir == dir2
 
-        1 * source1.visitContents(_) >> { FileCollectionStructureVisitor visitor ->
+        1 * source1.visitStructure(_) >> { FileCollectionStructureVisitor visitor ->
             visitor.visitFileTree(dir1, Stub(PatternSet), source1)
         }
-        1 * source2.visitContents(_) >> { FileCollectionStructureVisitor visitor ->
+        1 * source2.visitStructure(_) >> { FileCollectionStructureVisitor visitor ->
             visitor.visitFileTree(dir2, Stub(PatternSet), source2)
         }
         0 * _
@@ -175,10 +175,9 @@ class CompositeFileCollectionTest extends Specification {
         0 * _
 
         when:
-        fileTree.getSourceCollections()
+        fileTree.visitContentsAsFileTrees({})
 
         then:
-        fileTree instanceof CompositeFileTree
         1 * source1.visitStructure(_) >> { FileCollectionStructureVisitor visitor -> visitor.visitCollection(null, []) }
         1 * source2.visitStructure(_) >> { FileCollectionStructureVisitor visitor -> visitor.visitCollection(null, []) }
         0 * _
@@ -200,17 +199,16 @@ class CompositeFileCollectionTest extends Specification {
         0 * _
 
         when:
-        fileTree.getSourceCollections()
+        fileTree.visitContentsAsFileTrees({})
 
         then:
-        fileTree instanceof CompositeFileTree
         1 * source1.visitStructure(_) >> { FileCollectionStructureVisitor visitor -> visitor.visitCollection(null, [dir1]) }
         1 * source2.visitStructure(_) >> { FileCollectionStructureVisitor visitor -> visitor.visitCollection(null, [dir2]) }
         0 * _
 
         when:
         collection.sourceCollections.add(source3)
-        fileTree.getSourceCollections()
+        fileTree.visitContentsAsFileTrees({})
 
         then:
         1 * source1.visitStructure(_) >> { FileCollectionStructureVisitor visitor -> visitor.visitCollection(null, [dir1]) }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
@@ -88,9 +88,10 @@ class UnionFileCollectionTest extends Specification {
     }
 
     def "can replace one of the source collections"() {
-        def source1 = Stub(FileCollectionInternal)
-        def source2 = Stub(FileCollectionInternal)
-        def source3 = Stub(FileCollectionInternal)
+        def source1 = Mock(FileCollectionInternal)
+        def source2 = Mock(FileCollectionInternal)
+        def source3 = Mock(FileCollectionInternal)
+        def source4 = Mock(FileCollectionInternal)
 
         def collection = new UnionFileCollection(source1, source2)
 
@@ -98,13 +99,19 @@ class UnionFileCollectionTest extends Specification {
         def replaced = collection.replace(source3, {})
 
         then:
+        1 * source1.replace(source3, _) >> source1
+        1 * source2.replace(source3, _) >> source2
+
         replaced.is(collection)
 
         when:
-        def replaced2 = collection.replace(source2, { source3 })
+        def replaced2 = collection.replace(source3, {})
 
         then:
+        1 * source1.replace(source3, _) >> source1
+        1 * source2.replace(source3, _) >> source4
+
         replaced2 != collection
-        replaced2.sourceCollections == [source1, source3]
+        replaced2.sourceCollections == [source1, source4]
     }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.internal.tasks.TaskResolver
 
 import java.util.concurrent.Callable
+import java.util.function.Consumer
 import java.util.function.Supplier
 
 class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
@@ -591,11 +592,18 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         e.message == 'The value for <display> is final and cannot be changed.'
 
         when:
-        collection.setFrom(['some', 'more'])
+        collection.setFrom()
 
         then:
         def e2 = thrown(IllegalStateException)
         e2.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.setFrom(['some', 'more'])
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display> is final and cannot be changed.'
     }
 
     def cannotMutateFromSetWhenFinalized() {
@@ -1015,6 +1023,73 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         files as List == [file]
     }
 
+    def "can visit structure and children after finalized from paths"() {
+        given:
+        def file1 = new File('one')
+        def file2 = new File('two')
+        _ * fileResolver.resolve(file1) >> file1
+        _ * fileResolver.resolve(file2) >> file2
+
+        collection.from(file1, file2)
+        collection.finalizeValue()
+
+        def structureVisitor = Mock(FileCollectionStructureVisitor)
+        def childVisitor = Mock(Consumer)
+
+        when:
+        collection.visitStructure(structureVisitor)
+
+        then:
+        1 * structureVisitor.startVisit(_, collection) >> true
+        1 * structureVisitor.startVisit(_, _) >> { source, files ->
+            assert files.toList() == [file1]
+            true
+        }
+        1 * structureVisitor.visitCollection(_, _) >> { source, files ->
+            assert files.toList() == [file1]
+        }
+        1 * structureVisitor.startVisit(_, _) >> { source, files ->
+            assert files.toList() == [file2]
+            true
+        }
+        1 * structureVisitor.visitCollection(_, _) >> { source, files ->
+            assert files.toList() == [file2]
+        }
+        0 * structureVisitor._
+
+        when:
+        collection.visitChildren(childVisitor)
+
+        then:
+        2 * childVisitor.accept(_)
+        0 * childVisitor._
+    }
+
+    def "visiting structure and children does nothing when empty after finalization"() {
+        given:
+        def files1 = Mock(FileCollectionInternal)
+        def files2 = Mock(FileCollectionInternal)
+
+        collection.from(files1, files2)
+        collection.finalizeValue()
+
+        def structureVisitor = Mock(FileCollectionStructureVisitor)
+        def childVisitor = Mock(Consumer)
+
+        when:
+        collection.visitStructure(structureVisitor)
+
+        then:
+        1 * structureVisitor.startVisit(_, collection) >> true
+        0 * structureVisitor._
+
+        when:
+        collection.visitChildren(childVisitor)
+
+        then:
+        0 * childVisitor._
+    }
+
     def cannotSpecifyPathsWhenQueriedAfterFinalizeOnRead() {
         given:
         collection.from('a')
@@ -1052,6 +1127,13 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         then:
         def e = thrown(IllegalStateException)
         e.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.from()
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display> is final and cannot be changed.'
     }
 
     def cannotMutateFromSetWhenQueriedAfterFinalizeOnRead() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -481,8 +481,12 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         def fileCollectionMock = Mock(FileCollectionInternal)
         def file = new File("some-file")
 
+        when:
         collection.from("file")
         collection.from(fileCollectionMock)
+
+        then:
+        1 * fileCollectionMock.replace(_, _) >> fileCollectionMock
 
         when:
         collection.visitStructure(visitor)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ListBackedFileSetTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ListBackedFileSetTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.file.collections
 
+import com.google.common.collect.ImmutableSet
 import spock.lang.Specification
 
 class ListBackedFileSetTest extends Specification {
@@ -24,15 +25,15 @@ class ListBackedFileSetTest extends Specification {
         def testFile2 = new File('test-file2')
 
         expect:
-        new ListBackedFileSet().displayName == "empty file collection"
-        new ListBackedFileSet(testFile).displayName == "file '$testFile'"
-        new ListBackedFileSet(testFile, testFile2).displayName == "files '$testFile', '$testFile2'"
+        new ListBackedFileSet(ImmutableSet.of()).displayName == "empty file collection"
+        new ListBackedFileSet(ImmutableSet.of(testFile)).displayName == "file '$testFile'"
+        new ListBackedFileSet(ImmutableSet.of(testFile, testFile2)).displayName == "files '$testFile', '$testFile2'"
     }
 
     void containsSpecifiedFiles() {
         def testFile = new File('test-file')
 
         expect:
-        new ListBackedFileSet(testFile).files == [testFile] as Set
+        new ListBackedFileSet(ImmutableSet.of(testFile)).files == [testFile] as Set
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
