### PR TITLE
Fix plugin container to recognize plugins using getter injection

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.GeneratedSubclass;
 import org.gradle.api.plugins.PluginCollection;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.UnknownPluginException;
@@ -111,7 +112,11 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
     @Override
     public <P extends Plugin> P findPlugin(Class<P> type) {
         for (Plugin plugin : this) {
-            if (plugin.getClass().equals(type)) {
+            Class<?> pluginType = plugin.getClass();
+            if (plugin instanceof GeneratedSubclass) {
+                pluginType = ((GeneratedSubclass) plugin).publicType();
+            }
+            if (pluginType.equals(type)) {
                 return type.cast(plugin);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.GeneratedSubclass;
+import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.plugins.PluginCollection;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.UnknownPluginException;
@@ -112,10 +112,7 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
     @Override
     public <P extends Plugin> P findPlugin(Class<P> type) {
         for (Plugin plugin : this) {
-            Class<?> pluginType = plugin.getClass();
-            if (plugin instanceof GeneratedSubclass) {
-                pluginType = ((GeneratedSubclass) plugin).publicType();
-            }
+            Class<?> pluginType = GeneratedSubclasses.unpackType(plugin);
             if (pluginType.equals(type)) {
                 return type.cast(plugin);
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -103,6 +103,27 @@ class DefaultPluginContainerTest extends Specification {
         !container.hasPlugin(plugin2Class)
     }
 
+    def "offers plugin management via injectable plugin type "() {
+        when:
+        def basePluginClass = classLoader.parseClass("""
+        import org.gradle.api.Plugin
+        import org.gradle.api.Project
+        class TestPlugin1 implements Plugin<Project> {
+          void apply(Project project) {}
+          @javax.inject.Inject
+          public org.gradle.internal.reflect.Instantiator getter() {
+            throw new NullPointerException();
+          }
+        }
+    """)
+        def p = container.apply(basePluginClass)
+
+        then:
+        container.hasPlugin(basePluginClass)
+        container.getPlugin(basePluginClass) == p
+        container.findPlugin(basePluginClass) == p
+    }
+
     def "does not find plugin by unknown id"() {
         expect:
         !container.hasPlugin("x")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -67,14 +67,14 @@ class DefaultPluginContainerTest extends Specification {
 
     def "offers plugin management via plugin id"() {
         when:
-        def p = container.apply(plugin1Class)
+        def plugin = container.apply(plugin1Class)
 
         then:
-        p.is(container.apply("plugin"))
-        p.is(container.apply(plugin1Class))
+        plugin.is(container.apply("plugin"))
+        plugin.is(container.apply(plugin1Class))
 
-        p.is(container.findPlugin(plugin1Class))
-        p.is(container.findPlugin("plugin"))
+        plugin.is(container.findPlugin(plugin1Class))
+        plugin.is(container.findPlugin("plugin"))
 
         !container.findPlugin(UnknownPlugin)
         !container.findPlugin("unknown")
@@ -92,14 +92,14 @@ class DefaultPluginContainerTest extends Specification {
 
     def "offers plugin management via plugin type"() {
         when:
-        def p = container.apply(plugin1Class)
+        def plugin = container.apply(plugin1Class)
 
         then:
-        p.is(container.apply(plugin1Class))
-        p.is(container.findPlugin(plugin1Class))
+        plugin.is(container.apply(plugin1Class))
+        plugin.is(container.findPlugin(plugin1Class))
         container.hasPlugin(plugin1Class)
 
-        !p.is(container.findPlugin(plugin2Class))
+        !plugin.is(container.findPlugin(plugin2Class))
         !container.hasPlugin(plugin2Class)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -111,17 +111,17 @@ class DefaultPluginContainerTest extends Specification {
         class TestPlugin1 implements Plugin<Project> {
           void apply(Project project) {}
           @javax.inject.Inject
-          public org.gradle.internal.reflect.Instantiator getter() {
-            throw new NullPointerException();
+          public org.gradle.internal.reflect.Instantiator getInstantiator() {
+            throw UnsupportedOperationException();
           }
         }
     """)
-        def p = container.apply(basePluginClass)
+        def plugin = container.apply(basePluginClass)
 
         then:
         container.hasPlugin(basePluginClass)
-        container.getPlugin(basePluginClass) == p
-        container.findPlugin(basePluginClass) == p
+        container.getPlugin(basePluginClass) == plugin
+        container.findPlugin(basePluginClass) == plugin
     }
 
     def "does not find plugin by unknown id"() {


### PR DESCRIPTION
If a plugin uses getter injection, the `AsmBackedClassGenerator`
generates a new class using the `BaseName$Inject` pattern. This
is not equal to the real plugin class anymore.