### PR TITLE
Do not log environment to debug log

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -256,9 +256,6 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     public ExecHandle start() {
         LOGGER.info("Starting process '{}'. Working directory: {} Command: {} {}",
                 displayName, directory, command, ARGUMENT_JOINER.join(arguments));
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Environment for process '{}': {}", displayName, environment);
-        }
         lock.lock();
         try {
             if (!stateIn(ExecHandleState.INIT)) {


### PR DESCRIPTION
On CI, logging all of the environment will
cause leaking credentials for sure. For debugging
purposes, it may be better to print out the
environment variables by an extra task action
or by looking at the actual environment on the
machine.