### PR TITLE
Reduce memory usage of `ConsumerVariantMatchResult`

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -108,11 +108,11 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             }
         }
 
-        List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates = new ArrayList<>();
+        List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> candidates = new ArrayList<>();
         for (ResolvedVariant variant : producer.getVariants()) {
             AttributeContainerInternal variantAttributes = variant.getAttributes().asImmutable();
             ConsumerVariantMatchResult matchResult = consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, componentRequested);
-            for (ConsumerVariantMatchResult.ConsumerVariant consumerVariant : matchResult.getMatches()) {
+            for (MutableConsumerVariantMatchResult.ConsumerVariant consumerVariant : matchResult.getMatches()) {
                 candidates.add(Pair.of(variant, consumerVariant));
             }
         }
@@ -120,7 +120,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             candidates = tryDisambiguate(matcher, candidates, componentRequested, explanationBuilder);
         }
         if (candidates.size() == 1) {
-            Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> result = candidates.get(0);
+            Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant> result = candidates.get(0);
             ResolvedArtifactSet artifacts = result.getLeft().getArtifacts();
             ImmutableAttributes attributes = result.getRight().attributes.asImmutable();
             Transformation transformation = result.getRight().transformation;
@@ -137,7 +137,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         throw new NoMatchingVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, producer.getVariants(), matcher, DescriberSelector.selectDescriber(componentRequested, schema));
     }
 
-    private List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> tryDisambiguate(AttributeMatcher matcher, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates, ImmutableAttributes componentRequested, AttributeMatchingExplanationBuilder explanationBuilder) {
+    private List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> tryDisambiguate(AttributeMatcher matcher, List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> candidates, ImmutableAttributes componentRequested, AttributeMatchingExplanationBuilder explanationBuilder) {
         candidates = disambiguateWithSchema(matcher, candidates, componentRequested, explanationBuilder);
 
         if (candidates.size() == 1) {
@@ -151,7 +151,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
                 .orElse(candidates);
         }
 
-        List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> shortestTransforms = Lists.newArrayListWithExpectedSize(candidates.size());
+        List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> shortestTransforms = Lists.newArrayListWithExpectedSize(candidates.size());
         candidates.sort(Comparator.comparingInt(candidate -> candidate.right.depth));
 
         // Need to remember if a further element was matched by an earlier one, no need to consider it then
@@ -162,7 +162,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
                 continue;
             }
             boolean candidateIsDifferent = true;
-            Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> current = candidates.get(i);
+            Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant> current = candidates.get(i);
             for (int j = i + 1; j < candidates.size(); j++) {
                 if (hasBetterMatch[j]) {
                     continue;
@@ -186,7 +186,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         return shortestTransforms;
     }
 
-    private List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> disambiguateWithSchema(AttributeMatcher matcher, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates, ImmutableAttributes componentRequested, AttributeMatchingExplanationBuilder explanationBuilder) {
+    private List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> disambiguateWithSchema(AttributeMatcher matcher, List<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> candidates, ImmutableAttributes componentRequested, AttributeMatchingExplanationBuilder explanationBuilder) {
         List<AttributeContainerInternal> candidateAttributes = candidates.stream().map(pair -> pair.getRight().attributes).collect(Collectors.toList());
         List<AttributeContainerInternal> matches = matcher.matches(candidateAttributes, componentRequested, explanationBuilder);
         if (matches.size() == 1) {
@@ -199,9 +199,9 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         return candidates;
     }
 
-    private Optional<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> compareCandidates(AttributeMatcher matcher,
-                                                                                                          Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> firstCandidate,
-                                                                                                          Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> secondCandidate) {
+    private Optional<Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant>> compareCandidates(AttributeMatcher matcher,
+                                                                                                                 Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant> firstCandidate,
+                                                                                                                 Pair<ResolvedVariant, MutableConsumerVariantMatchResult.ConsumerVariant> secondCandidate) {
 
         if (matcher.isMatching(firstCandidate.right.attributes, secondCandidate.right.attributes) || matcher.isMatching(secondCandidate.right.attributes, firstCandidate.right.attributes)) {
             if (firstCandidate.right.depth >= secondCandidate.right.depth) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -55,12 +55,12 @@ public class ConsumerProvidedVariantFinder {
         return toCache.transforms.computeIfAbsent(actual, attrs -> findProducersFor(actual, requested).asImmutable());
     }
 
-    private ConsumerVariantMatchResult findProducersFor(AttributeContainerInternal actual, AttributeContainerInternal requested) {
+    private MutableConsumerVariantMatchResult findProducersFor(AttributeContainerInternal actual, AttributeContainerInternal requested) {
         // Prefer direct transformation over indirect transformation
         List<ArtifactTransformRegistration> candidates = new ArrayList<>();
         List<ArtifactTransformRegistration> transforms = variantTransforms.getTransforms();
         int nbOfTransforms = transforms.size();
-        ConsumerVariantMatchResult result = new ConsumerVariantMatchResult(nbOfTransforms * nbOfTransforms);
+        MutableConsumerVariantMatchResult result = new MutableConsumerVariantMatchResult(nbOfTransforms * nbOfTransforms);
         for (ArtifactTransformRegistration registration : transforms) {
             if (matchAttributes(registration.getTo(), requested)) {
                 if (matchAttributes(actual, registration.getFrom())) {
@@ -82,7 +82,7 @@ public class ConsumerProvidedVariantFinder {
             if (!inputVariants.hasMatches()) {
                 continue;
             }
-            for (ConsumerVariantMatchResult.ConsumerVariant inputVariant : inputVariants.getMatches()) {
+            for (MutableConsumerVariantMatchResult.ConsumerVariant inputVariant : inputVariants.getMatches()) {
                 ImmutableAttributes variantAttributes = attributesFactory.concat(inputVariant.attributes.asImmutable(), candidate.getTo().asImmutable());
                 Transformation transformation = new TransformationChain(inputVariant.transformation, candidate.getTransformationStep());
                 result.matched(variantAttributes, transformation, inputVariant.depth + 1);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableConsumerVariantMatchResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableConsumerVariantMatchResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+import java.util.List;
+
+public class ImmutableConsumerVariantMatchResult implements ConsumerVariantMatchResult {
+    private final List<ConsumerVariant> consumerVariants;
+
+    private ImmutableConsumerVariantMatchResult(List<ConsumerVariant> consumerVariants) {
+        assert consumerVariants.size() > 1;
+        this.consumerVariants = consumerVariants;
+    }
+
+    static ImmutableConsumerVariantMatchResult of(List<ConsumerVariant> consumerVariants) {
+        return new ImmutableConsumerVariantMatchResult(ImmutableList.copyOf(consumerVariants));
+    }
+
+    @Override
+    public boolean hasMatches() {
+        return true;
+    }
+
+    @Override
+    public Collection<ConsumerVariant> getMatches() {
+        return consumerVariants;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableConsumerVariantMatchResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableConsumerVariantMatchResult.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.Collection;
+import java.util.List;
+
+class MutableConsumerVariantMatchResult implements ConsumerVariantMatchResult {
+    private int minDepth;
+    private final List<ConsumerVariant> matches;
+
+    MutableConsumerVariantMatchResult(int estimateSize) {
+        matches = Lists.newArrayListWithExpectedSize(estimateSize);
+    }
+
+    public void matched(ImmutableAttributes output, Transformation transformation, int depth) {
+        // Collect only the shortest paths
+        if (minDepth == 0) {
+            minDepth = depth;
+        } else if (depth < minDepth) {
+            matches.clear();
+            minDepth = depth;
+        } else if (depth > minDepth) {
+            return;
+        }
+        matches.add(new ConsumerVariant(output, transformation, depth));
+    }
+
+    @Override
+    public boolean hasMatches() {
+        return !matches.isEmpty();
+    }
+
+    @Override
+    public Collection<ConsumerVariant> getMatches() {
+        return matches;
+    }
+
+    public ConsumerVariantMatchResult asImmutable() {
+        switch(matches.size()) {
+            case 0:
+                return NoMatchConsumerVariantMatchResult.getInstance();
+            case 1:
+                return SingleMatchConsumerVariantMatchResult.of(matches.get(0));
+            default:
+                return ImmutableConsumerVariantMatchResult.of(matches);
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/NoMatchConsumerVariantMatchResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/NoMatchConsumerVariantMatchResult.java
@@ -15,25 +15,27 @@
  */
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-
 import java.util.Collection;
+import java.util.Collections;
 
-public interface ConsumerVariantMatchResult {
+class NoMatchConsumerVariantMatchResult implements ConsumerVariantMatchResult {
+    private final static NoMatchConsumerVariantMatchResult INSTANCE = new NoMatchConsumerVariantMatchResult();
 
-    boolean hasMatches();
+    private NoMatchConsumerVariantMatchResult() {
 
-    Collection<ConsumerVariant> getMatches();
+    }
 
-    class ConsumerVariant {
-        final AttributeContainerInternal attributes;
-        final Transformation transformation;
-        final int depth;
+    static ConsumerVariantMatchResult getInstance() {
+        return INSTANCE;
+    }
 
-        public ConsumerVariant(AttributeContainerInternal attributes, Transformation transformation, int depth) {
-            this.attributes = attributes;
-            this.transformation = transformation;
-            this.depth = depth;
-        }
+    @Override
+    public boolean hasMatches() {
+        return false;
+    }
+
+    @Override
+    public Collection<ConsumerVariant> getMatches() {
+        return Collections.emptyList();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/SingleMatchConsumerVariantMatchResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/SingleMatchConsumerVariantMatchResult.java
@@ -15,25 +15,27 @@
  */
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-
 import java.util.Collection;
+import java.util.Collections;
 
-public interface ConsumerVariantMatchResult {
+class SingleMatchConsumerVariantMatchResult implements ConsumerVariantMatchResult {
+    private final Collection<ConsumerVariant> consumerVariants;
 
-    boolean hasMatches();
+    private SingleMatchConsumerVariantMatchResult(ConsumerVariant consumerVariant) {
+        this.consumerVariants = Collections.singletonList(consumerVariant);
+    }
 
-    Collection<ConsumerVariant> getMatches();
+    static ConsumerVariantMatchResult of(ConsumerVariant consumerVariant) {
+        return new SingleMatchConsumerVariantMatchResult(consumerVariant);
+    }
 
-    class ConsumerVariant {
-        final AttributeContainerInternal attributes;
-        final Transformation transformation;
-        final int depth;
+    @Override
+    public boolean hasMatches() {
+        return true;
+    }
 
-        public ConsumerVariant(AttributeContainerInternal attributes, Transformation transformation, int depth) {
-            this.attributes = attributes;
-            this.transformation = transformation;
-            this.depth = depth;
-        }
+    @Override
+    public Collection<ConsumerVariant> getMatches() {
+        return consumerVariants;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -343,8 +343,8 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         3 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, false, true]
     }
 
-    static ConsumerVariantMatchResult match(ImmutableAttributes output, Transformation trn, int depth) {
-        def result = new ConsumerVariantMatchResult(2)
+    static MutableConsumerVariantMatchResult match(ImmutableAttributes output, Transformation trn, int depth) {
+        def result = new MutableConsumerVariantMatchResult(2)
         result.matched(output, trn, depth)
         result
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -170,7 +170,7 @@ Found the following transforms:
         consumerSchema.withProducer(producerSchema) >> attributeMatcher
         attributeMatcher.matches(_, _, _) >> []
 
-        matchingCache.collectConsumerVariants(_, _) >> new ConsumerVariantMatchResult(0)
+        matchingCache.collectConsumerVariants(_, _) >> new MutableConsumerVariantMatchResult(0)
 
         expect:
         def result = transforms.variantSelector(typeAttributes("dll"), true, dependenciesResolver).select(set, factory)
@@ -195,7 +195,7 @@ Found the following transforms:
         consumerSchema.withProducer(producerSchema) >> attributeMatcher
         attributeMatcher.matches(_, _, _) >> []
 
-        matchingCache.collectConsumerVariants(_, _) >> new ConsumerVariantMatchResult(0)
+        matchingCache.collectConsumerVariants(_, _) >> new MutableConsumerVariantMatchResult(0)
 
         when:
         def result = transforms.variantSelector(typeAttributes("dll"), false, dependenciesResolver).select(set, factory)
@@ -222,8 +222,8 @@ Found the following transforms:
         attributeContainer.asImmutable()
     }
 
-    static ConsumerVariantMatchResult match(ImmutableAttributes output, Transformation trn, int depth) {
-        def result = new ConsumerVariantMatchResult(2)
+    static MutableConsumerVariantMatchResult match(ImmutableAttributes output, Transformation trn, int depth) {
+        def result = new MutableConsumerVariantMatchResult(2)
         result.matched(output, trn, depth)
         result
     }


### PR DESCRIPTION
This commit introduces specialized subtypes of match results
for the 3 common cases (empty, one element, n elements).

Fixes #13596
