### PR TITLE
Do not attempt to resolve file collection elements to files while calculating task dependencies

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.util.GUtil;
 
 import java.io.File;
@@ -72,6 +73,21 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     @Override
     public String toString() {
         return getDisplayName();
+    }
+
+    /**
+     * This is final - override {@link #appendContents(TreeFormatter)}  instead.
+     */
+    @Override
+    public final TreeFormatter describeContents(TreeFormatter formatter) {
+        formatter.node("collection type: ").appendType(getClass()).append(" (id: ").append(String.valueOf(System.identityHashCode(this))).append(")");
+        formatter.startChildren();
+        appendContents(formatter);
+        formatter.endChildren();
+        return formatter;
+    }
+
+    protected void appendContents(TreeFormatter formatter) {
     }
 
     // This is final - override {@link TaskDependencyContainer#visitDependencies} to provide the dependencies instead.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionBackedFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionBackedFileTree.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 
 import java.io.File;
@@ -38,6 +39,14 @@ public class FileCollectionBackedFileTree extends AbstractFileTree {
     public FileCollectionBackedFileTree(Factory<PatternSet> patternSetFactory, AbstractFileCollection collection) {
         super(patternSetFactory);
         this.collection = collection;
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        formatter.node("backing collection");
+        formatter.startChildren();
+        collection.describeContents(formatter);
+        formatter.endChildren();
     }
 
     public AbstractFileCollection getCollection() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -20,6 +20,7 @@ package org.gradle.api.internal.file;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.io.File;
 import java.util.function.Supplier;
@@ -44,6 +45,11 @@ public interface FileCollectionInternal extends FileCollection, TaskDependencyCo
      * <p>The implementation should call the most specific methods on {@link FileCollectionStructureVisitor} that it is able to.</p>
      */
     void visitStructure(FileCollectionStructureVisitor visitor);
+
+    /**
+     * Appends diagnostic information about the contents of this collection to the given formatter.
+     */
+    TreeFormatter describeContents(TreeFormatter formatter);
 
     /**
      * Some representation of a source of files.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -37,6 +38,14 @@ public class FilteredFileTree extends CompositeFileTree implements FileCollectio
     @Override
     public String getDisplayName() {
         return tree.getDisplayName();
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        formatter.node("backing tree");
+        formatter.startChildren();
+        tree.describeContents(formatter);
+        formatter.endChildren();
     }
 
     public FileTreeInternal getTree() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.Set;
 import java.util.function.Consumer;
@@ -39,6 +40,16 @@ public class UnionFileCollection extends CompositeFileCollection {
     @Override
     public String getDisplayName() {
         return "file collection";
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        formatter.node("source");
+        formatter.startChildren();
+        for (FileCollectionInternal files : source) {
+            files.describeContents(formatter);
+        }
+        formatter.endChildren();
     }
 
     public Set<? extends FileCollection> getSources() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -32,11 +32,13 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -139,6 +141,27 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     @Override
     public String getDisplayName() {
         return displayName == null ? "file collection" : displayName;
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        if (displayName != null) {
+            formatter.node("display name: " + displayName);
+        }
+        List<Object> paths = new ArrayList<>();
+        value.collectSource(paths);
+        if (!paths.isEmpty()) {
+            formatter.node("contents");
+            formatter.startChildren();
+            for (Object path : paths) {
+                if (path instanceof FileCollectionInternal) {
+                    ((FileCollectionInternal) path).describeContents(formatter);
+                } else {
+                    formatter.node(path.toString());
+                }
+            }
+            formatter.endChildren();
+        }
     }
 
     @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ProviderBackedFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ProviderBackedFileCollectionTest.groovy
@@ -61,7 +61,6 @@ class ProviderBackedFileCollectionTest extends Specification {
         then:
         1 * provider.producer >> ValueSupplier.ValueProducer.unknown()
         1 * provider.get() >> 'ignore'
-        1 * resolver.resolve('ignore') >> new File('ignore')
         result.empty
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -26,6 +26,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -68,6 +69,15 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
     @Override
     public String getDisplayName() {
         return outputDirectories.toString();
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        formatter.node("source set: " + outputDirectories.toString());
+        formatter.node("output directories");
+        formatter.startChildren();
+        ((FileCollectionInternal) outputDirectories).describeContents(formatter);
+        formatter.endChildren();
     }
 
     @Override


### PR DESCRIPTION

### Context

6.6-RC2 unintentionally resolves all user provided paths to files during task dependency calculation. This PR restores the previous behaviour, which is to ignore anything that cannot carry task dependencies.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
