### PR TITLE
Fix NPE when a failure appears on a different selector

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.platforms
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class EnforcedPlatformIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+    }
+
+    def "dependency on unsatisfiable range shouldn't trigger null pointer exception"() {
+        settingsFile << """
+            include 'platform'
+            include 'lib'
+        """
+
+        buildFile << """
+            allprojects {
+                ${mavenCentralRepository()}
+            }
+
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation enforcedPlatform(project(":platform"))
+                implementation project(':lib')
+            }
+        """
+
+        file("lib/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            dependencies {
+                api 'org.apache.commons:commons-lang3:3.10'
+            }
+        """
+
+        file('platform/build.gradle') << """
+            plugins {
+                id 'java-platform'
+            }
+
+            dependencies {
+                constraints {
+                    // Deliberately unsatisfiable constraint with version range
+                    api 'org.apache.commons:commons-lang3:[99,)'
+                }
+            }
+        """
+        def resolve = new ResolveTestFixture(buildFile, 'compileClasspath')
+        resolve.expectDefaultConfiguration("compile")
+        resolve.prepare()
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause "Could not find any version that matches org.apache.commons:commons-lang3:[99,)"
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.platforms
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 class EnforcedPlatformIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -27,6 +28,7 @@ class EnforcedPlatformIntegrationTest extends AbstractHttpDependencyResolutionTe
         """
     }
 
+    @ToBeFixedForInstantExecution(because = "Resolve test fixture doesn't support configuration cache")
     def "dependency on unsatisfiable range shouldn't trigger null pointer exception"() {
         settingsFile << """
             include 'platform'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -340,7 +340,18 @@ class EdgeState implements DependencyGraphEdge {
         if (selectorFailure != null) {
             return selectorFailure;
         }
-        return getSelectedComponent().getMetadataResolveFailure();
+        ComponentState selectedComponent = getSelectedComponent();
+        if (selectedComponent == null) {
+            ModuleSelectors<SelectorState> selectors = selector.getTargetModule().getSelectors();
+            for (SelectorState state : selectors) {
+                selectorFailure = state.getFailure();
+                if (selectorFailure != null) {
+                    return selectorFailure;
+                }
+            }
+            throw new IllegalStateException("Expected to find a selector with a failure but none was found");
+        }
+        return selectedComponent.getMetadataResolveFailure();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -203,15 +203,6 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         }
     }
 
-    @Override
-    public void failed(ModuleVersionResolveException failure) {
-        this.failure = failure;
-        BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
-        idResolveResult.failed(failure);
-        this.requireResult = idResolveResult;
-        this.preferResult = idResolveResult;
-    }
-
     private boolean requiresResolve(@Nullable ComponentIdResolveResult previousResult, @Nullable VersionSelector allRejects) {
         this.reusable = false;
         // If we've never resolved, must resolve

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 
 import javax.annotation.Nullable;
@@ -49,13 +48,6 @@ public interface ResolvableSelectorState {
      */
     @Nullable
     ComponentIdResolveResult resolvePrefer(VersionSelector allRejects);
-
-    /**
-     * Marks the selector as resolved with the passed in failure.
-     *
-     * @param failure the failure to record
-     */
-    void failed(ModuleVersionResolveException failure);
 
     /**
      * Mark the selector as resolved.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
@@ -91,11 +90,6 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
         BuildableComponentIdResolveResult result = new DefaultBuildableComponentIdResolveResult();
         resolver.resolve(null, acceptor, rejector, result);
         return result;
-    }
-
-    @Override
-    public void failed(ModuleVersionResolveException failure) {
-        throw new UnsupportedOperationException("To be implemented");
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.internal.artifacts.ResolvedVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.model.IvyArtifactName
-import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.result.ComponentIdResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult
 
@@ -57,11 +56,6 @@ class TestProjectSelectorState implements ResolvableSelectorState {
     @Override
     ComponentIdResolveResult resolvePrefer(VersionSelector allRejects) {
         return null
-    }
-
-    @Override
-    void failed(ModuleVersionResolveException failure) {
-        throw new UnsupportedOperationException("To be implemented")
     }
 
     @Override


### PR DESCRIPTION
It is possible that an edge has a failure, but that the
first selector being processed with an edge to the failure
isn't the one carrying the failure. This commit fixes
this by iterating on selectors to find the selector with
a failure.

Fixes #13699
