### PR TITLE
Add without_test_code attribute to Eclipse project dependencies

### DIFF
--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -24,6 +24,7 @@
 	<classpathentry kind="src" path="/api">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="without_test_code" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -11,11 +11,13 @@
 	<classpathentry kind="src" path="/common">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="without_test_code" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="/api" >
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="without_test_code" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="lib" path="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -12,6 +12,7 @@
 	<classpathentry kind="src" path="/api">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="without_test_code" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar" kind="lib" path="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar">

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
@@ -28,6 +28,9 @@ public class EclipsePluginConstants {
     public static final String GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME = "gradle_used_by_scope";
     public static final String GRADLE_SCOPE_ATTRIBUTE_NAME = "gradle_scope";
 
+    public static final String WITHOUT_TEST_CODE_ATTRIBUTE_KEY = "without_test_code";
+    public static final String WITHOUT_TEST_CODE_ATTRIBUTE_VALUE = "true";
+
     private EclipsePluginConstants() {
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -40,6 +40,7 @@ public class ProjectDependencyBuilder {
         if (asJavaModule) {
             dependency.getEntryAttributes().put(EclipsePluginConstants.MODULE_ATTRIBUTE_KEY, EclipsePluginConstants.MODULE_ATTRIBUTE_VALUE);
         }
+        dependency.getEntryAttributes().put(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_VALUE);
         return dependency;
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #12354

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Eclipse 3.14 introduced the `without_test_code` classpath attribute for project dependencies. If this attribute is set on project dependencies then only the main resources (i.e. the classes that were generated from source folders that are _not_ marked with `test` classpath attribute) will be contributed to the classpath. For Gradle projects, don't want the test classes to be visible for dependent projects, therefore the `without_test_code` should be always added to Eclipse project dependencies.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
