### PR TITLE
Make `InstantExecutionCacheFingerprintWriter` thread-safe

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintWriter.kt
@@ -73,7 +73,7 @@ class InstantExecutionCacheFingerprintWriter(
     val inputFiles = mutableListOf<InputFile>()
 
     private
-    val undeclaredSystemProperties = mutableSetOf<String>()
+    val undeclaredSystemProperties = newConcurrentHashSet<String>()
 
     private
     var closestChangingValue: InstantExecutionCacheFingerprint.ChangingDependencyResolutionValue? = null
@@ -127,8 +127,10 @@ class InstantExecutionCacheFingerprintWriter(
 
     private
     fun onChangingValue(changingValue: InstantExecutionCacheFingerprint.ChangingDependencyResolutionValue) {
-        if (closestChangingValue == null || closestChangingValue!!.expireAt > changingValue.expireAt) {
-            closestChangingValue = changingValue
+        synchronized(this) {
+            if (closestChangingValue == null || closestChangingValue!!.expireAt > changingValue.expireAt) {
+                closestChangingValue = changingValue
+            }
         }
     }
 


### PR DESCRIPTION
By protecting resources used by callbacks which could possibly be triggered in parallel:
 - use a concurrent `HashSet` to store environment variable seen by callback
 - synchronise access to field used by dependency resolution callback

