### PR TITLE
Don't store configuration cache state when failing the build because of found problems

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -657,7 +657,6 @@ If the artifacts are trustworthy, you will need to update the gradle/verificatio
         terse << [true, false]
     }
 
-    @ToBeFixedForInstantExecution
     @Unroll
     def "caches missing keys (terse output=#terse)"() {
         createMetadataFile {
@@ -727,7 +726,6 @@ This can indicate that a dependency has been compromised. Please carefully verif
     }
 
 
-    @ToBeFixedForInstantExecution
     def "cache takes ignored keys into consideration"() {
         createMetadataFile {
             keyServer(keyServerFixture.uri)

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -357,9 +357,11 @@ Running that task fails and print the following in the console:
 ----
 ❯ gradle --configuration-cache someTask -DsomeMessage=hello
 ...
-include::{snippetsPath}/configurationCache/problemsGroovy/tests/store.out[]
-Configuration cache entry stored.
+include::{snippetsPath}/configurationCache/problemsGroovy/tests/fail.out[]
+Configuration cache entry discarded with 2 problems.
 ----
+
+The configuration cache entry was discarded because of the found problems failing the build.
 
 Details can be found in the linked HTML report:
 
@@ -380,29 +382,34 @@ When changing your build or plugin to fix the problems you should consider <<con
 
 At this stage, you can decide to either <<configuration_cache#config_cache:usage:ignore_problems, turn the problems into warnings>> and continue exploring how your build reacts to the configuration cache, or fix the problems at hand.
 
-Let's ignore the problems reported when storing the configuration cache, and run the same build again to see what happens when reusing the problematic cached configuration:
+Let's ignore the reported problems, and run the same build again twice to see what happens when reusing the cached problematic configuration:
 
 ----
-❯ gradle --configuration-cache someTask -DsomeDestination=dest
-...
+❯ gradle --configuration-cache --configuration-cache-problems=warn someTask -DsomeDestination=dest
+include::{snippetsPath}/configurationCache/problemsGroovy/tests/store.out[]
+Configuration cache entry stored with 2 problems.
+❯ gradle --configuration-cache --configuration-cache-problems=warn someTask -DsomeDestination=dest
 include::{snippetsPath}/configurationCache/problemsGroovy/tests/load.out[]
-Configuration cache entry reused.
+Configuration cache entry reused with 1 problem.
 ----
 
-The build fails again, reporting the observed problems.
-The first problem that happened at configuration time when storing is not reported given the configuration phase was skipped.
-The second problem about using `Project` at execution time is reported.
+The two builds succeed reporting the observed problems, storing then reusing the configuration cache.
+The first problem, that happens at configuration time when storing, is not reported on the second run, reusing the configuration cache.
+The configuration phase was skipped.
+The second problem about using `Project` at execution time is reported in both when storing and reusing.
+Both builds did execute the task.
 
 With the help of the links present in the console problem summary and in the HTML report we can fix our problems.
-Here's a fixed version of the build script:
+Here's some fixed version of the build script:
 
 ====
 include::sample[dir="snippets/configurationCache/problemsFixed/groovy",files="build.gradle[tags=fixed]"]
 include::sample[dir="snippets/configurationCache/problemsFixed/kotlin",files="build.gradle.kts[tags=fixed]"]
 ====
-<1> we turned our ad-hoc task into a proper task class
-<2> this allows the injection of the `FileSystemOperations` service, a supported replacement for `project.copy {}`
-<3> finally, we declare the system property as a build configuration input, used at configuration time and wire it to our task input
+<1> We turned our ad-hoc task into a proper task class,
+<2> with inputs and outputs declaration,
+<3> and injected with the `FileSystemOperations` service, a supported replacement for <<configuration_cache#config_cache:requirements:use_project_during_execution, `project.copy {}`>>.
+<4> Finally, we declared the <<configuration_cache#config_cache:requirements:undeclared_sys_prop_read, system property used at configuration time>> as a build configuration input, and wire it to our task input.
 
 Running the task twice now succeeds without reporting any problem and reusing the configuration cache on the second run:
 
@@ -423,7 +430,7 @@ include::{snippetsPath}/configurationCache/problemsFixed/tests/store-another.out
 Configuration cache entry stored.
 ----
 
-The previous configuration cache entry could not be reused, and the task graph had to be calculated again.
+The previous configuration cache entry could not be reused, and the task graph had to be calculated and stored again.
 This is because we read the system property at configuration time, hence requiring Gradle to run the configuration phase again when the value of that property changes.
 Fixing that is as simple as wiring the system property directly, without reading it at configuration time.
 
@@ -431,9 +438,9 @@ Fixing that is as simple as wiring the system property directly, without reading
 include::sample[dir="snippets/configurationCache/problemsFixedReuse/groovy",files="build.gradle[tags=fixed-reuse]"]
 include::sample[dir="snippets/configurationCache/problemsFixedReuse/kotlin",files="build.gradle.kts[tags=fixed-reuse]"]
 ====
-<1> wire the declared system property directly, without reading it at configuration time
+<1> We wired the declared system property directly, without reading it at configuration time.
 
-With those changes in place we can run the task twice, changing the system property value:
+With this simple change in place we can run the task any number of time, change the system property value, and reuse the configuration cache:
 
 ----
 ❯ gradle --configuration-cache someTask -DsomeDestination=dest
@@ -568,13 +575,14 @@ These types almost never represent a task input or output.
 
 Gradle model types (e.g. `Gradle`, `Settings`, `Project`, `SourceSet`, `Configuration` etc...) are usually used to carry some task input that should be explicitly and precisely declared instead.
 
-For example, if you reference a `Project` in order to get the `project.version` at execution time, you should instead directly declare the _project version_  as an input to your task using a `Property<String>`.
+For example, if you reference a `Project` in order to get the `project.version` at execution time, you should instead directly declare the _project version_ as an input to your task using a `Property<String>`.
 Another example would be to reference a `SourceSet` to later get the source files, the compilation classpath or the outputs of the source set.
 You should instead declare these as a `FileCollection` input and reference just that.
 
 The same requirement applies to dependency management types with some nuances.
 
-Some types, such as `Configuration`, don't make good task input parameters, as they hold a lot of irrelevant state, and it is better to model these inputs as something more precise. We don't intend to make these types serializable at all.
+Some types, such as `Configuration`, don't make good task input parameters, as they hold a lot of irrelevant state, and it is better to model these inputs as something more precise.
+We don't intend to make these types serializable at all.
 For example, if you reference a `Configuration` to later get the resolved files, you should instead declare a `FileCollection` as an input to your task.
 
 Referencing dependency resolution results is also disallowed (e.g. `ArtifactResolutionQuery`, `ResolvedArtifact`, `ArtifactResult` etc...).
@@ -582,7 +590,8 @@ For example, if you reference some `ResolvedArtifactResult` instances, you shoul
 The rule of thumb is that tasks must not reference _resolved_ results, but lazy specifications instead, in order to do the dependency resolution at execution time.
 Some APIs are missing and cannot yet be used as task inputs, for example it is currently not possible for task actions to reason about the dependency _graph_, see link:{gradle-issues}12871[gradle/gradle#12871].
 
-Some types, such as `Publication` or `Dependency` are not serializable, but could be. We may, if necessary, allow these to be used as task inputs directly.
+Some types, such as `Publication` or `Dependency` are not serializable, but could be.
+We may, if necessary, allow these to be used as task inputs directly.
 
 Here's an example of a problematic task type referencing a `SourceSet`:
 
@@ -927,8 +936,7 @@ When running builds using <<test_kit#test_kit, TestKit>>, the configuration cach
 
 Gradle allows objects that support the link:https://docs.oracle.com/javase/8/docs/platform/serialization/spec/serialTOC.html[Java Object Serialization] protocol to be stored in the configuration cache.
 
-The implementation is currently limited to serializable classes that implement the `java.io.Serializable` interface
-and define one of the following combination of methods:
+The implementation is currently limited to serializable classes that implement the `java.io.Serializable` interface and define one of the following combination of methods:
 
 - a `writeObject` method combined with a `readObject` method to control exactly which information to store;
 - a `writeObject` method with no corresponding `readObject`; `writeObject` must eventually call `ObjectOutputStream.defaultWriteObject`;

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/build.gradle
@@ -3,15 +3,15 @@ import javax.inject.Inject
 
 abstract class MyCopyTask extends DefaultTask { // <1>
 
-    @InputDirectory abstract DirectoryProperty getSource()
+    @InputDirectory abstract DirectoryProperty getSource() // <2>
 
-    @OutputDirectory abstract DirectoryProperty getDestination()
+    @OutputDirectory abstract DirectoryProperty getDestination() // <2>
 
-    @Inject abstract FileSystemOperations getFs() // <2>
+    @Inject abstract FileSystemOperations getFs() // <3>
 
     @TaskAction
     void action() {
-        fs.copy {
+        fs.copy { // <3>
             from source
             into destination
         }
@@ -22,7 +22,7 @@ tasks.register('someTask', MyCopyTask) {
     def projectDir = layout.projectDirectory
     source = projectDir.dir('source')
     destination = projectDir.dir(
-        providers.systemProperty('someDestination').forUseAtConfigurationTime().get() // <3>
+        providers.systemProperty('someDestination').forUseAtConfigurationTime().get() // <4>
     )
 }
 // end::fixed[]

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/build.gradle.kts
@@ -3,15 +3,15 @@ import javax.inject.Inject
 
 abstract class MyCopyTask : DefaultTask() { // <1>
 
-    @get:InputDirectory abstract val source: DirectoryProperty
+    @get:InputDirectory abstract val source: DirectoryProperty // <2>
 
-    @get:OutputDirectory abstract val destination: DirectoryProperty
+    @get:OutputDirectory abstract val destination: DirectoryProperty // <2>
 
-    @get:Inject abstract val fs: FileSystemOperations // <2>
+    @get:Inject abstract val fs: FileSystemOperations // <3>
 
     @TaskAction
     fun action() {
-        fs.copy {
+        fs.copy { // <3>
             from(source)
             into(destination)
         }
@@ -22,7 +22,7 @@ tasks.register<MyCopyTask>("someTask") {
     val projectDir = layout.projectDirectory
     source.set(projectDir.dir("source"))
     destination.set(projectDir.dir(
-        providers.systemProperty("someDestination").forUseAtConfigurationTime().get() // <3>
+        providers.systemProperty("someDestination").forUseAtConfigurationTime().get() // <4>
     ))
 }
 // end::fixed[]

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/configurationCacheProblemsGroovy.sample.conf
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/configurationCacheProblemsGroovy.sample.conf
@@ -2,12 +2,18 @@ commands: [{
   executable: gradle
   args: "--rerun-tasks someTask -DsomeDestination=dest"
   expect-failure: true
+  expected-output-file: fail.out
+  allow-additional-output: true
+},{
+  executable: gradle
+  args: "--rerun-tasks --configuration-cache-problems=warn someTask -DsomeDestination=dest"
+  expect-failure: false
   expected-output-file: store.out
   allow-additional-output: true
 }, {
   executable: gradle
-  args: "--rerun-tasks someTask -DsomeDestination=dest"
-  expect-failure: true
+  args: "--rerun-tasks --configuration-cache-problems=warn someTask -DsomeDestination=dest"
+  expect-failure: false
   expected-output-file: load.out
   allow-additional-output: true
 }]

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
@@ -1,5 +1,5 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
-> Task :someTask
+* What went wrong:
+Configuration cache problems found in this build.
 
 2 problems were found storing the configuration cache.
 - build file 'build.gradle': read system property 'someDestination'
@@ -8,6 +8,13 @@ Calculating task graph as no configuration cache is available for tasks: someTas
   See https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
 
 See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
+> Read system property 'someDestination'
+> Invocation of 'Task.project' by task ':someTask' at execution time is unsupported.
 
-BUILD SUCCESSFUL in 0s
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/load.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/load.out
@@ -1,18 +1,11 @@
-* What went wrong:
-Configuration cache problems found in this build.
-Gradle can be made to ignore these problems, see https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:usage:ignore_problems.
+Reusing configuration cache.
+> Task :someTask
 
 1 problem was found reusing the configuration cache.
 - task `:someTask` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.
   See https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
 
 See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
-> Invocation of 'Task.project' by task ':someTask' at execution time is unsupported.
 
-* Try:
-Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
-
-* Get more help at https://help.gradle.org
-
-BUILD FAILED in 0s
+BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/configurationCacheProblemsKotlin.sample.conf
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/configurationCacheProblemsKotlin.sample.conf
@@ -2,12 +2,18 @@ commands: [{
   executable: gradle
   args: "--rerun-tasks someTask -DsomeDestination=dest"
   expect-failure: true
+  expected-output-file: fail.out
+  allow-additional-output: true
+},{
+  executable: gradle
+  args: "--rerun-tasks --configuration-cache-problems=warn someTask -DsomeDestination=dest"
+  expect-failure: false
   expected-output-file: store.out
   allow-additional-output: true
 }, {
   executable: gradle
-  args: "--rerun-tasks someTask -DsomeDestination=dest"
-  expect-failure: true
+  args: "--rerun-tasks --configuration-cache-problems=warn someTask -DsomeDestination=dest"
+  expect-failure: false
   expected-output-file: load.out
   allow-additional-output: true
 }]

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
@@ -1,5 +1,5 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
-> Task :someTask
+* What went wrong:
+Configuration cache problems found in this build.
 
 2 problems were found storing the configuration cache.
 - build file 'build.gradle.kts': read system property 'someDestination'
@@ -8,6 +8,13 @@ Calculating task graph as no configuration cache is available for tasks: someTas
   See https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
 
 See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
+> Read system property 'someDestination'
+> Invocation of 'Task.project' by task ':someTask' at execution time is unsupported.
 
-BUILD SUCCESSFUL in 0s
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/load.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/load.out
@@ -1,18 +1,11 @@
-* What went wrong:
-Configuration cache problems found in this build.
-Gradle can be made to ignore these problems, see https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:usage:ignore_problems.
+Reusing configuration cache.
+> Task :someTask
 
 1 problem was found reusing the configuration cache.
 - task `:someTask` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.
   See https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
 
 See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
-> Invocation of 'Task.project' by task ':someTask' at execution time is unsupported.
 
-* Try:
-Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
-
-* Get more help at https://help.gradle.org
-
-BUILD FAILED in 0s
+BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -39,6 +39,15 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         }
 
         when:
+        instantRunLenient("help")
+
+        then:
+        problems.assertResultHasProblems(result) {
+            withUniqueProblems(expectedProblem)
+            withProblemsWithStackTraceCount(0)
+        }
+
+        when:
         instantFails("help")
 
         then:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -96,6 +96,15 @@ class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExec
         }
 
         when:
+        instantRunLenient("help")
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems(expectedProblem)
+            withProblemsWithStackTraceCount(0)
+        }
+
+        when:
         instantFails("help")
 
         then:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -47,10 +47,10 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         ]
 
         when:
-        instantFails 'test', 'jacocoTestReport'
+        instantRunLenient 'test', 'jacocoTestReport'
 
         then:
-        problems.assertFailureHasProblems(failure) {
+        problems.assertResultHasProblems(result) {
             withUniqueProblems(expectedStoreProblems)
             withTotalProblemsCount(expectedStoreProblemCount)
             withProblemsWithStackTraceCount(0)

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -30,17 +30,17 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         def fixture = newInstantExecutionFixture()
 
         when:
-        instantFails("thing", "-DCI=$value")
+        instantRunLenient"thing", "-DCI=$value"
 
         then:
         fixture.assertStateStored()
         // TODO - use problems fixture, need to be able to ignore problems from the Kotlin plugin
-        failure.assertThatDescription(containsNormalizedString("$location: read system property 'CI'"))
+        result.normalizedOutput.contains("$location: read system property 'CI'")
         outputContains("apply = $value")
         outputContains("task = $value")
 
         when:
-        instantRun WARN_PROBLEMS_CLI_OPT, "thing", "-DCI=$value"
+        instantRunLenient "thing", "-DCI=$value"
 
         then:
         fixture.assertStateLoaded()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -30,7 +30,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractInst
         def fixture = newInstantExecutionFixture()
 
         when:
-        instantRunLenient"thing", "-DCI=$value"
+        instantRunLenient "thing", "-DCI=$value"
 
         then:
         fixture.assertStateStored()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -218,11 +218,11 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractInstantExecutionInteg
         noExceptionThrown()
 
         when:
-        instantFails("-DCI=$defaultValue") // use the default value
+        instantRunLenient("-DCI=$defaultValue") // use the default value
 
         then:
         fixture.assertStateStored()
-        problems.assertFailureHasProblems(failure) {
+        problems.assertResultHasProblems(result) {
             withProblem("plugin class 'SneakyPlugin': read system property 'CI'")
         }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -38,7 +38,6 @@ import org.gradle.instantexecution.serialization.runWriteOperation
 import org.gradle.instantexecution.serialization.withIsolate
 import org.gradle.internal.Factory
 import org.gradle.internal.classpath.Instrumented
-import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
@@ -60,8 +59,7 @@ class DefaultInstantExecution internal constructor(
     private val cacheFingerprintController: InstantExecutionCacheFingerprintController,
     private val beanConstructors: BeanConstructors,
     private val gradlePropertiesController: GradlePropertiesController,
-    private val relevantProjectsRegistry: RelevantProjectsRegistry,
-    private val listenerManager: ListenerManager
+    private val relevantProjectsRegistry: RelevantProjectsRegistry
 ) : InstantExecution {
 
     interface Host {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
@@ -59,9 +59,6 @@ open class InstantExecutionProblemsException : InstantExecutionException {
     protected
     object Documentation {
 
-        val ignoreProblems: String
-            get() = DocumentationRegistry().getDocumentationFor("configuration_cache", "config_cache:usage:ignore_problems")
-
         val maxProblems: String
             get() = DocumentationRegistry().getDocumentationFor("configuration_cache", "config_cache:usage:max_problems")
     }
@@ -85,8 +82,7 @@ open class InstantExecutionProblemsException : InstantExecutionException {
         problems: List<PropertyProblem>,
         htmlReportFile: File
     ) : this(
-        "Configuration cache problems found in this build.\n" +
-            "Gradle can be made to ignore these problems, see ${Documentation.ignoreProblems}.",
+        "Configuration cache problems found in this build.",
         causes,
         cacheAction,
         problems,

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
@@ -202,8 +202,8 @@ class InstantExecutionProblems(
             when {
                 isFailingBuildDueToSerializationError && !hasProblems -> log("Configuration cache entry discarded.")
                 isFailingBuildDueToSerializationError -> log("Configuration cache entry discarded with {}.", problemCount)
-                cacheAction == STORE && hasTooManyProblems -> log("Configuration cache entry discarded with too many problems ({}).", problemCount)
                 cacheAction == STORE && isFailOnProblems && hasProblems -> log("Configuration cache entry discarded with {}.", problemCount)
+                cacheAction == STORE && hasTooManyProblems -> log("Configuration cache entry discarded with too many problems ({}).", problemCount)
                 cacheAction == LOAD && !hasProblems -> log("Configuration cache entry reused.")
                 cacheAction == LOAD -> log("Configuration cache entry reused with {}.", problemCount)
                 !hasProblems -> log("Configuration cache entry stored.")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
@@ -49,7 +49,7 @@ fun buildConsoleSummary(cacheAction: String, problems: List<PropertyProblem>, re
             appendln("plus ${uniquePropertyProblems.size - maxConsoleProblems} more problems. Please see the report for details.")
         }
         appendln()
-        appendln(buildSummaryReportLink(reportFile))
+        append(buildSummaryReportLink(reportFile))
     }.toString()
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsSummary.kt
@@ -49,7 +49,7 @@ fun buildConsoleSummary(cacheAction: String, problems: List<PropertyProblem>, re
             appendln("plus ${uniquePropertyProblems.size - maxConsoleProblems} more problems. Please see the report for details.")
         }
         appendln()
-        append(buildSummaryReportLink(reportFile))
+        appendln(buildSummaryReportLink(reportFile))
     }.toString()
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/instantexecution/InstantExecutionProblemsFixture.groovy
@@ -198,9 +198,7 @@ final class InstantExecutionProblemsFixture {
 
     private static Matcher<String> failureDescriptionMatcherForProblems(HasInstantExecutionProblemsSpec spec) {
         return buildMatcherForProblemsFailureDescription(
-            "Configuration cache problems found in this build.\n" +
-                "Gradle can be made to ignore these problems, " +
-                "see ${new DocumentationRegistry().getDocumentationFor("configuration_cache", "config_cache:usage:ignore_problems")}.",
+            "Configuration cache problems found in this build.",
             spec
         )
     }


### PR DESCRIPTION
The previous behaviour of storing despite problems when `org.gradle.unsafe.configuration-cache.problems=fail` or when `org.gradle.unsafe.configuration-cache.max-problems` is reached was very confusing.
