### PR TITLE
Add codeowners for release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+subprojects/docs/src/docs/release/notes.md @pioterj


### PR DESCRIPTION
This change enables adding reviewers to PRs that contain changes to the release notes. This should allow us to get early feedback on release notes so we can avoid the bottleneck towards the end of the release.