### PR TITLE
Support Sdkman as installation supplier

### DIFF
--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(project(":platformBase"))
     implementation(project(":diagnostics"))
     implementation(project(":normalizationJava"))
+    implementation(project(":native"))
 
     implementation(libs.groovy)
     implementation(libs.guava)
@@ -27,7 +28,6 @@ dependencies {
     implementation(libs.inject)
     implementation(libs.asm)
 
-    testImplementation(project(":native"))
     testImplementation(project(":snapshots"))
     testImplementation(libs.ant)
     testImplementation(testFixtures(project(":core")))

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     implementation(project(":platformBase"))
     implementation(project(":diagnostics"))
     implementation(project(":normalizationJava"))
-    implementation(project(":native"))
 
     implementation(libs.groovy)
     implementation(libs.guava)

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
@@ -43,7 +43,10 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
         """
 
         when:
-        succeeds("show")
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withTasks("show")
+            .run()
 
         then:
         def currentVm = Jvm.current().getJavaHome().getAbsolutePath()

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -43,6 +43,7 @@ import org.gradle.jvm.toolchain.internal.JavaInstallationProbe;
 import org.gradle.jvm.toolchain.internal.JavaToolchainFactory;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
 import org.gradle.model.internal.manage.schema.ModelSchemaStore;
 
@@ -70,6 +71,7 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
         registration.add(LocationListInstallationSupplier.class);
         registration.add(EnvironmentVariableListInstallationSupplier.class);
         registration.add(CurrentInstallationSupplier.class);
+        registration.add(SdkmanInstallationSupplier.class);
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
+
+public abstract class AutoDetectingInstallationSupplier implements InstallationSupplier {
+
+    private final ProviderFactory factory;
+
+    @Inject
+    public AutoDetectingInstallationSupplier(ProviderFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public Set<InstallationLocation> get() {
+        if (isAutoDetectionEnabled()) {
+            return findCandidates();
+        }
+        return Collections.emptySet();
+    }
+
+    protected Provider<String> getEnvironmentProperty(String propertyName) {
+        return factory.environmentVariable(propertyName).forUseAtConfigurationTime();
+    }
+
+    protected abstract Set<InstallationLocation> findCandidates();
+
+    private boolean isAutoDetectionEnabled() {
+        final Provider<String> autoDetectionEnabled = factory.gradleProperty("org.gradle.java.installations.auto-detect").forUseAtConfigurationTime();
+        return Boolean.parseBoolean(autoDetectionEnabled.getOrElse("true"));
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
@@ -28,27 +28,17 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 
-public class SdkmanInstallationSupplier implements InstallationSupplier {
-
-    private final ProviderFactory factory;
+public class SdkmanInstallationSupplier extends AutoDetectingInstallationSupplier {
 
     @Inject
     public SdkmanInstallationSupplier(ProviderFactory factory) {
-        this.factory = factory;
+        super(factory);
     }
 
     @Override
-    public Set<InstallationLocation> get() {
-        if (isAutoDetectionEnabled()) {
-            final Provider<String> candidatesDir = factory.environmentVariable("SDKMAN_CANDIDATES_DIR").forUseAtConfigurationTime();
-            return candidatesDir.map(findJavaCandidates()).getOrElse(Collections.emptySet());
-        }
-        return Collections.emptySet();
-    }
-
-    private boolean isAutoDetectionEnabled() {
-        final Provider<String> autoDetectionEnabled = factory.gradleProperty("org.gradle.java.installations.auto-detect").forUseAtConfigurationTime();
-        return Boolean.parseBoolean(autoDetectionEnabled.getOrElse("true"));
+    protected Set<InstallationLocation> findCandidates() {
+        final Provider<String> candidatesDir = getEnvironmentProperty("SDKMAN_CANDIDATES_DIR");
+        return candidatesDir.map(findJavaCandidates()).getOrElse(Collections.emptySet());
     }
 
     private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+public class SdkmanInstallationSupplier implements InstallationSupplier {
+
+    private final ProviderFactory factory;
+
+    @Inject
+    public SdkmanInstallationSupplier(ProviderFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public Set<InstallationLocation> get() {
+        if (isAutoDetectionEnabled()) {
+            final Provider<String> candidatesDir = factory.environmentVariable("SDKMAN_CANDIDATES_DIR").forUseAtConfigurationTime();
+            return candidatesDir.map(findJavaCandidates()).getOrElse(Collections.emptySet());
+        }
+        return Collections.emptySet();
+    }
+
+    private boolean isAutoDetectionEnabled() {
+        final Provider<String> autoDetectionEnabled = factory.gradleProperty("org.gradle.java.installations.auto-detect").forUseAtConfigurationTime();
+        return Boolean.parseBoolean(autoDetectionEnabled.getOrElse("true"));
+    }
+
+    private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {
+        return candidatesDir -> {
+            final File[] javaCandidates = new File(candidatesDir, "java").listFiles();
+            if (javaCandidates == null) {
+                return Collections.emptySet();
+            }
+            return Stream.of(javaCandidates)
+                .filter(File::isDirectory)
+                .map(this::asInstallation)
+                .collect(toSet());
+        };
+    }
+
+    private InstallationLocation asInstallation(File file) {
+        return new InstallationLocation(file, "SDKMAN");
+    }
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -91,7 +91,8 @@ class JavaToolchainQueryServiceTest extends Specification {
                 installations.collect { new InstallationLocation(new File("/path/${it}"), "test") } as Set
             }
         }
-        def registry = new SharedJavaInstallationRegistry([supplier]) {
+        def canonicalizer = { File it -> it.canonicalFile }
+        def registry = new SharedJavaInstallationRegistry([supplier], canonicalizer) {
             boolean installationExists(InstallationLocation installationLocation) {
                 return true
             }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -91,8 +91,7 @@ class JavaToolchainQueryServiceTest extends Specification {
                 installations.collect { new InstallationLocation(new File("/path/${it}"), "test") } as Set
             }
         }
-        def canonicalizer = { File it -> it.canonicalFile }
-        def registry = new SharedJavaInstallationRegistry([supplier], canonicalizer) {
+        def registry = new SharedJavaInstallationRegistry([supplier]) {
             boolean installationExists(InstallationLocation installationLocation) {
                 return true
             }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplierTest.groovy
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
+
+@CleanupTestDirectory
+class SdkmanInstallationSupplierTest extends Specification {
+
+    @Rule
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
+
+    def candidates = temporaryFolder.createDir("sdkman")
+
+    def "supplies no installations for absent property"() {
+        given:
+        def supplier = createSupplier(null)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+
+    def "supplies no installations for empty property"() {
+        given:
+        def supplier = createSupplier("")
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations for non-existing directory"() {
+        assert candidates.delete()
+
+        given:
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations for empty directory"() {
+        given:
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies single installations for single candidate"() {
+        given:
+        candidates.createDir("java/11.0.6.hs-adpt")
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([new File(candidates, "java/11.0.6.hs-adpt").absolutePath])
+        directories*.source == ["SDKMAN"]
+    }
+
+    def "supplies multiple installations for multiple paths"() {
+        given:
+        candidates.createDir("java/11.0.6.hs-adpt")
+        candidates.createDir("java/14")
+        candidates.createDir("java/8.0.262.fx-librca")
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(candidates, "java/11.0.6.hs-adpt").absolutePath,
+            new File(candidates, "java/14").absolutePath,
+            new File(candidates, "java/8.0.262.fx-librca").absolutePath
+        ])
+        directories*.source == ["SDKMAN", "SDKMAN", "SDKMAN"]
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "supplies installations with symlinked candidate"() {
+        given:
+        def otherLocation = temporaryFolder.createDir("other")
+        def javaCandidates = candidates.createDir("java")
+        javaCandidates.createDir("14-real")
+        javaCandidates.file("other-symlinked").createLink(otherLocation.canonicalFile)
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(candidates, "java/14-real").absolutePath,
+            new File(candidates, "java/other-symlinked").absolutePath
+        ])
+        directories*.source == ["SDKMAN", "SDKMAN"]
+    }
+
+    def directoriesAsStablePaths(Set<InstallationLocation> actualDirectories) {
+        actualDirectories*.location.absolutePath.sort()
+    }
+
+    def stablePaths(List<String> expectedPaths) {
+        expectedPaths.replaceAll({ String s -> systemSpecificAbsolutePath(s) })
+        expectedPaths
+    }
+
+    SdkmanInstallationSupplier createSupplier(String propertyValue) {
+        new SdkmanInstallationSupplier(createProviderFactory(propertyValue))
+    }
+
+    ProviderFactory createProviderFactory(String propertyValue) {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.environmentVariable("SDKMAN_CANDIDATES_DIR") >> mockProvider(propertyValue)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> mockProvider(null)
+        providerFactory
+    }
+
+    Provider<String> mockProvider(String value) {
+        def provider = new DefaultProperty(PropertyHost.NO_OP, String)
+        provider.set(value)
+        provider
+    }
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
@@ -22,8 +22,7 @@ import spock.lang.Unroll
 
 class SharedJavaInstallationRegistryTest extends Specification {
 
-    def canonicalizer = { File it -> it.canonicalFile }
-    def registry = new SharedJavaInstallationRegistry(Collections.emptyList(), canonicalizer)
+    def registry = new SharedJavaInstallationRegistry(Collections.emptyList())
     def tempFolder = createTempDir()
 
     def "registry keeps track of newly added installations"() {
@@ -61,7 +60,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
         def tmpDir3 = createTempDir()
 
         when:
-        def registry = new SharedJavaInstallationRegistry([forDirectory(tmpDir2), forDirectory(tmpDir3)], canonicalizer)
+        def registry = new SharedJavaInstallationRegistry([forDirectory(tmpDir2), forDirectory(tmpDir3)])
         registry.add(forDirectory(tempFolder))
 
         then:
@@ -117,7 +116,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
         file.isDirectory() >> directory
         file.absolutePath >> path
         def logger = Mock(Logger)
-        def registry = SharedJavaInstallationRegistry.withLogger(canonicalizer, logger)
+        def registry = SharedJavaInstallationRegistry.withLogger(logger)
         registry.add(forDirectory(file))
 
         when:


### PR DESCRIPTION
Add initial support for SDKMAN to establish a structure. It is yet to be discussed whether this code lives in core or will be moved out into a plugin. This is part of #13871