### PR TITLE
Some configuration time improvements for Android builds

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -16,8 +16,8 @@
 
 package org.gradle.composite.internal;
 
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -56,15 +56,15 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
         public BuildStateRegistry createIncludedBuildRegistry(CompositeBuildContext context,
                                                               Instantiator instantiator,
                                                               WorkerLeaseService workerLeaseService,
-                                                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                               GradleLauncherFactory gradleLauncherFactory,
                                                               ListenerManager listenerManager,
                                                               ServiceRegistry rootServices,
                                                               ObjectFactory objectFactory,
+                                                              NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                                               ImmutableAttributesFactory attributesFactory) {
             IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, workerLeaseService);
             NotationParser<Object, Capability> capabilityNotationParser = new CapabilityNotationParserFactory(false).create();
-            IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory, capabilityNotationParser);
+            IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, capabilityNotationParser);
             return new DefaultIncludedBuildRegistry(includedBuildFactory, dependencySubstitutionsBuilder, gradleLauncherFactory, listenerManager, (BuildTreeScopeServices) rootServices);
         }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -16,8 +16,8 @@
 
 package org.gradle.composite.internal;
 
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -33,23 +33,23 @@ public class IncludedBuildDependencySubstitutionsBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(IncludedBuildDependencySubstitutionsBuilder.class);
 
     private final CompositeBuildContext context;
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final Instantiator instantiator;
     private final ObjectFactory objectFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private final NotationParser<Object, ComponentSelector> moduleSelectorNotationParser;
     private final NotationParser<Object, Capability> capabilitiesParser;
 
     public IncludedBuildDependencySubstitutionsBuilder(CompositeBuildContext context,
-                                                       ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                        Instantiator instantiator,
                                                        ObjectFactory objectFactory,
                                                        ImmutableAttributesFactory attributesFactory,
+                                                       NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                                        NotationParser<Object, Capability> capabilitiesParser) {
         this.context = context;
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.attributesFactory = attributesFactory;
+        this.moduleSelectorNotationParser = moduleSelectorNotationParser;
         this.capabilitiesParser = capabilitiesParser;
     }
 
@@ -66,9 +66,8 @@ public class IncludedBuildDependencySubstitutionsBuilder {
     }
 
     private DependencySubstitutionsInternal resolveDependencySubstitutions(IncludedBuildState build) {
-        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory, capabilitiesParser);
+        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, capabilitiesParser);
         build.getRegisteredDependencySubstitutions().execute(dependencySubstitutions);
         return dependencySubstitutions;
     }
-
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/JustReturningParser.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/JustReturningParser.java
@@ -17,23 +17,27 @@ package org.gradle.internal.typeconversion;
 
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 
-public class JustReturningConverter<N, T> implements NotationConverter<N, T> {
-
+public class JustReturningParser<N, T> implements NotationParser<N, T> {
     private final Class<? extends T> passThroughType;
+    private final NotationParser<N, T> delegate;
 
-    public JustReturningConverter(Class<? extends T> passThroughType) {
+    public JustReturningParser(Class<? extends T> passThroughType, NotationParser<N, T> delegate) {
         this.passThroughType = passThroughType;
+        this.delegate = delegate;
     }
 
     @Override
     public void describe(DiagnosticsVisitor visitor) {
         visitor.candidate(String.format("Instances of %s.", passThroughType.getSimpleName()));
+        delegate.describe(visitor);
     }
 
     @Override
-    public void convert(N notation, NotationConvertResult<? super T> result) throws TypeConversionException {
+    public T parseNotation(N notation) throws TypeConversionException {
         if (passThroughType.isInstance(notation)) {
-            result.converted(passThroughType.cast(notation));
+            return passThroughType.cast(notation);
+        } else {
+            return delegate.parseNotation(notation);
         }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapter.java
@@ -27,7 +27,7 @@ public class NotationConverterToNotationParserAdapter<N, T> implements NotationP
 
     @Override
     public T parseNotation(N notation) throws TypeConversionException {
-        ResultImpl<T> result = new ResultImpl<T>();
+        ResultImpl<T> result = new ResultImpl<>();
         converter.convert(notation, result);
         if (!result.hasResult) {
             throw new UnsupportedNotationException(notation);

--- a/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
@@ -31,18 +31,18 @@ public class NotationParserBuilder<N, T> {
     private Object typeDisplayName;
     private boolean implicitConverters = true;
     private boolean allowNullInput;
-    private final Collection<NotationConverter<? super N, ? extends T>> notationParsers = new LinkedList<NotationConverter<? super N, ? extends T>>();
+    private final Collection<NotationConverter<? super N, ? extends T>> notationParsers = new LinkedList<>();
 
     public static <T> NotationParserBuilder<Object, T> toType(Class<T> resultingType) {
-        return new NotationParserBuilder<Object, T>(Object.class, new TypeInfo<T>(resultingType));
+        return new NotationParserBuilder<>(Object.class, new TypeInfo<>(resultingType));
     }
 
     public static <T> NotationParserBuilder<Object, T> toType(TypeInfo<T> resultingType) {
-        return new NotationParserBuilder<Object, T>(Object.class, resultingType);
+        return new NotationParserBuilder<>(Object.class, resultingType);
     }
 
     public static <N, T> NotationParserBuilder<N, T> builder(Class<N> notationType, Class<T> resultingType) {
-        return new NotationParserBuilder<N, T>(notationType, new TypeInfo<T>(resultingType));
+        return new NotationParserBuilder<>(notationType, new TypeInfo<>(resultingType));
     }
 
     private NotationParserBuilder(Class<N> notationType, TypeInfo<T> resultingType) {
@@ -126,7 +126,7 @@ public class NotationParserBuilder<N, T> {
     }
 
     public NotationParser<N, Set<T>> toFlatteningComposite() {
-        return wrapInErrorHandling(new FlatteningNotationParser<N, T>(create()));
+        return wrapInErrorHandling(new FlatteningNotationParser<>(create()));
     }
 
     public NotationParser<N, T> toComposite() {
@@ -135,15 +135,15 @@ public class NotationParserBuilder<N, T> {
 
     private <S> NotationParser<N, S> wrapInErrorHandling(NotationParser<N, S> parser) {
         if (typeDisplayName == null) {
-            typeDisplayName = new LazyDisplayName<T>(resultingType);
+            typeDisplayName = new LazyDisplayName<>(resultingType);
         }
-        return new ErrorHandlingNotationParser<N, S>(typeDisplayName, invalidNotationMessage, allowNullInput, parser);
+        return new ErrorHandlingNotationParser<>(typeDisplayName, invalidNotationMessage, allowNullInput, parser);
     }
 
     private NotationParser<N, T> create() {
-        List<NotationConverter<? super N, ? extends T>> composites = new LinkedList<NotationConverter<? super N, ? extends T>>();
+        List<NotationConverter<? super N, ? extends T>> composites = new LinkedList<>();
         if (notationType.isAssignableFrom(resultingType.getTargetType()) && implicitConverters) {
-            composites.add(new JustReturningConverter<N, T>(resultingType.getTargetType()));
+            composites.add(new JustReturningConverter<>(resultingType.getTargetType()));
         }
         composites.addAll(this.notationParsers);
 
@@ -151,9 +151,9 @@ public class NotationParserBuilder<N, T> {
         if (composites.size() == 1) {
             notationConverter = composites.get(0);
         } else {
-            notationConverter = new CompositeNotationConverter<N, T>(composites);
+            notationConverter = new CompositeNotationConverter<>(composites);
         }
-        return new NotationConverterToNotationParserAdapter<N, T>(notationConverter);
+        return new NotationConverterToNotationParserAdapter<>(notationConverter);
     }
 
     private static class LazyDisplayName<T> implements Describable {

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/CrossBuildCachingNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/CrossBuildCachingNotationConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.typeconversion;
+
+import org.gradle.cache.internal.CrossBuildInMemoryCache;
+import org.gradle.internal.exceptions.DiagnosticsVisitor;
+
+/**
+ * A {@link NotationConverter} that caches the result of conversion across build invocations.
+ */
+public class CrossBuildCachingNotationConverter<T> implements NotationConverter<Object, T> {
+    private final CrossBuildInMemoryCache<Object, T> cache;
+    private final NotationConverterToNotationParserAdapter<Object, T> delegate;
+
+    public CrossBuildCachingNotationConverter(NotationConverter<Object, T> delegate, CrossBuildInMemoryCache<Object, T> cache) {
+        this.cache = cache;
+        this.delegate = new NotationConverterToNotationParserAdapter<>(delegate);
+    }
+
+    @Override
+    public void convert(Object notation, NotationConvertResult<? super T> result) throws TypeConversionException {
+        T value = cache.get(notation, key -> delegate.parseNotation(notation));
+        result.converted(value);
+    }
+
+    @Override
+    public void describe(DiagnosticsVisitor visitor) {
+        delegate.describe(visitor);
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
@@ -44,6 +44,22 @@ class NotationParserBuilderSpec extends Specification {
         parser.parseNotation(12) == "[12]"
     }
 
+    def "can add multiple converters"() {
+        def converter1 = Mock(NotationConverter)
+        def converter2 = Mock(NotationConverter)
+
+        given:
+        _ * converter1.convert(12, _) >> { Object n, NotationConvertResult result -> result.converted("[12]") }
+        converter2.convert(true, _) >> { Object n, NotationConvertResult result -> result.converted("True") }
+
+        and:
+        def parser = NotationParserBuilder.toType(String.class).converter(converter1).converter(converter2).toComposite()
+
+        expect:
+        parser.parseNotation(12) == "[12]"
+        parser.parseNotation(true) == "True"
+    }
+
     def "can add a converter that converts notations of a given type"() {
         def converter = Mock(NotationConverter)
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -46,7 +46,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-        ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, TestUtil.domainObjectCollectionFactory(), TestUtil.objectFactory())],
+        ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, TestUtil.domainObjectCollectionFactory(), null, TestUtil.objectFactory())],
         ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
         ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -21,6 +21,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
@@ -510,6 +511,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                     CollectionCallbackActionDecorator callbackDecorator,
                                                                     UserCodeApplicationContext userCodeApplicationContext,
                                                                     DomainObjectCollectionFactory domainObjectCollectionFactory,
+                                                                    NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                                                     ObjectFactory objectFactory) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                     configurationResolver,
@@ -534,6 +536,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                     callbackDecorator,
                     userCodeApplicationContext,
                     domainObjectCollectionFactory,
+                    moduleSelectorNotationParser,
                     objectFactory
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.artifacts;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
+import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.ModuleSelectorStringNotationConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultLocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultDependencyDescriptorFactory;
@@ -53,6 +55,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.instantiation.InstantiationScheme;
@@ -63,6 +66,9 @@ import org.gradle.internal.resource.connector.ResourceConnectorFactory;
 import org.gradle.internal.resource.local.FileResourceConnector;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.transport.file.FileConnectorFactory;
+import org.gradle.internal.typeconversion.CrossBuildCachingNotationConverter;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.work.Incremental;
 
 class DependencyManagementGlobalScopeServices {
@@ -72,6 +78,13 @@ class DependencyManagementGlobalScopeServices {
 
     ImmutableModuleIdentifierFactory createModuleIdentifierFactory() {
         return new DefaultImmutableModuleIdentifierFactory();
+    }
+
+    NotationParser<Object, ComponentSelector> createComponentSelectorFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, CrossBuildInMemoryCacheFactory cacheFactory) {
+        return NotationParserBuilder
+            .toType(ComponentSelector.class)
+            .converter(new CrossBuildCachingNotationConverter<>(new ModuleSelectorStringNotationConverter(moduleIdentifierFactory), cacheFactory.newCache()))
+            .toComposite();
     }
 
     IvyContextManager createIvyContextManager() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
@@ -17,7 +17,10 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scopes.Global)
 public interface ImmutableModuleIdentifierFactory {
     ModuleIdentifier module(String group, String name);
     ModuleVersionIdentifier moduleWithVersion(String group, String name, String version);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
@@ -105,6 +106,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                                          CollectionCallbackActionDecorator callbackDecorator,
                                          UserCodeApplicationContext userCodeApplicationContext,
                                          DomainObjectCollectionFactory domainObjectCollectionFactory,
+                                         NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                          ObjectFactory objectFactory) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
         this.resolver = resolver;
@@ -125,7 +127,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         NotationParser<Object, Capability> dependencyCapabilityNotationParser = new CapabilityNotationParserFactory(false).create();
         resolutionStrategyFactory = () -> {
             CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class, new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create());
-            return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory, dependencyCapabilityNotationParser);
+            return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, dependencyCapabilityNotationParser);
         };
         this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, localComponentMetadataBuilder, this, projectStateRegistry, dependencyLockingProvider);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
@@ -27,7 +27,7 @@ import org.gradle.util.GUtil;
 
 import static org.gradle.api.internal.notations.ModuleNotationValidation.*;
 
-class ModuleSelectorStringNotationConverter extends TypedNotationConverter<String, ComponentSelector> {
+public class ModuleSelectorStringNotationConverter extends TypedNotationConverter<String, ComponentSelector> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
     public ModuleSelectorStringNotationConverter(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.ResolutionStrategy;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -92,8 +93,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
                                      Instantiator instantiator,
                                      ObjectFactory objectFactory,
                                      ImmutableAttributesFactory attributesFactory,
+                                     NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                      NotationParser<Object, Capability> capabilitiesNotationParser) {
-        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, instantiator, objectFactory, attributesFactory, capabilitiesNotationParser), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
+        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleSelectorNotationParser, instantiator, objectFactory, attributesFactory, capabilitiesNotationParser), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
     }
 
     DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider, CapabilitiesResolutionInternal capabilitiesResolution) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -36,6 +36,7 @@ import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
@@ -74,7 +75,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider,
         projectAccessListener, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
         immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry, documentationRegistry,
-        domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory(), TestUtil.objectFactory())
+        domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory(), Mock(NotationParser), TestUtil.objectFactory())
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import org.gradle.vcs.internal.VcsMappingsStore
@@ -92,6 +93,7 @@ class DefaultConfigurationContainerTest extends Specification {
         callbackActionDecorator,
         userCodeApplicationContext,
         TestUtil.domainObjectCollectionFactory(),
+        Mock(NotationParser),
         TestUtil.objectFactory()
     )
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.MutationValidator
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
@@ -33,6 +32,7 @@ import org.gradle.internal.Actions
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.TestComponentIdentifiers
 import org.gradle.internal.typeconversion.NotationParser
+import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -43,11 +43,11 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 
 class DefaultDependencySubstitutionsSpec extends Specification {
     ComponentIdentifierFactory componentIdentifierFactory = Mock(ComponentIdentifierFactory)
-    ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     DependencySubstitutionsInternal substitutions;
+    NotationParser moduleNotationParser = NotationParserBuilder.builder(Object, ComponentSelector).converter(new ModuleSelectorStringNotationConverter(new DefaultImmutableModuleIdentifierFactory())).toComposite()
 
     def setup() {
-        substitutions = DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory, TestUtil.instantiatorFactory().decorateScheme().instantiator(), TestUtil.objectFactory(), AttributeTestUtil.attributesFactory(), Stub(NotationParser))
+        substitutions = DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleNotationParser, TestUtil.instantiatorFactory().decorateScheme().instantiator(), TestUtil.objectFactory(), AttributeTestUtil.attributesFactory(), Stub(NotationParser))
     }
 
     def "provides no op resolve rule when no rules or forced modules configured"() {
@@ -295,10 +295,10 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.hasRules() == result
 
         where:
-        from        | to                | result
-        "org:test"  | ":foo"            | true
-        ":bar"      | "org:test:1.0"    | true
-        "org:test"  | "org:foo:1.0"     | false
+        from       | to             | result
+        "org:test" | ":foo"         | true
+        ":bar"     | "org:test:1.0" | true
+        "org:test" | "org:foo:1.0"  | false
     }
 
     ComponentSelector createComponent(String componentNotation) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -20,18 +20,9 @@ For Java, Groovy, Kotlin and Android compatibility, see the [full compatibility 
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. --> 
 
-<!-- 
-Add release features here!
-## 1
+## Configuration cache improvements
 
-details of 1
-
-## 2
-
-details of 2
-
-## n
--->
+TBD - load from cache performance improvements and reduced memory consumption for Android builds
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -16,6 +16,9 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -28,6 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * All other values are referenced only by weak or soft references, allowing them to be collected.
  */
 @ThreadSafe
+@ServiceScope(Scopes.Global)
 public interface CrossBuildInMemoryCacheFactory {
     /**
      * Creates a new cache instance. Keys are always referenced using strong references, values by strong or soft references depending on their usage.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
@@ -64,7 +64,7 @@ public class JvmLibraryResolveContext implements ResolveContext {
         this.displayName = displayName;
         this.variants = variants;
         this.dependencies = dependencies;
-        this.resolutionStrategy = new DefaultResolutionStrategy(DependencySubstitutionRules.NO_OP, VcsMappingsStore.NO_OP, null, moduleIdentifierFactory, null, NoOpDependencyLockingProvider.getInstance(), new DefaultCapabilitiesResolution(new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create()), DirectInstantiator.INSTANCE, null, null, new CapabilityNotationParserFactory(false).create());
+        this.resolutionStrategy = new DefaultResolutionStrategy(DependencySubstitutionRules.NO_OP, VcsMappingsStore.NO_OP, null, moduleIdentifierFactory, null, NoOpDependencyLockingProvider.getInstance(), new DefaultCapabilitiesResolution(new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create()), DirectInstantiator.INSTANCE, null, null, null, new CapabilityNotationParserFactory(false).create());
     }
 
     @Override


### PR DESCRIPTION

### Context

Apply some caching to the conversion of the parameter of `DependencySubstitutions.module()` to a `ComponentSelector`, as this method can be called many, many times in large Android builds.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
