### PR TITLE
Move Kotlin DSL specific build logic to buildSrc plugins

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -1,6 +1,8 @@
 
 dependencies {
     implementation(project(":basics"))
+    implementation(project(":dependencyModules"))
+    implementation(project(":jvm"))
 
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions")
     implementation(kotlin("gradle-plugin"))

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-compiler-embeddable.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-compiler-embeddable.gradle.kts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gradlebuild
+
+import gradlebuild.basics.BuildEnvironment
+import gradlebuild.kotlindsl.compiler.tasks.CheckKotlinCompilerEmbeddableDependencies
+import gradlebuild.kotlindsl.compiler.tasks.PatchKotlinCompilerEmbeddable
+
+plugins {
+    id("gradlebuild.dependency-modules")
+    id("gradlebuild.unittest-and-compile")
+}
+
+val kotlinCompilerEmbeddable by configurations.creating
+
+dependencies {
+    findProject(":distributionsDependencies")?.let { kotlinCompilerEmbeddable(it) }
+    kotlinCompilerEmbeddable(libs.futureKotlin("compiler-embeddable"))
+}
+
+tasks {
+    val checkKotlinCompilerEmbeddableDependencies by registering(CheckKotlinCompilerEmbeddableDependencies::class) {
+        current.from(configurations.runtimeClasspath)
+        expected.from(kotlinCompilerEmbeddable)
+    }
+
+    val patchKotlinCompilerEmbeddable by registering(PatchKotlinCompilerEmbeddable::class) {
+        dependsOn(checkKotlinCompilerEmbeddableDependencies)
+        excludes.set(listOf(
+            "META-INF/services/javax.annotation.processing.Processor",
+            "META-INF/native/**/*jansi.*"
+        ))
+        originalFiles.from(kotlinCompilerEmbeddable)
+        dependencies.from(configurations.detachedConfiguration(
+            project.dependencies.project(":distributionsDependencies"),
+            project.dependencies.create(libs.jansi)
+        ))
+        dependenciesIncludes.set(mapOf(
+            "jansi-" to listOf("META-INF/native/**", "org/fusesource/jansi/internal/CLibrary*.class")
+        ))
+        additionalRootFiles.from(classpathManifest)
+
+        outputFile.set(jar.get().archiveFile)
+
+        outputs.doNotCacheIfSlowInternetConnection()
+    }
+
+    jar.configure {
+        dependsOn(patchKotlinCompilerEmbeddable)
+        actions.clear()
+    }
+}
+
+fun TaskOutputs.doNotCacheIfSlowInternetConnection() {
+    doNotCacheIf("Slow internet connection") {
+        BuildEnvironment.isSlowInternetConnection
+    }
+}

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-dependencies-embedded.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-dependencies-embedded.gradle.kts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gradlebuild
+
+import gradlebuild.basics.accessors.kotlin
+import gradlebuild.basics.util.ReproduciblePropertiesWriter
+import gradlebuild.kotlindsl.generator.tasks.GenerateKotlinDependencyExtensions
+
+plugins {
+    id("gradlebuild.dependency-modules")
+    kotlin("jvm")
+}
+
+// --- Enable automatic generation of API extensions -------------------
+val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
+
+val publishedKotlinDslPluginVersion = "1.3.6" // TODO:kotlin-dsl
+
+tasks {
+    val generateKotlinDependencyExtensions by registering(GenerateKotlinDependencyExtensions::class) {
+        outputDir.set(apiExtensionsOutputDir)
+        embeddedKotlinVersion.set(libs.kotlinVersion)
+        kotlinDslPluginsVersion.set(publishedKotlinDslPluginVersion)
+    }
+
+    val generateExtensions by registering {
+        dependsOn(generateKotlinDependencyExtensions)
+    }
+
+    sourceSets.main {
+        kotlin.srcDir(files(apiExtensionsOutputDir).builtBy(generateExtensions))
+    }
+
+// -- Version manifest properties --------------------------------------
+    val writeVersionsManifest by registering(WriteProperties::class) {
+        outputFile = buildDir.resolve("versionsManifest/gradle-kotlin-dsl-versions.properties")
+        property("kotlin", libs.kotlinVersion)
+    }
+
+    processResources {
+        from(writeVersionsManifest)
+    }
+}
+
+// -- Embedded Kotlin dependencies -------------------------------------
+
+val embeddedKotlinBaseDependencies by configurations.creating
+
+dependencies {
+    embeddedKotlinBaseDependencies(libs.futureKotlin("stdlib-jdk8"))
+    embeddedKotlinBaseDependencies(libs.futureKotlin("reflect"))
+}
+
+val writeEmbeddedKotlinDependencies by tasks.registering {
+    val outputFile = layout.buildDirectory.file("embeddedKotlinDependencies/gradle-kotlin-dsl-embedded-kotlin.properties")
+    outputs.file(outputFile)
+    val values = embeddedKotlinBaseDependencies
+    inputs.files(values)
+    val skippedModules = setOf(project.name, "distributionsDependencies", "kotlinCompilerEmbeddable")
+    // https://github.com/gradle/instant-execution/issues/183
+    val modules = provider { embeddedKotlinBaseDependencies.incoming.resolutionResult.allComponents
+        .asSequence()
+        .mapNotNull { it.moduleVersion }
+        .filter { it.name !in skippedModules }
+        .associate { "${it.group}:${it.name}" to it.version }
+    }
+
+    doLast {
+        ReproduciblePropertiesWriter.store(
+            modules.get(),
+            outputFile.get().asFile.apply { parentFile.mkdirs() },
+            null
+        )
+    }
+}
+
+tasks.processResources {
+    from(writeEmbeddedKotlinDependencies)
+}

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-extensions.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlin-dsl-plugin-extensions.gradle.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gradlebuild
+
+import gradlebuild.basics.accessors.kotlin
+import gradlebuild.kotlindsl.generator.tasks.GenerateKotlinDslPluginsExtensions
+
+plugins {
+    java
+}
+
+val generatedSourcesDir = layout.buildDirectory.dir("generated-sources/kotlin")
+
+val generateSources by tasks.registering(GenerateKotlinDslPluginsExtensions::class) {
+    outputDir.set(generatedSourcesDir)
+    kotlinDslPluginsVersion.set(project.version)
+}
+
+sourceSets.main {
+    kotlin.srcDir(files(generatedSourcesDir).builtBy(generateSources))
+}

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/CheckKotlinCompilerEmbeddableDependencies.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/CheckKotlinCompilerEmbeddableDependencies.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.kotlindsl.tasks
+package gradlebuild.kotlindsl.compiler.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/PatchKotlinCompilerEmbeddable.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/PatchKotlinCompilerEmbeddable.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.kotlindsl.tasks
+package gradlebuild.kotlindsl.compiler.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/CodeGenerationTask.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/CodeGenerationTask.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.kotlindsl.tasks
+package gradlebuild.kotlindsl.generator.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -30,7 +30,7 @@ abstract class CodeGenerationTask : DefaultTask() {
     abstract val outputDir: DirectoryProperty
 
     protected
-    abstract fun File.writeFiles(): Unit
+    abstract fun File.writeFiles()
 
     @Suppress("unused")
     @TaskAction

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.kotlindsl.tasks
+package gradlebuild.kotlindsl.generator.tasks
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDslPluginsExtensions.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDslPluginsExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.kotlindsl.tasks
+package gradlebuild.kotlindsl.generator.tasks
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input

--- a/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
@@ -4,7 +4,6 @@ dependencies {
     implementation(project(":buildquality"))
     implementation(project(":cleanup"))
     implementation(project(":dependencyModules"))
-    implementation(project(":kotlinDsl"))
     implementation(project(":jvm"))
     implementation(project(":profiling"))
     implementation(project(":publishing"))

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import gradlebuild.basics.accessors.kotlin
-import gradlebuild.kotlindsl.tasks.GenerateKotlinDslPluginsExtensions
 import gradlebuild.cleanup.WhenNotEmpty
 
 plugins {
     id("gradlebuild.portalplugin.kotlin")
+    id("gradlebuild.kotlin-dsl-plugin-extensions")
 }
 
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
@@ -28,26 +27,6 @@ group = "org.gradle.kotlin"
 version = "1.3.7"
 
 base.archivesBaseName = "plugins"
-
-val generatedSourcesDir = layout.buildDirectory.dir("generated-sources/kotlin")
-
-val generateSources by tasks.registering(GenerateKotlinDslPluginsExtensions::class) {
-    outputDir.set(generatedSourcesDir)
-    kotlinDslPluginsVersion.set(project.version)
-}
-
-sourceSets.main {
-    kotlin.srcDir(files(generatedSourcesDir).builtBy(generateSources))
-}
-
-configurations {
-    compileOnly {
-        attributes {
-            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
-        }
-    }
-}
 
 dependencies {
     compileOnly(project(":baseServices"))


### PR DESCRIPTION
- better build structure
- makes it work with included builds for build logic in the future (https://github.com/gradle/gradle-private/issues/3139)
- Get rid of warning: `:kotlinDsl:jar: No valid plugin descriptors were found in META-INF/gradle-plugins`
