### PR TITLE
Let JavaExec use toolchain if configured

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -54,6 +54,8 @@
               files=".*[/\\]subprojects[/\\]testing-jvm[/\\]src[/\\]main[/\\]java[/\\]org[/\\]gradle[/\\]jvm[/\\]plugins[/\\][^/\\]+"/>
     <suppress checks="JavadocPackage"
               files=".*[/\\]subprojects[/\\]testing-jvm[/\\]src[/\\]main[/\\]java[/\\]org[/\\]gradle[/\\]api[/\\]tasks[/\\]testing[/\\][^/\\]+"/>
+    <suppress checks="JavadocPackage"
+              files=".*[/\\]subprojects[/\\]language-java[/\\]src[/\\]main[/\\]java[/\\]org[/\\]gradle[/\\]api[/\\]tasks[/\\][^/\\]+"/>
 
     <!-- These packages are duplicated in ide-native from ide, don't require a package-info.java in each place -->
     <suppress checks="JavadocPackage"

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation(project(":internalTesting"))
     testImplementation(project(":resources"))
     testImplementation(project(":internalIntegTesting"))
+    testImplementation(project(":languageJava"))
     testImplementation(testFixtures(project(":core")))
 
     testRuntimeOnly(project(":distributionsCore")) {

--- a/subprojects/javascript/javascript.gradle.kts
+++ b/subprojects/javascript/javascript.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":plugins"))
     implementation(project(":workers"))
     implementation(project(":dependencyManagement")) // Required by JavaScriptExtension#getGoogleApisRepository()
+    implementation(project(":languageJava")) // Required by RhinoShellExec
 
     implementation(libs.groovy)
     implementation(libs.slf4jApi)

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -6,22 +6,18 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
-
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.PolymorphicDomainObjectContainer
 import org.gradle.api.Task
 import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskContainer
-
 import org.gradle.kotlin.dsl.support.uncheckedCast
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
 
 
@@ -273,14 +269,14 @@ class NamedDomainObjectContainerExtensionsTest {
     @Test
     fun `can get element of specific type within configuration block via delegated property`() {
 
-        val task = mock<JavaExec>()
+        val task = mock<Exec>()
         val tasks = mock<TaskContainer> {
             on { getByName("hello") } doReturn task
         }
 
         @Suppress("unused_variable")
         tasks {
-            val hello by getting(JavaExec::class)
+            val hello by getting(Exec::class)
         }
         verify(tasks).getByName("hello")
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+class JavaExecToolchainIntegrationTest extends AbstractPluginIntegrationTest {
+
+    @Unroll
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "can manually set java launcher via  #type toolchain on java exec task #jdk"() {
+        buildFile << """
+            import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService
+            import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
+
+            plugins {
+                id 'java'
+                id 'application'
+            }
+
+            abstract class ApplyTestToolchain implements Plugin<Project> {
+                @javax.inject.Inject
+                abstract JavaToolchainQueryService getQueryService()
+
+                void apply(Project project) {
+                    def filter = project.objects.newInstance(DefaultToolchainSpec)
+                    filter.languageVersion = JavaVersion.${jdk.javaVersion.name()}
+                    def toolchain = getQueryService().findMatchingToolchain(filter)
+
+                    project.tasks.withType(JavaCompile) {
+                        javaCompiler = toolchain.map({it.javaCompiler})
+                    }
+                    project.tasks.withType(JavaExec) {
+                        javaLauncher = toolchain.map({it.javaLauncher})
+                    }
+                }
+            }
+
+            apply plugin: ApplyTestToolchain
+
+            application {
+                mainClassName = 'App'
+            }
+        """
+
+        file('src/main/java/App.java') << testApp()
+
+        when:
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath)
+            .withArgument("--info")
+            .withTasks("run")
+            .run()
+
+        then:
+        outputContains("App running with ${jdk.javaHome.absolutePath}")
+        noExceptionThrown()
+
+        where:
+        type           | jdk
+        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+        'current'      | Jvm.current()
+    }
+
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "JavaExec task is configured using default toolchain"() {
+        def someJdk = AvailableJavaHomes.getDifferentJdk()
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'application'
+            }
+
+            java {
+                toolchain {
+                    languageVersion = JavaVersion.toVersion(${someJdk.javaVersion.majorVersion})
+                }
+            }
+
+            application {
+                mainClassName = 'App'
+            }
+        """
+
+        file('src/main/java/App.java') << testApp()
+
+        when:
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + someJdk.javaHome.absolutePath)
+            .withArgument("--info")
+            .withTasks("run")
+            .run()
+
+        then:
+        outputContains("App running with ${someJdk.javaHome.absolutePath}")
+        noExceptionThrown()
+    }
+
+    private static String testApp() {
+        return """
+            public class App {
+               public static void main(String[] args) {
+                 System.out.println("App running with " + System.getProperty("java.home"));
+               }
+            }
+        """.stripIndent()
+    }
+
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ import java.util.Map;
 /**
  * Executes a Java application in a child process.
  * <p>
- * Similar to {@link org.gradle.api.tasks.Exec}, but starts a JVM with the given classpath and application class.
+ * Similar to {@link Exec}, but starts a JVM with the given classpath and application class.
  * </p>
  * <pre class='autoTested'>
  * plugins {


### PR DESCRIPTION
`JavaExec` was moved from `core` to `languageJava` to not move toolchain support down into core/jvmServices yet. See issue for more details. Toolchain support is implemented similarly to support for `Test` by computing the effective executable under the good. 

Fixes #13998