### PR TITLE
Change std:cpp17 to std:c++17 for LanguageStandard

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/AbstractVisualStudioProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/AbstractVisualStudioProjectIntegrationTest.groovy
@@ -293,12 +293,12 @@ abstract class AbstractVisualStudioProjectIntegrationTest extends AbstractVisual
         where:
         // UniqueIndex: // uniqueIndex: https://github.com/gradle/gradle/issues/8787
         compilerFlag     | expectedLanguageStandard | uniqueIndex
-        '/std:cpp14'     | 'stdcpp14'               | 1
-        '-std:cpp14'     | 'stdcpp14'               | 2
-        '/std:cpp17'     | 'stdcpp17'               | 3
-        '-std:cpp17'     | 'stdcpp17'               | 4
-        '/std:cpplatest' | 'stdcpplatest'           | 5
-        '-std:cpplatest' | 'stdcpplatest'           | 6
+        '/std:c++14'     | 'stdcpp14'               | 1
+        '-std:c++14'     | 'stdcpp14'               | 2
+        '/std:c++17'     | 'stdcpp17'               | 3
+        '-std:c++17'     | 'stdcpp17'               | 4
+        '/std:c++latest' | 'stdcpplatest'           | 5
+        '-std:c++latest' | 'stdcpplatest'           | 6
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelSingleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelSingleProjectIntegrationTest.groovy
@@ -988,12 +988,12 @@ model {
         where:
         // uniqueIndex: https://github.com/gradle/gradle/issues/8787
         compilerFlag     | expectedLanguageStandard | uniqueIndex
-        '/std:cpp14'     | 'stdcpp14'               | 1
-        '-std:cpp14'     | 'stdcpp14'               | 2
-        '/std:cpp17'     | 'stdcpp17'               | 3
-        '-std:cpp17'     | 'stdcpp17'               | 4
-        '/std:cpplatest' | 'stdcpplatest'           | 5
-        '-std:cpplatest' | 'stdcpplatest'           | 6
+        '/std:c++14'     | 'stdcpp14'               | 1
+        '-std:c++14'     | 'stdcpp14'               | 2
+        '/std:c++17'     | 'stdcpp17'               | 3
+        '-std:c++17'     | 'stdcpp17'               | 4
+        '/std:c++latest' | 'stdcpplatest'           | 5
+        '-std:c++latest' | 'stdcpplatest'           | 6
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioTargetBinary.java
@@ -174,12 +174,12 @@ public interface VisualStudioTargetBinary {
         }
 
         public static LanguageStandard from(List<String> arguments) {
-            return arguments.stream().filter(it -> it.matches("^[-/]std:cpp.+")).findFirst().map(it -> {
-                if (it.endsWith("cpp14")) {
+            return arguments.stream().filter(it -> it.matches("^[-/]std:c\\+\\+.+")).findFirst().map(it -> {
+                if (it.endsWith("++14")) {
                     return LanguageStandard.STD_CPP_14;
-                } else if (it.endsWith("cpp17")) {
+                } else if (it.endsWith("++17")) {
                     return LanguageStandard.STD_CPP_17;
-                } else if (it.endsWith("cpplatest")) {
+                } else if (it.endsWith("++latest")) {
                     return LanguageStandard.STD_CPP_LATEST;
                 }
                 return LanguageStandard.NONE;


### PR DESCRIPTION
std:c++xx is actually the documented option for the compiler. 

https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=vs-2019

Previously, only cppxx would be accepted, which isn't even a valid msvc compiler flag.


### Context
Because the actual documented flag doesn't give proper intellisense

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
