### PR TITLE
Toolchain download fails with user-readable errors

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -330,7 +330,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
      * @since 4.0
      */
     @Nested
-    @SuppressWarnings("deprecation")
+    @Deprecated
     protected org.gradle.jvm.toolchain.JavaToolChain getJavaToolChain() {
         return getJavaToolChainFactory().forCompileOptions(getOptions());
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -145,6 +145,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      * @return The tool chain.
      */
     @Nested
+    @Deprecated
     public JavaToolChain getToolChain() {
         if (toolChain != null) {
             return toolChain;
@@ -157,6 +158,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      *
      * @param toolChain The tool chain.
      */
+    @Deprecated
     public void setToolChain(JavaToolChain toolChain) {
         this.toolChain = toolChain;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -207,6 +207,7 @@ public class Javadoc extends SourceTask {
      * Returns the tool chain that will be used to generate the Javadoc.
      */
     @Inject
+    @Deprecated
     public JavaToolChain getToolChain() {
         // Implementation is generated
         throw new UnsupportedOperationException();
@@ -215,6 +216,7 @@ public class Javadoc extends SourceTask {
     /**
      * Sets the tool chain to use to generate the Javadoc.
      */
+    @Deprecated
     public void setToolChain(@SuppressWarnings("unused") JavaToolChain toolChain) {
         // Implementation is generated
         throw new UnsupportedOperationException();

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -22,7 +22,7 @@ import java.io.File;
 
 public interface FileLockManager {
     /**
-     * Creates a locks for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
+     * Creates a lock for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
      * released by calling {@link FileLock#close()}. This method blocks until the lock can be acquired.
      *
      * @param target The file to be locked.
@@ -32,7 +32,7 @@ public interface FileLockManager {
     FileLock lock(File target, LockOptions options, String targetDisplayName) throws LockTimeoutException;
 
     /**
-     * Creates a locks for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
+     * Creates a lock for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
      * released by calling {@link FileLock#close()}. This method blocks until the lock can be acquired.
      *
      * @param target The file to be locked.
@@ -43,7 +43,7 @@ public interface FileLockManager {
     FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName) throws LockTimeoutException;
 
     /**
-     * Creates a locks for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
+     * Creates a lock for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
      * released by calling {@link FileLock#close()}. This method blocks until the lock can be acquired.
      * <p>
      * Enable other processes to request access to the provided lock. Provided action runs when the lock access request is received

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -137,7 +137,7 @@ public class DefaultFileLockManager implements FileLockManager {
             this.port = port;
             this.lockId = generator.generateId();
             if (options.getMode() == LockMode.OnDemand) {
-                throw new UnsupportedOperationException("Locking mode None is not supported.");
+                throw new UnsupportedOperationException("Locking mode OnDemand is not supported.");
             }
 
             this.target = target;

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":diagnostics"))
     implementation(project(":normalizationJava"))
     implementation(project(":resources"))
+    implementation(project(":persistentCache"))
 
     implementation(libs.groovy)
     implementation(libs.guava)

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can properly fails for missing combination"() {
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaVersion.VERSION_17
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        result = executer
+            .withArguments("-Porg.gradle.java.installations.auto-detect=false", "--info")
+            .withTasks("compileJava")
+            .requireOwnGradleUserHomeDir()
+            .run()
+
+        then:
+        outputContains("""
+* What went wrong:
+Execution failed for task ':compileJava'.
+> Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
+   > Unable to download toolchain matching these requirements: {languageVersion=17}
+      > Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.
+         > Could not read 'https://api.adoptopenjdk.net/v3/binary/latest/17/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk' as it does not exist.
+""")
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -109,8 +109,6 @@ public class AdoptOpenJdkRemoteBinary {
         return operatingSystem.getFamilyName();
     }
 
-    // TODO: [bm] determine using API?
-    // https://github.com/AdoptOpenJDK/openjdk-api-v3/issues/256
     private String determineReleaseState() {
         return "ga";
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.jvm.toolchain.install.internal;
 
-import com.google.common.io.Files;
 import net.rubygrapefruit.platform.SystemInfo;
 import org.gradle.api.JavaVersion;
 import org.gradle.internal.os.OperatingSystem;
@@ -40,15 +39,13 @@ public class AdoptOpenJdkRemoteBinary {
         this.downloader = downloader;
     }
 
-    // TODO: [bm] this might be downloading the same jdk multiple times in parallel builds
-    public Optional<File> download(JavaToolchainSpec spec) {
+    public Optional<File> download(JavaToolchainSpec spec, File destinationFile) {
         if (!canProvidesMatchingJdk(spec)) {
             return Optional.empty();
         }
-        File tmpFile = new File(Files.createTempDir(), toFilename(spec));
         URI source = toDownloadUri(spec);
-        downloader.download(source, tmpFile);
-        return Optional.of(tmpFile);
+        downloader.download(source, destinationFile);
+        return Optional.of(destinationFile);
     }
 
     private boolean canProvidesMatchingJdk(JavaToolchainSpec spec) {
@@ -71,7 +68,7 @@ public class AdoptOpenJdkRemoteBinary {
             "/jdk/hotspot/normal/adoptopenjdk");
     }
 
-    String toFilename(JavaToolchainSpec spec) {
+    public String toFilename(JavaToolchainSpec spec) {
         return String.format("adoptopenjdk-%s-%s-%s.%s", getLanguageVersion(spec), determineArch(), determineOs(), determineFileExtension());
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
@@ -17,13 +17,24 @@
 package org.gradle.jvm.toolchain.install.internal;
 
 import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Optional;
 
 public class DefaultJavaToolchainProvisioningService implements JavaToolchainProvisioningService {
+
+    @Contextual
+    private static class MissingToolchainException extends GradleException {
+
+        public MissingToolchainException(JavaToolchainSpec spec, @Nullable Throwable cause) {
+            super("Unable to download toolchain matching these requirements: " + spec.getDisplayName(), cause);
+        }
+
+    }
 
     private final AdoptOpenJdkRemoteBinary openJdkBinary;
     private final JdkCacheDirectory cacheDirProvider;
@@ -39,7 +50,7 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
             final Optional<File> jdkArchive = openJdkBinary.download(spec);
             return jdkArchive.map(cacheDirProvider::provisionFromArchive);
         } catch (Exception e) {
-            throw new GradleException("Unable to download toolchain matching these requirements: " + spec.getDisplayName(), e);
+            throw new MissingToolchainException(spec, e);
         }
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/JdkCacheDirectory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/JdkCacheDirectory.java
@@ -42,7 +42,6 @@ public class JdkCacheDirectory {
 
     public JdkCacheDirectory(GradleUserHomeDirProvider homeDirProvider, FileOperations operations) {
         this.operations = operations;
-        // TODO: [bm] any reason to use CacheScopeMapping instead?
         this.jdkDirectory = new File(homeDirProvider.getGradleUserHomeDirectory(), "jdks");
     }
 
@@ -80,7 +79,6 @@ public class JdkCacheDirectory {
         return installLocation;
     }
 
-    // TODO: [bm] anyway to cancel after first visit? or a better way to find the single root
     private String getRootDirectory(FileTree fileTree) {
         AtomicReference<File> rootDir = new AtomicReference<>();
         fileTree.visit(new EmptyFileVisitor() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -70,7 +70,6 @@ public class JavaToolchainQueryService {
             new NoToolchainAvailableException(spec));
     }
 
-    // TODO: [bm] to be replaced with AttributeContainer/AttributeMatcher
     private Predicate<JavaToolchain> matchingToolchain(JavaToolchainSpec spec) {
         return toolchain -> toolchain.getJavaMajorVersion() == spec.getLanguageVersion().get();
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -22,10 +22,15 @@ import org.gradle.internal.SystemProperties
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.gradle.util.TestUtil
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class AdoptOpenJdkRemoteBinaryTest extends Specification {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
 
     @Unroll
     def "generates url for jdk #jdkVersion on #operatingSystemName (#architecture)"() {
@@ -118,10 +123,10 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader)
 
         when:
-        def downloadFile = binary.download(spec)
+        def targetFile = temporaryFolder.newFile("jdk")
+        def downloadFile = binary.download(spec, targetFile)
 
         then:
-        downloadFile.get().name == "adoptopenjdk-12-x64-mac.tar.gz"
         1 * downloader.download(URI.create("https://api.adoptopenjdk.net/v3/binary/latest/12/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"), _)
     }
 
@@ -135,7 +140,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader))
 
         when:
-        def file = binary.download(spec)
+        def file = binary.download(spec, Mock(File))
 
         then:
         !file.present

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.install.internal
+
+
+import org.gradle.cache.FileLock
+import org.gradle.jvm.toolchain.JavaToolchainSpec
+import spock.lang.Specification
+
+class DefaultJavaToolchainProvisioningServiceTest extends Specification {
+
+    def "cache is properly locked around provisioning a jdk"() {
+        def cache = Mock(JdkCacheDirectory)
+        def lock = Mock(FileLock)
+        def binary = Mock(AdoptOpenJdkRemoteBinary)
+        def spec = Mock(JavaToolchainSpec)
+
+        given:
+        binary.toFilename(spec) >> 'jdk-123.zip'
+        cache.getDownloadLocation(_ as String) >> Mock(File)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(binary, cache)
+
+        when:
+        provisioningService.tryInstall(spec)
+
+        then:
+        1 * cache.acquireWriteLock("jdk-123.zip") >> lock
+
+        then:
+        1 * binary.download(_, _) >> Optional.empty()
+
+        then:
+        1 * lock.close()
+    }
+
+}


### PR DESCRIPTION
In case the download fails, multiple downloads happen in parallel or a requested JDK is not available, fail the build with human-readable error messages.