### PR TITLE
Expose "What is Gradle?" section in user manual ToC

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -115,8 +115,8 @@
             </div>
         </div>
         <ul>
-            <li><a href="../userguide/getting_started.html">Getting Started</a></li>
             <li><a href="../userguide/what_is_gradle.html">What is Gradle?</a></li>
+            <li><a href="../userguide/getting_started.html">Getting Started</a></li>
             <li><a href="../userguide/installation.html">Installing Gradle</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle...</a>
                 <ul id="upgrading-gradle">

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -116,6 +116,7 @@
         </div>
         <ul>
             <li><a href="../userguide/getting_started.html">Getting Started</a></li>
+            <li><a href="../userguide/what_is_gradle.html">What is Gradle?</a></li>
             <li><a href="../userguide/installation.html">Installing Gradle</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle...</a>
                 <ul id="upgrading-gradle">


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/what_is_gradle.html#what_is_gradle section is currently reachable via links in https://docs.gradle.org/current/userguide/getting_started.html section but not directly via table of contents.

"Getting Started" section firstly suggests reading "What is Gradle?". I think it is natural to expose and move the "What is Gradle?" above the "Getting Started" section.