### PR TITLE
Search for daemon crash logs in more places

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonLogsAnalyzer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonLogsAnalyzer.groovy
@@ -97,8 +97,12 @@ class DaemonLogsAnalyzer implements DaemonsFixture {
     }
 
     void assertNoCrashedDaemon() {
-        List<File> crashLogs = daemonLogsDir.listFiles().findAll { it.name.endsWith('.log') && it.name.startsWith('hs_err') }
+        List<File> crashLogs = findCrashLogs(daemonLogsDir)
         crashLogs.each { println(it.text) }
         assert crashLogs.empty: "Found crash logs: ${crashLogs}"
+    }
+
+    static List<File> findCrashLogs(File dir) {
+        dir.listFiles()?.findAll { it.name.endsWith('.log') && it.name.startsWith('hs_err') } ?: []
     }
 }


### PR DESCRIPTION
So crash logs for shared daemons and in the
working directory are detected as well.

Fixes gradle/gradle-private#2996