### PR TITLE
FlakyTest with multi versions is retried properly with test-distribution

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
@@ -296,14 +296,17 @@ public abstract class AbstractMultiTestRunner extends Runner implements Filterab
         }
 
         @Override
-        public void filter(Filter filter) throws NoTestsRemainException {
-            filters.add(filter);
-            for (Map.Entry<Description, Description> entry : descriptionTranslations.entrySet()) {
-                if (!filter.shouldRun(entry.getKey())) {
-                    enabledTests.remove(entry.getValue());
-                    disabledTests.remove(entry.getValue());
+        public void filter(Filter filter) {
+            filters.add(new Filter() {
+                @Override
+                public boolean shouldRun(Description description) {
+                    return filter.shouldRun(description) || filter.shouldRun(translateDescription(description));
                 }
-            }
+                @Override
+                public String describe() {
+                    return filter.describe();
+                }
+            });
         }
 
         protected void before() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
@@ -319,7 +319,7 @@ public abstract class AbstractMultiTestRunner extends Runner implements Filterab
             for (Description child : source.getChildren()) {
                 Description mappedChild;
                 if (child.getMethodName() != null) {
-                    mappedChild = Description.createSuiteDescription(String.format("%s <%s>(%s)", child.getMethodName(), getDisplayName(), child.getClassName()));
+                    mappedChild = Description.createSuiteDescription(String.format("%s [%s](%s)", child.getMethodName(), getDisplayName(), child.getClassName()));
                     parent.addChild(mappedChild);
                     if (!isTestEnabled(new TestDescriptionBackedTestDetails(source, child))) {
                         disabledTests.add(child);


### PR DESCRIPTION
This PR contains the proposed changes to the `AbstractMultiTestRunner` to make it compatible with test distribution:
* the filter implementation on execution level is replaced
* the commit c19535e is reverted - in order that the retry plugin is compatible with descriptions containing parameters (using [] instead of <>)

A patch file contains the `FlakyTest` class as well as changes to the `unittest-and-compile` build script to execute tests.

## Executions w/o test distribution

`./gradlew internalIntegTesting:test -PtestVersions=all -DenableTestDistribution=false --tests FlakyTest`

--> tests with all parameters are retried (just as it was before)

## Executions w/ test distribution

`./gradlew internalIntegTesting:test -PtestVersions=all -DenableTestDistribution=true --tests FlakyTest`

--> tests are picked up on retry, but
--> only tests for failed parameters are retried


## Patch for testing

[Setup-6334.patch.zip](https://github.com/gradle/gradle/files/5051679/Setup-6334.patch.zip)

See also: https://github.com/gradle/dotcom/issues/6334
