### PR TITLE
Update "State of support in popular annotation processors"

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -682,10 +682,6 @@ Many popular annotation processors support incremental annotation processing (se
 | link:https://github.com/bumptech/glide/releases/tag/v4.9.0[4.9.0]
 | N/A
 
-| Toothpick
-| link:https://github.com/stephanenicolas/toothpick/pull/320[2.0]
-| N/A
-
 | Android-State
 | link:https://github.com/evernote/android-state/releases/tag/v1.3.0[1.3.0]
 | N/A
@@ -698,24 +694,24 @@ Many popular annotation processors support incremental annotation processing (se
 | link:https://github.com/f2prateek/dart/releases/tag/3.1.0[3.1.0]
 | N/A
 
-| MapStruct
-| link:https://github.com/mapstruct/mapstruct/issues/1420[Open issue]
+| link:https://github.com/mapstruct/mapstruct[MapStruct]
+| link:https://github.com/mapstruct/mapstruct/releases/tag/1.4.0.Beta1[1.4.0.Beta1]
 | N/A
 
 | link:https://github.com/square/AssistedInject[Assisted Inject]
 | link:https://github.com/square/AssistedInject/blob/master/CHANGELOG.md#version-050-2019-08-08[0.5.0]
 | N/A
 
-| Realm
-| link:https://github.com/realm/realm-java/issues/5906[Open issue]
+| link:https://github.com/realm/realm-java[Realm]
+| link:https://github.com/realm/realm-java/blob/v5.11.0/CHANGELOG.md[5.11.0]
 | N/A
 
 | Requery
 | link:https://github.com/requery/requery/issues/773[Open issue]
 | N/A
 
-| EventBus
-| link:https://github.com/greenrobot/EventBus/issues/528[Open issue]
+| link:https://github.com/greenrobot/EventBus[EventBus]
+| link:https://github.com/greenrobot/EventBus/releases/tag/V3.2.0[3.2.0]
 | N/A
 
 | EclipseLink
@@ -732,14 +728,14 @@ Many popular annotation processors support incremental annotation processing (se
 
 | link:https://developer.android.com/topic/libraries/architecture/room[Room]
 | link:https://developer.android.com/jetpack/androidx/releases/room#version_220_3[2.2.0]
-| Hidden behind a feature toggle
+| 2.2.0 Feature toggle support, 2.3.0-alpha02 Enabled by default
 
 | link:https://developer.android.com/jetpack/androidx/releases/lifecycle[Lifecycle]
 | link:https://issuetracker.google.com/issues/129115778[2.2.0-alpha02]
 | N/A
 
-| Android Annotations
-| link:https://github.com/androidannotations/androidannotations/issues/2193[Open issue]
+| link:https://github.com/androidannotations/androidannotations[AndroidAnnotations]
+| link:https://github.com/androidannotations/androidannotations/wiki/ReleaseNotes#4.7.0[4.7.0]
 | N/A
 
 | DBFlow
@@ -758,12 +754,20 @@ Many popular annotation processors support incremental annotation processing (se
 | https://github.com/moxy-community/Moxy/releases/tag/2.0.0[2.0]
 | N/A
 
-| Epoxy
-| link:https://github.com/airbnb/epoxy/pull/902[Open PR]
+| link:https://github.com/airbnb/epoxy[Epoxy]
+| link:https://github.com/airbnb/epoxy/releases/tag/4.0.0-beta1[4.0.0-beta1]
 | N/A
 
 | link:https://docs.jboss.org/hibernate/orm/5.4/topical/html_single/metamodelgen/MetamodelGenerator.html[JPA Static Metamodel Generator]
 | link:https://github.com/hibernate/hibernate-orm/releases/tag/5.4.11[5.4.11]
+| N/A
+
+| link:https://github.com/airbnb/DeepLinkDispatch[DeepLinkDispatch]
+| link:https://github.com/airbnb/DeepLinkDispatch/releases/tag/5.0.0-beta01[5.0.0-beta01]
+| Hidden behind a feature toggle
+
+| link:https://github.com/MatthiasRobbers/shortbread[Shortbread]
+| link:https://github.com/MatthiasRobbers/shortbread/releases/tag/v1.1.0[1.1.0]
 | N/A
 
 |===


### PR DESCRIPTION
Signed-off-by: Matthias Robbers <matthias.robbers@gmail.com>

- Update incremental annotation support status of MapStruct, Realm, EventBus, Room, AndroidAnnotations, Epoxy
- Delete duplicate Toothpick entry
- Add status of [DeepLinkDispatch](https://github.com/airbnb/DeepLinkDispatch) and [Shortbread](https://github.com/MatthiasRobbers/shortbread)

I am the author of Shortbread. If this is not considered to be a popular annotation processor, I am happy to remove the entry. Although I think it is a popular Android library (~1.8k stars on GitHub) based on annotation processing.