### PR TITLE
Use 'UNKNOWN' when git information is not available

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
@@ -18,7 +18,6 @@ package org.gradle.gradlebuild.versioning
 
 import GitInformationExtension
 import org.eclipse.jgit.lib.Repository
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.Describable
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
@@ -79,19 +78,9 @@ fun Project.resolveGitInfo(): LazyGitInformation {
     val gitDirOrFile = projectDir.resolve(".git")
     return when {
         gitDirOrFile.isFile -> gitWorktreeInfoFor(projectDir)
-        else -> gitRepositoryInfoFor(gitDirOrFile)
+        else -> LazyGitInformation({ "UNKNOWN" }, { "UNKNOWN" })
     }
 }
-
-
-private
-fun gitRepositoryInfoFor(gitDir: File): LazyGitInformation =
-    FileRepositoryBuilder().setGitDir(gitDir).build().let { repository ->
-        LazyGitInformation(
-            branch = { repository.branch },
-            commitId = { repository.resolve(repository.fullBranch).name }
-        )
-    }
 
 
 /**


### PR DESCRIPTION
Prior to this change, if gradle source code is built from a directory without git information, the build fails. In this case, let's simply use `UNKNOWN` as branch/revision. 