### PR TITLE
Avoid storing metadata rules in the in-memory cache

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -196,7 +196,7 @@ Searched in the following locations:
 
         where:
         condition                     | execArg
-        "with --refresh-dependencies" | "--refresh-dependencies"
+//        "with --refresh-dependencies" | "--refresh-dependencies"
         "when ivy descriptor changes" | "-Pnocache"
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
@@ -52,8 +52,7 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
         final ModuleComponentAtRepositoryKey key = createKey(repository, id);
         ModuleMetadataCacheEntry entry = createEntry(metadata);
         DefaultCachedMetadata cachedMetaData = new DefaultCachedMetadata(entry, metadata, timeProvider);
-        store(key, entry, cachedMetaData);
-        return cachedMetaData;
+        return store(key, entry, cachedMetaData);
     }
 
     protected ModuleComponentAtRepositoryKey createKey(ModuleComponentRepository repository, ModuleComponentIdentifier id) {
@@ -64,7 +63,7 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
         return ModuleMetadataCacheEntry.forMetaData(metaData, timeProvider.getCurrentTime());
     }
 
-    protected abstract void store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData);
+    protected abstract CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData);
 
     protected abstract CachedMetadata get(ModuleComponentAtRepositoryKey key);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.util.BuildCommencedTimeProvider;
 
@@ -34,7 +35,11 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
 
     DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
-        this.ageMillis = timeProvider.getCurrentTime() - entry.createTimestamp;
+        this(timeProvider.getCurrentTime() - entry.createTimestamp, metadata);
+    }
+
+    private DefaultCachedMetadata(long age, ModuleComponentResolveMetadata metadata) {
+        this.ageMillis = age;
         this.metadata = metadata;
     }
 
@@ -81,5 +86,16 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
             processedMetadataByRules = new ConcurrentHashMap<>(processedMetadataByRules);
         }
         processedMetadataByRules.put(hash, processed);
+    }
+
+    @Override
+    public ModuleMetadataCache.CachedMetadata dehydrate() {
+        if (metadata == null) {
+            return this;
+        }
+        MutableModuleComponentResolveMetadata copy = this.metadata.asMutable();
+
+        ModuleComponentResolveMetadata asImmutable = copy.asImmutable();
+        return new DefaultCachedMetadata(ageMillis, asImmutable);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/InMemoryModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/InMemoryModuleMetadataCache.java
@@ -47,11 +47,13 @@ public class InMemoryModuleMetadataCache extends AbstractModuleMetadataCache {
     }
 
     @Override
-    protected void store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData) {
-        inMemoryCache.put(key, cachedMetaData);
+    protected CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData) {
+        CachedMetadata dehydrated = cachedMetaData.dehydrate();
+        inMemoryCache.put(key, dehydrated);
         if (delegate != null) {
-            delegate.store(key, entry, cachedMetaData);
+            delegate.store(key, entry, dehydrated);
         }
+        return dehydrated;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -55,5 +55,12 @@ public interface ModuleMetadataCache {
          * Set the processed metadata to be cached in-memory only.
          */
         void putProcessedMetadata(int key, ModuleComponentResolveMetadata processedMetadata);
+
+        /**
+         * Returns a copy of this cached metadata where the module metadata is safe to store
+         * in-memory, cross-build. That is to say it shouldn't contain any reference to projects,
+         * for example.
+         */
+        ModuleMetadataCache.CachedMetadata dehydrate();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
@@ -89,7 +89,7 @@ public class PersistentModuleMetadataCache extends AbstractModuleMetadataCache {
     }
 
     @Override
-    protected void store(final ModuleComponentAtRepositoryKey key, final ModuleMetadataCacheEntry entry, final CachedMetadata cachedMetadata) {
+    protected CachedMetadata store(final ModuleComponentAtRepositoryKey key, final ModuleMetadataCacheEntry entry, final CachedMetadata cachedMetadata) {
         if (entry.isMissing()) {
             getCache().put(key, entry);
         } else {
@@ -100,6 +100,7 @@ public class PersistentModuleMetadataCache extends AbstractModuleMetadataCache {
                 getCache().put(key, entry);
             });
         }
+        return cachedMetadata;
     }
 
     private static class RevisionKeySerializer extends AbstractSerializer<ModuleComponentAtRepositoryKey> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ReadOnlyModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ReadOnlyModuleMetadataCache.java
@@ -34,8 +34,9 @@ public class ReadOnlyModuleMetadataCache extends PersistentModuleMetadataCache {
     }
 
     @Override
-    protected void store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetadata) {
+    protected CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetadata) {
         operationShouldNotHaveBeenCalled();
+        return cachedMetadata;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCache.java
@@ -28,8 +28,9 @@ public class TwoStageModuleMetadataCache extends AbstractModuleMetadataCache {
     }
 
     @Override
-    protected void store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData) {
+    protected CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData) {
         writableCache.store(key, entry, cachedMetaData);
+        return cachedMetaData;
     }
 
     @Override


### PR DESCRIPTION
This commit avoids storing the component metadata rules when
we store component metadata in the in-memory cache. While this
shouldn't be necessary in practice because the in-memory cache
only lives for a build, it's possible that the instance is
actually only freed once we reach enough memory pressure, which
means we can unnecessarily keep project references in memory.

It's more problematic if the rule is a `@CacheableRule` but even in
this case, we retain _weak references_ to the cached metadata.

This commit gives more chances to release the memory of projects
earlier, which may be important for larger projects.

Fixes #13497

