### PR TITLE
Do not output environment variable values to debug log

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -62,7 +62,9 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
             System.setProperty(entry.getKey(), entry.getValue());
         }
 
+        // Log only the variable names and not their values. Environment variables often contain sensitive data that should not be leaked to log files.
         LOGGER.debug("Configuring env variables: {}", build.getParameters().getEnvVariables().keySet());
+
         EnvironmentModificationResult setEnvironmentResult = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
         if(!setEnvironmentResult.isSuccess()) {
             LOGGER.warn("Warning: Unable able to set daemon's environment variables to match the client because: "

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -62,7 +62,7 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
             System.setProperty(entry.getKey(), entry.getValue());
         }
 
-        LOGGER.debug("Configuring env variables: {}", build.getParameters().getEnvVariables());
+        LOGGER.debug("Configuring env variables: {}", build.getParameters().getEnvVariables().keySet());
         EnvironmentModificationResult setEnvironmentResult = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
         if(!setEnvironmentResult.isSuccess()) {
             LOGGER.warn("Warning: Unable able to set daemon's environment variables to match the client because: "


### PR DESCRIPTION
Only output the environment variable names as debugging aid. Environment variables often contain sensitive data/credentials which should not be leaked to the log files.