### PR TITLE
Fix toolchain soak tests

### DIFF
--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
@@ -18,12 +18,11 @@ package org.gradle.jvm.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.internal.jvm.Jvm
 import spock.lang.IgnoreIf
 
 class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
 
-    def "installation registry has only current vm without environment setup"() {
+    def "installation registry has no installations without environment setup or auto-detection"() {
         buildFile << """
             import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
             import javax.inject.Inject
@@ -49,8 +48,7 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
             .run()
 
         then:
-        def currentVm = Jvm.current().getJavaHome().getAbsolutePath()
-        outputContains("installations:[${currentVm}]")
+        outputContains("installations:[]")
     }
 
     @IgnoreIf({ AvailableJavaHomes.availableJvms.size() < 2 })

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/CurrentInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/CurrentInstallationSupplier.java
@@ -16,16 +16,23 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.jvm.Jvm;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
-public class CurrentInstallationSupplier implements InstallationSupplier {
+public class CurrentInstallationSupplier extends AutoDetectingInstallationSupplier {
+
+    @Inject
+    public CurrentInstallationSupplier(ProviderFactory factory) {
+        super(factory);
+    }
 
     @Override
-    public Set<InstallationLocation> get() {
+    protected Set<InstallationLocation> findCandidates() {
         return Collections.singleton(asInstallation(Jvm.current().getJavaHome()));
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplierTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.jvm.toolchain.internal
 
 import org.gradle.api.internal.file.FileOperations
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
-import org.gradle.api.provider.Provider
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.jvm.toolchain.install.internal.JdkCacheDirectory
@@ -100,14 +98,8 @@ class AutoInstalledInstallationSupplierTest extends Specification {
 
     ProviderFactory createProviderFactory() {
         def providerFactory = Mock(ProviderFactory)
-        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> mockProvider(null)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
         providerFactory
-    }
-
-    Provider<String> mockProvider(String value) {
-        def provider = new DefaultProperty(PropertyHost.NO_OP, String)
-        provider.set(value)
-        provider
     }
 
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/CurrentInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/CurrentInstallationSupplierTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.jvm.toolchain.internal
 
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.jvm.Jvm
 import spock.lang.Specification
 
@@ -23,7 +25,7 @@ class CurrentInstallationSupplierTest extends Specification {
 
     def "supplies java home as installation"() {
         given:
-        def supplier = new CurrentInstallationSupplier()
+        def supplier = new CurrentInstallationSupplier(createProviderFactory())
 
         when:
         def directories = supplier.get()
@@ -33,5 +35,21 @@ class CurrentInstallationSupplierTest extends Specification {
         directories*.source == ["current jvm"]
     }
 
+    def "skips current jre as installation if auto-detection is disabled"() {
+        given:
+        def supplier = new CurrentInstallationSupplier(createProviderFactory("false"))
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    ProviderFactory createProviderFactory(String autoDetect = null) {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(autoDetect)
+        providerFactory
+    }
 
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplierTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.jvm.toolchain.internal
 
 
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
-import org.gradle.api.provider.Provider
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import spock.lang.Specification
 
@@ -98,17 +96,11 @@ class EnvironmentVariableListInstallationSupplierTest extends Specification {
 
     private ProviderFactory createProviderFactory(String propertyValue) {
         def providerFactory = Mock(ProviderFactory)
-        providerFactory.gradleProperty("org.gradle.java.installations.fromEnv") >> mockProvider(propertyValue)
-        providerFactory.environmentVariable("JDK8") >> mockProvider("/path/jdk8")
-        providerFactory.environmentVariable("JDK9") >> mockProvider("/path/jdk9")
-        providerFactory.environmentVariable("") >> mockProvider(null)
+        providerFactory.gradleProperty("org.gradle.java.installations.fromEnv") >> Providers.ofNullable(propertyValue)
+        providerFactory.environmentVariable("JDK8") >> Providers.of("/path/jdk8")
+        providerFactory.environmentVariable("JDK9") >> Providers.of("/path/jdk9")
+        providerFactory.environmentVariable("") >> Providers.ofNullable(null)
         providerFactory
-    }
-
-    Provider<String> mockProvider(String value) {
-        def provider = new DefaultProperty(PropertyHost.NO_OP, String)
-        provider.set(value)
-        provider
     }
 
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplierTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.jvm.toolchain.internal
 
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
+
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import spock.lang.Specification
 
@@ -74,9 +74,7 @@ class LocationListInstallationSupplierTest extends Specification {
 
     private ProviderFactory createProviderFactory(String propertyValue) {
         def providerFactory = Mock(ProviderFactory)
-        def provider = new DefaultProperty(PropertyHost.NO_OP, String)
-        provider.set(propertyValue)
-        providerFactory.gradleProperty("org.gradle.java.installations.paths") >> provider
+        providerFactory.gradleProperty("org.gradle.java.installations.paths") >> Providers.ofNullable(propertyValue)
         providerFactory
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplierTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.jvm.toolchain.internal
 
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
-import org.gradle.api.provider.Provider
+
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -151,15 +150,9 @@ class SdkmanInstallationSupplierTest extends Specification {
 
     ProviderFactory createProviderFactory(String propertyValue) {
         def providerFactory = Mock(ProviderFactory)
-        providerFactory.environmentVariable("SDKMAN_CANDIDATES_DIR") >> mockProvider(propertyValue)
-        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> mockProvider(null)
+        providerFactory.environmentVariable("SDKMAN_CANDIDATES_DIR") >> Providers.ofNullable(propertyValue)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
         providerFactory
-    }
-
-    Provider<String> mockProvider(String value) {
-        def provider = new DefaultProperty(PropertyHost.NO_OP, String)
-        provider.set(value)
-        provider
     }
 
 }


### PR DESCRIPTION
If the toolchain soak tests are run using Java 14, they detect the running VM and reuse that as toolchain instead of downloading a new one. The current VM supplier should also be marked as an auto-detecting supplier and return no VM if detection is disabled.