### PR TITLE
Document potential breakage following dependency substitution improvements

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
@@ -217,7 +217,7 @@ include::sample[dir="snippets/dependencyManagement/customizingResolution-attribu
 include::sample[dir="snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin",files="build.gradle.kts[tags=substitution_rule]"]
 ====
 
-The same rule _without_ the `platform` keyword would try to substitute _regular dependencies_ with a regular dependency, which is not what you want, so it's important to understand that the substitution rules apply on a _dependency specification_: it matches the requested dependency (`substitute XXX`) with a substitute (`with YYY`).
+The same rule _without_ the `platform` keyword would try to substitute _regular dependencies_ with a regular dependency, which is not what you want, so it's important to understand that the substitution rules apply on a _dependency specification_: it matches the requested dependency (`substitute XXX`) with a substitute (`using YYY`).
 
 You can have attributes on both the requested dependency _or_ the substitute and the substitution is not limited to `platform`: you can actually specify the whole set of dependency attributes using the `variant` notation.
 The following rule is _strictly equivalent_ to the rule above:
@@ -232,7 +232,8 @@ Please refer to the link:{javadocPath}/org/gradle/api/artifacts/DependencySubsti
 
 [WARNING]
 ====
-In <<composite_builds.adoc#composite_build_intro,composite builds>>, the rule that you have to match the exact requested dependency attributes is not applied: when using composites, Gradle will automatically match the requested attributes. In other words, it is implicit that if you include another build, you are substituting _all variants__ of the substituted module with an equivalent variant in the included build.]
+In <<composite_builds.adoc#composite_build_intro,composite builds>>, the rule that you have to match the exact requested dependency attributes is not applied: when using composites, Gradle will automatically match the requested attributes.
+In other words, it is implicit that if you include another build, you are substituting _all variants_ of the substituted module with an equivalent variant in the included build.
 ====
 
 [[sec:substitution_with_capabilities]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -43,6 +43,22 @@ Some plugins will break with this new version of Gradle, for example because the
 - Ant has been updated to https://downloads.apache.org/ant/RELEASE-NOTES-1.10.8.html[1.10.8].
 - Groovy has been updated to https://groovy-lang.org/changelogs/changelog-2.5.12.html[Groovy 2.5.12].
 
+==== Dependency substitutions and variant aware dependency resolution
+
+While adding support for expressing <<resolution_rules#sec:variant_aware_substitutions, variant support>> in dependency substitutions, a bug fix introduced a behaviour change that some builds may rely upon.
+Previously a substituted dependency would still use the <<variant_attributes#, attributes>> of the original selector instead of the ones from the replacement selector.
+
+With that change, existing substitutions around dependencies with richer selectors, such as for platform dependencies, will no longer work as they did.
+It becomes mandatory to define the variant aware part in the target selector.
+
+You can be affected by this change if you:
+
+* have dependencies on platforms, like `implementation platform("org:platform:1.0")`
+* _or_ if you specify attributes on dependencies,
+* _and_ you use <<resolution_rules#, resolution rules>> on these dependencies.
+
+See the <<resolution_rules#sec:variant_aware_substitutions, documentation>> for resolving issues if you are impacted.
+
 === Deprecations
 
 No deprecations were made in Gradle 6.6.

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/groovy/build.gradle
@@ -6,15 +6,15 @@ configurations {
 // tag::module_to_project_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute module("org.utils:api") because "we work with the unreleased development version" with project(":api")
-        substitute module("org.utils:util:2.5") with project(":util")
+        substitute module("org.utils:api") using project(":api") because "we work with the unreleased development version"
+        substitute module("org.utils:util:2.5") using project(":util")
     }
 }
 // end::module_to_project_substitution[]
 // tag::project_to_module_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute project(":api") because "we use a stable version of org.utils:api" with module("org.utils:api:1.3")
+        substitute project(":api") using module("org.utils:api:1.3") because "we use a stable version of org.utils:api"
     }
 }
 // end::project_to_module_substitution[]

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/kotlin/build.gradle.kts
@@ -4,21 +4,17 @@ val conf by configurations.creating
 // tag::module_to_project_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute(module("org.utils:api")).apply {
-            with(project(":api"))
-            because("we work with the unreleased development version")
-        }
-        substitute(module("org.utils:util:2.5")).with(project(":util"))
+        substitute(module("org.utils:api"))
+            .using(project(":api")).because("we work with the unreleased development version")
+        substitute(module("org.utils:util:2.5")).using(project(":util"))
     }
 }
 // end::module_to_project_substitution[]
 // tag::project_to_module_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute(project(":api")).apply {
-            with(module("org.utils:api:1.3"))
-            because("we use a stable version of org.utils:api")
-        }
+        substitute(project(":api"))
+            .using(module("org.utils:api:1.3")).because("we use a stable version of org.utils:api")
     }
 }
 // end::project_to_module_substitution[]


### PR DESCRIPTION
The enhanced APIs for dependency substitution required a bug fix that
can impact existing builds which could rely on the bug being exercised.