### PR TITLE
Fix UpdateBranchStatus and clean up githubToken parameter

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -77,7 +77,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
     steps {
         gradleWrapper {
             name = "GRADLE_RUNNER"
-            tasks = ":baseServices:createBuildReceipt" + if (stage.stageName == StageNames.READY_FOR_NIGHTLY) " updateBranchStatus" else ""
+            tasks = ":baseServices:createBuildReceipt" + if (stage.stageName == StageNames.READY_FOR_NIGHTLY) " updateBranchStatus -PgithubToken=%github.bot-teamcity.token%" else ""
             gradleParams = defaultGradleParameters
         }
         script {

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -49,7 +49,7 @@ fun performanceTestCommandLine(task: String, baselines: String, extraParameters:
 )
 
 fun distributedPerformanceTestParameters(workerId: String = "Gradle_Check_IndividualPerformanceScenarioWorkersLinux") = listOf(
-        "-Porg.gradle.performance.buildTypeId=$workerId -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id% -PgithubToken=%github.ci.oauth.token%"
+        "-Porg.gradle.performance.buildTypeId=$workerId -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%"
 )
 
 val individualPerformanceTestArtifactRules = """

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -204,7 +204,7 @@ class CIConfigIntegrationTests {
     fun onlyReadyForNightlyTriggerHasUpdateBranchStatus() {
         val triggerNameToTasks = rootProject.buildTypes.map { it.uuid to ((it as StagePasses).steps.items[0] as GradleBuildStep).tasks }.toMap()
         val readyForNightlyId = toTriggerId("MasterAccept")
-        assertEquals(":baseServices:createBuildReceipt updateBranchStatus", triggerNameToTasks[readyForNightlyId])
+        assertEquals(":baseServices:createBuildReceipt updateBranchStatus -PgithubToken=%github.bot-teamcity.token%", triggerNameToTasks[readyForNightlyId])
         val otherTaskNames = triggerNameToTasks.filterKeys { it != readyForNightlyId }.values.toSet()
         assertEquals(setOf(":baseServices:createBuildReceipt"), otherTaskNames)
     }

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -77,7 +77,6 @@ class PerformanceTestBuildTypeTest {
                 "-Porg.gradle.performance.buildTypeId=Gradle_Check_IndividualPerformanceScenarioWorkersLinux",
                 "-Porg.gradle.performance.workerTestTaskName=fullPerformanceTest",
                 "-Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%",
-                "-PgithubToken=%github.ci.oauth.token%",
                 "\"-Dscan.tag.PerformanceTest\"",
                 "\"-Dgradle.cache.remote.url=%gradle.cache.remote.url%\"",
                 "\"-Dgradle.cache.remote.username=%gradle.cache.remote.username%\"",

--- a/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateBranchStatus.kt
+++ b/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateBranchStatus.kt
@@ -40,7 +40,7 @@ abstract class UpdateBranchStatus : DefaultTask() {
     private
     fun publishBranchStatus(branch: String) {
         println("Publishing branch status of $branch")
-        project.execAndGetStdout("git", "push", "origin", "$branch:green-$branch")
+        project.execAndGetStdout("git", "push", "https://bot-teamcity:${project.property("githubToken")}@github.com/gradle/gradle.git", "$branch:green-$branch")
     }
 
     private

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/reporter/DefaultPerformanceReporter.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/reporter/DefaultPerformanceReporter.groovy
@@ -40,8 +40,6 @@ class DefaultPerformanceReporter implements PerformanceReporter {
 
     String projectName
 
-    String githubToken
-
     String commitId
 
     @Inject
@@ -69,7 +67,6 @@ class DefaultPerformanceReporter implements PerformanceReporter {
                 spec.systemProperty("gradleBuildBranch", performanceTest.branchName)
                 spec.systemProperty("gradleBuildCommitId", commitId)
 
-                spec.systemProperty("githubToken", githubToken)
                 spec.setClasspath(performanceTest.classpath)
 
                 spec.ignoreExitValue = true

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -18,7 +18,6 @@ package gradlebuild.performance
 
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.kotlindsl.selectStringProperties
-import gradlebuild.basics.kotlindsl.stringPropertyOrEmpty
 import gradlebuild.basics.kotlindsl.stringPropertyOrNull
 import gradlebuild.identity.extension.ModuleIdentityExtension
 import gradlebuild.performance.tasks.BuildCommitDistribution

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -225,7 +225,6 @@ class PerformanceTestPlugin : Plugin<Project> {
         objects.newInstance(DefaultPerformanceReporter::class).also {
             it.projectName = name
             it.reportGeneratorClass = "org.gradle.performance.results.report.DefaultReportGenerator"
-            it.githubToken = stringPropertyOrEmpty("githubToken")
             it.commitId = the<ModuleIdentityExtension>().gradleBuildCommitId.get()
         }
 


### PR DESCRIPTION
After we used https and bot-teamcity account, the old authentication way was
invalid. Now we use token based https url to do the pushing.

This also cleaned up unused `githubToken`.
