### PR TITLE
Remove `kotlinEapRepositoryDefinition` from Kotlin DSL test fixture

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/KotlinDslTestUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/KotlinDslTestUtil.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.fixtures
 import org.gradle.test.fixtures.dsl.GradleDsl
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepositoryDefinition
-import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.kotlinEapRepositoryDefinition
 
 class KotlinDslTestUtil {
 
@@ -29,8 +28,6 @@ class KotlinDslTestUtil {
 
             allprojects {
                 repositories {
-                    //TODO:kotlin-dsl remove once we're no longer on a kotlin eap 
-                    ${kotlinEapRepositoryDefinition(GradleDsl.KOTLIN)}
                     ${jcenterRepositoryDefinition(GradleDsl.KOTLIN)}
                 }
             }


### PR DESCRIPTION
As the tests no longer require it.