### PR TITLE
Ensure test-retry-plugin usages are visible in gradle

### DIFF
--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * Documents that the type or method is referenced by the build scan plugin,
  * and therefore changes need to be carefully managed. Other plugins like the
- * test-retry-plugin or the test-distribution-plugin clarify their usage in the {@code value}
+ * test-retry or the test-distribution plugin clarify their usage in the {@link #value}.
  * property.
  *
  * @since 4.0

--- a/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
+++ b/subprojects/base-annotations/src/main/java/org/gradle/internal/scan/UsedByScanPlugin.java
@@ -23,7 +23,9 @@ import java.lang.annotation.Target;
 
 /**
  * Documents that the type or method is referenced by the build scan plugin,
- * and therefore changes need to be carefully managed.
+ * and therefore changes need to be carefully managed. Other plugins like the
+ * test-retry-plugin or the test-distribution-plugin clarify their usage in the {@code value}
+ * property.
  *
  * @since 4.0
  */

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/Instantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/Instantiator.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.reflect;
 
 import org.gradle.api.reflect.ObjectInstantiationException;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * An object that can create new instances of various types. An {@code Instantiator}, depending on its implementation and configuration, may provide
@@ -34,6 +35,7 @@ import org.gradle.api.reflect.ObjectInstantiationException;
  *
  * <p>A service of this type is available in all scopes. However, the recommended way to receive an {@code Instantiator} is via a {@link org.gradle.internal.instantiation.InstantiatorFactory}.</p>
  */
+@UsedByScanPlugin("test-retry")
 public interface Instantiator {
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
@@ -36,7 +36,7 @@ public interface ServiceRegistry extends ServiceLookup {
      * @throws UnknownServiceException When there is no service of the given type available.
      * @throws ServiceLookupException On failure to lookup the specified service.
      */
-    @UsedByScanPlugin
+    @UsedByScanPlugin //and test-retry-plugin
     <T> T get(Class<T> serviceType) throws UnknownServiceException, ServiceLookupException;
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
@@ -36,7 +36,7 @@ public interface ServiceRegistry extends ServiceLookup {
      * @throws UnknownServiceException When there is no service of the given type available.
      * @throws ServiceLookupException On failure to lookup the specified service.
      */
-    @UsedByScanPlugin //and test-retry-plugin
+    @UsedByScanPlugin("scan, test-retry")
     <T> T get(Class<T> serviceType) throws UnknownServiceException, ServiceLookupException;
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
@@ -19,10 +19,12 @@ package org.gradle.api.internal.initialization.loadercache;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.function.Function;
 
+@UsedByScanPlugin("test-retry")
 public interface ClassLoaderCache {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -45,7 +45,7 @@ import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 
-@UsedByScanPlugin
+@UsedByScanPlugin //and test-retry-plugin
 public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptServices, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced
@@ -85,7 +85,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     DynamicObject getInheritedScope();
 
     @Override
-    @UsedByScanPlugin("test-distribution")
+    @UsedByScanPlugin("test-distribution, test-retry")
     GradleInternal getGradle();
 
     ProjectEvaluationListener getProjectEvaluationBroadcaster();
@@ -96,7 +96,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     FileResolver getFileResolver();
 
-    @UsedByScanPlugin
+    @UsedByScanPlugin //and test-retry-plugin
     ServiceRegistry getServices();
 
     ServiceRegistryFactory getServiceRegistryFactory();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -45,7 +45,7 @@ import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 
-@UsedByScanPlugin //and test-retry-plugin
+@UsedByScanPlugin("scan, test-retry")
 public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptServices, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced
@@ -96,7 +96,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     FileResolver getFileResolver();
 
-    @UsedByScanPlugin //and test-retry-plugin
+    @UsedByScanPlugin("scan, test-retry")
     ServiceRegistry getServices();
 
     ServiceRegistryFactory getServiceRegistryFactory();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
@@ -22,7 +22,7 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 /**
  * A processor for test results. Implementations are not required to be thread-safe.
  */
-@UsedByScanPlugin("test-distribution")
+@UsedByScanPlugin("test-distribution, test-retry")
 public interface TestResultProcessor {
     /**
      * Notifies this processor that a test has started execution.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-@UsedByScanPlugin("test-distribution")
+@UsedByScanPlugin("test-distribution, test-retry")
 public class DefaultTestFilter implements TestFilter {
 
     private final Set<String> includeTestNames = new HashSet<String>();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.testing;
 
 import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 
@@ -49,6 +50,7 @@ public interface TestDescriptor {
      * @return The class name. May return null.
      */
     @Nullable
+    @UsedByScanPlugin("test-retry")
     String getClassName();
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
-@UsedByScanPlugin("test-distribution")
+@UsedByScanPlugin("test-distribution, test-retry")
 public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final TestFramework testFramework;
     private final Iterable<? extends File> classpath;
@@ -41,13 +41,12 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final int maxParallelForks;
     private final Set<String> previousFailedTestClasses;
 
-    /**
-     * Required by test-retry-gradle-plugin <= 1.1.3
-     */
+    @UsedByScanPlugin("test-retry <= 1.1.3")
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
         this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
     }
 
+    @UsedByScanPlugin("test-retry")
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
         this.testFramework = testFramework;
         this.classpath = classpath;
@@ -86,6 +85,7 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         return scanForTestClasses;
     }
 
+    @UsedByScanPlugin("test-retry")
     public FileCollection getTestClassesDirs() {
         return testClassesDirs;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
@@ -19,10 +19,12 @@ package org.gradle.api.internal.tasks.testing;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.detection.TestFrameworkDetector;
 import org.gradle.api.tasks.testing.TestFrameworkOptions;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
 import java.util.List;
 
+@UsedByScanPlugin("test-retry")
 public interface TestFramework {
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -30,10 +30,12 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.junit.JUnitOptions;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
+@UsedByScanPlugin("test-retry")
 public class JUnitTestFramework implements TestFramework {
     private JUnitOptions options;
     private final JUnitDetector detector;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -29,6 +29,7 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
@@ -38,6 +39,7 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.List;
 
+@UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
     private final JUnitPlatformOptions options;
     private final DefaultTestFilter filter;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.testing.testng.TestNGOptions;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+@UsedByScanPlugin("test-retry")
 public class TestNGTestFramework implements TestFramework {
     private final TestNGOptions options;
     private final TestNGDetector detector;
@@ -54,6 +56,7 @@ public class TestNGTestFramework implements TestFramework {
     private final Factory<File> testTaskTemporaryDir;
     private transient ClassLoader testClassLoader;
 
+    @UsedByScanPlugin("test-retry")
     public TestNGTestFramework(final Test testTask, FileCollection classpath, DefaultTestFilter filter, ObjectFactory objects) {
         this.filter = filter;
         this.objects = objects;


### PR DESCRIPTION
The internal gradle api usages of the test-retry-plugin should be visible to gradle, so that api changes are considered carefully.  