### PR TITLE
Ignore jacoco plugin tests under JDK15

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -577,6 +577,12 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching "org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.java-modules-*.sample"
         }
 
+        // Do not execute JaCoCo tests on JDK >= 15 until JaCoCo we use starts supporting newer JDKs
+        if (buildJvms.testJvm.get().javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {
+            excludeTestsMatching 'org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.jvm-multi-project-with-code-coverage_*_testTask.sample'
+            excludeTestsMatching 'org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.snippet-testing-jacoco-applicationª_*_jacocoApp.sample'
+        }
+
         excludeTestsMatching 'org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.android-application_*.sample' // has build deprecations
         excludeTestsMatching 'org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.snippet-best-practices-logic-during-configuration-dont_*.sample' // negative sanity check fails (= build succeeds) for Kotlin variant
         excludeTestsMatching 'org.gradle.docs.samples.ExemplarExternalSamplesFunctionalTest.snippet-scala-cross-compilation_groovy_sanityCheck.sample' // There is no java executable in /Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin. Expression: executable.exists()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
@@ -17,9 +17,12 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution(bottomSpecs = [
         "JavaGradlePluginRelocationTest",
         "CheckstyleRelocationIntegrationTest",

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractTaskRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractTaskRelocationIntegrationTest.groovy
@@ -16,8 +16,12 @@
 
 package org.gradle.integtests.fixtures
 
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
 abstract class AbstractTaskRelocationIntegrationTest extends AbstractIntegrationSpec {
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution(bottomSpecs = [
         "JacocoReportRelocationIntegrationTest",
         "ScalaDocRelocationIntegrationTest"

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
@@ -32,9 +34,9 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
 
         buildFile << """
             jacocoTestReport.dependsOn test
-            
+
             sourceSets.test.java.outputDir = file("build/classes/test")
-            
+
             test {
                 jacoco {
                     classDumpDir = file("\$buildDir/tmp/jacoco/classpathdumps")
@@ -43,6 +45,7 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
         """
     }
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution
     def "jacoco file results are cached"() {
         when:
@@ -64,6 +67,7 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
         reportFile.assertContentsHaveNotChangedSince(snapshot)
     }
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution
     def "jacoco file results are not cached when sharing output with another task"() {
         javaProjectUnderTest.writeIntegrationTestSourceFiles()
@@ -91,6 +95,7 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
         executedAndNotSkipped ":test", ":jacocoTestReport"
     }
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution
     def "test execution is cached with different gradle user home"() {
         when:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportFixture
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
 
@@ -101,6 +103,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         output.contains "org.jacoco:org.jacoco.ant:0.6.0.201210061924"
     }
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution
     def "jacoco report is incremental"() {
         def reportResourceDir = file("${REPORTING_BASE}/jacoco/test/html/jacoco-resources")

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -25,8 +25,11 @@ final class JacocoCoverage {
 
     private static final String[] ALL = [JacocoPlugin.DEFAULT_JACOCO_VERSION, '0.7.1.201405082137', '0.7.6.201602180812', '0.8.3'].asImmutable()
 
+    // Release notes: https://www.jacoco.org/jacoco/trunk/doc/changes.html
     static List<String> getSupportedVersionsByJdk() {
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
+            return filter(JacocoVersion.SUPPORTS_JDK_15)
+        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
             return filter(JacocoVersion.SUPPORTS_JDK_14)
         } else if (JavaVersion.current().isJava9Compatible()) {
             return filter(JacocoVersion.SUPPORTS_JDK_9)
@@ -42,6 +45,7 @@ final class JacocoCoverage {
         static final SUPPORTS_JDK_8 = new JacocoVersion(0, 7, 0)
         static final SUPPORTS_JDK_9 = new JacocoVersion(0, 7, 8)
         static final SUPPORTS_JDK_14 = new JacocoVersion(0, 8, 5)
+        static final SUPPORTS_JDK_15 = new JacocoVersion(0, 8, 6)
 
         private final int major
         private final int minor

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -352,6 +354,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         hasReport(':subproject:test', 'junitXml')
     }
 
+    @Requires(TestPrecondition.JDK14_OR_EARLIER) // reevaluate when upgrading JaCoco from current 0.8.5
     @ToBeFixedForInstantExecution(because = ":buildDashboard")
     void 'dashboard includes JaCoCo reports'() {
         given:


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/13529

JaCoCo does not yet support JDK15: https://www.jacoco.org/jacoco/trunk/doc/changes.html
Official JDK14 support is coming in the next release 0.8.6, although our tests currently pass on JDK14 with 0.8.5.
This is not the case for JDK15. This change ignores JaCoCo integration tests when running on JDK15.