### PR TITLE
Classes to be compiled should only include classes with sources

### DIFF
--- a/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/extension/BuildJvms.kt
+++ b/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/extension/BuildJvms.kt
@@ -47,6 +47,14 @@ abstract class BuildJvms(javaInstallationRegistry: JavaInstallationRegistry, tes
             throw IllegalStateException("Must use $productionJdkName to perform this build. Is currently ${buildInstallation.vendorAndMajorVersion()} at ${buildInstallation.installationDirectory}.")
         }
     }
+
+    fun whenTestingWithEarlierThan(version: JavaVersion, action: (jvm: JavaInstallation) -> Unit) {
+        if (testJvm.map {
+                it.javaVersion < version
+            }.get()) {
+            action(testJvm.get())
+        }
+    }
 }
 
 

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -60,6 +60,11 @@ dependencies {
     }
     integTestDistributionRuntimeOnly(project(":distributionsCore"))
     crossVersionTestDistributionRuntimeOnly(project(":distributionsBasics"))
+
+    buildJvms.whenTestingWithEarlierThan(JavaVersion.VERSION_1_9) {
+        val tools = it.jdk.get().toolsClasspath
+        testRuntimeOnly(tools)
+    }
 }
 
 strictCompile {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.tasks.compile.processing.DynamicProcessor;
 import org.gradle.api.internal.tasks.compile.processing.IsolatingProcessor;
 import org.gradle.api.internal.tasks.compile.processing.NonIncrementalProcessor;
 import org.gradle.api.internal.tasks.compile.processing.SupportedOptionsCollectingProcessor;
-import org.gradle.api.internal.tasks.compile.processing.TimeTrackingProcessor;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 
@@ -162,7 +161,8 @@ class AnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
     }
 
     private Processor decorateForTimeTracking(Processor processor, AnnotationProcessorResult processorResult) {
-        return new TimeTrackingProcessor(processor, processorResult);
+        return processor;
+        //return new TimeTrackingProcessor(processor, processorResult);
     }
 
     private void cleanupProcessors() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.tasks.compile.processing.DynamicProcessor;
 import org.gradle.api.internal.tasks.compile.processing.IsolatingProcessor;
 import org.gradle.api.internal.tasks.compile.processing.NonIncrementalProcessor;
 import org.gradle.api.internal.tasks.compile.processing.SupportedOptionsCollectingProcessor;
+import org.gradle.api.internal.tasks.compile.processing.TimeTrackingProcessor;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 
@@ -161,8 +162,7 @@ class AnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
     }
 
     private Processor decorateForTimeTracking(Processor processor, AnnotationProcessorResult processorResult) {
-        return processor;
-        //return new TimeTrackingProcessor(processor, processorResult);
+        return new TimeTrackingProcessor(processor, processorResult);
     }
 
     private void cleanupProcessors() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import com.sun.tools.javac.code.Symbol;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.GeneratedResource;
 
@@ -26,6 +27,7 @@ import javax.tools.JavaFileManager;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType.AGGREGATING;
 
@@ -57,12 +59,22 @@ class AggregatingProcessingStrategy extends IncrementalProcessingStrategy {
 
     private void recordAggregatedTypes(Set<String> supportedAnnotationTypes, Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         if (supportedAnnotationTypes.contains("*")) {
-            result.getAggregatedTypes().addAll(ElementUtils.getTopLevelTypeNames(roundEnv.getRootElements()));
+            result.getAggregatedTypes().addAll(namesOfElementsWithSource(roundEnv.getRootElements()));
         } else {
             for (TypeElement annotation : annotations) {
-                result.getAggregatedTypes().addAll(ElementUtils.getTopLevelTypeNames(roundEnv.getElementsAnnotatedWith(annotation)));
+                result.getAggregatedTypes().addAll(namesOfElementsWithSource(roundEnv.getElementsAnnotatedWith(annotation)));
             }
         }
+    }
+
+    // We need to filter classes which actually _have_ sources
+    // see https://github.com/gradle/gradle/issues/13767
+    private static Set<String> namesOfElementsWithSource(Set<? extends Element> orig) {
+        return ElementUtils.getTopLevelTypeNames(orig.stream()
+            .filter(Symbol.ClassSymbol.class::isInstance)
+            .map(Symbol.ClassSymbol.class::cast)
+            .filter(e -> e.sourcefile != null)
+            .collect(Collectors.toSet()));
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
@@ -26,6 +26,7 @@ import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileManager;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -70,6 +71,9 @@ class AggregatingProcessingStrategy extends IncrementalProcessingStrategy {
     // We need to filter classes which actually _have_ sources
     // see https://github.com/gradle/gradle/issues/13767
     private static Set<String> namesOfElementsWithSource(Set<? extends Element> orig) {
+        if (orig == null || orig.isEmpty()) {
+            return Collections.emptySet();
+        }
         return ElementUtils.getTopLevelTypeNames(orig.stream()
             .filter(Symbol.ClassSymbol.class::isInstance)
             .map(Symbol.ClassSymbol.class::cast)

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
@@ -69,7 +69,8 @@ public class ElementUtils {
             }
         }
         if (current instanceof TypeElement) {
-            return ((TypeElement) current).getQualifiedName().toString();
+            TypeElement typeElement = (TypeElement) current;
+            return typeElement.getQualifiedName().toString();
         }
         throw new IllegalArgumentException("Unexpected element " + originatingElement);
     }


### PR DESCRIPTION
It's possible that an annotation processor directly generates bytecode.
In this case, the generated classes shouldn't be part of the classes
to be recompiled even if they are annotated by an annotation recognized
by an annotation processor.

Fixes #13767
