### PR TITLE
Use 64 kB buffer size for Windows file events

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -28,7 +28,9 @@ import java.util.concurrent.BlockingQueue;
 import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.FileSystemLocationToWatchValidator.NO_VALIDATION;
 
 public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<WindowsFileEventFunctions> {
-    private static final int BUFFER_SIZE = 128 * 1024;
+    // 64 kB is the limit for SMB drives
+    // See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw#remarks:~:text=ERROR_INVALID_PARAMETER
+    private static final int BUFFER_SIZE = 64 * 1024;
 
     public WindowsFileWatcherRegistryFactory() throws NativeIntegrationUnavailableException {
         super(Native.get(WindowsFileEventFunctions.class));


### PR DESCRIPTION
This is the limit for SMB drives. Without this watching for file system events on a drive mapped to a SMB share will result in the following error (see https://github.com/gradle/gradle/issues/12018#issuecomment-668254130):

```text
Error while receiving file changes
net.rubygrapefruit.platform.NativeException: Error received when handling events, error = 87: S:\native-platform
        at net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions$NativeFileWatcher.executeRunLoop0(Native Method)
        at net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions$NativeFileWatcher.access$100(AbstractFileEventFunctions.java:156)
        at net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions$NativeFileWatcher$1.run(AbstractFileEventFunctions.java:169)
```

See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw\#remarks:\~:text\=ERROR_INVALID_PARAMETER

