### PR TITLE
Improve the throwable cycle detection

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/TopLevelExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/TopLevelExceptionPlaceholder.java
@@ -20,10 +20,11 @@ import org.gradle.api.Transformer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashSet;
 
 public class TopLevelExceptionPlaceholder extends ExceptionPlaceholder {
     private static final long serialVersionUID = 1L;
     public TopLevelExceptionPlaceholder(Throwable throwable, Transformer<ExceptionReplacingObjectOutputStream, OutputStream> objectOutputStreamCreator) throws IOException {
-        super(throwable, objectOutputStreamCreator);
+        super(throwable, objectOutputStreamCreator, new HashSet<Throwable>(10));
     }
 }


### PR DESCRIPTION
Instead of navigating suppressed and their cause, we record the
throwables that have been seen already.