### PR TITLE
Add distribution size tests

### DIFF
--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -38,7 +38,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
         }
         localGradle {
             name = "QUICKCHECK_WITH_GRADLE_BUILT_BY_GRADLE"
-            tasks = "clean sanityCheck test"
+            tasks = "clean sanityCheck test distributionsIntegTests:quickTest"
             gradleHome = "%teamcity.build.checkoutDir%/dogfood-second"
             gradleParams = defaultParameters
         }

--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -38,7 +38,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
         }
         localGradle {
             name = "QUICKCHECK_WITH_GRADLE_BUILT_BY_GRADLE"
-            tasks = "clean sanityCheck test distributionsIntegTests:quickTest"
+            tasks = "clean sanityCheck test distributionsIntegTests:embeddedIntegTest"
             gradleHome = "%teamcity.build.checkoutDir%/dogfood-second"
             gradleParams = defaultParameters
         }

--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -38,7 +38,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
         }
         localGradle {
             name = "QUICKCHECK_WITH_GRADLE_BUILT_BY_GRADLE"
-            tasks = "clean sanityCheck test distributionsIntegTests:embeddedIntegTest"
+            tasks = "clean sanityCheck test distributionsIntegTests:forkingIntegTest"
             gradleHome = "%teamcity.build.checkoutDir%/dogfood-second"
             gradleParams = defaultParameters
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.7-20200730190051+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.7-20200730220045+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -32,6 +32,11 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
         "all"
     }
 
+    @Override
+    int getMaxDistributionSizeBytes() {
+        return 139 * 1024 * 1024
+    }
+
     def allZipContents() {
         given:
         TestFile contentsDir = unpackDistribution()

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 139 * 1024 * 1024
+        return 140 * 1024 * 1024
     }
 
     def allZipContents() {

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
@@ -29,6 +29,11 @@ class BinDistributionIntegrationSpec extends DistributionIntegrationSpec {
         "bin"
     }
 
+    @Override
+    int getMaxDistributionSizeBytes() {
+        return 98 * 1024 * 1024
+    }
+
     def binZipContents() {
         given:
         TestFile contentsDir = unpackDistribution()

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
@@ -31,7 +31,7 @@ class BinDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 98 * 1024 * 1024
+        return 99 * 1024 * 1024
     }
 
     def binZipContents() {

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -44,6 +44,8 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
     abstract String getDistributionLabel()
 
+    abstract int getMaxDistributionSizeBytes()
+
     /**
      * Change this whenever you add or remove subprojects for distribution core modules (lib/).
      */
@@ -67,6 +69,11 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
     int getLibJarsCount() {
         coreLibJarsCount + packagedPluginsJarCount + thirdPartyLibJarsCount
+    }
+
+    def "distribution size should not exceed a certain number"() {
+        expect:
+        getZip().size() <= getMaxDistributionSizeBytes()
     }
 
     def "no duplicate entries"() {

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -35,7 +35,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 98 * 1024 * 1024
+        return 99 * 1024 * 1024
     }
 
     @Issue(['https://github.com/gradle/gradle/issues/9990', 'https://github.com/gradle/gradle/issues/10038'])

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -33,6 +33,11 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
         'bin'
     }
 
+    @Override
+    int getMaxDistributionSizeBytes() {
+        return 98 * 1024 * 1024
+    }
+
     @Issue(['https://github.com/gradle/gradle/issues/9990', 'https://github.com/gradle/gradle/issues/10038'])
     def "validate dependency archives"() {
         when:

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class DocsDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 36 * 1024 * 1024
+        return 37 * 1024 * 1024
     }
 
     @Override

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
@@ -31,6 +31,11 @@ class DocsDistributionIntegrationSpec extends DistributionIntegrationSpec {
     }
 
     @Override
+    int getMaxDistributionSizeBytes() {
+        return 36 * 1024 * 1024
+    }
+
+    @Override
     int getLibJarsCount() {
         0
     }

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -34,6 +34,11 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
     }
 
     @Override
+    int getMaxDistributionSizeBytes() {
+        return 42 * 1024 * 1024
+    }
+
+    @Override
     int getLibJarsCount() {
         0
     }

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -35,7 +35,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 42 * 1024 * 1024
+        return 43 * 1024 * 1024
     }
 
     @Override


### PR DESCRIPTION
So that we won't introduce unexpected jars in distribution.