### PR TITLE
Bump native-platform: use new macOS watcher, take 2

### DIFF
--- a/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
+++ b/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
@@ -118,7 +118,7 @@ dependencies {
         api(libs.maven3WagonHttpShared) { version { strictly(mavenWagonVersion) }}
         api(libs.maven3WagonProviderApi) { version { strictly(mavenWagonVersion) }}
         api(libs.minlog)                { version { strictly("1.2") }}
-        api(libs.nativePlatform)        { version { strictly("0.22-milestone-4") }}
+        api(libs.nativePlatform)        { version { strictly("0.22-snapshot-20200715094808+0000") }}
         api(libs.nekohtml)              { version { strictly("1.9.22") }}
         api(libs.objenesis)             { version { strictly("2.6") }}
         api(libs.plexusCipher)          { version { strictly("1.7") }}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
@@ -22,7 +22,7 @@ import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_D
 
 public class FileSystemWatchingHelper {
 
-    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 80;
+    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 120;
 
     public static void waitForChangesToBePickedUp() throws InterruptedException {
         Thread.sleep(WAIT_FOR_CHANGES_PICKED_UP_MILLIS);

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
@@ -25,6 +25,10 @@ class CachedPlatformScalaCompileIntegrationTest extends AbstractCachedCompileInt
     String compilationTask = ':compileMainJarMainScala'
     String compiledFile = "build/classes/main/jar/Person.class"
 
+    def setup() {
+        executer.withFullDeprecationStackTraceDisabled()
+    }
+
     def expectDeprecationWarnings() {
         executer.expectDocumentedDeprecationWarning("The jvm-component plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#upgrading_jvm_plugins")


### PR DESCRIPTION
Re-try https://github.com/gradle/gradle/pull/13785

PRs merged since `0.22-milestone-4`:

- https://github.com/gradle/native-platform/pull/238
- https://github.com/gradle/native-platform/pull/241
- https://github.com/gradle/native-platform/pull/243