### PR TITLE
Remove Groovy switch bug workaround

### DIFF
--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -205,7 +205,6 @@ class ModuleVersionSpec {
         expectGetMetadata.each {
             switch (it) {
                 case InteractionExpectation.NONE:
-                    true // workaround for groovy-2.5.10 regression: https://issues.apache.org/jira/browse/GROOVY-9424
                     break
                 case InteractionExpectation.MAYBE:
                     if (module instanceof MavenModule) {


### PR DESCRIPTION
This [regression](https://issues.apache.org/jira/browse/GROOVY-9424) was affecting Groovy 2.5.10 and was fixed in 2.5.11: https://issues.apache.org/jira/browse/GROOVY-9438
We are currently on 2.5.12