### PR TITLE
Compile options are configured according to toolchain

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.compile
 
-
 import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
@@ -29,7 +28,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
 
     @Unroll
     @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
-    def "can manually set java compiler via  #type toolchain on java compile task"() {
+    def "can manually set java compiler via #type toolchain on java compile task"() {
         buildFile << """
             import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService
             import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
@@ -55,10 +54,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
         when:
-        result = executer
-            .withArguments("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath, "--info")
-            .withTasks("compileJava")
-            .run()
+        runWithToolchainConfigured(jdk)
 
         then:
         outputContains("Compiling with toolchain '${jdk.javaHome.absolutePath}'.")
@@ -85,10 +81,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
         when:
-        result = executer
-            .withArguments("-Porg.gradle.java.installations.paths=" + someJdk.javaHome.absolutePath, "--info")
-            .withTasks("compileJava")
-            .run()
+        runWithToolchainConfigured(someJdk)
 
         then:
         outputContains("Compiling with toolchain '${someJdk.javaHome.absolutePath}'.")
@@ -111,14 +104,20 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
         file("src/main/java/Foo.java") << "public interface Foo { private void init() { }}"
 
         when:
-        result = executer
-            .withArguments("-Porg.gradle.java.installations.paths=" + jdk9.javaHome.absolutePath, "--info")
-            .withTasks("compileJava")
-            .run()
+        runWithToolchainConfigured(jdk9)
 
         then:
         outputContains("Compiling with toolchain '${jdk9.javaHome.absolutePath}'.")
         javaClassFile("Foo.class").exists()
+    }
+
+    def runWithToolchainConfigured(Jvm jvm) {
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + jvm.javaHome.absolutePath)
+            .withArgument("--info")
+            .withTasks("compileJava")
+            .run()
     }
 
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -206,9 +206,11 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
     }
 
     private void validateConfiguration() {
-        checkState(toolChain == null, "Must not use `javaCompiler` property together with (deprecated) `toolchain`");
-        checkState(getOptions().getForkOptions().getJavaHome() == null, "Must not use `javaHome` property on `ForkOptions` together with `javaCompiler` property");
-        checkState(getOptions().getForkOptions().getExecutable() == null, "Must not use `exectuable` property on `ForkOptions` together with `javaCompiler` property");
+        if (javaCompiler.isPresent()) {
+            checkState(toolChain == null, "Must not use `javaCompiler` property together with (deprecated) `toolchain`");
+            checkState(getOptions().getForkOptions().getJavaHome() == null, "Must not use `javaHome` property on `ForkOptions` together with `javaCompiler` property");
+            checkState(getOptions().getForkOptions().getExecutable() == null, "Must not use `exectuable` property on `ForkOptions` together with `javaCompiler` property");
+        }
     }
 
     private void performIncrementalCompilation(InputChanges inputs, DefaultJavaCompileSpec spec) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
@@ -34,6 +34,10 @@ public class DefaultToolchainJavaCompiler implements JavaCompiler {
         this.compilerFactory = compilerFactory;
     }
 
+    public JavaToolchain getJavaToolchain() {
+        return javaToolchain;
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends CompileSpec> WorkResult execute(T spec) {
         LOGGER.info("Compiling with toolchain '{}'.", javaToolchain.getDisplayName());

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -18,8 +18,6 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.internal.provider.Providers;
-import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -18,10 +18,13 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.provider.Providers;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
 
 import javax.inject.Inject;
+import java.io.File;
 
 public class JavaToolchain implements Describable {
 
@@ -42,9 +45,13 @@ public class JavaToolchain implements Describable {
         return installation.getJavaVersion();
     }
 
+    public File getJavaHome() {
+        return installation.getInstallationDirectory().getAsFile();
+    }
+
     @Override
     public String getDisplayName() {
-        return installation.getInstallationDirectory().getAsFile().getAbsolutePath();
+        return getJavaHome().getAbsolutePath();
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -24,6 +24,7 @@ import org.gradle.jvm.toolchain.install.internal.JavaToolchainProvisioningServic
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -51,8 +52,16 @@ public class JavaToolchainQueryService {
         return registry.listInstallations().stream()
             .map(this::asToolchain)
             .filter(matchingToolchain(filter))
+            .sorted(bestMatch())
             .findFirst()
             .orElseGet(() -> downloadToolchain(filter));
+    }
+
+    // TOOD: [bm] temporary order until #13892 is implemented
+    private Comparator<JavaToolchain> bestMatch() {
+        return Comparator.<JavaToolchain, String>
+            comparing(t -> t.getJavaHome().getName())
+            .reversed();
     }
 
     private JavaToolchain downloadToolchain(JavaToolchainSpec spec) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -53,6 +53,29 @@ class JavaToolchainQueryServiceTest extends Specification {
         JavaVersion.VERSION_12  | "/path/12"
     }
 
+    @Unroll
+    def "uses most recent version of multiple matches for version #versionToFind"() {
+        given:
+        def registry = createInstallationRegistry(["8.0", "8.0.242.hs-adpt", "7.9", "7.7", "14.0.2+12"])
+        def toolchainFactory = newToolchainFactory()
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService))
+
+        when:
+        def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
+        filter.languageVersion.set(versionToFind)
+        def toolchain = queryService.findMatchingToolchain(filter).get()
+
+        then:
+        toolchain.javaMajorVersion == versionToFind
+        toolchain.installation.installationDirectory.asFile.absolutePath == systemSpecificAbsolutePath(expectedPath)
+
+        where:
+        versionToFind           | expectedPath
+        JavaVersion.VERSION_1_7 | "/path/7.9"
+        JavaVersion.VERSION_1_8 | "/path/8.0.242.hs-adpt"
+        JavaVersion.VERSION_14  | "/path/14.0.2+12"
+    }
+
     def "returns failing provider if no toolchain matches"() {
         given:
         def registry = createInstallationRegistry(["8", "9", "10"])


### PR DESCRIPTION
The fork options and source/target compatibility should match the configured toolchain, otherwise, we may end up using the wrong compiler backend.

For now, we explicitly request command line compilation. This might be optimized once we tackle #12513 