### PR TITLE
Do not reference project during task execution in a test

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -168,11 +168,15 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
     def "runs a module using the module path in a generic task with main class defined in compile task"() {
         given:
         buildFile << """
+            interface Services {
+                @javax.inject.Inject ExecOperations getExec()
+            }
+
             task run {
                 dependsOn jar
-                def processOperations = project.processOperations
+                def execOperations = project.objects.newInstance(Services).exec
                 doLast {
-                    processOperations.javaexec { action ->
+                    execOperations.javaexec { action ->
                         action.modularity.inferModulePath.set(true)
                         action.classpath = files(jar) + configurations.runtimeClasspath
                         action.mainModule.set('consumer')
@@ -198,11 +202,15 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
     def "runs a module using the module path with main class defined in a generic task"() {
         given:
         buildFile << """
+            interface Services {
+                @javax.inject.Inject ExecOperations getExec()
+            }
+
             task run {
                 dependsOn jar
-                def processOperations = project.processOperations
+                def execOperations = project.objects.newInstance(Services).exec
                 doLast {
-                    processOperations.javaexec { action ->
+                    execOperations.javaexec { action ->
                         action.modularity.inferModulePath.set(true)
                         action.classpath = files(jar) + configurations.runtimeClasspath
                         action.mainModule.set('consumer')

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -170,11 +170,12 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
         buildFile << """
             task run {
                 dependsOn jar
+                def processOperations = project.processOperations
                 doLast {
-                    project.javaexec {
-                        modularity.inferModulePath.set(true)
-                        classpath = files(jar) + configurations.runtimeClasspath
-                        mainModule.set('consumer')
+                    processOperations.javaexec { action ->
+                        action.modularity.inferModulePath.set(true)
+                        action.classpath = files(jar) + configurations.runtimeClasspath
+                        action.mainModule.set('consumer')
                     }
                 }
             }
@@ -199,12 +200,13 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
         buildFile << """
             task run {
                 dependsOn jar
+                def processOperations = project.processOperations
                 doLast {
-                    project.javaexec {
-                        modularity.inferModulePath.set(true)
-                        classpath = files(jar) + configurations.runtimeClasspath
-                        mainModule.set('consumer')
-                        mainClass.set('consumer.MainModule')
+                    processOperations.javaexec { action ->
+                        action.modularity.inferModulePath.set(true)
+                        action.classpath = files(jar) + configurations.runtimeClasspath
+                        action.mainModule.set('consumer')
+                        action.mainClass.set('consumer.MainModule')
                     }
                 }
             }


### PR DESCRIPTION
`JavaModuleExecutionIntegrationTest` was failing when executed with configuration cache enabled as `instantIntegTest`.
We only run `instantIntegTest` as part of the pipeline using JDK8 at the moment and with JDK8 the java modules tests are skipped.

This change works around the `project` references during task execution in `JavaModuleExecutionIntegrationTest` to make it run with configuration cache enabled.