### PR TITLE
Fix race conditions in credentials providers when evaluated during execution

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
@@ -219,20 +219,22 @@ class CredentialsProviderIntegrationTest extends AbstractIntegrationSpec {
         """
         file('submodule1/build.gradle') << buildScript
         file('submodule2/build.gradle') << buildScript
+        file('submodule3/build.gradle') << buildScript
+        file('submodule4/build.gradle') << buildScript
         settingsFile << """
             rootProject.name="test"
-            include("submodule1", "submodule2")
+            include("submodule1", "submodule2", "submodule3", "submodule4")
         """
         buildFile << ""
 
         expect:
         for (int i = 0; i < 10; i++) {
-            args '--parallel'
+            args '--parallel', '--continue'
             fails 'executionCredentials'
 
             failure.assertNotOutput("ConcurrentModificationException")
             failure.assertThatCause(CoreMatchers.equalTo(errorMessage))
-            failure.assertHasFailures(2)
+            failure.assertHasFailures(4)
         }
 
         where:


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/13770

Credentials providers will be evaluated at execution time possibly in a multi-threaded environment if they are not declared as task inputs and not validated before execution.
This change uses thread-safe collections for storing credentials providers and synchronizes their evaluation. Evaluation part is synchronized because error messages may be constructed there and error messages are assembled from possibly multiple missing properties - we don't want them duplicated and we want to have a deterministic order when missing properties are reported.
