### PR TITLE
Fix typo in Marge Simpson full name used in sample

### DIFF
--- a/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.tuple.Pair;
 // tag::sample[]
 public class Simpsons {
     private static final Person HOMER = new Person("Homer", "Simpson");
-    private static final Person MARGE = new Person("Majorie", "Simpson");
+    private static final Person MARGE = new Person("Marjorie", "Simpson");
     private static final Person BART = new Person("Bartholomew", "Simpson");
     private static final Person LISA = new Person("Elisabeth Marie", "Simpson");
     private static final Person MAGGIE = new Person("Margaret Eve", "Simpson");

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.tuple.Pair;
 // tag::sample[]
 public class Simpsons {
     private static final Person HOMER = new Person("Homer", "Simpson");
-    private static final Person MARGE = new Person("Majorie", "Simpson");
+    private static final Person MARGE = new Person("Marjorie", "Simpson");
     private static final Person BART = new Person("Bartholomew", "Simpson");
     private static final Person LISA = new Person("Elisabeth Marie", "Simpson");
     private static final Person MAGGIE = new Person("Margaret Eve", "Simpson");


### PR DESCRIPTION
Her full first name was missing an "r". This PR fixes it.

### Context
This tiny typo appears in the documentation [here](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
