### PR TITLE
Preserve causes of custom AssertionError

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -263,7 +263,7 @@ class ExceptionPlaceholder implements Serializable {
                 placeholder = new ContextualPlaceholderException(type, message, getMessageExec, toString, toStringRuntimeExec, causes.isEmpty() ? null : causes.get(0));
             } else {
                 if (assertionError) {
-                    placeholder = new PlaceholderAssertionError(type, message, getMessageExec, toString, toStringRuntimeExec);
+                    placeholder = new PlaceholderAssertionError(type, message, getMessageExec, toString, toStringRuntimeExec, causes.isEmpty() ? null : causes.get(0));
                 } else {
                     placeholder = new PlaceholderException(type, message, getMessageExec, toString, toStringRuntimeExec, causes.isEmpty() ? null : causes.get(0));
                 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderAssertionError.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderAssertionError.java
@@ -33,12 +33,14 @@ public class PlaceholderAssertionError extends AssertionError implements Placeho
                                      @Nullable String message,
                                      @Nullable Throwable getMessageException,
                                      @Nullable String toString,
-                                     @Nullable Throwable toStringException) {
+                                     @Nullable Throwable toStringException,
+                                     @Nullable Throwable cause) {
         super(message);
         this.exceptionClassName = exceptionClassName;
         this.getMessageException = getMessageException;
         this.toString = toString;
         this.toStringRuntimeEx = toStringException;
+        initCause(cause);
     }
 
     @Override

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
@@ -337,6 +337,18 @@ class MessageTest extends Specification {
         looksLike(assertionError, transported)
     }
 
+    def "preserves nested assertion errors"() {
+        def assertionError = new CustomAssertionError("Boom", new CustomAssertionError("Boom cause!"))
+
+        when:
+        def transported = transport(assertionError)
+
+        then:
+        transported instanceof PlaceholderAssertionError
+        looksLike(assertionError, transported)
+        looksLike(assertionError.cause, transported.cause)
+    }
+
     void looksLike(Throwable original, Throwable transported) {
         assert transported instanceof PlaceholderExceptionSupport
         assert transported.exceptionClassName == original.class.name
@@ -484,6 +496,10 @@ class MessageTest extends Specification {
     static class CustomAssertionError extends AssertionError {
         CustomAssertionError(Object message) {
             super(message)
+        }
+
+        CustomAssertionError(String message, Throwable cause) {
+            super(message, cause)
         }
 
         private void readObject(ObjectInputStream outstr) {


### PR DESCRIPTION
While adding the support for custom AssertionError types, used in
testing libraries, the cause chain of such errors was lost.
This commit makes sure that the cause is preserved.