### PR TITLE
Enable console tests with watchFs

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
@@ -16,12 +16,9 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
-import org.gradle.integtests.fixtures.ToBeFixedForFileSystemWatching
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
-import org.gradle.util.TestPrecondition
 
-@ToBeFixedForFileSystemWatching(because = "https://github.com/gradle/gradle/issues/13366", failsOnlyIf = TestPrecondition.WINDOWS)
 abstract class AbstractConsoleCompositeBuildGroupedTaskFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest {
     private static final String PROJECT_A_NAME = 'projectA'
     private static final String PROJECT_B_NAME = 'projectB'


### PR DESCRIPTION
they should work now that `Couldn't cancel watch point` is gone with native platform `0.22-milestone-6`.