### PR TITLE
PluginContainer supports id-based plugins if those use injection

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -92,7 +92,8 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
             Plugin<?> plugin = Iterables.tryFind(DefaultPluginContainer.this, new Predicate<Plugin>() {
                 @Override
                 public boolean apply(Plugin plugin) {
-                    return pluginWithId.clazz.equals(plugin.getClass());
+                    Class<?> pluginType = GeneratedSubclasses.unpackType(plugin);
+                    return pluginWithId.clazz.equals(pluginType);
                 }
             }).orNull();
 
@@ -155,8 +156,9 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
             public void execute(final DefaultPluginManager.PluginWithId pluginWithId) {
                 matching(new Spec<Plugin>() {
                     @Override
-                    public boolean isSatisfiedBy(Plugin element) {
-                        return pluginWithId.clazz.equals(element.getClass());
+                    public boolean isSatisfiedBy(Plugin plugin) {
+                        Class<?> pluginType = GeneratedSubclasses.unpackType(plugin);
+                        return pluginWithId.clazz.equals(pluginType);
                     }
                 }).all(action);
             }

--- a/subprojects/core/src/test/groovy/org/gradle/testfixtures/CustomPluginWithInjection.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/testfixtures/CustomPluginWithInjection.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testfixtures
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.internal.reflect.Instantiator
+
+import javax.inject.Inject
+
+
+public class CustomPluginWithInjection implements Plugin<Project> {
+    void apply(Project target) {
+        target.task('hello');
+    }
+
+    @Inject
+    public Instantiator getInstantiator() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/subprojects/core/src/test/resources/META-INF/gradle-plugins/org.gradle.custom-plugin-with-injection.properties
+++ b/subprojects/core/src/test/resources/META-INF/gradle-plugins/org.gradle.custom-plugin-with-injection.properties
@@ -1,0 +1,1 @@
+implementation-class=org.gradle.testfixtures.CustomPluginWithInjection


### PR DESCRIPTION
This is a follow up to support id-based plugins as well. The initial
fix for plugins using injection was added in commit
c584c55f89c81db72140aca5a8a95a5b733fb50a