### PR TITLE
Do not use deprecated method in Kotlin sample

### DIFF
--- a/subprojects/docs/src/samples/templates/kotlin-utilities-library/src/main/kotlin/org/gradle/sample/utilities/SplitUtils.kt
+++ b/subprojects/docs/src/samples/templates/kotlin-utilities-library/src/main/kotlin/org/gradle/sample/utilities/SplitUtils.kt
@@ -33,7 +33,7 @@ class SplitUtils {
         }
 
         private fun isTokenValid(token: String): Boolean {
-            return token.length > 0
+            return token.isNotEmpty()
         }
     }
 }

--- a/subprojects/docs/src/samples/templates/kotlin-utilities-library/src/main/kotlin/org/gradle/sample/utilities/SplitUtils.kt
+++ b/subprojects/docs/src/samples/templates/kotlin-utilities-library/src/main/kotlin/org/gradle/sample/utilities/SplitUtils.kt
@@ -33,7 +33,7 @@ class SplitUtils {
         }
 
         private fun isTokenValid(token: String): Boolean {
-            return !token.isEmpty()
+            return token.length > 0
         }
     }
 }


### PR DESCRIPTION
When executed on JDK15, samples that were compiling the changed code were emitting a deprecation warning:
```
> Task :compileKotlin
w: /home/user/gradle/samples/src/main/kotlin/org/gradle/sample/utilities/SplitUtils.kt: (36, 27): 'isEmpty(): Boolean' is deprecated. This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version
```

I find this a bit odd as I could not find any evidence of `CharSequence.isEmpty` being deprecated: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/is-empty.html

This changes only the code in a sample that gets rid of the deprecation warning.