### PR TITLE
Improve configuration cache stack safety

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -37,7 +37,7 @@ import org.gradle.internal.serialize.Encoder
 interface Codec<T> : EncodingProvider<T>, DecodingProvider<T>
 
 
-interface WriteContext : IsolateContext, MutableIsolateContext, Encoder {
+interface WriteContext : IsolateContext, MutableIsolateContext, StackSafe, Encoder {
 
     val sharedIdentities: WriteIdentities
 
@@ -51,7 +51,7 @@ interface WriteContext : IsolateContext, MutableIsolateContext, Encoder {
 }
 
 
-interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
+interface ReadContext : IsolateContext, MutableIsolateContext, StackSafe, Decoder {
 
     val sharedIdentities: ReadIdentities
 
@@ -75,7 +75,16 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
 }
 
 
-suspend fun <T : Any> ReadContext.readNonNull() = read()!!.uncheckedCast<T>()
+suspend fun <T : Any> ReadContext.readNonNull() =
+    read()!!.uncheckedCast<T>()
+
+
+interface StackSafe {
+
+    fun saveCallStack(): Any?
+
+    fun restoreCallStack(savedCallStack: Any?)
+}
 
 
 interface IsolateContext {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -38,8 +38,8 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 
 internal
@@ -107,8 +107,9 @@ class DefaultWriteContext(
                     pendingWriteCall = null
                 }
             }
-            else -> suspendCoroutine<Unit> { k ->
+            else -> suspendCoroutineUninterceptedOrReturn<Unit> { k ->
                 pendingWriteCall = WriteCall(value, k)
+                COROUTINE_SUSPENDED
             }
         }
     }
@@ -317,8 +318,9 @@ class DefaultReadContext(
                     readCallResult = UNDEFINED_RESULT
                 }
             }
-            else -> suspendCoroutine { k ->
+            else -> suspendCoroutineUninterceptedOrReturn { k ->
                 pendingReadCall = k
+                COROUTINE_SUSPENDED
             }
         }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -105,15 +105,20 @@ class DefaultWriteContext(
                 }
             }
             else -> {
-                try {
-                    pendingWriteCall = WriteCall(value, continuation)
-                    inCallLoop = true
-                    writeCallLoop()
-                } finally {
-                    inCallLoop = false
-                    pendingWriteCall = null
-                }
+                runWriteCallLoop(value)
             }
+        }
+    }
+
+    private
+    fun runWriteCallLoop(value: Any?) {
+        try {
+            pendingWriteCall = WriteCall(value, continuation)
+            inCallLoop = true
+            writeCallLoop()
+        } finally {
+            inCallLoop = false
+            pendingWriteCall = null
         }
     }
 
@@ -334,16 +339,20 @@ class DefaultReadContext(
                 }
             }
             else -> {
-                try {
-                    pendingReadCall = continuation
-                    inCallLoop = true
-                    readCallLoop()
-                } finally {
-                    inCallLoop = false
-                    pendingReadCall = null
-                    readCallResult = UNDEFINED_RESULT
-                }
+                runReadCallLoop()
             }
+        }
+
+    private
+    fun runReadCallLoop(): Any? =
+        try {
+            pendingReadCall = continuation
+            inCallLoop = true
+            readCallLoop()
+        } finally {
+            inCallLoop = false
+            pendingReadCall = null
+            readCallResult = UNDEFINED_RESULT
         }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -101,7 +101,11 @@ class DefaultWriteContext(
             }
             pendingWriteCall === null -> {
                 pendingWriteCall = WriteCall(value, continuation)
-                writeCallLoop()
+                try {
+                    writeCallLoop()
+                } finally {
+                    pendingWriteCall = null
+                }
             }
             else -> suspendCoroutine<Unit> { k ->
                 pendingWriteCall = WriteCall(value, k)
@@ -306,7 +310,11 @@ class DefaultReadContext(
             }
             pendingReadCall === null -> {
                 pendingReadCall = continuation
-                readCallLoop()
+                try {
+                    readCallLoop()
+                } finally {
+                    pendingReadCall = null
+                }
             }
             else -> suspendCoroutine { k ->
                 pendingReadCall = k

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -127,6 +127,10 @@ class DefaultWriteContext(
         while (true) {
             val call = nextWriteCall() ?: break
             val k = call.k
+            if (Thread.interrupted()) {
+                k.resumeWithException(InterruptedException())
+                continue
+            }
             val result = try {
                 unsafeWrite.invoke(call.value, k)
             } catch (error: Throwable) {
@@ -352,6 +356,10 @@ class DefaultReadContext(
         while (true) {
             val call = nextReadCall()
                 ?: return readCallResult.getOrThrow()
+            if (Thread.interrupted()) {
+                call.resumeWithException(InterruptedException())
+                continue
+            }
             val result = try {
                 unsafeRead.invoke(call)
             } catch (error: Throwable) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -499,7 +499,7 @@ class DefaultReadContext(
  * chance that a very deep object graph could blow up the stack.
  */
 private
-const val MAX_STACK_DEPTH = 64
+const val MAX_STACK_DEPTH = 1
 
 
 private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/ExceptionHandling.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/ExceptionHandling.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization
+
+import org.gradle.instantexecution.InstantExecutionThrowable
+import java.io.IOException
+
+
+/**
+ * Rethrows the error if it [must bubble up][mustBubbleUp] to avoid multiple reports
+ * of the same error or undue exception wrapping.
+ */
+@Suppress("nothing_to_inline")
+internal
+inline fun Throwable.bubbleUp() {
+    if (mustBubbleUp) {
+        throw this
+    }
+}
+
+
+/**
+ * [JVM errors][Error], [configuration cache errors][InstantExecutionThrowable], [IO exceptions][IOException] and
+ * [interruptions][InterruptedException] must always bubble up.
+ *
+ * - [JVM errors][Error] because it doesn't make sense to try to recover from or try to report OOM/stack overflow style errors
+ * during serialization.
+ * - [Configuration cache errors][InstantExecutionThrowable] so they are reported only once.
+ * - [IO exceptions][IOException] because codecs have no business with them.
+ * - [Interruptions][InterruptedException] because the callstack might be holding locks.
+ */
+internal
+val Throwable.mustBubbleUp: Boolean
+    get() = when (this) {
+        is Error -> true
+        is InstantExecutionThrowable -> true
+        is IOException -> true
+        is InterruptedException -> true
+        else -> false
+    }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/ExceptionHandling.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/ExceptionHandling.kt
@@ -28,6 +28,9 @@ import java.io.IOException
 internal
 inline fun Throwable.bubbleUp() {
     if (mustBubbleUp) {
+        if (this is InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
         throw this
     }
 }
@@ -50,5 +53,7 @@ val Throwable.mustBubbleUp: Boolean
         is InstantExecutionThrowable -> true
         is IOException -> true
         is InterruptedException -> true
+        is org.gradle.api.UncheckedIOException -> true
+        is org.gradle.internal.UncheckedException -> true
         else -> false
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -27,9 +27,7 @@ internal
 fun <T : ReadContext, R> T.runReadOperation(readOperation: suspend T.() -> R): R {
     val callStack = saveCallStack()
     try {
-        return runToCompletion {
-            readOperation()
-        }
+        return runToCompletion(readOperation)
     } finally {
         restoreCallStack(callStack)
     }
@@ -43,9 +41,7 @@ internal
 fun <T : WriteContext> T.runWriteOperation(writeOperation: suspend T.() -> Unit) {
     val callStack = saveCallStack()
     try {
-        runToCompletion {
-            writeOperation()
-        }
+        runToCompletion(writeOperation)
     } finally {
         restoreCallStack(callStack)
     }
@@ -58,9 +54,9 @@ fun <T : WriteContext> T.runWriteOperation(writeOperation: suspend T.() -> Unit)
  */
 @Suppress("unchecked_cast")
 private
-fun <R> runToCompletion(block: suspend () -> R): R {
-    val blockFunction = block as Function1<Continuation<R>, Any?>
-    val result = blockFunction.invoke(continuation)
+fun <T, R> T.runToCompletion(block: suspend T.() -> R): R {
+    val blockFunction = block as Function2<T, Continuation<R>, Any?>
+    val result = blockFunction.invoke(this, continuation)
     require(result !== kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED) {
         "Coroutine didn't run to completion."
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Running.kt
@@ -24,10 +24,16 @@ import kotlin.coroutines.startCoroutine
  * Runs the given [readOperation] synchronously.
  */
 internal
-fun <T : ReadContext, R> T.runReadOperation(readOperation: suspend T.() -> R): R =
-    runToCompletion {
-        readOperation()
+fun <T : ReadContext, R> T.runReadOperation(readOperation: suspend T.() -> R): R {
+    val callStack = saveCallStack()
+    try {
+        return runToCompletion {
+            readOperation()
+        }
+    } finally {
+        restoreCallStack(callStack)
     }
+}
 
 
 /**
@@ -35,8 +41,13 @@ fun <T : ReadContext, R> T.runReadOperation(readOperation: suspend T.() -> R): R
  */
 internal
 fun <T : WriteContext> T.runWriteOperation(writeOperation: suspend T.() -> Unit) {
-    runToCompletion {
-        writeOperation()
+    val callStack = saveCallStack()
+    try {
+        runToCompletion {
+            writeOperation()
+        }
+    } finally {
+        restoreCallStack(callStack)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -19,15 +19,14 @@ package org.gradle.instantexecution.serialization.beans
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
 import org.gradle.instantexecution.InstantExecutionError
-import org.gradle.instantexecution.InstantExecutionProblemsException
 import org.gradle.instantexecution.extensions.maybeUnwrapInvocationTargetException
 import org.gradle.instantexecution.problems.PropertyKind
 import org.gradle.instantexecution.problems.propertyDescriptionFor
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.bubbleUp
 import org.gradle.instantexecution.serialization.logPropertyInfo
-import java.io.IOException
 
 
 class BeanPropertyWriter(
@@ -69,11 +68,8 @@ suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: Prop
     withPropertyTrace(kind, name) {
         try {
             write(value)
-        } catch (passThrough: IOException) {
-            throw passThrough
-        } catch (passThrough: InstantExecutionProblemsException) {
-            throw passThrough
         } catch (error: Exception) {
+            error.bubbleUp()
             throw InstantExecutionError(
                 propertyErrorMessage(value),
                 error.maybeUnwrapInvocationTargetException()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -54,7 +54,6 @@ import org.gradle.instantexecution.serialization.codecs.transform.Transformation
 import org.gradle.instantexecution.serialization.codecs.transform.TransformationStepCodec
 import org.gradle.instantexecution.serialization.codecs.transform.TransformedExternalArtifactSetCodec
 import org.gradle.instantexecution.serialization.ownerServiceCodec
-import org.gradle.instantexecution.serialization.reentrant
 import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
@@ -204,10 +203,7 @@ class Codecs(
         bind(unsupported<Externalizable>(NotYetImplementedJavaSerialization))
         bind(JavaObjectSerializationCodec())
 
-        // This protects the BeanCodec against StackOverflowErrors but
-        // we can still get them for the other codecs, for instance,
-        // with deeply nested Lists, deeply nested Maps, etc.
-        bind(reentrant(BeanCodec()))
+        bind(BeanCodec())
     }
 
     val internalTypesCodec = BindingsBackedCodec {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.bubbleUp
 import org.gradle.instantexecution.serialization.codecs.transform.FixedDependenciesResolver
 import org.gradle.instantexecution.serialization.decodePreservingIdentity
 import org.gradle.instantexecution.serialization.encodePreservingIdentityOf
@@ -64,13 +65,14 @@ class FileCollectionCodec(
                 onSuccess { elements ->
                     write(elements)
                 }
-                onFailure { ex ->
-                    logPropertyProblem("serialize", ex) {
+                onFailure { error ->
+                    error.bubbleUp()
+                    logPropertyProblem("serialize", error) {
                         text("value ")
                         reference(value.toString())
                         text(" failed to visit file collection")
                     }
-                    write(BrokenValue(ex))
+                    write(BrokenValue(error))
                 }
             }
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -22,6 +22,7 @@ import org.gradle.instantexecution.serialization.EncodingProvider
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.beans.BeanStateReader
+import org.gradle.instantexecution.serialization.bubbleUp
 import org.gradle.instantexecution.serialization.codecs.BrokenValue
 import org.gradle.instantexecution.serialization.codecs.Decoding
 import org.gradle.instantexecution.serialization.codecs.Encoding
@@ -167,13 +168,14 @@ class JavaObjectSerializationCodec : EncodingProducer, Decoding {
                         writeClass(beanType)
                         record.run { playback() }
                     }
-                    onFailure { ex ->
-                        logPropertyProblem("serialize", ex, NotYetImplementedJavaSerialization) {
+                    onFailure { error ->
+                        error.bubbleUp()
+                        logPropertyProblem("serialize", error, NotYetImplementedJavaSerialization) {
                             failedJOS(value)
                         }
                         writeEnum(Format.Broken)
                         writeClass(beanType)
-                        write(BrokenValue(ex))
+                        write(BrokenValue(error))
                     }
                 }
             }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintCheckerTest.kt
@@ -281,6 +281,13 @@ class InstantExecutionFingerprintCheckerTest {
         override fun writeClass(type: Class<*>): Unit =
             undefined()
 
+        override fun saveCallStack(): Any? =
+            null
+
+        override fun restoreCallStack(savedCallStack: Any?) {
+            require(savedCallStack === null)
+        }
+
         override val logger: Logger
             get() = undefined()
 
@@ -396,6 +403,13 @@ class InstantExecutionFingerprintCheckerTest {
 
         override fun pop(): Unit =
             undefined()
+
+        override fun saveCallStack(): Any? =
+            null
+
+        override fun restoreCallStack(savedCallStack: Any?) {
+            require(savedCallStack === null)
+        }
 
         override fun readInt(): Int =
             undefined()


### PR DESCRIPTION
By moving the stack protection logic to the contexts which makes it available to all codecs (and not only `BeanCodec`).

And improve performance (~10%) by allowing a maximum number of direct recursive calls to proceed thus avoiding the allocation of `Continuation` instances.

![improve-stack-safety](https://user-images.githubusercontent.com/51689/88457748-4d297900-ce5f-11ea-8809-a42981eea61a.png)
