### PR TITLE
Ensure configuration cache fingerprint resources are always disposed of

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -164,6 +164,8 @@ class DefaultInstantExecution internal constructor(
                     invalidateInstantExecutionState(layout)
                     problems.failingBuildDueToSerializationError()
                     throw error
+                } finally {
+                    cacheFingerprintController.stop()
                 }
             }
         }


### PR DESCRIPTION
This should finally fix the listener leak identified in #13190

Cherry-picked from release.
