### PR TITLE
Increase daemon idle timeout in DaemonLifecycleSpec

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
@@ -43,7 +43,7 @@ import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 class DaemonLifecycleSpec extends DaemonIntegrationSpec {
 
     public static final int BUILD_EXECUTION_TIMEOUT = 40
-    int daemonIdleTimeout = 100
+    int daemonIdleTimeout = 200
     int periodicCheckInterval = 5
     //normally, state transition timeout must be lower than the daemon timeout
     //so that the daemon does not timeout in the middle of the state verification
@@ -130,7 +130,7 @@ class DaemonLifecycleSpec extends DaemonIntegrationSpec {
 
     void waitForBuildToWait(buildNum = 0) {
         run {
-            poll(BUILD_EXECUTION_TIMEOUT) { assert builds[buildNum].standardOutput.contains("waiting for stop file"); }
+            poll(BUILD_EXECUTION_TIMEOUT) { assert builds[buildNum].standardOutput.contains("waiting for stop file") }
         }
     }
 


### PR DESCRIPTION
When tests are running in parallel, the daemon
may be waiting quite long for a lock on the
shared caches.

Increasing the daemon idle timeout also increases
the stateTransitionTimeout, so the daemon has
more time to start up.

Here is the flakiness graph in Gradle Enterprise: https://ge.gradle.org/scans/tests?list.size=50&list.sortColumn=startTime&list.sortOrder=desc&search.buildToolType=gradle&search.buildToolType=maven&search.names=Git%20Branch%20Name&search.startTimeMax=1595343897983&search.startTimeMin=1594677600000&search.timeZoneId=Europe/Berlin&search.values=master&tests.container=org.gradle.launcher.daemon.DaemonLifecycleSpec&tests.sortField=FLAKY&tests.test=existing%20foreground%20idle%20daemons%20are%20used&tests.unstableOnly=true