### PR TITLE
Allow build operations to throw checked exceptions

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -39,7 +39,6 @@ import org.gradle.caching.internal.controller.service.StoreTarget;
 import org.gradle.caching.local.internal.BuildCacheTempFileStore;
 import org.gradle.caching.local.internal.DefaultBuildCacheTempFileStore;
 import org.gradle.caching.local.internal.LocalBuildCacheService;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -51,7 +50,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.util.Optional;
 
 public class DefaultBuildCacheController implements BuildCacheController {
@@ -145,11 +143,9 @@ public class DefaultBuildCacheController implements BuildCacheController {
         public void execute(File file) {
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
-                public void run(BuildOperationContext context) {
+                public void run(BuildOperationContext context) throws IOException {
                     try (InputStream input = new FileInputStream(file)) {
                         result = command.load(input);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
                     }
                     context.setResult(new UnpackOperationResult(
                         result.getArtifactEntryCount()
@@ -200,15 +196,13 @@ public class DefaultBuildCacheController implements BuildCacheController {
         public void execute(final File file) {
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
-                public void run(BuildOperationContext context) {
+                public void run(BuildOperationContext context) throws IOException {
                     try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
                         BuildCacheStoreCommand.Result result = command.store(fileOutputStream);
                         context.setResult(new PackOperationResult(
                             result.getArtifactEntryCount(),
                             file.length()
                         ));
-                    } catch (IOException e) {
-                        throw UncheckedException.throwAsUncheckedException(e);
                     }
                 }
 

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -146,10 +146,10 @@ public class DefaultBuildCacheController implements BuildCacheController {
                 public void run(BuildOperationContext context) throws IOException {
                     try (InputStream input = new FileInputStream(file)) {
                         result = command.load(input);
+                        context.setResult(new UnpackOperationResult(
+                            result.getArtifactEntryCount()
+                        ));
                     }
-                    context.setResult(new UnpackOperationResult(
-                        result.getArtifactEntryCount()
-                    ));
                 }
 
                 @Override

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationRunner.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationRunner.java
@@ -27,7 +27,9 @@ public interface BuildOperationRunner {
     /**
      * Runs the given build operation synchronously. Invokes the given operation from the current thread.
      *
-     * <p>Rethrows any exception thrown by the action.</p>
+     * <p>Rethrows any exception thrown by the action.
+     * Runtime exceptions are rethrown as is.
+     * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
     void run(RunnableBuildOperation buildOperation);
 
@@ -35,7 +37,9 @@ public interface BuildOperationRunner {
      * Calls the given build operation synchronously. Invokes the given operation from the current thread.
      * Returns the result.
      *
-     * <p>Rethrows any exception thrown by the action.</p>
+     * <p>Rethrows any exception thrown by the action.
+     * Runtime exceptions are rethrown as is.
+     * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
     <T> T call(CallableBuildOperation<T> buildOperation);
 

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationWorker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationWorker.java
@@ -27,5 +27,5 @@ public interface BuildOperationWorker<O extends BuildOperation> {
      */
     String getDisplayName();
 
-    void execute(O buildOperation, BuildOperationContext context);
+    void execute(O buildOperation, BuildOperationContext context) throws Exception;
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/CallableBuildOperation.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/CallableBuildOperation.java
@@ -18,5 +18,5 @@ package org.gradle.internal.operations;
 
 public interface CallableBuildOperation<T> extends BuildOperation {
 
-    T call(BuildOperationContext context);
+    T call(BuildOperationContext context) throws Exception;
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
@@ -325,7 +325,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
         }
 
         @Override
-        public void execute(RunnableBuildOperation buildOperation, BuildOperationContext context) {
+        public void execute(RunnableBuildOperation buildOperation, BuildOperationContext context) throws Exception {
             buildOperation.run(context);
         }
     }
@@ -339,7 +339,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
         }
 
         @Override
-        public void execute(CallableBuildOperation<T> buildOperation, BuildOperationContext context) {
+        public void execute(CallableBuildOperation<T> buildOperation, BuildOperationContext context) throws Exception {
             returnValue = buildOperation.call(context);
         }
 

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/RunnableBuildOperation.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/RunnableBuildOperation.java
@@ -18,5 +18,5 @@ package org.gradle.internal.operations;
 
 public interface RunnableBuildOperation extends BuildOperation {
 
-    void run(BuildOperationContext context);
+    void run(BuildOperationContext context) throws Exception;
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
@@ -151,7 +151,7 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         then:
         fails("clean", "customTask")
         failureHasCause("Failed to load cache entry for task ':customTask'")
-        errorOutput.contains("Caused by: java.io.UncheckedIOException: java.io.EOFException: Unexpected end of ZLIB input stream")
+        errorOutput.contains("Caused by: java.io.EOFException: Unexpected end of ZLIB input stream")
         localCache.listCacheFailedFiles().size() == 1
 
         and:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -90,15 +89,11 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
             );
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
-                public void run(BuildOperationContext context) {
+                public void run(BuildOperationContext context) throws IOException {
                     for (File file : filesToDelete) {
                         if (file.exists()) {
                             logger.info("Deleting stale output file: {}", file.getAbsolutePath());
-                            try {
-                                deleter.deleteRecursively(file);
-                            } catch (IOException ex) {
-                                throw new UncheckedIOException("Couldn't delete stale output file", ex);
-                            }
+                            deleter.deleteRecursively(file);
                         }
                     }
                 }


### PR DESCRIPTION
This is to avoid unnecessarily wrapping exceptions and adding boilerplate.