### PR TITLE
Propagate sdkman candidates directory to tests

### DIFF
--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -41,6 +41,7 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by Gradle test infrastructure
     "REPO_MIRROR_URL",
+    "SDKMAN_CANDIDATES_DIR",
 
     // temp dir
     "TMPDIR",

--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -41,6 +41,8 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by Gradle test infrastructure
     "REPO_MIRROR_URL",
+    
+    // Used to find local java installations
     "SDKMAN_CANDIDATES_DIR",
 
     // temp dir

--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -41,7 +41,7 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by Gradle test infrastructure
     "REPO_MIRROR_URL",
-    
+
     // Used to find local java installations
     "SDKMAN_CANDIDATES_DIR",
 


### PR DESCRIPTION
This is required in order to let AvailableJavaHomes pick up sdkman
java installations.
