### PR TITLE
Ensure isolated daemons are stopped for plugin builds in testkit tests

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testkit.runner
 
-import org.gradle.integtests.fixtures.ToBeFixedForFileSystemWatching
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.nativeintegration.ProcessEnvironment
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
@@ -25,7 +24,6 @@ import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
 import org.gradle.testkit.runner.fixtures.PluginUnderTest
 import org.gradle.util.GradleVersion
-import org.gradle.util.TestPrecondition
 import org.gradle.util.UsesNativeServices
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
@@ -37,9 +35,8 @@ import static org.hamcrest.CoreMatchers.containsString
 @InjectsPluginClasspath
 @InspectsBuildOutput
 @UsesNativeServices
-@SuppressWarnings('IntegrationTestFixtures')
+@SuppressWarnings('IntegrationTestFixtures') // result.output.contains does mean something different here
 @IgnoreIf({ GradleContextualExecuter.embedded }) // Test causes builds to hang
-@ToBeFixedForFileSystemWatching(because = "https://github.com/gradle/gradle-private/issues/3145", failsOnlyIf = TestPrecondition.WINDOWS)
 class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     def plugin = new PluginUnderTest(1, file("plugin"))

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -84,11 +84,16 @@ class PluginUnderTest {
     PluginUnderTest build() {
         writeSourceFiles()
         writeBuildScript()
-        new GradleContextualExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider, IntegrationTestBuildContext.INSTANCE)
-            .usingProjectDirectory(projectDir)
-            .withArguments('classes')
-            .withWarningMode(null)
-            .run()
+        def executer = new GradleContextualExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider, IntegrationTestBuildContext.INSTANCE)
+        try {
+            executer
+                .usingProjectDirectory(projectDir)
+                .withArguments('classes')
+                .withWarningMode(null)
+                .run()
+        } finally {
+            executer.stop()
+        }
         this
     }
 


### PR DESCRIPTION
The test fails to cleanup the daemon log
directory since the daemon still writes
to it in the background.

See also #12604.

Fixes gradle/gradle-private#3145.