### PR TITLE
Fix project dependency metadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -75,7 +75,7 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
 
     @Override
     public boolean isConstraint() {
-        return false;
+        return delegate.isConstraint();
     }
 
     @Override


### PR DESCRIPTION
This commit fixes the "project dependency metadata" not reporting the
dependency constraint flag properly. The consequence was that a binary
dependency constraint would be converted to a hard dependency if a
dependency substitution applied on the constraint.

Fixes #13658
