### PR TITLE
Protect ProgressLogEventGenerator#onComplete() against NPEs

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
@@ -70,8 +70,13 @@ public class ProgressLogEventGenerator implements OutputEventListener {
     }
 
     private void onComplete(ProgressCompleteEvent progressCompleteEvent) {
-        assert !operations.isEmpty();
+        if (operations.isEmpty()) {
+            return;
+        }
         Operation operation = operations.remove(progressCompleteEvent.getProgressOperationId());
+        if (operation == null) {
+            return;
+        }
         completeOperation(progressCompleteEvent, operation);
     }
 


### PR DESCRIPTION
Hi,

we're currently facing a lot of issues around `ProgressLogEventGenerator#onComplete()` that randomly throws NPEs which seem to only happen when we're running tasks in parallel.

While I couldn't find the root-cause of this randomness, this PR fixes at least the symptomatic NPEs. With this we would able to run in parallel instead of getting major slowdowns in our build times by running tasks sequentially, so I hope this PR is considered in order to fix #13830 .

Cheers,
Christoph