### PR TITLE
Lock in build cache performance improvements

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -43,7 +43,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumBaseVersion = "3.5"
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200804220106+0000"]
     }
 
     def "clean #tasks on #testProject with remote http cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
@@ -23,7 +23,7 @@ class TaskOutputCachingNativePerformanceTest extends AbstractTaskOutputCachingPe
 
     def setup() {
         runner.minimumBaseVersion = "4.3"
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200804220106+0000"]
         runner.args += ["-Dorg.gradle.caching.native=true", "--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -23,7 +23,7 @@ class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPer
 
     def setup() {
         runner.minimumBaseVersion = "4.5"
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200804220106+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 


### PR DESCRIPTION
caused by enabling partial invalidation by default. For the large multiproject, those improvements are about 10%, while for the monolithic projects there isn't a change.

See #13920.