### PR TITLE
Add a linebreak in the example for `Provider.zip`

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -198,7 +198,9 @@ When using [Lazy Properties](userguide/lazy_configuration.html), it’s common t
 ```groovy
 def hello = objects.property(String).convention("Hello")
 def world = objects.property(String).convention("World")
-def helloWorld = hello.zip(world) { left, right -> "${left}, ${right}!".toString() }
+def helloWorld = hello.zip(world) { left, right ->
+   "${left}, ${right}!".toString()
+}
 // ...
 hello.set("Bonjour")
 world.set("le monde")


### PR DESCRIPTION
It used to go over the margin.

![image](https://user-images.githubusercontent.com/423186/88169352-26c7cb80-cc1c-11ea-9e5f-0b6f9eb3e521.png)
