### PR TITLE
Handle cycle in suppressed exceptions

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -114,7 +114,7 @@ class ExceptionPlaceholder implements Serializable {
                 }
                 int suppressedIndex = suppressed.indexOf(obj);
                 if (suppressedIndex >= 0) {
-                    return new NestedExceptionPlaceholder(NestedExceptionPlaceholder.Kind.suppressed, causeIndex);
+                    return new NestedExceptionPlaceholder(NestedExceptionPlaceholder.Kind.suppressed, suppressedIndex);
                 }
                 return obj;
             }


### PR DESCRIPTION
With the added support for suppressed exceptions in ExceptionPlaceholder
the code needs to handle when those have a cycle, which has a higher
chance of happening than a cycle in exception cause.
This commit makes sure we attempt to detect such a cycle and break the
exception chain during serialization if that is the case.