### PR TITLE
Fixed worker leaking its classpath to compilation classpath in ZincSc…

### DIFF
--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFacade.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFacade.java
@@ -33,17 +33,22 @@ public class ZincScalaCompilerFacade implements Compiler<ScalaJavaJointCompileSp
 
     private final HashedClasspath scalaClasspath;
 
+    private final boolean leakCompilerClasspath;
+
+
     @Inject
-    public ZincScalaCompilerFacade(CacheFactory cacheFactory, GradleUserHomeDirProvider gradleUserHomeDirProvider, HashedClasspath scalaClasspath) {
+    public ZincScalaCompilerFacade(CacheFactory cacheFactory, GradleUserHomeDirProvider gradleUserHomeDirProvider, HashedClasspath scalaClasspath, @Deprecated boolean leakCompilerClasspath) {
         // TODO: This should be injectable
+        // TODO: remove leakCompilerClasspath when ScalaLanguagePlugin is removed
         DefaultCacheScopeMapping cacheScopeMapping = new DefaultCacheScopeMapping(
                 gradleUserHomeDirProvider.getGradleUserHomeDirectory(), null, GradleVersion.current());
         this.cacheRepository = new DefaultCacheRepository(cacheScopeMapping, cacheFactory);
         this.scalaClasspath = scalaClasspath;
+        this.leakCompilerClasspath = leakCompilerClasspath;
     }
 
     @Override
     public WorkResult execute(ScalaJavaJointCompileSpec spec) {
-        return ZincScalaCompilerFactory.getCompiler(cacheRepository, scalaClasspath).execute(spec);
+        return ZincScalaCompilerFactory.getCompiler(cacheRepository, scalaClasspath, leakCompilerClasspath).execute(spec);
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -87,7 +87,7 @@ public class ZincScalaCompilerFactory {
         }
     }
 
-    static ZincScalaCompiler getCompiler(CacheRepository cacheRepository, HashedClasspath hashedScalaClasspath) {
+    static ZincScalaCompiler getCompiler(CacheRepository cacheRepository, HashedClasspath hashedScalaClasspath, boolean leakCompilerClasspath) {
         ScalaInstance scalaInstance = getScalaInstance(hashedScalaClasspath);
         String zincVersion = ZincCompilerUtil.class.getPackage().getImplementationVersion();
         String scalaVersion = scalaInstance.actualVersion();
@@ -105,12 +105,12 @@ public class ZincScalaCompilerFactory {
         ScalaCompiler scalaCompiler = new AnalyzingCompiler(
             scalaInstance,
             ZincUtil.constantBridgeProvider(scalaInstance, bridgeJar),
-            ClasspathOptionsUtil.auto(),
+            ClasspathOptionsUtil.manual(),
             k -> scala.runtime.BoxedUnit.UNIT,
             Option.apply(COMPILER_CLASSLOADER_CACHE)
         );
 
-        return new ZincScalaCompiler(scalaInstance, scalaCompiler, new AnalysisStoreProvider());
+        return new ZincScalaCompiler(scalaInstance, scalaCompiler, new AnalysisStoreProvider(), leakCompilerClasspath);
     }
 
     private static ClassLoader getClassLoader(ClassPath classpath) {

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/internal/toolchain/DefaultScalaToolProvider.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/internal/toolchain/DefaultScalaToolProvider.java
@@ -65,7 +65,7 @@ public class DefaultScalaToolProvider implements ToolProvider {
                     new DaemonScalaCompiler<ScalaJavaJointCompileSpec>(
                             daemonWorkingDir,
                             ZincScalaCompilerFacade.class,
-                            new Object[]{resolvedScalaClasspath},
+                            new Object[]{resolvedScalaClasspath, true},
                             workerDaemonFactory,
                             resolvedZincClasspath,
                             forkOptionsFactory,

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/PlatformScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/PlatformScalaCompile.java
@@ -17,8 +17,8 @@
 package org.gradle.language.scala.tasks;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Nested;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.CompilerUtil;

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompilerFactory.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompilerFactory.java
@@ -66,7 +66,7 @@ public class ScalaCompilerFactory implements CompilerFactory<ScalaJavaJointCompi
 
         // currently, we leave it to ZincScalaCompiler to also compile the Java code
         Compiler<ScalaJavaJointCompileSpec> scalaCompiler = new DaemonScalaCompiler<ScalaJavaJointCompileSpec>(
-            daemonWorkingDir, ZincScalaCompilerFacade.class, new Object[] {hashedScalaClasspath},
+            daemonWorkingDir, ZincScalaCompilerFacade.class, new Object[] {hashedScalaClasspath, false},
             workerDaemonFactory, zincClasspathFiles, forkOptionsFactory, classPathRegistry, classLoaderRegistry, actionExecutionSpecFactory);
         return new NormalizingScalaCompiler(scalaCompiler);
     }


### PR DESCRIPTION
Signed-off-by: Sheliak Lyr <sheliak.lyr@gmail.com>

<!--- The issue this PR addresses -->
Fixes #13535 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See related issue. When using scala plugin classpath for the worker (compilation process) is incorrectly added to the classpath of the compiled module/sourceSet. Worst case scenario: the compiled program throws ClassNotFound exceptions or other, more subtle exceptions (caused by misaligned versions etc.)

This PR fixes the issue, but only for the `scala` plugin. Deprecated `scala-lang` plugin is left as-is. That's because:
- I doubt that anyone uses `scala-lang`
- It is going to be removed in Gradle 7.0
- All tests in `scala-lang` fail when the fix is applied. I understand why this happens, but do not see any simple method to fix this. More complex solutions are not worth it when we consider the future if this plugin.

To support the previous behavior in `scala-lang` I left a simple switch (`leakCompilerClasspath`) in the code. To be removed in Gradle 7.

Obviously, the fix **may cause the current projects to stop compiling**. This will happen if some project uses undeclared dependencies that happen to be used by the worker process (like scala-xml in related issue). In that case, the project must be fixed by adding the required dependencies to a proper section in the build file.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
