### PR TITLE
Add empty output dirs always as output

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -85,8 +85,14 @@ public class OutputFilterUtil {
      * Decide whether an entry should be considered to be part of the output. See class Javadoc for definition of what is considered output.
      */
     private static boolean isOutputEntry(Map<String, FileSystemLocationFingerprint> afterPreviousExecutionFingerprints, Map<String, CompleteFileSystemLocationSnapshot> beforeExecutionSnapshots, CompleteFileSystemLocationSnapshot afterExecutionSnapshot, Boolean isRoot) {
-        if (isRoot && afterExecutionSnapshot.getType() == FileType.Missing) {
-            return false;
+        if (isRoot) {
+            FileType afterExecutionSnapshotType = afterExecutionSnapshot.getType();
+            if (afterExecutionSnapshotType == FileType.Missing) {
+                return false;
+            }
+            if (afterExecutionSnapshotType == FileType.Directory) {
+                return true;
+            }
         }
         CompleteFileSystemLocationSnapshot beforeSnapshot = beforeExecutionSnapshots.get(afterExecutionSnapshot.getAbsolutePath());
         // Was it created during execution?

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -86,12 +86,14 @@ public class OutputFilterUtil {
      */
     private static boolean isOutputEntry(Map<String, FileSystemLocationFingerprint> afterPreviousExecutionFingerprints, Map<String, CompleteFileSystemLocationSnapshot> beforeExecutionSnapshots, CompleteFileSystemLocationSnapshot afterExecutionSnapshot, Boolean isRoot) {
         if (isRoot) {
-            FileType afterExecutionSnapshotType = afterExecutionSnapshot.getType();
-            if (afterExecutionSnapshotType == FileType.Missing) {
-                return false;
-            }
-            if (afterExecutionSnapshotType == FileType.Directory) {
-                return true;
+            switch (afterExecutionSnapshot.getType()) {
+                case Missing:
+                    return false;
+                case Directory:
+                    return true;
+                default:
+                    // continue
+                    break;
             }
         }
         CompleteFileSystemLocationSnapshot beforeSnapshot = beforeExecutionSnapshots.get(afterExecutionSnapshot.getAbsolutePath());

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -51,7 +51,7 @@ class OutputFilterUtilTest extends Specification {
         when:
         def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
-        filteredOutputs.empty
+        collectFiles(filteredOutputs) == [outputDir]
 
         when:
         def outputDirFile = outputDir.file("in-output-dir").createFile()
@@ -70,7 +70,7 @@ class OutputFilterUtilTest extends Specification {
         when:
         def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
-        filteredOutputs.empty
+        collectFiles(filteredOutputs) == [outputDir]
 
         when:
         def outputOfCurrent = outputDir.file("outputOfCurrent").createFile()
@@ -106,7 +106,7 @@ class OutputFilterUtilTest extends Specification {
         def beforeExecution = FileSystemSnapshot.EMPTY
         expect:
         collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [emptyDir]
-        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterExecution, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterExecution, afterExecution)) == [emptyDir]
     }
 
     def "updated files in output directory are part of the output"() {
@@ -138,7 +138,7 @@ class OutputFilterUtilTest extends Specification {
 
         expect:
         collectFiles(filterOutputSnapshotAfterExecution(afterPreviousExecutionFingerprint, beforeExecutionSnapshot, afterExecution)) == [outputDir]
-        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterPreviousExecutionFingerprint, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterPreviousExecutionFingerprint, afterExecution)) == [outputDir]
     }
 
     def "overlapping directories are not included"() {


### PR DESCRIPTION
We currently do not consider everything in a task's declared output location as outputs of the task. This is important when two different tasks produce output in the same output directory.

Assume you have a task producing a single empty output directory.
Before task execution: directory exists and is empty
After task execution: directory exists and is empty

Current behaviour: Output directory is not part of the task's output stored in the execution history.

When you now delete the empty task directory and rerun the task, then it will be up-to-date.

On the other hand, when with no output directory being present, then the task will be out of date after the same sequence of steps.

Fixes #13554