### PR TITLE
Elaborate name matching in user guide

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -223,7 +223,7 @@ samples {
             readmeFile = file("src/snippets/default-readme.adoc")
             sampleDirectory = snippetDir
             promoted = false
-        }            
+        }
     }
 
     publishedSamples {

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -140,12 +140,16 @@ If a task fails, any subsequent tasks that were depending on it will not be exec
 
 When you specify tasks on the command-line, you don’t have to provide the full name of the task. You only need to provide enough of the task name to uniquely identify the task. For example, it's likely `gradle che` is enough for Gradle to identify the `check` task.
 
-You can also abbreviate each word in a camel case task name. For example, you can execute task `compileTest` by running `gradle compTest` or even `gradle cT`.
+The same applies for project names. You can execute the run the `check` task in the `library` subproject with the `gradle lib:che` command.
 
-.Abbreviated camel case task name
+You can use https://en.wikipedia.org/wiki/Camel_case[camel case] patterns for more complex abbreviations. These patterns are expanded to match to camel case and https://en.wikipedia.org/wiki/Kebab_case[kebab case] names. For example the pattern `foBa` (or even `fB`) matches to `fooBar` and to `foo-bar`.
+
+More concretely, you can run the `compileTest` task in the `my-awesome-library` subproject with the `gradle  mAL:cT` command.
+
+.Abbreviated project and task names
 ----
-$ gradle cT
-include::{snippetsPath}/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.out[]
+$ gradle  mAL:cT
+include::{snippetsPath}/tutorial/nameMatching/tests/nameMatching.out[]
 ----
 
 You can also use these abbreviations with the -x command-line option.

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -140,7 +140,7 @@ If a task fails, any subsequent tasks that were depending on it will not be exec
 
 When you specify tasks on the command-line, you don’t have to provide the full name of the task. You only need to provide enough of the task name to uniquely identify the task. For example, it's likely `gradle che` is enough for Gradle to identify the `check` task.
 
-The same applies for project names. You can execute the run the `check` task in the `library` subproject with the `gradle lib:che` command.
+The same applies for project names. You can execute the `check` task in the `library` subproject with the `gradle lib:che` command.
 
 You can use https://en.wikipedia.org/wiki/Camel_case[camel case] patterns for more complex abbreviations. These patterns are expanded to match to camel case and https://en.wikipedia.org/wiki/Kebab_case[kebab case] names. For example the pattern `foBa` (or even `fB`) matches to `fooBar` and to `foo-bar`.
 

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -142,7 +142,7 @@ When you specify tasks on the command-line, you don’t have to provide the full
 
 The same applies for project names. You can execute the `check` task in the `library` subproject with the `gradle lib:che` command.
 
-You can use https://en.wikipedia.org/wiki/Camel_case[camel case] patterns for more complex abbreviations. These patterns are expanded to match to camel case and https://en.wikipedia.org/wiki/Kebab_case[kebab case] names. For example the pattern `foBa` (or even `fB`) matches to `fooBar` and to `foo-bar`.
+You can use https://en.wikipedia.org/wiki/Camel_case[camel case] patterns for more complex abbreviations. These patterns are expanded to match camel case and https://en.wikipedia.org/wiki/Kebab_case[kebab case] names. For example the pattern `foBa` (or even `fB`) matches `fooBar` and `foo-bar`.
 
 More concretely, you can run the `compileTest` task in the `my-awesome-library` subproject with the `gradle  mAL:cT` command.
 

--- a/subprojects/docs/src/snippets/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.out
+++ b/subprojects/docs/src/snippets/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.out
@@ -1,9 +1,0 @@
-
-> Task :compile
-compiling source
-
-> Task :compileTest
-compiling unit tests
-
-BUILD SUCCESSFUL in 0s
-2 actionable tasks: 2 executed

--- a/subprojects/docs/src/snippets/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.sample.conf
+++ b/subprojects/docs/src/snippets/tutorial/excludeTasks/tests/abbreviateCamelCaseTaskName.sample.conf
@@ -1,6 +1,0 @@
-# tag::cli[]
-# gradle cT
-# end::cli[]
-executable: gradle
-args: cT
-expected-output-file: abbreviateCamelCaseTaskName.out

--- a/subprojects/docs/src/snippets/tutorial/nameMatching/groovy/my-awesome-library/build.gradle
+++ b/subprojects/docs/src/snippets/tutorial/nameMatching/groovy/my-awesome-library/build.gradle
@@ -1,0 +1,5 @@
+tasks.register('compileTest') {
+    doLast {
+        println 'compiling unit tests'
+    }
+}

--- a/subprojects/docs/src/snippets/tutorial/nameMatching/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tutorial/nameMatching/groovy/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'name-matching'
+include 'my-awesome-library'

--- a/subprojects/docs/src/snippets/tutorial/nameMatching/tests/nameMatching.out
+++ b/subprojects/docs/src/snippets/tutorial/nameMatching/tests/nameMatching.out
@@ -1,0 +1,6 @@
+
+> Task :my-awesome-library:compileTest
+compiling unit tests
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/subprojects/docs/src/snippets/tutorial/nameMatching/tests/nameMatching.sample.conf
+++ b/subprojects/docs/src/snippets/tutorial/nameMatching/tests/nameMatching.sample.conf
@@ -1,0 +1,3 @@
+executable: gradle
+args: "mAL:cT"
+expected-output-file: nameMatching.out


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #14060

The rendered version of the updated section:
![image](https://user-images.githubusercontent.com/419883/90118823-15746980-dd59-11ea-88f3-547b3b8544bf.png)

