### PR TITLE
Stop test filters from hiding suite failures

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/NoMatchingTestsReporter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/NoMatchingTestsReporter.java
@@ -21,6 +21,8 @@ import org.gradle.api.tasks.testing.TestDescriptor;
 import org.gradle.api.tasks.testing.TestListener;
 import org.gradle.api.tasks.testing.TestResult;
 
+import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE;
+
 public class NoMatchingTestsReporter implements TestListener {
     private final String message;
 
@@ -33,7 +35,7 @@ public class NoMatchingTestsReporter implements TestListener {
 
     @Override
     public void afterSuite(TestDescriptor suite, TestResult result) {
-        if (suite.getParent() == null && result.getTestCount() == 0) {
+        if (suite.getParent() == null && result.getTestCount() == 0 && result.getResultType() != FAILURE) {
             throw new TestExecutionException(message);
         }
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -414,7 +414,7 @@ public class StaticInnerTest {
     }
 
     @Unroll
-    @Issue("https://github.com/junit-team/junit5/issues/2028 and https://github.com/junit-team/junit5/issues/12073")
+    @Issue("https://github.com/junit-team/junit5/issues/2028 and https://github.com/gradle/gradle/issues/12073")
     def 'properly fails when engine fails during discovery #scenario'() {
         given:
         createSimpleJupiterTest()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -413,38 +413,38 @@ public class StaticInnerTest {
         }
     }
 
-    @Issue("https://github.com/junit-team/junit5/issues/2028")
-    def 'properly fails when engine fails during discovery'() {
+    @Unroll
+    @Issue("https://github.com/junit-team/junit5/issues/2028 and https://github.com/junit-team/junit5/issues/12073")
+    def 'properly fails when engine fails during discovery #scenario'() {
         given:
         createSimpleJupiterTest()
         file('src/test/java/EngineFailingDiscovery.java') << '''
-import org.junit.platform.engine.*;
-public class EngineFailingDiscovery implements TestEngine {
-    @Override
-    public String getId() {
-        return "EngineFailingDiscovery";
-    }
+            import org.junit.platform.engine.*;
+            public class EngineFailingDiscovery implements TestEngine {
+                @Override
+                public String getId() {
+                    return "EngineFailingDiscovery";
+                }
 
-    @Override
-    public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-        throw new RuntimeException("oops");
-    }
+                @Override
+                public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+                    throw new RuntimeException("oops");
+                }
 
-    @Override
-    public void execute(ExecutionRequest request) {
-    }
-}
-
-'''
-        file('src/test/resources/META-INF/services/org.junit.platform.engine.TestEngine') << 'EngineFailingDiscovery'
-        buildFile << '''
-            test {
-                systemProperty('junit.jupiter.extensions.autodetection.enabled', 'true')
+                @Override
+                public void execute(ExecutionRequest request) {
+                }
             }
         '''
+        file('src/test/resources/META-INF/services/org.junit.platform.engine.TestEngine') << 'EngineFailingDiscovery'
 
         expect:
-        fails('test')
+        fails('test', *extraArgs)
         failureCauseContains('There were failing tests.')
+
+        where:
+        scenario       | extraArgs
+        "w/o filters"  | []
+        "with filters" | ['--tests', 'JUnitJupiterTest']
     }
 }


### PR DESCRIPTION
Prior to this commit, failures on the test suite level, e.g. a failing
worker or a failure on the JUnit Platform engine level, was hidden when
a test filter (e.g. using `--tests`) was active and no test method was
actually executed. The root cause was only visible in the HTML test
report while the task failed with "No tests found". Now, the task fails
with "there were failing tests" and points to the report.

Resolves #12073.