### PR TITLE
Add javadoc comments to classes in samples with javadocs

### DIFF
--- a/subprojects/docs/src/snippets/signing/maven-publish/groovy/src/main/java/Sample.java
+++ b/subprojects/docs/src/snippets/signing/maven-publish/groovy/src/main/java/Sample.java
@@ -1,2 +1,5 @@
+/**
+ * Sample class
+ */
 public class Sample {
 }

--- a/subprojects/docs/src/snippets/signing/maven-publish/kotlin/src/main/java/Sample.java
+++ b/subprojects/docs/src/snippets/signing/maven-publish/kotlin/src/main/java/Sample.java
@@ -1,2 +1,5 @@
+/**
+ * Sample class
+ */
 public class Sample {
 }


### PR DESCRIPTION
When executed on JDK15, the javadoc task starts emitting a warning when a public class has no Javadoc comments:
```
> Task :compileJava
> Task :processResources
> Task :classes
> Task :jar

> Task :javadoc
/home/user/gradle/samples/src/main/java/Sample.java:1: warning: no comment
public class Sample {
       ^
1 warning
```

This looks to be related to https://bugs.openjdk.java.net/browse/JDK-8242607 and changes in https://hg.openjdk.java.net/jdk/jdk15/rev/fb88a17c572c

This doesn't seem to impact Gradle in any way apart from the Javadoc tool emitting warnings in such cases.
We could either ignore the extra output in our samples in such case, or add the Javadoc comments where the warnings are caused. This PR chooses the latter.