### PR TITLE
Update test to work with configuration cache with JDK9+

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -293,7 +293,7 @@ If the artifacts are trustworthy, you will need to update the gradle/verificatio
                 signAsciiArmored(it)
                 if (name.endsWith(".jar")) {
                     // change contents of original file so that the signature doesn't match anymore
-                    bytes = [0, 1, 2, 3]
+                    tamperWithFile(it)
                 }
             }
         }
@@ -341,7 +341,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
                 signAsciiArmored(it)
                 if (name.endsWith(".jar")) {
                     // change contents of original file so that the signature doesn't match anymore
-                    bytes = [0, 1, 2, 3]
+                    tamperWithFile(it)
                 }
             }
         }
@@ -1058,7 +1058,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
                 signAsciiArmored(it)
             }
         }
-        module.artifactFile.bytes = [0, 1, 2]
+        tamperWithFile(module.artifactFile)
 
         buildFile << """
             dependencies {
@@ -1110,7 +1110,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
                 signAsciiArmored(it)
             }
         }
-        module.artifactFile.bytes = [0, 1, 2]
+        tamperWithFile(module.artifactFile)
 
         buildFile << """
             dependencies {
@@ -1384,5 +1384,9 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
 """
         where:
         terse << [true, false]
+    }
+
+    private static void tamperWithFile(File file) {
+        file.bytes = [0, 1, 2, 3] + file.readBytes().toList() as byte[]
     }
 }


### PR DESCRIPTION
We only run `instantIntegTest` as part of the pipeline using JDK8 at the moment. After fixing the currently failing tests on later JDKs we should be able to run `instantIntegTest` with more JDK variants as we do with the rest of tests: https://github.com/gradle/configuration-cache/issues/421

With later JDKs this test fails on configuration cache with:
```
error: error reading /home/tcagent1/agent/work/e67123fb5b9af0ac/subprojects/dependency-management/build/tmp/test files/DependencyV.Test/xjaf7/user-home/caches/modules-2/files-2.1/org/foo/1.0/c7a623fd2bbc05b06423be359e4021d36e721ad/foo-1.0.jar; zip END header not found
/home/tcagent1/agent/work/e67123fb5b9af0ac/subprojects/dependency-management/build/tmp/test files/DependencyV.Test/xjaf7/src/main/java/com/acme/main/Foo.java:2: error: cannot access com.acme.main
        package com.acme.main;
        ^
  zip END header not found
1 error
```

This change tampers with signed zip files in a way that does not cause configuration cache to fail with `zip END header not found` by prepending junk bytes to the jar instead of replacing the whole content.
