### PR TITLE
Avoid zipping empty directory

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
@@ -151,9 +151,17 @@ fun Task.attachedReportLocations() = when (this) {
     else -> emptyList()
 }
 
+fun File.isEmptyDirectory() = list()?.isEmpty() == true
+
 fun prepareReportForCiPublishing(report: File, projectName: String) {
     if (report.exists()) {
         if (report.isDirectory) {
+            report.listFiles()?.forEach {
+                if (it.isEmptyDirectory()) {
+                    // Remove empty directories to avoid it appearing in the result zip
+                    it.delete()
+                }
+            }
             val destFile = rootProject.layout.buildDirectory.file("report-$projectName-${report.name}.zip").get().asFile
             ant.withGroovyBuilder {
                 "zip"("destFile" to destFile) {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
@@ -66,6 +66,7 @@ fun getCleanUpPolicy(childProjectName: String) = childProjects[childProjectName]
 
 fun verifyTestFilesCleanup(failedTasks: List<Task>, tmpTestFiles: List<Pair<File, String>>) {
     if (failedTasks.any { it is Test }) {
+        println("Leftover files: ${tmpTestFiles}")
         return
     }
 

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/ci-reporting.gradle.kts
@@ -17,13 +17,13 @@ package gradlebuild
 
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.classycle.tasks.Classycle
-import gradlebuild.cleanup.extension.TestFileCleanUpExtension
 import gradlebuild.cleanup.WhenNotEmpty
+import gradlebuild.cleanup.extension.TestFileCleanUpExtension
+import gradlebuild.docs.FindBrokenInternalLinks
 import gradlebuild.integrationtests.tasks.DistributionTest
+import gradlebuild.performance.tasks.DistributedPerformanceTest
 import me.champeau.gradle.japicmp.JapicmpTask
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultSerializer
-import gradlebuild.docs.FindBrokenInternalLinks
-import gradlebuild.performance.tasks.DistributedPerformanceTest
 
 /**
  * When run from a Continuous Integration environment, we only want to archive a subset of reports, mostly for
@@ -66,7 +66,7 @@ fun getCleanUpPolicy(childProjectName: String) = childProjects[childProjectName]
 
 fun verifyTestFilesCleanup(failedTasks: List<Task>, tmpTestFiles: List<Pair<File, String>>) {
     if (failedTasks.any { it is Test }) {
-        println("Leftover files: ${tmpTestFiles}")
+        println("Leftover files: $tmpTestFiles")
         return
     }
 


### PR DESCRIPTION
When there're file handle leaking and some empty directories happen to exist in the tmp test directory:

```
+-- LeakingTest
  +--- test directory
    +--- leaked files
  +--- empty directory 1
  +--- empty directory 2
```

The empty directories are zipped into published artifact, which makes it difficult to find out the real leaking directory:

![image](https://user-images.githubusercontent.com/12689835/87938929-d93b4980-cac9-11ea-9cf3-bc62d6648125.png)

This PR deletes the empty directories before zipping them into the published artifact.