### PR TITLE
Support configuring java default toolchain requirements

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -99,7 +99,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
                                     .withProjectDir(projectDir)
                                     .withGradleUserHomeDir(userHome)
                                     .build()
-                    project.apply(plugin: 'groovy')
+                    project.apply(plugin: 'base')
                     project.evaluate()
                 }
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -99,7 +99,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
                                     .withProjectDir(projectDir)
                                     .withGradleUserHomeDir(userHome)
                                     .build()
-                    project.apply(plugin: 'base')
+                    project.apply(plugin: 'groovy')
                     project.evaluate()
                 }
             }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.jvm.toolchain.internal;
+package org.gradle.jvm.toolchain;
 
 import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.provider.Property;
 
 public interface JavaToolchainSpec extends Describable {
 
-    JavaVersion getLanguageVersion();
+    Property<JavaVersion> getLanguageVersion();
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -17,11 +17,24 @@
 package org.gradle.jvm.toolchain;
 
 import org.gradle.api.Describable;
+import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.provider.Property;
 
+/**
+ * Requirements for selecting a Java toolchain.
+ * <p>
+ * A toolchain is a JRE/JDK used by the tasks of a build. Tasks of a build may require one or more of the tools javac, java, or javadoc) of a toolchain.
+ * Depending on the needs of a build, only toolchains matching specific characteristics can be used to run a build or a specific task of a build.
+ *
+ * @since 6.7
+ */
+@Incubating
 public interface JavaToolchainSpec extends Describable {
 
+    /**
+     * The exact version of the Java language that the toolchain is required to support.
+     */
     Property<JavaVersion> getLanguageVersion();
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -17,24 +17,33 @@
 package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.JavaVersion;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
-// TODO: turn this into API with Properties
+import javax.inject.Inject;
+
 public class DefaultToolchainSpec implements JavaToolchainSpec {
 
-    private JavaVersion languageVersion;
+    private final Property<JavaVersion> languageVersion;
 
-    public DefaultToolchainSpec(JavaVersion languageVersion) {
-        this.languageVersion = languageVersion;
+    @Inject
+    public DefaultToolchainSpec(ObjectFactory factory) {
+        this.languageVersion = factory.property(JavaVersion.class);
     }
 
     @Override
-    public JavaVersion getLanguageVersion() {
+    public Property<JavaVersion> getLanguageVersion() {
         return languageVersion;
+    }
+
+    public boolean isConfigured() {
+        return languageVersion.isPresent();
     }
 
     @Override
     public String getDisplayName() {
-        return "{languageVersion=" + languageVersion + "}";
+        return "{languageVersion=" + languageVersion.get() + "}";
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -20,6 +20,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
+import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
 
 import javax.inject.Inject;
@@ -35,7 +36,7 @@ public class JavaToolchain implements Describable {
         this.compilerFactory = compilerFactory;
     }
 
-    public Provider<DefaultToolchainJavaCompiler> getJavaCompiler() {
+    public Provider<JavaCompiler> getJavaCompiler() {
         return Providers.of(new DefaultToolchainJavaCompiler(this, compilerFactory));
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -17,7 +17,9 @@
 package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.internal.provider.DefaultProvider;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -35,6 +37,9 @@ public class JavaToolchainQueryService {
     }
 
     public Provider<JavaToolchain> findMatchingToolchain(JavaToolchainSpec filter) {
+        if (!((DefaultToolchainSpec) filter).isConfigured()) {
+            return Providers.notDefined();
+        }
         return new DefaultProvider<>(() -> query(filter));
     }
 
@@ -48,7 +53,7 @@ public class JavaToolchainQueryService {
 
     // TODO: to be replaced with AttributeContainer/AttributeMatcher
     private Predicate<JavaToolchain> matchingToolchain(JavaToolchainSpec spec) {
-        return toolchain -> toolchain.getJavaMajorVersion() == spec.getLanguageVersion();
+        return toolchain -> toolchain.getJavaMajorVersion() == spec.getLanguageVersion().get();
     }
 
     private JavaToolchain asToolchain(File javaHome) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/NoToolchainAvailableException.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/NoToolchainAvailableException.java
@@ -17,6 +17,7 @@
 package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.GradleException;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 public class NoToolchainAvailableException extends GradleException {
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -21,6 +21,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.jvm.ModularitySpec;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 /**
  * Common configuration for Java based projects. This is added by the {@link JavaBasePlugin}.
@@ -118,5 +119,11 @@ public interface JavaPluginExtension {
      */
     @Incubating
     ModularitySpec getModularity();
+
+    @Incubating
+    JavaToolchainSpec getToolchain();
+
+    @Incubating
+    JavaToolchainSpec toolchain(Action<? super JavaToolchainSpec> action);
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -120,9 +120,19 @@ public interface JavaPluginExtension {
     @Incubating
     ModularitySpec getModularity();
 
+    /**
+     * Configure the toolchain requirements for tasks that require a tool from the toolchain (e.g. {@link org.gradle.api.tasks.compile.JavaCompile}.
+     *
+     * @since 6.7
+     */
     @Incubating
     JavaToolchainSpec getToolchain();
 
+    /**
+     * Configure the toolchain requirements for tasks that require a tool from the toolchain (e.g. {@link org.gradle.api.tasks.compile.JavaCompile}.
+     *
+     * @since 6.7
+     */
     @Incubating
     JavaToolchainSpec toolchain(Action<? super JavaToolchainSpec> action);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -32,8 +32,11 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.Actions;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 
 import java.util.regex.Pattern;
 
@@ -53,6 +56,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final Project project;
     private final ModularitySpec modularity;
     private final JvmPluginServices jvmPluginServices;
+    private JavaToolchainSpec toolchain;
 
     public DefaultJavaPluginExtension(JavaPluginConvention convention,
                                       Project project,
@@ -61,8 +65,9 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         this.objectFactory = project.getObjects();
         this.components = project.getComponents();
         this.project = project;
-        this.modularity = project.getObjects().newInstance(DefaultModularitySpec.class);
+        this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         this.jvmPluginServices = jvmPluginServices;
+        this.toolchain = objectFactory.newInstance(DefaultToolchainSpec.class);
     }
 
     @Override
@@ -120,6 +125,17 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     @Override
     public ModularitySpec getModularity() {
         return modularity;
+    }
+
+    @Override
+    public JavaToolchainSpec getToolchain() {
+        return toolchain(Actions.doNothing());
+    }
+
+    @Override
+    public JavaToolchainSpec toolchain(Action<? super JavaToolchainSpec> action) {
+        action.execute(toolchain);
+        return toolchain;
     }
 
     private static String validateFeatureName(String name) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -32,7 +32,6 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
-import org.gradle.internal.Actions;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -129,7 +128,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
 
     @Override
     public JavaToolchainSpec getToolchain() {
-        return toolchain(Actions.doNothing());
+        return toolchain;
     }
 
     @Override

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -208,12 +208,11 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
     void "wires toolchain for sourceset if toolchain is configured"() {
         given:
-        // workaround for https://github.com/gradle/gradle/issues/13122
-        ((DefaultProject) project).getServices().get(GradlePropertiesController.class).loadGradlePropertiesFrom(new File(project.projectDir, "gradle.properties"));
-
         def someJdk = Jvm.current()
         project.pluginManager.apply(JavaBasePlugin)
         project.java.toolchain.languageVersion = someJdk.javaVersion
+        // workaround for https://github.com/gradle/gradle/issues/13122
+        ((DefaultProject) project).getServices().get(GradlePropertiesController.class).loadGradlePropertiesFrom(project.projectDir);
 
         when:
         project.sourceSets.create('custom')


### PR DESCRIPTION
Wires up the `JavaCompile` task and the new toolchain spec to configure the tasks using the default toolchain requirements.

```
java {
  toolchain {
    languageVersion = JavaVersion.VERSION_11
  }
}
```

Fixes #13867
