### PR TITLE
Move ServiceScope and EventScope to :base-annotations

### DIFF
--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/EventScope.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/EventScope.java
@@ -21,16 +21,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Attached to a service interface to indicate in which scope it is defined in.
- * Services are lifecycled with their scope, and stopped/closed when the scope is closed.
+ * Attached to a listener interface to indicate which scope its events are generated in.
  *
- * Services are visible to other services in the same scope and descendent scopes.
- * Services are not visible to services in ancestor scopes.
+ * Events generated in a particular scope are visible to listeners in the same scope and ancestor scopes.
+ * Events are not visible to listeners in descendent scopes.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-public @interface ServiceScope {
-
-    Scopes value();
-
+public @interface EventScope {
+    Class<? extends Scope> value();
 }

--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -16,18 +16,6 @@
 
 package org.gradle.internal.service.scopes;
 
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
-/**
- * Attached to a listener interface to indicate which scope its events are generated in.
- *
- * Events generated in a particular scope are visible to listeners in the same scope and ancestor scopes.
- * Events are not visible to listeners in descendent scopes.
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Inherited
-public @interface EventScope {
-    Scopes value();
+public interface Scope {
+    interface Global extends Scope {}
 }

--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.execution;
+package org.gradle.internal.service.scopes;
 
-import org.gradle.api.internal.TaskInternal;
-import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Attached to a service interface to indicate in which scope it is defined in.
+ * Services are lifecycled with their scope, and stopped/closed when the scope is closed.
+ *
+ * Services are visible to other services in the same scope and descendent scopes.
+ * Services are not visible to services in ancestor scopes.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ServiceScope {
 
-@EventScope(Scopes.Build.class)
-public interface TaskExecutionAccessListener {
+    Class<? extends Scope> value();
 
-    /**
-     * Called when accessing the project during task execution.
-     */
-    void onProjectAccess(String invocationDescription, TaskInternal task);
-
-    /**
-     * Called when accessing task dependencies during task execution.
-     */
-    void onTaskDependenciesAccess(String invocationDescription, TaskInternal task);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationListener.java
@@ -16,7 +16,7 @@
 package org.gradle.internal.operations;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
 /**
  * A listener that is notified as build operations are executed.
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.Scopes;
  *
  * @since 3.5
  */
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface BuildOperationListener {
 
     void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.operations;
 
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
 
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Specialised event emitter for cross cutting type progress events not tied more deeply to operation execution.
  */
-@ServiceScope(Scopes.Global)
+@ServiceScope(Global.class)
 public class BuildOperationProgressEventEmitter {
 
     private final Clock clock;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
@@ -30,7 +30,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 4.0
  */
 @UsedByScanPlugin("obtained from the root build's root project's service registry")
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public interface BuildOperationNotificationListenerRegistrar {
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/scopes/Scopes.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/scopes/Scopes.java
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.service.scopes;
 
-public enum Scopes {
-    Global,
-    UserHome,
-    BuildSession,
-    BuildTree,
-    Build,
-    Gradle
+public interface Scopes {
+    interface UserHome extends Scope.Global {}
+    interface BuildSession extends UserHome {}
+    interface BuildTree extends BuildSession {}
+    interface Build extends BuildTree {}
+    interface Gradle extends Build {}
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -55,7 +55,7 @@ import static org.gradle.internal.resources.DefaultResourceLockCoordinationServi
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
 import static org.gradle.internal.resources.ResourceLockState.Disposition.FINISHED;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class DefaultWorkerLeaseService implements WorkerLeaseService {
     public static final String PROJECT_LOCK_STATS_PROPERTY = "org.gradle.internal.project.lock.stats";
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWorkerLeaseService.class);

--- a/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileListener.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileListener.java
@@ -18,7 +18,7 @@ package org.gradle.profile;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ProfileListener {
     void buildFinished(BuildProfile result);
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -45,7 +45,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.Map;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppable {
     private final IncludedBuildFactory includedBuildFactory;
     private final IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder;

--- a/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.Scopes;
  *
  * @see org.gradle.api.invocation.Gradle#addListener(Object)
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface BuildListener {
     /**
      * <p>Called when the build is started.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/ProjectEvaluationListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ProjectEvaluationListener.java
@@ -23,7 +23,7 @@ import org.gradle.internal.service.scopes.Scopes;
  * ProjectEvaluationListener} to a {@link org.gradle.api.invocation.Gradle} using {@link
  * org.gradle.api.invocation.Gradle#addProjectEvaluationListener(ProjectEvaluationListener)}.</p>
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ProjectEvaluationListener {
     /**
      * This method is called immediately before a project is evaluated.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolutionListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolutionListener.java
@@ -21,7 +21,7 @@ import org.gradle.internal.service.scopes.Scopes;
 /**
  * A {@code DependencyResolutionListener} is notified as dependencies are resolved.
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface DependencyResolutionListener {
     /**
      * This method is called immediately before a set of dependencies are resolved.

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskActionListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskActionListener.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.Scopes;
 /**
  * <p>A {@code TaskActionListener} is notified of the actions that a task performs.</p>
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TaskActionListener {
     /**
      * This method is called immediately before the task starts performing its actions.

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraphListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraphListener.java
@@ -24,7 +24,7 @@ import org.gradle.internal.service.scopes.Scopes;
  * use this interface in your build file to perform some action based on the contents of the graph, before any tasks are
  * actually executed.</p>
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TaskExecutionGraphListener {
     /**
      * <p>This method is called when the {@link TaskExecutionGraph} has been populated, and before any tasks are

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionListener.java
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.Scopes;
  *
  * <p>You can add a {@code TaskExecutionListener} to a build using {@link org.gradle.api.execution.TaskExecutionGraph#addTaskExecutionListener}
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TaskExecutionListener {
     /**
      * This method is called immediately before a task is executed.

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformListener.java
@@ -20,7 +20,7 @@ import org.gradle.api.Describable;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ArtifactTransformListener {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VcsMappingsStore.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VcsMappingsStore.java
@@ -26,7 +26,7 @@ import org.gradle.vcs.VersionControlSpec;
 
 import javax.annotation.Nullable;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public interface VcsMappingsStore {
     VcsResolver asResolver();
 

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskInputsListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskInputsListener.java
@@ -19,12 +19,12 @@ package org.gradle.api.execution.internal;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
 /**
  * Registered via {@link TaskInputsListeners}.
  */
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface TaskInputsListener {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskInputsListeners.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskInputsListeners.java
@@ -18,13 +18,13 @@ package org.gradle.api.execution.internal;
 
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Allows the registration of {@link TaskInputsListener task inputs listeners}.
  */
-@ServiceScope(Scopes.Global)
+@ServiceScope(Global.class)
 public interface TaskInputsListeners {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildScopeListenerRegistrationListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildScopeListenerRegistrationListener.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface BuildScopeListenerRegistrationListener {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class DefaultImmutableAttributesFactory implements ImmutableAttributesFactory {
     private final ImmutableAttributes root;
     private final Map<ImmutableAttributes, List<DefaultImmutableAttributes>> children;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
@@ -28,7 +28,7 @@ import java.io.File;
  *
  * There is no additional logic apart from what is also in {@link FileTimeStampInspector}.
  */
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class BuildSessionScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
     public BuildSessionScopeFileTimeStampInspector(File workDir) {
         super(workDir);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * Discards hashes for all files from the {@link CachingFileHasher} which have been queried on this daemon
  * during the last build and which have a timestamp equal to the end of build timestamp.
  */
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public class GradleUserHomeScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
     private CachingFileHasher fileHasher;
     private final Object lock = new Object();

--- a/subprojects/core/src/main/java/org/gradle/configuration/internal/UserCodeApplicationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/internal/UserCodeApplicationContext.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Assigns and stores an ID for the application of some user code (e.g. scripts and plugins).
  */
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public interface UserCodeApplicationContext {
     /**
      * Applies some user code, assigning an ID for this particular application.

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskListenerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskListenerInternal.java
@@ -21,7 +21,7 @@ import org.gradle.api.tasks.TaskState;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TaskListenerInternal {
     /**
      * This method is called immediately before a task is executed.

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptClassCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptClassCompiler.java
@@ -23,7 +23,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public interface ScriptClassCompiler {
     <T extends Script, M> CompiledScript<T, M> compile(ScriptSource source, ClassLoaderScope targetScope, CompileOperation<M> transformer, Class<T> scriptBaseClass, Action<? super ClassNode> verifier);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildCompletionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildCompletionListener.java
@@ -19,7 +19,7 @@ package org.gradle.initialization;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface BuildCompletionListener {
     /**
      * Called after a build has completed and all its services and domain objects torn down. Implementations should take care to not use any such services.

--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  * @see ClassLoaderScopeRegistry
  * @see org.gradle.api.internal.initialization.ClassLoaderScope
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ClassLoaderScopeRegistryListener {
 
     void rootScopeCreated(ClassLoaderScopeId rootScopeId);

--- a/subprojects/core/src/main/java/org/gradle/initialization/InternalBuildFinishedListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InternalBuildFinishedListener.java
@@ -19,7 +19,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface InternalBuildFinishedListener {
     /**
      * Called after all user buildFinished hooks have been executed, but before

--- a/subprojects/core/src/main/java/org/gradle/initialization/ModelConfigurationListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ModelConfigurationListener.java
@@ -19,7 +19,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ModelConfigurationListener {
     /**
      * Invoked when the model has been configured successfully. This listener should not do any further configuration.

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
@@ -27,7 +27,7 @@ import org.gradle.internal.service.scopes.Scopes;
  *
  * This listener type is available to services from build tree up to global services.
  */
-@EventScope(Scopes.BuildTree)
+@EventScope(Scopes.BuildTree.class)
 public interface RootBuildLifecycleListener {
     /**
      * Called at the start of the root build, immediately after the creation of the root build services.

--- a/subprojects/core/src/main/java/org/gradle/initialization/SessionLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SessionLifecycleListener.java
@@ -24,7 +24,7 @@ import org.gradle.internal.service.scopes.Scopes;
  *
  * One or more builds may be run during a session. For example, when running in continuous mode, multiple builds are run during a single session.
  */
-@EventScope(Scopes.BuildSession)
+@EventScope(Scopes.BuildSession.class)
 public interface SessionLifecycleListener {
     /**
      * Called at the start of the session, immediately after initializing the session services.

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -46,7 +46,7 @@ import java.io.File;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public class BuildSourceBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildSourceBuilder.class);
     private static final BuildBuildSrcBuildOperationType.Result BUILD_BUILDSRC_RESULT = new BuildBuildSrcBuildOperationType.Result() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildAddedListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildAddedListener.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.Scopes;
 /**
  * Listener for changes to the {@link BuildStateRegistry}.
  */
-@EventScope(Scopes.BuildTree)
+@EventScope(Scopes.BuildTree.class)
 public interface BuildAddedListener {
     /**
      * Called every time a build is added to the {@link BuildStateRegistry}.

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CachedClasspathTransformer.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 /**
  * Represents a transformer that takes a given ClassPath and transforms it to a ClassPath with cached jars
  */
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public interface CachedClasspathTransformer {
     enum StandardTransform {
         BuildLogic, None

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -33,7 +33,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
 
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public class ClasspathBuilder {
     private static final int BUFFER_SIZE = 8192;
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathTransformerCacheFactory.java
@@ -23,7 +23,7 @@ import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public interface ClasspathTransformerCacheFactory {
     PersistentCache createCache(CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -36,7 +36,7 @@ import java.util.Comparator;
 /**
  * Allows the classes and resources of a classpath element such as a jar or directory to be visited.
  */
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public class ClasspathWalker {
     private final Stat stat;
 

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/PendingChangesListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/PendingChangesListener.java
@@ -19,7 +19,7 @@ package org.gradle.internal.filewatch;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.BuildSession)
+@EventScope(Scopes.BuildSession.class)
 public interface PendingChangesListener {
     void onPendingChanges();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
@@ -22,7 +22,7 @@ import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class AbsolutePathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
     public AbsolutePathFileCollectionFingerprinter(FileCollectionSnapshotter fileCollectionSnapshotter) {

--- a/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultChecksumService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultChecksumService.java
@@ -25,7 +25,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class DefaultChecksumService implements ChecksumService {
     private final CachingFileHasher md5;
     private final CachingFileHasher sha1;

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/JavaModuleDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/JavaModuleDetector.java
@@ -34,7 +34,7 @@ import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 
-@ServiceScope(Scopes.UserHome)
+@ServiceScope(Scopes.UserHome.class)
 public class JavaModuleDetector {
 
     private final Spec<? super File> classpathFilter = this::isNotModule;

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class DefaultBuildOperationExecutor implements BuildOperationExecutor, Stoppable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBuildOperationExecutor.class);
     private static final String LINE_SEPARATOR = SystemProperties.getInstance().getLineSeparator();

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class BuildOperationNotificationBridge implements BuildOperationNotificationListenerRegistrar {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildOperationNotificationBridge.class);

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptExecutionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptExecutionListener.java
@@ -19,7 +19,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ScriptExecutionListener {
     void onScriptClassLoaded(ScriptSource source, Class<?> scriptClass);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
@@ -48,6 +48,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.internal.remote.services.MessagingServices;
 import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.ExecHandleFactory;
@@ -118,7 +119,7 @@ public class BasicGlobalScopeServices {
     }
 
     ListenerManager createListenerManager() {
-        return new DefaultListenerManager(Scopes.Global);
+        return new DefaultListenerManager(Global.class);
     }
 }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -279,7 +279,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
     }
 
     protected ListenerManager createListenerManager(ListenerManager listenerManager) {
-        return listenerManager.createChild(Scopes.Build);
+        return listenerManager.createChild(Scopes.Build.class);
     }
 
     protected ClassPathRegistry createClassPathRegistry() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -113,7 +113,7 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     }
 
     ListenerManager createListenerManager(ListenerManager parent) {
-        return parent.createChild(Scopes.BuildSession);
+        return parent.createChild(Scopes.BuildSession.class);
     }
 
     CrossProjectConfigurator createCrossProjectConfigurator(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildTreeScopeServices.java
@@ -46,7 +46,7 @@ public class BuildTreeScopeServices extends DefaultServiceRegistry {
     }
 
     protected ListenerManager createListenerManager(ListenerManager parent) {
-        return parent.createChild(Scopes.BuildTree);
+        return parent.createChild(Scopes.BuildTree.class);
     }
 
     protected ExceptionAnalyser createExceptionAnalyser(ListenerManager listenerManager, LoggingConfiguration loggingConfiguration) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -105,7 +105,7 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
     }
 
     ListenerManager createListenerManager(ListenerManager parent) {
-        return parent.createChild(Scopes.UserHome);
+        return parent.createChild(Scopes.UserHome.class);
     }
 
     GradleUserHomeScopeFileTimeStampInspector createFileTimestampInspector(CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager) {

--- a/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
@@ -29,7 +29,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class RoutingVirtualFileSystem implements VirtualFileSystem {
     private final GlobalCacheLocations globalCacheLocations;
     private final VirtualFileSystem gradleUserHomeVirtualFileSystem;

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
@@ -25,7 +25,7 @@ import org.gradle.plugin.management.internal.PluginRequests;
 
 import javax.annotation.Nullable;
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public interface PluginRequestApplicator {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -94,7 +94,8 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider, Closea
             "gradle-files",
             "gradle-file-collections",
             "gradle-hashing",
-            "gradle-snapshots"
+            "gradle-snapshots",
+            "gradle-base-annotations"
     };
 
     public static final String[] RUNTIME_EXTERNAL_MODULES = new String[] {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -31,7 +31,7 @@ import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.process.internal.worker.RequestHandler;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 import org.gradle.process.internal.worker.child.WorkerLogEventListener;
@@ -62,7 +62,7 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
         try {
             ServiceRegistry parentServices = workerProcessContext.getServiceRegistry();
             if (instantiatorFactory == null) {
-                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager(Scopes.Global)), Collections.emptyList(), new OutputPropertyRoleAnnotationHandler(Collections.emptyList()));
+                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager(Global.class)), Collections.emptyList(), new OutputPropertyRoleAnnotationHandler(Collections.emptyList()));
             }
             DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry("worker-action-services", parentServices);
             // Make the argument serializers available so work implementations can register their own serializers

--- a/subprojects/core/src/main/java/org/gradle/util/BuildCommencedTimeProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/util/BuildCommencedTimeProvider.java
@@ -19,7 +19,7 @@ import org.gradle.StartParameter;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildSession)
+@ServiceScope(Scopes.BuildSession.class)
 public class BuildCommencedTimeProvider {
     private final long fixedTime;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
@@ -17,10 +17,10 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.Global)
+@ServiceScope(Global.class)
 public interface ImmutableModuleIdentifierFactory {
     ModuleIdentifier module(String group, String name);
     ModuleVersionIdentifier moduleWithVersion(String group, String name, String version);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ChangingValueDependencyResolutionListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ChangingValueDependencyResolutionListener.java
@@ -25,7 +25,7 @@ import org.gradle.internal.service.scopes.Scopes;
 /**
  * Notified of the use of changing values during dependency resolution, so this can be noted in the configuration cache inputs
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface ChangingValueDependencyResolutionListener {
     ChangingValueDependencyResolutionListener NO_OP = new ChangingValueDependencyResolutionListener() {
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * A service that will resolve a ProjectDependency into publication coordinates, to use for publishing.
  * For now is a simple implementation, but at some point could utilise components in the dependency project, usage in the referencing project, etc.
  */
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public class DefaultProjectDependencyPublicationResolver implements ProjectDependencyPublicationResolver {
     private final ProjectPublicationRegistry publicationRegistry;
     private final ProjectConfigurer projectConfigurer;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
@@ -28,7 +28,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprisePluginBuildState {
 
     private final Clock clock;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
@@ -23,7 +23,7 @@ import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePluginConfig {
 
     private final BuildScanRequest buildScanRequest;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginRequiredServices.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginRequiredServices.java
@@ -22,7 +22,7 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginRequiredServices implements GradleEnterprisePluginRequiredServices {
 
     private final UserInputHandler userInputHandler;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginServiceRef.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginServiceRef.java
@@ -21,7 +21,7 @@ import org.gradle.internal.enterprise.GradleEnterprisePluginServiceRef;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginServiceRef implements GradleEnterprisePluginServiceRef {
 
     private GradleEnterprisePluginService service;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
@@ -19,7 +19,7 @@ package org.gradle.internal.execution;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface OutputChangeListener {
     /**
      * Invoked when the outputs of a work item are about to change.

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -89,7 +89,7 @@ class BuildServicesProvider {
 }
 
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree::class)
 class BuildTreeListenerManager(
     val service: ListenerManager
 )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/RelevantProjectsRegistry.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/RelevantProjectsRegistry.kt
@@ -23,7 +23,7 @@ import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
 
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build::class)
 class RelevantProjectsRegistry : ProjectAccessHandler {
     private
     val targetProjects = mutableSetOf<ProjectInternal>()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/UndeclaredBuildInputListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/UndeclaredBuildInputListener.kt
@@ -20,7 +20,7 @@ import org.gradle.internal.service.scopes.EventScope
 import org.gradle.internal.service.scopes.Scopes
 
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build::class)
 interface UndeclaredBuildInputListener {
     /**
      * Called when an undeclared system property read happens for a system property with no value.

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionCacheFingerprintController.kt
@@ -44,7 +44,7 @@ import java.io.OutputStream
 /**
  * Coordinates the writing and reading of the instant execution cache fingerprint.
  */
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build::class)
 internal
 class InstantExecutionCacheFingerprintController internal constructor(
     private val startParameter: InstantExecutionStartParameter,

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionProblemsListener.kt
@@ -35,7 +35,7 @@ import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
 
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build::class)
 interface InstantExecutionProblemsListener : TaskExecutionAccessListener, BuildScopeListenerRegistrationListener
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.ServiceScope
 import java.io.File
 
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree::class)
 class InstantExecutionStartParameter(
     private val buildLayout: BuildLayout,
     startParameter: StartParameter

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/InstantExecutionProblems.kt
@@ -41,7 +41,7 @@ private
 const val maxCauses = 5
 
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree::class)
 class InstantExecutionProblems(
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/problems/ProblemsListener.kt
@@ -20,7 +20,7 @@ import org.gradle.internal.service.scopes.EventScope
 import org.gradle.internal.service.scopes.Scopes
 
 
-@EventScope(Scopes.BuildTree)
+@EventScope(Scopes.BuildTree::class)
 interface ProblemsListener {
 
     fun onProblem(problem: PropertyProblem)

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultCompilationStateCacheFactory.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultCompilationStateCacheFactory.java
@@ -31,7 +31,7 @@ import java.io.Closeable;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
-@ServiceScope(Scopes.Gradle)
+@ServiceScope(Scopes.Gradle.class)
 public class DefaultCompilationStateCacheFactory implements CompilationStateCacheFactory, Closeable {
 
     private final PersistentIndexedCache<String, CompilationState> compilationStateIndexedCache;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStartListener.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStartListener.java
@@ -17,13 +17,13 @@
 package org.gradle.launcher.daemon.client;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.launcher.daemon.context.DaemonConnectDetails;
 
 /**
  * Notified when a daemon is started.
  */
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface DaemonStartListener {
     void daemonStarted(DaemonConnectDetails daemonInfo);
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/DaemonExpirationListener.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/DaemonExpirationListener.java
@@ -17,13 +17,13 @@
 package org.gradle.launcher.daemon.server.expiry;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
 /**
  * Represents an event where a daemon expiration condition was detected and the daemon
  * should now stop.
  */
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface DaemonExpirationListener {
     /**
      * Will be fired when the daemon expiration event occurs.

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
@@ -58,7 +58,7 @@ public class SessionFailureReportingActionExecuter implements BuildActionExecute
             // TODO - wire this stuff in properly
 
             // Sanitise the exception and report it
-            ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(new DefaultExceptionAnalyser(new DefaultListenerManager(Scopes.BuildSession)));
+            ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(new DefaultExceptionAnalyser(new DefaultListenerManager(Scopes.BuildSession.class)));
             if (action.getStartParameter().getShowStacktrace() != ShowStacktrace.ALWAYS_FULL) {
                 exceptionAnalyser = new StackTraceSanitizingExceptionAnalyser(exceptionAnalyser);
             }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.BuildResult
 import org.gradle.api.Action
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.launcher.daemon.registry.DaemonRegistry
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationListener
@@ -84,7 +85,7 @@ class DefaultDaemonScanInfoSpec extends ConcurrentSpec {
     }
 
     def "should not deadlock with daemon scan info"() {
-        def manager = new DefaultListenerManager(Scopes.Global)
+        def manager = new DefaultListenerManager(Scope.Global)
         def daemonScanInfo = new DefaultDaemonScanInfo(new DaemonRunningStats(), 1000, false, Mock(DaemonRegistry), manager)
         daemonScanInfo.notifyOnUnhealthy {
             println "Hello"

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.filewatch.FileSystemChangeWaiterFactory
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.time.Clock
 import org.gradle.internal.time.Time
@@ -59,7 +60,7 @@ class ContinuousBuildActionExecuterTest extends ConcurrentSpec {
     def actionParameters = Stub(BuildActionParameters)
     def waiterFactory = Mock(FileSystemChangeWaiterFactory)
     def waiter = Mock(FileSystemChangeWaiter)
-    def listenerManager = new DefaultListenerManager(Scopes.Global)
+    def listenerManager = new DefaultListenerManager(Scope.Global)
     def inputsListeners = new DefaultTaskInputsListeners(listenerManager)
     def buildSessionScopeServices = Stub(ServiceRegistry)
     def deploymentRegistry = Mock(DeploymentRegistryInternal)

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressListener.java
@@ -20,9 +20,9 @@ import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface ProgressListener {
     void started(ProgressStartEvent event);
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -22,7 +22,7 @@ import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
 import org.gradle.internal.dispatch.ReflectionDispatch;
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,14 +41,14 @@ public class DefaultListenerManager implements ListenerManager {
     private final Map<Object, ListenerDetails> allLoggers = new LinkedHashMap<Object, ListenerDetails>();
     private final Map<Class<?>, EventBroadcast<?>> broadcasters = new ConcurrentHashMap<Class<?>, EventBroadcast<?>>();
     private final Object lock = new Object();
-    private final Scopes scope;
+    private final Class<? extends Scope> scope;
     private final DefaultListenerManager parent;
 
-    public DefaultListenerManager(Scopes scope) {
+    public DefaultListenerManager(Class<? extends Scope> scope) {
         this(scope, null);
     }
 
-    private DefaultListenerManager(Scopes scope, DefaultListenerManager parent) {
+    private DefaultListenerManager(Class<? extends Scope> scope, DefaultListenerManager parent) {
         this.scope = scope;
         this.parent = parent;
     }
@@ -138,12 +138,12 @@ public class DefaultListenerManager implements ListenerManager {
             throw new IllegalArgumentException(String.format("Listener type %s is not annotated with @EventScope.", listenerClass.getName()));
         }
         if (!scope.value().equals(this.scope)) {
-            throw new IllegalArgumentException(String.format("Listener type %s with scope %s cannot be used to generate events in scope %s.", listenerClass.getName(), scope.value(), this.scope));
+            throw new IllegalArgumentException(String.format("Listener type %s with scope %s cannot be used to generate events in scope %s.", listenerClass.getName(), scope.value().getSimpleName(), this.scope.getSimpleName()));
         }
     }
 
     @Override
-    public ListenerManager createChild(Scopes scope) {
+    public ListenerManager createChild(Class<? extends Scope> scope) {
         return new DefaultListenerManager(scope, this);
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.event;
 
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope;
 
 /**
  * Unified manager for all Gradle events.  Provides a simple way to find all listeners of a given type in the
@@ -112,5 +112,5 @@ public interface ListenerManager {
      *
      * @return The child
      */
-    ListenerManager createChild(Scopes scope);
+    ListenerManager createChild(Class<? extends Scope> scope);
 }

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.event
 
 import com.google.common.reflect.ClassPath
 import org.gradle.internal.service.scopes.EventScope
+import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import spock.lang.Ignore
@@ -976,32 +977,32 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         manager.hasListeners(TestBarListener)
     }
 
-    @EventScope(Scopes.BuildTree)
+    @EventScope(Scopes.BuildTree.class)
     interface TestFooListener {
         void foo(String param);
     }
 
-    @EventScope(Scopes.Build)
+    @EventScope(Scopes.Build.class)
     interface BuildScopeListener {
         void foo(String param);
     }
 
-    @EventScope(Scopes.BuildTree)
+    @EventScope(Scopes.BuildTree.class)
     interface TestBarListener {
         void bar(int value);
     }
 
-    @EventScope(Scopes.BuildTree)
+    @EventScope(Scopes.BuildTree.class)
     interface BothListener extends TestFooListener, TestBarListener {
     }
 
-    @EventScope(Scopes.BuildTree)
+    @EventScope(Scopes.BuildTree.class)
     interface TestBazListener {
         void baz()
     }
 
-    @EventScope(Scopes.Global)
-    public interface TestListenerWithWrongScope {
+    @EventScope(Scope.Global)
+    interface TestListenerWithWrongScope {
         void foo(String param);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  *
  * @since 6.1
  */
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public interface ValueSourceProviderFactory {
 
     <T, P extends ValueSourceParameters> Provider<T> createProviderOf(
@@ -53,7 +53,7 @@ public interface ValueSourceProviderFactory {
         @Nullable P parameters
     );
 
-    @EventScope(Scopes.Build)
+    @EventScope(Scopes.Build.class)
     interface Listener {
 
         <T, P extends ValueSourceParameters> void valueObtained(

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -16,7 +16,7 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * All other values are referenced only by weak or soft references, allowing them to be collected.
  */
 @ThreadSafe
-@ServiceScope(Scopes.Global)
+@ServiceScope(Global.class)
 public interface CrossBuildInMemoryCacheFactory {
     /**
      * Creates a new cache instance. Keys are always referenced using strong references, values by strong or soft references depending on their usage.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
@@ -40,7 +40,7 @@ import java.io.FileNotFoundException;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry {
     private final JavaInstallationProbe installationProbe;
     private final ProviderFactory providerFactory;

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
@@ -40,7 +40,7 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 
 import javax.annotation.Nullable;
@@ -67,7 +67,7 @@ public class PropertyValidationAccess {
         builder.provider(new Object() {
             @SuppressWarnings("unused")
             void configure(ServiceRegistration registration) {
-                registration.add(ListenerManager.class, new DefaultListenerManager(Scopes.Global));
+                registration.add(ListenerManager.class, new DefaultListenerManager(Global.class));
                 registration.add(DefaultCrossBuildInMemoryCacheFactory.class);
                 // TODO: do we need any factories here?
                 registration.add(DefaultManagedFactoryRegistry.class, new DefaultManagedFactoryRegistry());

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathInstrumentationStrategy.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/InjectedClasspathInstrumentationStrategy.java
@@ -20,7 +20,7 @@ import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildTree)
+@ServiceScope(Scopes.BuildTree.class)
 public interface InjectedClasspathInstrumentationStrategy {
     CachedClasspathTransformer.StandardTransform getTransform();
 }

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/JvmMemoryStatusListener.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/JvmMemoryStatusListener.java
@@ -17,9 +17,9 @@
 package org.gradle.process.internal.health.memory;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface JvmMemoryStatusListener {
     void onJvmMemoryStatus(JvmMemoryStatus jvmMemoryStatus);
 }

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/OsMemoryStatusListener.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/OsMemoryStatusListener.java
@@ -17,9 +17,9 @@
 package org.gradle.process.internal.health.memory;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 
-@EventScope(Scopes.Global)
+@EventScope(Global.class)
 public interface OsMemoryStatusListener {
     void onOsMemoryStatus(OsMemoryStatus osMemoryStatus);
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/TextFileResourceLoader.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/TextFileResourceLoader.java
@@ -21,7 +21,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import javax.annotation.Nullable;
 import java.io.File;
 
-@ServiceScope(Scopes.Build)
+@ServiceScope(Scopes.Build.class)
 public interface TextFileResourceLoader {
     TextResource loadFile(String description, @Nullable File sourceFile);
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileResourceListener.java
@@ -21,7 +21,7 @@ import org.gradle.internal.service.scopes.Scopes;
 
 import java.io.File;
 
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface FileResourceListener {
     /**
      * Called when a file system resource is accessed.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestListenerInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestListenerInternal.java
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
 @UsedByScanPlugin
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TestListenerInternal {
     void started(TestDescriptorInternal testDescriptor, TestStartEvent startEvent);
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestListener.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestListener.java
@@ -28,7 +28,7 @@ import org.gradle.internal.service.scopes.Scopes;
  * framework agnostic.  Currently this interface can support feedback
  * from JUnit and TestNG tests.
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TestListener {
     /**
      * Called before a test suite is started.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestOutputListener.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestOutputListener.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.Scopes;
 /**
  * Listens to the output events like printing to standard output or error
  */
-@EventScope(Scopes.Build)
+@EventScope(Scopes.Build.class)
 public interface TestOutputListener {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/SynchronizedLogging.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/SynchronizedLogging.java
@@ -22,7 +22,7 @@ import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
 import org.gradle.internal.logging.progress.ProgressListener;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationIdFactory;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.time.Clock;
 
 /**
@@ -51,7 +51,7 @@ public class SynchronizedLogging implements LoggingProvider {
     private ThreadLoggingServices services() {
         ThreadLoggingServices threadServices = services.get();
         if (threadServices == null) {
-            DefaultListenerManager manager = new DefaultListenerManager(Scopes.Global);
+            DefaultListenerManager manager = new DefaultListenerManager(Global.class);
             DefaultProgressLoggerFactory progressLoggerFactory = new DefaultProgressLoggerFactory(manager.getBroadcaster(ProgressListener.class), clock, buildOperationIdFactory);
             threadServices = new ThreadLoggingServices(manager, progressLoggerFactory);
             services.set(threadServices);

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -38,7 +38,7 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.InputStreamBackedDecoder;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.process.internal.health.memory.DefaultJvmMemoryInfo;
 import org.gradle.process.internal.health.memory.DefaultMemoryManager;
 import org.gradle.process.internal.health.memory.DisabledOsMemoryInfo;
@@ -225,7 +225,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         }
 
         ListenerManager createListenerManager() {
-            return new DefaultListenerManager(Scopes.Global);
+            return new DefaultListenerManager(Global.class);
         }
 
         OsMemoryInfo createOsMemoryInfo() {


### PR DESCRIPTION
Here we are sharing the concept of event and service scopes by making scopes themselves extensible. This is achieved by replacing the single enum with types. The scope types inherit each other, representing the inheritance between scopes.

This is a pre-requisite to merging #13935.