### PR TITLE
Reduce the amount of heap retained by resolved project dependencies

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -30,6 +32,7 @@ import java.util.Collection;
  * A registry of all of the projects present in a build tree.
  */
 @ThreadSafe
+@ServiceScope(Scopes.BuildTree.class)
 public interface ProjectStateRegistry {
     /**
      * Returns all projects in the build tree.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -82,6 +82,8 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProject
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectArtifactResolver;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectArtifactSetResolver;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver;
@@ -168,6 +170,7 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.resource.local.ivy.LocallyAvailableResourceFinderFactory;
 import org.gradle.internal.resource.transfer.CachingTextUriResourceLoader;
 import org.gradle.internal.resource.transport.http.HttpConnectorFactory;
+import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -187,6 +190,12 @@ import java.util.concurrent.atomic.AtomicReference;
  * The set of dependency management services that are created per build.
  */
 class DependencyManagementBuildScopeServices {
+    void configure(ServiceRegistration registration) {
+        registration.add(ProjectArtifactResolver.class);
+        registration.add(ProjectArtifactSetResolver.class);
+        registration.add(ProjectDependencyResolver.class);
+    }
+
     DependencyManagementServices createDependencyManagementServices(ServiceRegistry parent) {
         return new DefaultDependencyManagementServices(parent);
     }
@@ -552,11 +561,7 @@ class DependencyManagementBuildScopeServices {
         return new DefaultLocalComponentRegistry(providers);
     }
 
-    ProjectDependencyResolver createProjectDependencyResolver(LocalComponentRegistry localComponentRegistry, ComponentIdentifierFactory componentIdentifierFactory, ProjectStateRegistry projectStateRegistry) {
-        return new ProjectDependencyResolver(localComponentRegistry, componentIdentifierFactory, projectStateRegistry);
-    }
-
-    ComponentSelectorConverter createModuleVersionSelectorFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
+    ComponentSelectorConverter createModuleVersionSelectorFactory(ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
         return new DefaultComponentSelectorConverter(componentIdentifierFactory, localComponentRegistry);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -18,12 +18,16 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.util.Path;
 
+import java.util.Collection;
 import java.util.Set;
 
 public interface ConfigurationInternal extends ResolveContext, Configuration, DeprecatableConfiguration, DependencyMetaDataProvider {
@@ -31,7 +35,8 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
         UNRESOLVED,
         BUILD_DEPENDENCIES_RESOLVED,
         GRAPH_RESOLVED,
-        ARTIFACTS_RESOLVED}
+        ARTIFACTS_RESOLVED
+    }
 
     @Override
     ResolutionStrategyInternal getResolutionStrategy();
@@ -62,6 +67,11 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     OutgoingVariant convertToOutgoingVariant();
 
     /**
+     * Visits the variants of this configuration.
+     */
+    void collectVariants(VariantVisitor visitor);
+
+    /**
      * Registers an action to execute before locking for further mutation.
      */
     void beforeLocking(Action<? super ConfigurationInternal> action);
@@ -75,4 +85,15 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     Set<ExcludeRule> getAllExcludeRules();
 
     ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver();
+
+    interface VariantVisitor {
+        // The artifacts to use when this configuration is used as a configuration
+        void visitArtifacts(Collection<? extends PublishArtifact> artifacts);
+
+        // This configuration as a variant. May not always be present
+        void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
+
+        // A child variant. May not always be present
+        void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -929,6 +929,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
+    public void collectVariants(VariantVisitor visitor) {
+        outgoing.collectVariants(visitor);
+    }
+
+    @Override
     public void beforeLocking(Action<? super ConfigurationInternal> action) {
         if (canBeMutated) {
             if (beforeLocking != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -84,6 +84,19 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         this.attributes = attributesFactory.mutable(parentAttributes);
     }
 
+    public void collectVariants(ConfigurationInternal.VariantVisitor visitor) {
+        visitor.visitArtifacts(artifacts);
+        PublishArtifactSet allArtifactSet = allArtifacts.getPublishArtifactSet();
+        if (variants == null || variants.isEmpty() || !allArtifactSet.isEmpty()) {
+            visitor.visitOwnVariant(displayName, attributes.asImmutable(), allArtifactSet);
+        }
+        if (variants != null) {
+            for (DefaultVariant variant : variants.withType(DefaultVariant.class)) {
+                variant.visit(visitor);
+            }
+        }
+    }
+
     public OutgoingVariant convertToOutgoingVariant() {
         return new OutgoingVariant() {
             @Override
@@ -186,7 +199,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         canCreate = false;
         if (variants != null) {
             for (ConfigurationVariant variant : variants) {
-                ((ConfigurationVariantInternal)variant).preventFurtherMutation();
+                ((ConfigurationVariantInternal) variant).preventFurtherMutation();
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -45,7 +45,8 @@ public class DefaultVariant implements ConfigurationVariantInternal {
     private final PublishArtifactSet artifacts;
     private Factory<List<PublishArtifact>> lazyArtifacts;
 
-    public DefaultVariant(Describable parentDisplayName, String name,
+    public DefaultVariant(Describable parentDisplayName,
+                          String name,
                           AttributeContainerInternal parentAttributes,
                           NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
                           FileCollectionFactory fileCollectionFactory,
@@ -65,6 +66,10 @@ public class DefaultVariant implements ConfigurationVariantInternal {
 
     public OutgoingVariant convertToOutgoingVariant() {
         return new LeafOutgoingVariant(getAsDescribable(), attributes, getArtifacts());
+    }
+
+    public void visit(ConfigurationInternal.VariantVisitor visitor) {
+        visitor.visitChildVariant(name, getAsDescribable(), attributes.asImmutable(), getArtifacts());
     }
 
     private DisplayName getAsDescribable() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
+
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.resolve.resolver.ArtifactResolver;
+import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
+import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.io.File;
+
+@ServiceScope(Scopes.Build.class)
+public class ProjectArtifactResolver implements ArtifactResolver {
+    private final ProjectStateRegistry projectStateRegistry;
+
+    public ProjectArtifactResolver(ProjectStateRegistry projectStateRegistry) {
+        this.projectStateRegistry = projectStateRegistry;
+    }
+
+    @Override
+    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+        final LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
+        ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) artifact.getComponentId();
+        projectStateRegistry.stateFor(projectId).withMutableState(() -> {
+            File localArtifactFile = projectArtifact.getFile();
+            if (localArtifactFile != null) {
+                result.resolved(localArtifactFile);
+            } else {
+                result.notFound(projectArtifact.getId());
+            }
+        });
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactSetResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactSetResolver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DefaultArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+import org.gradle.internal.component.model.VariantWithOverloadAttributes;
+import org.gradle.internal.resolve.resolver.ArtifactResolver;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ServiceScope(Scopes.Build.class)
+public class ProjectArtifactSetResolver {
+    private final ArtifactResolver artifactResolver;
+    // Move this state closer to the project metadata
+    private final Map<ComponentArtifactIdentifier, ResolvableArtifact> allProjectArtifacts = new ConcurrentHashMap<>();
+    private final Map<VariantResolveMetadata.Identifier, ResolvedVariant> allProjectVariants = new ConcurrentHashMap<>();
+
+    public ProjectArtifactSetResolver(ProjectArtifactResolver artifactResolver) {
+        this.artifactResolver = artifactResolver;
+    }
+
+    /**
+     * Creates an {@link ArtifactSet} that represents the available artifacts for the given set of project variants.
+     */
+    public ArtifactSet resolveArtifacts(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
+        ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builderWithExpectedSize(variants.size());
+        for (VariantResolveMetadata variant : variants) {
+            ResolvedVariant resolvedVariant = mapVariant(ownerId, moduleSources, exclusions, artifactTypeRegistry, variant);
+            result.add(resolvedVariant);
+        }
+        return DefaultArtifactSet.createFromVariants(componentIdentifier, result.build(), schema, selectionAttributes);
+    }
+
+    private ResolvedVariant mapVariant(ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, ArtifactTypeRegistry artifactTypeRegistry, VariantResolveMetadata variant) {
+        VariantResolveMetadata.Identifier identifier = variant.getIdentifier();
+        if (identifier == null) {
+            throw new IllegalArgumentException(String.format("Project variant %s does not have an identifier.", variant.asDescribable()));
+        }
+
+        // Apply any artifact type mappings to the attributes of the variant
+        ImmutableAttributes variantAttributes = artifactTypeRegistry.mapAttributesFor(variant.getAttributes().asImmutable(), variant.getArtifacts());
+
+        if (exclusions.mayExcludeArtifacts()) {
+            // Some artifact may be excluded, so do not reuse. It might be better to apply the exclusions and reuse if none of them apply
+            return DefaultArtifactSet.toResolvedVariant(variant, ownerId, moduleSources, exclusions, artifactResolver, allProjectArtifacts, variantAttributes);
+        }
+
+        VariantWithOverloadAttributes key = new VariantWithOverloadAttributes(identifier, variantAttributes);
+        return allProjectVariants.computeIfAbsent(key, k -> DefaultArtifactSet.toResolvedVariant(variant, ownerId, moduleSources, exclusions, artifactResolver, allProjectArtifacts, variantAttributes));
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -41,19 +42,19 @@ import java.util.List;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.EMPTY;
 
 public class ArtifactBackedResolvedVariant implements ResolvedVariant {
-    private final Identifier identifier;
+    private final VariantResolveMetadata.Identifier identifier;
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final ResolvedArtifactSet artifacts;
 
-    private ArtifactBackedResolvedVariant(@Nullable ResolvedVariant.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, ResolvedArtifactSet artifacts) {
+    private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, ResolvedArtifactSet artifacts) {
         this.identifier = identifier;
         this.displayName = displayName;
         this.attributes = attributes;
         this.artifacts = artifacts;
     }
 
-    public static ResolvedVariant create(@Nullable ResolvedVariant.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, Collection<? extends ResolvableArtifact> artifacts) {
+    public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, Collection<? extends ResolvableArtifact> artifacts) {
         if (artifacts.isEmpty()) {
             return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, EMPTY);
         }
@@ -68,7 +69,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     }
 
     @Override
-    public Identifier getIdentifier() {
+    public VariantResolveMetadata.Identifier getIdentifier() {
         return identifier;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -34,7 +34,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -87,17 +86,17 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     }
 
     public static ArtifactSet createForConfiguration(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ConfigurationMetadata configuration, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.asDescribable(), configuration.getAttributes(), artifacts, ImmutableCapabilities.EMPTY);
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), configuration.asDescribable(), configuration.getAttributes(), artifacts, ImmutableCapabilities.EMPTY);
         ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, new ComponentVariantIdentifier(componentIdentifier, configuration.getName()), ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
 
-    public static ArtifactSet adHocVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes) {
+    public static ArtifactSet adHocVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes) {
         ResolvedVariant.Identifier identifier = null;
         if (artifacts.size() == 1) {
             identifier = new SingleArtifactVariantIdentifier(artifacts.iterator().next().getId());
         }
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(displayName, variantAttributes, ImmutableList.copyOf(artifacts), ImmutableCapabilities.EMPTY);
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(null, Describables.of(componentIdentifier), variantAttributes, ImmutableList.copyOf(artifacts), ImmutableCapabilities.EMPTY);
         ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, identifier, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
@@ -107,7 +106,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
 
         // Apply any artifact type mappings to the attributes of the variant
-        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant);
+        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant.getAttributes().asImmutable(), artifacts);
 
         boolean hasExcludedArtifact = false;
         for (ComponentArtifactMetadata artifact : artifacts) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -37,6 +37,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -45,7 +46,6 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
@@ -74,39 +74,46 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     public static ArtifactSet createFromVariantMetadata(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
         if (variants.size() == 1) {
             VariantResolveMetadata variantMetadata = variants.iterator().next();
-            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, new ComponentVariantIdentifier(componentIdentifier, variantMetadata.getName()), ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
         }
         ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
         for (VariantResolveMetadata variant : variants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant, new ComponentVariantIdentifier(componentIdentifier, variant.getName()), ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             result.add(resolvedVariant);
         }
         return new MultipleVariantArtifactSet(componentIdentifier, schema, result.build(), selectionAttributes);
     }
 
+    public static ArtifactSet createFromVariants(ComponentIdentifier componentIdentifier, ImmutableSet<ResolvedVariant> variants, AttributesSchemaInternal schema, ImmutableAttributes selectionAttributes) {
+        return new MultipleVariantArtifactSet(componentIdentifier, schema, variants, selectionAttributes);
+    }
+
     public static ArtifactSet createForConfiguration(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ConfigurationMetadata configuration, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), configuration.asDescribable(), configuration.getAttributes(), artifacts, ImmutableCapabilities.EMPTY);
-        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, new ComponentVariantIdentifier(componentIdentifier, configuration.getName()), ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), new ComponentConfigurationIdentifier(componentIdentifier, configuration.getName()), configuration.asDescribable(), configuration.getAttributes(), artifacts, ImmutableCapabilities.EMPTY);
+        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
 
     public static ArtifactSet adHocVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes) {
-        ResolvedVariant.Identifier identifier = null;
+        VariantResolveMetadata.Identifier identifier = null;
         if (artifacts.size() == 1) {
             identifier = new SingleArtifactVariantIdentifier(artifacts.iterator().next().getId());
         }
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(null, Describables.of(componentIdentifier), variantAttributes, ImmutableList.copyOf(artifacts), ImmutableCapabilities.EMPTY);
-        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, identifier, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(null, identifier, Describables.of(componentIdentifier), variantAttributes, ImmutableList.copyOf(artifacts), ImmutableCapabilities.EMPTY);
+        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
 
-    private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, @Nullable ResolvedVariant.Identifier identifier, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
+    private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
+        // Apply any artifact type mappings to the attributes of the variant
+        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant.getAttributes().asImmutable(), variant.getArtifacts());
+        return toResolvedVariant(variant, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, attributes);
+    }
+
+    public static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ImmutableAttributes variantAttributes) {
         List<? extends ComponentArtifactMetadata> artifacts = variant.getArtifacts();
         ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
-
-        // Apply any artifact type mappings to the attributes of the variant
-        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant.getAttributes().asImmutable(), artifacts);
 
         boolean hasExcludedArtifact = false;
         for (ComponentArtifactMetadata artifact : artifacts) {
@@ -125,12 +132,13 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             resolvedArtifacts.add(resolvedArtifact);
         }
 
+        VariantResolveMetadata.Identifier identifier = variant.getIdentifier();
         if (hasExcludedArtifact) {
             // An ad hoc variant, has no identifier
             identifier = null;
         }
 
-        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), attributes, resolvedArtifacts.build());
+        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), variantAttributes, resolvedArtifacts.build());
     }
 
     @Override
@@ -194,7 +202,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         }
     }
 
-    private static class SingleArtifactVariantIdentifier implements ResolvedVariant.Identifier {
+    private static class SingleArtifactVariantIdentifier implements VariantResolveMetadata.Identifier {
         private final ComponentArtifactIdentifier artifactIdentifier;
 
         public SingleArtifactVariantIdentifier(ComponentArtifactIdentifier artifactIdentifier) {
@@ -216,33 +224,6 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             }
             SingleArtifactVariantIdentifier other = (SingleArtifactVariantIdentifier) obj;
             return artifactIdentifier.equals(other.artifactIdentifier);
-        }
-    }
-
-    private static class ComponentVariantIdentifier implements ResolvedVariant.Identifier {
-        private final ComponentIdentifier componentIdentifier;
-        private final String variantName;
-
-        public ComponentVariantIdentifier(ComponentIdentifier componentIdentifier, String variantName) {
-            this.componentIdentifier = componentIdentifier;
-            this.variantName = variantName;
-        }
-
-        @Override
-        public int hashCode() {
-            return componentIdentifier.hashCode() ^ variantName.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (obj == null || obj.getClass() != getClass()) {
-                return false;
-            }
-            ComponentVariantIdentifier other = (ComponentVariantIdentifier) obj;
-            return componentIdentifier.equals(other.componentIdentifier) && variantName.equals(other.variantName);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -42,6 +42,7 @@ import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
@@ -145,7 +146,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         }
 
         @Override
-        public Identifier getIdentifier() {
+        public VariantResolveMetadata.Identifier getIdentifier() {
             return null;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import javax.annotation.Nullable;
 
@@ -31,13 +32,10 @@ public interface ResolvedVariant extends HasAttributes {
      * using {@link org.gradle.api.artifacts.ModuleDependency#artifact(Action)} or where individual artifacts have been excluded from the variant.
      */
     @Nullable
-    Identifier getIdentifier();
+    VariantResolveMetadata.Identifier getIdentifier();
 
     @Override
     AttributeContainerInternal getAttributes();
 
     ResolvedArtifactSet getArtifacts();
-
-    interface Identifier {
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
@@ -20,6 +20,8 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+import org.gradle.internal.component.model.VariantWithOverloadAttributes;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 @ThreadSafe
 public class DefaultTransformedVariantFactory implements TransformedVariantFactory {
     private final TransformationNodeRegistry transformationNodeRegistry;
-    private final ConcurrentMap<Key, TransformedExternalArtifactSet> variants = new ConcurrentHashMap<>();
+    private final ConcurrentMap<VariantWithOverloadAttributes, TransformedExternalArtifactSet> variants = new ConcurrentHashMap<>();
 
     public DefaultTransformedVariantFactory(TransformationNodeRegistry transformationNodeRegistry) {
         this.transformationNodeRegistry = transformationNodeRegistry;
@@ -36,37 +38,16 @@ public class DefaultTransformedVariantFactory implements TransformedVariantFacto
 
     @Override
     public ResolvedArtifactSet transformedExternalArtifacts(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, ImmutableAttributes target, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
-        ResolvedVariant.Identifier identifier = sourceVariant.getIdentifier();
+        VariantResolveMetadata.Identifier identifier = sourceVariant.getIdentifier();
         if (identifier == null) {
             // An ad hoc variant, do not cache the result
             return new TransformedExternalArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), target, transformation, dependenciesResolverFactory, transformationNodeRegistry);
         }
-        return variants.computeIfAbsent(new Key(identifier, target), key -> new TransformedExternalArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), target, transformation, dependenciesResolverFactory, transformationNodeRegistry));
+        return variants.computeIfAbsent(new VariantWithOverloadAttributes(identifier, target), key -> new TransformedExternalArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), target, transformation, dependenciesResolverFactory, transformationNodeRegistry));
     }
 
     @Override
     public ResolvedArtifactSet transformedProjectArtifacts(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, ImmutableAttributes target, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
         return new TransformedProjectArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), target, transformation, dependenciesResolverFactory, transformationNodeRegistry);
-    }
-
-    private static class Key {
-        final ResolvedVariant.Identifier variantIdentifier;
-        final ImmutableAttributes targetVariant;
-
-        public Key(ResolvedVariant.Identifier variantIdentifier, ImmutableAttributes targetVariant) {
-            this.variantIdentifier = variantIdentifier;
-            this.targetVariant = targetVariant;
-        }
-
-        @Override
-        public int hashCode() {
-            return variantIdentifier.hashCode() ^ targetVariant.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            Key other = (Key) obj;
-            return variantIdentifier.equals(other.variantIdentifier) && targetVariant.equals(other.targetVariant);
-        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
@@ -19,12 +19,12 @@ package org.gradle.api.internal.artifacts.type;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
-import org.gradle.internal.component.model.VariantResolveMetadata;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
 
 import java.io.File;
 
 public interface ArtifactTypeRegistry extends Factory<ArtifactTypeContainer> {
-    ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant);
+    ImmutableAttributes mapAttributesFor(ImmutableAttributes attributes, Iterable<? extends ComponentArtifactMetadata> artifacts);
 
     ImmutableAttributes mapAttributesFor(File file);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.io.File;
@@ -68,13 +67,11 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
     }
 
     @Override
-    public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant) {
-        ImmutableAttributes attributes = variant.getAttributes().asImmutable();
-
+    public ImmutableAttributes mapAttributesFor(ImmutableAttributes attributes, Iterable<? extends ComponentArtifactMetadata> artifacts) {
         // Add attributes to be applied given the extension
         if (artifactTypeDefinitions != null) {
             String extension = null;
-            for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
+            for (ComponentArtifactMetadata artifact : artifacts) {
                 String candidateExtension = artifact.getName().getExtension();
                 if (extension == null) {
                     extension = candidateExtension;
@@ -91,7 +88,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
         // Add artifact format as an implicit attribute when all artifacts have the same format
         if (!attributes.contains(ArtifactAttributes.ARTIFACT_FORMAT)) {
             String format = null;
-            for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
+            for (ComponentArtifactMetadata artifact : artifacts) {
                 String candidateFormat = artifact.getName().getType();
                 if (format == null) {
                     format = candidateFormat;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -151,7 +151,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
 
     @Override
     public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -104,6 +104,11 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
     }
 
     @Override
+    public Identifier getIdentifier() {
+        return null;
+    }
+
+    @Override
     public ImmutableSet<String> getHierarchy() {
         return hierarchy;
     }
@@ -151,7 +156,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
 
     @Override
     public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(name, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, null, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -37,6 +37,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -575,6 +576,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         @Override
         public String getName() {
             return name;
+        }
+
+        @Override
+        public Identifier getIdentifier() {
+            return new ComponentConfigurationIdentifier(componentId, name);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -114,6 +114,11 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
+        public Identifier getIdentifier() {
+            return null;
+        }
+
+        @Override
         public DisplayName asDescribable() {
             throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
         }
@@ -145,9 +150,9 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         private final ImmutableList<GradleDependencyMetadata> dependencyMetadata;
 
         public ImmutableRealisedVariantImpl(ModuleComponentIdentifier componentId, String name, ImmutableAttributes attributes,
-                                     ImmutableList<? extends Dependency> dependencies, ImmutableList<? extends DependencyConstraint> dependencyConstraints,
-                                     ImmutableList<? extends File> files, ImmutableCapabilities capabilities,
-                                     List<GradleDependencyMetadata> dependencyMetadata) {
+                                            ImmutableList<? extends Dependency> dependencies, ImmutableList<? extends DependencyConstraint> dependencyConstraints,
+                                            ImmutableList<? extends File> files, ImmutableCapabilities capabilities,
+                                            List<GradleDependencyMetadata> dependencyMetadata) {
             this.componentId = componentId;
             this.name = name;
             this.attributes = attributes;
@@ -161,6 +166,11 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         @Override
         public String getName() {
             return name;
+        }
+
+        @Override
+        public Identifier getIdentifier() {
+            return null;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -86,6 +86,11 @@ class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
+    public Identifier getIdentifier() {
+        return null;
+    }
+
+    @Override
     public ImmutableSet<String> getHierarchy() {
         return ImmutableSet.of(variant.getName());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -33,9 +33,6 @@ import java.util.List;
  * TODO - this should replace or merge into VariantResolveMetadata, OutgoingVariant, ConfigurationMetadata
  */
 public interface ComponentVariant extends VariantResolveMetadata {
-    @Override
-    String getName();
-
     ImmutableList<? extends Dependency> getDependencies();
 
     ImmutableList<? extends DependencyConstraint> getDependencyConstraints();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -105,7 +105,7 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
 
     @Override
     public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -67,6 +67,11 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
+    public Identifier getIdentifier() {
+        return null;
+    }
+
+    @Override
     public List<? extends ModuleDependencyMetadata> getDependencies() {
         if (computedDependencies == null) {
             computedDependencies = variantMetadataRules.applyDependencyMetadataRules(this, base == null ? ImmutableList.of() : base.getDependencies());
@@ -105,7 +110,7 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
 
     @Override
     public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(name, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, null, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -79,6 +79,11 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         }
 
         @Override
+        public Identifier getIdentifier() {
+            return delegate.getIdentifier();
+        }
+
+        @Override
         public DisplayName asDescribable() {
             return delegate.asDescribable();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
@@ -55,6 +55,11 @@ public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantB
         }
 
         @Override
+        public Identifier getIdentifier() {
+            return delegate.getIdentifier();
+        }
+
+        @Override
         public DisplayName asDescribable() {
             return delegate.asDescribable();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
@@ -20,11 +20,13 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -37,15 +39,16 @@ public interface BuildableLocalComponentMetadata {
     /**
      * Adds some artifacts to this component. Artifacts are attached to the given configuration and each of its children. These are used only for publishing.
      */
-    void addArtifacts(String configuration, Iterable<? extends PublishArtifact> artifacts);
+    void addArtifacts(String configuration, Collection<? extends PublishArtifact> artifacts);
 
     /**
      * Adds a variant to this component, extending from the given configuration. Every configuration should include at least one variant.
      */
-    void addVariant(String configuration, OutgoingVariant variant);
+    void addVariant(String configuration, String name, VariantResolveMetadata.Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
 
     /**
      * Adds a configuration to this component.
+     *
      * @param hierarchy Must include name
      * @param attributes the attributes of the configuration.
      */
@@ -53,6 +56,7 @@ public interface BuildableLocalComponentMetadata {
 
     /**
      * Provides a backing configuration instance from which dependencies and excludes will be sourced.
+     *
      * @param configuration The configuration instance that provides dependencies and excludes
      * @param localConfigurationMetadataBuilder A builder for translating Configuration to LocalConfigurationMetadata
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -111,7 +111,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             for (ComponentArtifactMetadata oldArtifact : oldVariant.getArtifacts()) {
                 newArtifacts.add(copyArtifact((LocalComponentArtifactMetadata) oldArtifact, artifacts, transformedArtifacts));
             }
-            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts.build(), oldVariant.getCapabilities()));
+            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.getName(), oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts.build(), oldVariant.getCapabilities()));
         }
 
         for (DefaultLocalConfigurationMetadata configuration : allConfigurations.values()) {
@@ -158,7 +158,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             }
             artifacts = builder.build();
         }
-        allVariants.put(configuration, new DefaultVariantMetadata(variant.asDescribable(), variant.getAttributes().asImmutable(), artifacts, null));
+        allVariants.put(configuration, new DefaultVariantMetadata(configuration, variant.asDescribable(), variant.getAttributes().asImmutable(), artifacts, null));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentConfigurationIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentConfigurationIdentifier.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+
+/**
+ * An general identifier for a variant that represents a configuration in a component.
+ */
+public class ComponentConfigurationIdentifier implements VariantResolveMetadata.Identifier {
+    private final ComponentIdentifier component;
+    private final String configurationName;
+
+    public ComponentConfigurationIdentifier(ComponentIdentifier component, String configurationName) {
+        this.component = component;
+        this.configurationName = configurationName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        ComponentConfigurationIdentifier other = (ComponentConfigurationIdentifier) obj;
+        return component.equals(other.component) && configurationName.equals(other.configurationName);
+    }
+
+    @Override
+    public int hashCode() {
+        return component.hashCode() ^ configurationName.hashCode();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -24,12 +24,14 @@ import org.gradle.internal.DisplayName;
 import javax.annotation.Nullable;
 
 public class DefaultVariantMetadata implements VariantResolveMetadata {
+    private final String name;
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final ImmutableList<? extends ComponentArtifactMetadata> artifacts;
     private final CapabilitiesMetadata capabilitiesMetadata;
 
-    public DefaultVariantMetadata(DisplayName displayName, AttributeContainerInternal attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, @Nullable CapabilitiesMetadata capabilitiesMetadata) {
+    public DefaultVariantMetadata(String name, DisplayName displayName, AttributeContainerInternal attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, @Nullable CapabilitiesMetadata capabilitiesMetadata) {
+        this.name = name;
         this.displayName = displayName;
         this.attributes = attributes;
         this.artifacts = artifacts;
@@ -38,7 +40,7 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
 
     @Override
     public String getName() {
-        return displayName.getDisplayName();
+        return name;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -25,13 +25,15 @@ import javax.annotation.Nullable;
 
 public class DefaultVariantMetadata implements VariantResolveMetadata {
     private final String name;
+    private final Identifier identifier;
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final ImmutableList<? extends ComponentArtifactMetadata> artifacts;
     private final CapabilitiesMetadata capabilitiesMetadata;
 
-    public DefaultVariantMetadata(String name, DisplayName displayName, AttributeContainerInternal attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, @Nullable CapabilitiesMetadata capabilitiesMetadata) {
+    public DefaultVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, @Nullable CapabilitiesMetadata capabilitiesMetadata) {
         this.name = name;
+        this.identifier = identifier;
         this.displayName = displayName;
         this.attributes = attributes;
         this.artifacts = artifacts;
@@ -41,6 +43,11 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Identifier getIdentifier() {
+        return identifier;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -21,11 +21,19 @@ import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.DisplayName;
 
+import javax.annotation.Nullable;
+
 /**
  * Metadata for a basic variant of a component, that defines only artifacts and no dependencies.
  */
 public interface VariantResolveMetadata {
     String getName();
+
+    /**
+     * An identifier for this variant, if available. A variant may not necessarily have an identifier associated with it, for example if it represents some ad hoc variant.
+     */
+    @Nullable
+    Identifier getIdentifier();
 
     DisplayName asDescribable();
 
@@ -34,4 +42,7 @@ public interface VariantResolveMetadata {
     ImmutableList<? extends ComponentArtifactMetadata> getArtifacts();
 
     CapabilitiesMetadata getCapabilities();
+
+    interface Identifier {
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantWithOverloadAttributes.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantWithOverloadAttributes.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+public class VariantWithOverloadAttributes implements VariantResolveMetadata.Identifier {
+    private final VariantResolveMetadata.Identifier variantIdentifier;
+    private final ImmutableAttributes targetVariant;
+
+    public VariantWithOverloadAttributes(VariantResolveMetadata.Identifier variantIdentifier, ImmutableAttributes targetVariant) {
+        this.variantIdentifier = variantIdentifier;
+        this.targetVariant = targetVariant;
+    }
+
+    @Override
+    public int hashCode() {
+        return variantIdentifier.hashCode() ^ targetVariant.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        VariantWithOverloadAttributes other = (VariantWithOverloadAttributes) obj;
+        return variantIdentifier.equals(other.variantIdentifier) && targetVariant.equals(other.targetVariant);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.simpl
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.Describables;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -72,6 +71,6 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.adHocVariant(component.getId(), component.getModuleVersionId(), Describables.of(component.getId()), artifacts, component.getSources(), EXCLUDE_NONE, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getAttributes(), overriddenAttributes);
+        return DefaultArtifactSet.adHocVariant(component.getId(), component.getModuleVersionId(), artifacts, component.getSources(), EXCLUDE_NONE, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getAttributes(), overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule
 
-import org.gradle.api.artifacts.ModuleIdentifier
+
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.project.ProjectState
@@ -36,7 +36,9 @@ class ProjectDependencyResolverTest extends Specification {
     final LocalComponentRegistry registry = Mock()
     final ComponentIdentifierFactory componentIdentifierFactory = Mock()
     final ProjectStateRegistry projectRegistry = Stub()
-    final ProjectDependencyResolver resolver = new ProjectDependencyResolver(registry, componentIdentifierFactory, projectRegistry)
+    final ProjectArtifactResolver projectArtifactResolver = Stub()
+    final ProjectArtifactSetResolver projectArtifactSetResolver = Stub()
+    final ProjectDependencyResolver resolver = new ProjectDependencyResolver(registry, componentIdentifierFactory, projectArtifactSetResolver, projectArtifactResolver)
 
     def setup() {
         def projectState = Stub(ProjectState)
@@ -82,7 +84,6 @@ class ProjectDependencyResolverTest extends Specification {
     def "doesn't try to resolve non-project dependency"() {
         def result = Mock(BuildableComponentIdResolveResult)
         def dependencyMetaData = Stub(DependencyMetadata)
-        def targetModuleId = Stub(ModuleIdentifier)
 
         when:
         resolver.resolve(dependencyMetaData, null, null, result)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -25,13 +25,14 @@ import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.Describables
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
+import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Specification
 
 class ArtifactBackedResolvedVariantTest extends Specification {
     def variant = Mock(AttributeContainerInternal)
     def variantDisplayName = Describables.of("<variant>")
-    def id = Mock(ResolvedVariant.Identifier)
+    def id = Mock(VariantResolveMetadata.Identifier)
     def queue = new TestBuildOperationExecutor.TestBuildOperationQueue()
     def artifact1 = Mock(TestArtifact)
     def artifact2 = Mock(TestArtifact)
@@ -154,7 +155,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         then:
         1 * artifact1.id >> new ComponentFileArtifactIdentifier(Stub(ProjectComponentIdentifier), "some-file")
         1 * artifact2.id >> new ComponentFileArtifactIdentifier(Stub(ModuleComponentIdentifier), "some-file")
-        1 * visitor.visitArtifact({it.artifact == artifact1})
+        1 * visitor.visitArtifact({ it.artifact == artifact1 })
         0 * _
 
         when:
@@ -162,7 +163,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
         then:
         1 * artifact1.id >> new ComponentFileArtifactIdentifier(Stub(ProjectComponentIdentifier), "some-file")
-        1 * visitor.visitArtifact({it.artifact == artifact1})
+        1 * visitor.visitArtifact({ it.artifact == artifact1 })
         0 * _
     }
 
@@ -191,6 +192,6 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         return ArtifactBackedResolvedVariant.create(id, variantDisplayName, variant, artifacts)
     }
 
-    interface TestArtifact extends ResolvableArtifact, Buildable { }
+    interface TestArtifact extends ResolvableArtifact, Buildable {}
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.internal.DisplayName
 import org.gradle.internal.component.model.VariantResolveMetadata
 import spock.lang.Specification
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -41,7 +41,7 @@ class DefaultArtifactSetTest extends Specification {
         given:
         def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
         def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         expect:
         artifacts1.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
@@ -58,7 +58,7 @@ class DefaultArtifactSetTest extends Specification {
         given:
         def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
         def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         selector.select(_, _) >> resolvedVariant1
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -52,37 +52,28 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "does not apply any mapping when no artifact types registered"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantResolveMetadata)
-
-        given:
-        variant.attributes >> attrs
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(attrs, []) == attrs
     }
 
     def "does not apply any mapping when variant has no artifacts"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantResolveMetadata)
 
         given:
-        variant.attributes >> attrs
-        variant.artifacts >> ImmutableList.of()
+        registry.create().create("aar")
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(attrs, []) == attrs
     }
 
     def "adds artifactType attribute but does not apply any mapping when no matching artifact type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar"])
-        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
         given:
-        variant.attributes >> attrs
-        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -90,19 +81,16 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("aar")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(attrs, [artifact]) == attrsPlusFormat
     }
 
     def "applies mapping when no attributes defined for matching type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar"])
-        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
         given:
-        variant.attributes >> attrs
-        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -110,19 +98,16 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("jar")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(attrs, [artifact]) == attrsPlusFormat
     }
 
     def "applies mapping to matching artifact type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar", "custom": "123"])
-        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
         given:
-        variant.attributes >> attrs
-        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -130,20 +115,17 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("jar").attributes.attribute(Attribute.of("custom", String), "123")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(attrs, [artifact]) == attrsPlusFormat
     }
 
     def "does not apply mapping when multiple artifacts with different types"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantResolveMetadata)
         def artifact1 = Stub(ComponentArtifactMetadata)
         def artifactName1 = Stub(IvyArtifactName)
         def artifact2 = Stub(ComponentArtifactMetadata)
         def artifactName2 = Stub(IvyArtifactName)
 
         given:
-        variant.attributes >> attrs
-        variant.artifacts >> ImmutableList.of(artifact1, artifact2)
         artifact1.name >> artifactName1
         artifactName1.extension >> "jar"
         artifactName1.type >> "jar"
@@ -155,7 +137,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("zip").attributes.attribute(Attribute.of("custom", String), "234")
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(attrs, [artifact1, artifact2]) == attrs
     }
 
     def "maps only artifactType attribute for arbitrary files when no extensions are registered"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.type
 
-import com.google.common.collect.ImmutableList
+
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
@@ -24,7 +24,6 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.IvyArtifactName
-import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -47,8 +47,8 @@ import org.gradle.api.specs.Specs;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.language.base.internal.resolve.LibraryResolveException;
@@ -149,8 +149,8 @@ public class DependencyResolvingClasspath extends AbstractOpaqueFileCollection {
             }
 
             @Override
-            public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant) {
-                return variant.getAttributes().asImmutable();
+            public ImmutableAttributes mapAttributesFor(ImmutableAttributes attributes, Iterable<? extends ComponentArtifactMetadata> artifacts) {
+                return attributes;
             }
 
             @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
@@ -16,23 +16,18 @@
 
 package org.gradle.jvm.internal.resolve;
 
-import com.google.common.collect.ImmutableSet;
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ResolveContext;
-import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCapabilitiesResolution;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
 import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.locking.NoOpDependencyLockingProvider;
 import org.gradle.internal.reflect.DirectInstantiator;
@@ -40,7 +35,7 @@ import org.gradle.language.base.internal.model.DefaultLibraryLocalComponentMetad
 import org.gradle.platform.base.DependencySpec;
 import org.gradle.vcs.internal.VcsMappingsStore;
 
-import java.util.Set;
+import java.util.Collections;
 
 import static org.gradle.language.base.internal.model.DefaultLibraryLocalComponentMetadata.newResolvingLocalComponentMetadata;
 
@@ -90,27 +85,7 @@ public class JvmLibraryResolveContext implements ResolveContext {
     public ComponentResolveMetadata toRootComponentMetaData() {
         final DefaultLibraryLocalComponentMetadata componentMetadata = newResolvingLocalComponentMetadata(libraryBinaryIdentifier, usage.getConfigurationName(), dependencies);
         for (UsageKind usageKind : UsageKind.values()) {
-            componentMetadata.addVariant(usageKind.getConfigurationName(), new OutgoingVariant() {
-                @Override
-                public DisplayName asDescribable() {
-                    return Describables.of(componentMetadata.getId());
-                }
-
-                @Override
-                public AttributeContainerInternal getAttributes() {
-                    return ImmutableAttributes.EMPTY;
-                }
-
-                @Override
-                public Set<? extends PublishArtifact> getArtifacts() {
-                    return ImmutableSet.of();
-                }
-
-                @Override
-                public Set<? extends OutgoingVariant> getChildren() {
-                    return ImmutableSet.of();
-                }
-            });
+            componentMetadata.addVariant(usageKind.getConfigurationName(), usageKind.getConfigurationName(), null, Describables.of(componentMetadata.getId()), ImmutableAttributes.EMPTY, Collections.emptyList());
         }
         return componentMetadata;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLocalLibraryMetaDataAdapter.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLocalLibraryMetaDataAdapter.java
@@ -16,16 +16,12 @@
 
 package org.gradle.jvm.internal.resolve;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.resolve.LocalLibraryMetaDataAdapter;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.Describables;
 import org.gradle.jvm.JvmLibrarySpec;
 import org.gradle.jvm.internal.JarBinarySpecInternal;
@@ -42,7 +38,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -76,29 +71,9 @@ public class JvmLocalLibraryMetaDataAdapter implements LocalLibraryMetaDataAdapt
         final DefaultLibraryLocalComponentMetadata metadata = newResolvedLibraryMetadata(selectedBinary.getId(), toStringMap(dependenciesPerUsage), projectPath);
         for (Map.Entry<UsageKind, List<PublishArtifact>> entry : artifacts.entrySet()) {
             UsageKind usage = entry.getKey();
-            final List<PublishArtifact> publishArtifacts = entry.getValue();
+            List<PublishArtifact> publishArtifacts = entry.getValue();
             metadata.addArtifacts(usage.getConfigurationName(), publishArtifacts);
-            metadata.addVariant(usage.getConfigurationName(), new OutgoingVariant() {
-                @Override
-                public DisplayName asDescribable() {
-                    return Describables.of(metadata.getId());
-                }
-
-                @Override
-                public AttributeContainerInternal getAttributes() {
-                    return ImmutableAttributes.EMPTY;
-                }
-
-                @Override
-                public Set<? extends PublishArtifact> getArtifacts() {
-                    return new LinkedHashSet<PublishArtifact>(publishArtifacts);
-                }
-
-                @Override
-                public Set<? extends OutgoingVariant> getChildren() {
-                    return ImmutableSet.of();
-                }
-            });
+            metadata.addVariant(usage.getConfigurationName(), usage.getConfigurationName(), null, Describables.of(metadata.getId()), ImmutableAttributes.EMPTY, publishArtifacts);
         }
         return metadata;
     }


### PR DESCRIPTION

### Context

This PR reduces the number of duplicate instances of a `ResolvedVariant` are created and retained for a given project outgoing variant by applying some build scoped caching. This continues from a previous change to reduce the number of duplicate instances are created for a transformed external dependency variant, by pushing the variant id introduced there down and reusing this for project variants. Similar caching can later be applied for transformed project variants, to help write less duplicate data to the configuration cache.
 
### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
