### PR TITLE
Test task uses toolchain launcher if configured

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -29,6 +29,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.jvm.DefaultModularitySpec;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecResult;
@@ -146,6 +147,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         setJvmArgs(getJvmArgs()); // convention mapping for 'jvmArgs'
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();
         javaExecSpec.copyTo(javaExecAction);
+        javaExecAction.setExecutable(getEffectiveExecutable());
         execResult.set(javaExecAction.execute());
     }
 
@@ -523,7 +525,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Input
     public JavaVersion getJavaVersion() {
-        return getServices().get(JvmVersionDetector.class).getJavaVersion(getExecutable());
+        return getServices().get(JvmVersionDetector.class).getJavaVersion(getEffectiveExecutable());
     }
 
     /**
@@ -739,4 +741,11 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     public Provider<ExecResult> getExecutionResult() {
         return execResult;
     }
+
+    @Nullable
+    private String getEffectiveExecutable() {
+        final String executable = getExecutable();
+        return executable == null ? Jvm.current().getJavaExecutable().getAbsolutePath() : executable;
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -39,6 +39,7 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.jvm.JavaModuleDetector;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
@@ -122,7 +123,9 @@ public class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public JavaForkOptionsInternal newJavaForkOptions() {
-        return new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
+        final DefaultJavaForkOptions forkOptions = new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
+        forkOptions.setExecutable(Jvm.current().getJavaExecutable());
+        return forkOptions;
     }
 
     @Override
@@ -204,7 +207,9 @@ public class DefaultExecActionFactory implements ExecFactory {
         @Override
         public JavaForkOptionsInternal newDecoratedJavaForkOptions() {
             JavaDebugOptions javaDebugOptions = objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory);
-            return instantiator.newInstance(DefaultJavaForkOptions.class, fileResolver, fileCollectionFactory, javaDebugOptions);
+            final DefaultJavaForkOptions forkOptions = instantiator.newInstance(DefaultJavaForkOptions.class, fileResolver, fileCollectionFactory, javaDebugOptions);
+            forkOptions.setExecutable(Jvm.current().getJavaExecutable());
+            return forkOptions;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -201,7 +201,9 @@ public class DefaultExecActionFactory implements ExecFactory {
 
         @Override
         public JavaExecAction newDecoratedJavaExecAction() {
-            return instantiator.newInstance(DefaultJavaExecAction.class, fileResolver, fileCollectionFactory, objectFactory, executor, buildCancellationToken, javaModuleDetector, newDecoratedJavaForkOptions());
+            final JavaForkOptionsInternal forkOptions = newDecoratedJavaForkOptions();
+            forkOptions.setExecutable(Jvm.current().getJavaExecutable());
+            return instantiator.newInstance(DefaultJavaExecAction.class, fileResolver, fileCollectionFactory, objectFactory, executor, buildCancellationToken, javaModuleDetector, forkOptions);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
@@ -41,13 +40,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
 
     @Inject
     public DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, JavaDebugOptions debugOptions) {
-        this(resolver, fileCollectionFactory, Jvm.current(), debugOptions);
-    }
-
-    private DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, Jvm jvm, JavaDebugOptions debugOptions) {
         super(resolver);
         options = new JvmOptions(fileCollectionFactory, debugOptions);
-        setExecutable(jvm.getJavaExecutable());
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -50,7 +50,6 @@ class DefaultJavaForkOptionsTest extends Specification {
 
     def "provides correct default values"() {
         expect:
-        options.executable != null
         options.jvmArgs.isEmpty()
         options.systemProperties.isEmpty()
         options.minHeapSize == null

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -95,6 +95,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
 
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, groovyOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
+        javaForkOptions.setExecutable(javaOptions.getExecutable());
         if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
             javaForkOptions.jvmArgs(GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS);
         }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -59,6 +59,7 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.Deleter;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.IncubationLogger;
@@ -302,6 +303,8 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
             GFileUtils.mkdirs(dir);
             spec.getGroovyCompileOptions().setStubDir(dir);
         }
+        spec.getCompileOptions().getForkOptions().setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath());
+
         return spec;
     }
 

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -47,6 +47,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.file.Deleter;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.GFileUtils;
 
@@ -131,6 +132,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
             ? ImmutableList.of()
             : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
         spec.setBuildStartTimestamp(getServices().get(BuildStartedTime.class).getStartTime());
+        spec.getCompileOptions().getForkOptions().setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath());
         return spec;
     }
 

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -77,6 +77,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
         this.scalaCompileOptions.setIncrementalOptions(objectFactory.newInstance(IncrementalCompileOptions.class));
 
         CompilerForkUtils.doNotCacheIfForkingViaExecutable(compileOptions, getOutputs());
+        compileOptions.getForkOptions().setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath());
     }
 
     /**
@@ -132,7 +133,6 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
             ? ImmutableList.of()
             : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));
         spec.setBuildStartTimestamp(getServices().get(BuildStartedTime.class).getStartTime());
-        spec.getCompileOptions().getForkOptions().setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath());
         return spec;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaLauncher.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaLauncher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A java executable used to execute applications or run tests.
+ *
+ * @since 6.7
+ */
+@Incubating
+public interface JavaLauncher {
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaLauncher.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaLauncher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.tasks.Internal;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+import java.io.File;
+
+public class DefaultToolchainJavaLauncher implements JavaLauncher {
+
+    private final String javaExecutable;
+
+    public DefaultToolchainJavaLauncher(File javaExecutable) {
+        this.javaExecutable = javaExecutable.getAbsolutePath();
+    }
+
+    @Internal
+    public String getExecutable() {
+        return javaExecutable;
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -40,8 +40,8 @@ public class JavaToolchain implements Describable {
         return new DefaultToolchainJavaCompiler(this, compilerFactory);
     }
 
-    public Provider<JavaLauncher> getJavaLauncher() {
-        return Providers.of(new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile()));
+    public JavaLauncher getJavaLauncher() {
+        return new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile());
     }
 
     public JavaVersion getJavaMajorVersion() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -20,6 +20,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
+import org.gradle.jvm.toolchain.JavaLauncher;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -37,6 +38,10 @@ public class JavaToolchain implements Describable {
 
     public JavaCompiler getJavaCompiler() {
         return new DefaultToolchainJavaCompiler(this, compilerFactory);
+    }
+
+    public Provider<JavaLauncher> getJavaLauncher() {
+        return Providers.of(new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile()));
     }
 
     public JavaVersion getJavaMajorVersion() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -223,6 +223,22 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredToolchain.displayName == someJdk.javaHome.absolutePath
     }
 
+    void "wires toolchain for test if toolchain is configured"() {
+        given:
+        def someJdk = Jvm.current()
+        project.pluginManager.apply(JavaPlugin)
+        project.java.toolchain.languageVersion = someJdk.javaVersion
+        // workaround for https://github.com/gradle/gradle/issues/13122
+        ((DefaultProject) project).getServices().get(GradlePropertiesController.class).loadGradlePropertiesFrom(project.projectDir)
+
+        when:
+        project.tasks.all { println it }
+        def testTask = project.tasks.named("test", Test).get()
+        def configuredJavaLauncher = testTask.javaLauncher.get()
+
+        then:
+        configuredJavaLauncher.javaExecutable == someJdk.javaExecutable.absolutePath
+    }
 
     void tasksReflectChangesToSourceSetConfiguration() {
         def classesDir = project.file('target/classes')

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -36,7 +36,9 @@ import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.api.internal.tasks.testing.report.TestReporter
 import org.gradle.api.tasks.AbstractConventionTaskTest
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.work.WorkerLeaseRegistry
+import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaLauncher
 import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.internal.worker.WorkerProcessBuilder
 
@@ -276,6 +278,17 @@ class TestTest extends AbstractConventionTaskTest {
 
         then:
         javaForkOptions.getJvmArgs() == ['First', 'Second']
+    }
+
+    def "java version is determined with toolchain if set"() {
+
+        def launcher = new DefaultToolchainJavaLauncher(Jvm.current().javaExecutable)
+
+        when:
+        test.javaLauncher.set(launcher)
+
+        then:
+        test.getJavaVersion() == Jvm.current().javaVersion
     }
 
     private void assertIsDirectoryTree(FileTreeInternal classFiles, Set<String> includes, Set<String> excludes) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.AbstractConventionTaskTest
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.work.WorkerLeaseRegistry
+import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaLauncher
 import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.internal.worker.WorkerProcessBuilder
@@ -121,8 +122,6 @@ class TestTest extends AbstractConventionTaskTest {
         1 * testReporter.generateReport(_ as TestResultsProvider, reportDir)
         1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor)
     }
-
-    /* TODO(pepper): WTF?!? This test wasn't ever doing shit. Fuck this! */
 
     def "execute with test failures and ignore failures"() {
         given:
@@ -281,7 +280,6 @@ class TestTest extends AbstractConventionTaskTest {
     }
 
     def "java version is determined with toolchain if set"() {
-
         def launcher = new DefaultToolchainJavaLauncher(Jvm.current().javaExecutable)
 
         when:
@@ -289,6 +287,17 @@ class TestTest extends AbstractConventionTaskTest {
 
         then:
         test.getJavaVersion() == Jvm.current().javaVersion
+    }
+
+    def "cannot set executable and toolchain launcher at the same time"() {
+        when:
+        test.javaLauncher.set(Mock(JavaLauncher))
+        test.executable = "something"
+        test.createTestExecutionSpec()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Must not use `executable` property on `Test` together with `javaLauncher` property"
     }
 
     private void assertIsDirectoryTree(FileTreeInternal classFiles, Set<String> includes, Set<String> excludes) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+
+import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
+
+    @Unroll
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "can manually set java launcher via  #type toolchain on java test task"() {
+        buildFile << """
+            import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService
+            import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
+
+            apply plugin: "java"
+
+            ${jcenterRepository()}
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            abstract class ApplyTestToolchain implements Plugin<Project> {
+                @javax.inject.Inject
+                abstract JavaToolchainQueryService getQueryService()
+
+                void apply(Project project) {
+                    project.tasks.withType(Test) {
+                        def filter = project.objects.newInstance(DefaultToolchainSpec)
+                        filter.languageVersion = JavaVersion.${jdk.javaVersion.name()}
+                        javaLauncher = getQueryService().findMatchingToolchain(filter).map({it.javaLauncher.get()})
+                    }
+                }
+            }
+
+            apply plugin: ApplyTestToolchain
+        """
+
+        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
+
+        when:
+        result = executer
+            .withArguments("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath, "--info")
+            .withTasks("test")
+            .run()
+
+        then:
+        outputContains("Tests running with ${jdk.javaHome.absolutePath}")
+        noExceptionThrown()
+
+        where:
+        type           | jdk
+        'differentJdk' | AvailableJavaHomes.getDifferentJdk()
+        'current'      | Jvm.current()
+    }
+
+    private static String testClass(String className) {
+        return """
+            import org.junit.*;
+
+            public class $className {
+               @Test
+               public void test() {
+                  System.out.println("Tests running with " + System.getProperty("java.home"));
+                  Assert.assertEquals(1,1);
+               }
+            }
+        """.stripIndent()
+    }
+
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -79,56 +79,7 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
         'current'      | Jvm.current()
     }
 
-    // TODO: remove me, just trying somethings
-//    @Unroll
-//    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
-//    def "can manually set java exectuable on java test task #jdk"() {
-//        buildFile << """
-//            apply plugin: "java"
-//
-//            ${jcenterRepository()}
-//
-//            dependencies {
-//                testImplementation 'junit:junit:4.13'
-//            }
-//
-//            abstract class ApplyTestToolchain implements Plugin<Project> {
-//
-//                void apply(Project project) {
-//                    project.tasks.withType(JavaCompile) {
-//                        options.with {
-//                            fork = true
-//                            forkOptions.javaHome =
-//                        }
-//                    }
-//                    project.tasks.withType(Test) {
-//                        javaLauncher = toolchain.map({it.javaLauncher})
-//                    }
-//                }
-//            }
-//
-//            apply plugin: ApplyTestToolchain
-//        """
-//
-//        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
-//
-//        when:
-//        result = executer
-//            .withArguments("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath, "--info")
-//            .withTasks("test")
-//            .run()
-//
-//        then:
-//        outputContains("Tests running with ${jdk.javaHome.absolutePath}")
-//        noExceptionThrown()
-//
-//        where:
-//        type           | jdk
-//        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
-//        'current'      | Jvm.current()
-//    }
-
-
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
     def "Test task is configured using default toolchain"() {
         def someJdk = AvailableJavaHomes.getDifferentJdk()
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testing
 
-
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
@@ -27,7 +27,7 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
 
     @Unroll
     @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
-    def "can manually set java launcher via  #type toolchain on java test task"() {
+    def "can manually set java launcher via  #type toolchain on java test task #jdk"() {
         buildFile << """
             import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService
             import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
@@ -45,10 +45,15 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
                 abstract JavaToolchainQueryService getQueryService()
 
                 void apply(Project project) {
+                    def filter = project.objects.newInstance(DefaultToolchainSpec)
+                    filter.languageVersion = JavaVersion.${jdk.javaVersion.name()}
+                    def toolchain = getQueryService().findMatchingToolchain(filter)
+
+                    project.tasks.withType(JavaCompile) {
+                        javaCompiler = toolchain.map({it.javaCompiler})
+                    }
                     project.tasks.withType(Test) {
-                        def filter = project.objects.newInstance(DefaultToolchainSpec)
-                        filter.languageVersion = JavaVersion.${jdk.javaVersion.name()}
-                        javaLauncher = getQueryService().findMatchingToolchain(filter).map({it.javaLauncher.get()})
+                        javaLauncher = toolchain.map({it.javaLauncher})
                     }
                 }
             }
@@ -70,8 +75,89 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
 
         where:
         type           | jdk
-        'differentJdk' | AvailableJavaHomes.getDifferentJdk()
+        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
         'current'      | Jvm.current()
+    }
+
+    // TODO: remove me, just trying somethings
+//    @Unroll
+//    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+//    def "can manually set java exectuable on java test task #jdk"() {
+//        buildFile << """
+//            apply plugin: "java"
+//
+//            ${jcenterRepository()}
+//
+//            dependencies {
+//                testImplementation 'junit:junit:4.13'
+//            }
+//
+//            abstract class ApplyTestToolchain implements Plugin<Project> {
+//
+//                void apply(Project project) {
+//                    project.tasks.withType(JavaCompile) {
+//                        options.with {
+//                            fork = true
+//                            forkOptions.javaHome =
+//                        }
+//                    }
+//                    project.tasks.withType(Test) {
+//                        javaLauncher = toolchain.map({it.javaLauncher})
+//                    }
+//                }
+//            }
+//
+//            apply plugin: ApplyTestToolchain
+//        """
+//
+//        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
+//
+//        when:
+//        result = executer
+//            .withArguments("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath, "--info")
+//            .withTasks("test")
+//            .run()
+//
+//        then:
+//        outputContains("Tests running with ${jdk.javaHome.absolutePath}")
+//        noExceptionThrown()
+//
+//        where:
+//        type           | jdk
+//        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+//        'current'      | Jvm.current()
+//    }
+
+
+    def "Test task is configured using default toolchain"() {
+        def someJdk = AvailableJavaHomes.getDifferentJdk()
+        buildFile << """
+            apply plugin: "java"
+
+            ${jcenterRepository()}
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            java {
+                toolchain {
+                    languageVersion = JavaVersion.toVersion(${someJdk.javaVersion.majorVersion})
+                }
+            }
+        """
+
+        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
+
+        when:
+        result = executer
+            .withArguments("-Porg.gradle.java.installations.paths=" + someJdk.javaHome.absolutePath, "--info")
+            .withTasks("test")
+            .run()
+
+        then:
+        outputContains("Tests running with ${someJdk.javaHome.absolutePath}")
+        noExceptionThrown()
     }
 
     private static String testClass(String className) {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -67,6 +67,7 @@ import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -635,6 +636,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         JavaForkOptions javaForkOptions = getForkOptionsFactory().newJavaForkOptions();
         copyTo(javaForkOptions);
         // TODO: check invariants
+
+
         JavaModuleDetector javaModuleDetector = getJavaModuleDetector();
         boolean testIsModule = javaModuleDetector.isModule(modularity.getInferModulePath().get(), getTestClassesDirs());
         FileCollection classpath = javaModuleDetector.inferClasspath(testIsModule, stableClasspath);
@@ -1166,12 +1169,13 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         return javaLauncher;
     }
 
+    @Nullable
     private String getEffectiveExecutable() {
         if (javaLauncher.isPresent()) {
             return ((DefaultToolchainJavaLauncher) javaLauncher.get()).getExecutable();
         }
-        return getExecutable();
+        final String executable = getExecutable();
+        return executable == null ? Jvm.current().getJavaExecutable().getAbsolutePath() : executable;
     }
-
 
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -180,6 +180,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         });
         forkOptions = getForkOptionsFactory().newDecoratedJavaForkOptions();
         forkOptions.setEnableAssertions(true);
+        forkOptions.setExecutable(null);
         modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
         javaLauncher = getObjectFactory().property(JavaLauncher.class);
     }

--- a/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
+++ b/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.commonsIo)
 
     testImplementation(project(":fileCollections"))
+    testImplementation(project(":platformJvm"))
 }
 
 strictCompile {


### PR DESCRIPTION
* Remove the current JVM as default when using ForkOptions
* Explicitly set the correct executable (by user or by toolchain) for `Test` tasks
* Explicitly use current JVM in remaining places

<!--- The issue this PR addresses -->
Fixes #13868
