### PR TITLE
Handle PlaceholderAssertionError in ShortExceptionFormatter

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatter.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.testing.logging;
 import com.google.common.base.Strings;
 import org.gradle.api.tasks.testing.TestDescriptor;
 import org.gradle.api.tasks.testing.logging.TestLogging;
-import org.gradle.internal.serialize.PlaceholderException;
+import org.gradle.internal.serialize.PlaceholderExceptionSupport;
 
 import java.util.List;
 
@@ -47,8 +47,8 @@ public class ShortExceptionFormatter implements TestExceptionFormatter {
         if (cause) {
             builder.append("Caused by: ");
         }
-        String className = exception instanceof PlaceholderException
-                ? ((PlaceholderException) exception).getExceptionClassName() : exception.getClass().getName();
+        String className = exception instanceof PlaceholderExceptionSupport
+                ? ((PlaceholderExceptionSupport) exception).getExceptionClassName() : exception.getClass().getName();
         builder.append(className);
 
         StackTraceFilter filter = new StackTraceFilter(new ClassMethodNameStackTraceSpec(descriptor.getClassName(), null));

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatterTest.groovy
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.tasks.testing.logging
 
-import spock.lang.Specification
 import org.gradle.api.tasks.testing.logging.TestLogging
+import org.gradle.internal.serialize.PlaceholderAssertionError
 import org.gradle.internal.serialize.PlaceholderException
+import spock.lang.Specification
+import spock.lang.Unroll
 
 class ShortExceptionFormatterTest extends Specification {
     def testDescriptor = new SimpleTestDescriptor()
@@ -45,7 +47,7 @@ class ShortExceptionFormatterTest extends Specification {
 
         expect:
         formatter.format(testDescriptor, [exception]) == """\
-    java.lang.Exception at ShortExceptionFormatterTest.groovy:43
+    java.lang.Exception at ShortExceptionFormatterTest.groovy:45
 """
     }
 
@@ -64,14 +66,19 @@ class ShortExceptionFormatterTest extends Specification {
 """
     }
 
-    def "formats PlaceholderException correctly"() {
-        def exception = new PlaceholderException(Exception.class.name, "oops", null, "java.lang.Exception: oops", null, null)
+    @Unroll
+    def "formats placeholder exceptions correctly"() {
+        given:
         testDescriptor.className = getClass().name
 
         expect:
-        formatter.format(testDescriptor, [exception]) == """\
-    java.lang.Exception at ShortExceptionFormatterTest.groovy:68
-"""
+        formatter.format(testDescriptor, [exception]).contains("java.lang.Exception at ShortExceptionFormatterTest.groovy")
+
+        where:
+        exception << [
+            new PlaceholderException(Exception.class.name, "oops", null, "java.lang.Exception: oops", null, null),
+            new PlaceholderAssertionError(Exception.class.name, "oops", null, "java.lang.Exception: oops", null)
+        ]
     }
 
     private createStackTrace() {


### PR DESCRIPTION
Prior to this commit only `PlaceholderException` was handled which lead
to `PlaceholderAssertionError` being printed to the console by default
in case of assertion errors.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
