### PR TITLE
Do not handle RuntimeException specifically

### DIFF
--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationInvocationException.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationInvocationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+public class BuildOperationInvocationException extends RuntimeException {
+    public BuildOperationInvocationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
@@ -72,7 +72,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
                     }
                     listener.stop(operationState, context);
                     if (failure != null) {
-                        throw throwAsUncheckedException(failure);
+                        throw throwAsBuildOperationInvocationException(failure);
                     }
                     return buildOperation;
                 } finally {
@@ -219,7 +219,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
         long getCurrentTime();
     }
 
-    private static RuntimeException throwAsUncheckedException(Throwable t) {
+    private static RuntimeException throwAsBuildOperationInvocationException(Throwable t) {
         if (t instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         }
@@ -229,7 +229,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
         if (t instanceof Error) {
             throw (Error) t;
         }
-        throw new RuntimeException(t.getMessage(), t);
+        throw new BuildOperationInvocationException(t.getMessage(), t);
     }
 
     protected long getCurrentTime() {

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/AbstractBroadcastDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/AbstractBroadcastDispatch.java
@@ -19,6 +19,7 @@ package org.gradle.internal.event;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
+import org.gradle.internal.operations.BuildOperationInvocationException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +43,9 @@ public abstract class AbstractBroadcastDispatch<T> implements Dispatch<MethodInv
             handler.dispatch(invocation);
         } catch (UncheckedException e) {
             throw new ListenerNotificationException(invocation, getErrorMessage(), Collections.singletonList(e.getCause()));
-        } catch (ListenerNotificationException t) {
+        } catch (BuildOperationInvocationException e) {
+            throw new ListenerNotificationException(invocation, getErrorMessage(), Collections.singletonList(e.getCause()));
+        } catch (RuntimeException t) {
             throw t;
         } catch (Throwable t) {
             throw new ListenerNotificationException(invocation, getErrorMessage(), Collections.singletonList(t));

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/AbstractBroadcastDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/AbstractBroadcastDispatch.java
@@ -42,7 +42,7 @@ public abstract class AbstractBroadcastDispatch<T> implements Dispatch<MethodInv
             handler.dispatch(invocation);
         } catch (UncheckedException e) {
             throw new ListenerNotificationException(invocation, getErrorMessage(), Collections.singletonList(e.getCause()));
-        } catch (RuntimeException t) {
+        } catch (ListenerNotificationException t) {
             throw t;
         } catch (Throwable t) {
             throw new ListenerNotificationException(invocation, getErrorMessage(), Collections.singletonList(t));


### PR DESCRIPTION
Doing so causes RuntimeExceptions to lack the nice wrapper and breaks the build scan plugin tests in dotcom.
