### PR TITLE
Fix Configuration cache typo

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -128,7 +128,7 @@ It can also be enabled persistently in a `gradle.properties` file:
 
 [source,properties]
 ----
-org.gradle.unsafe.configuration-cache=true
+org.gradle.unsafe.configuration-cache=on
 ----
 
 If it is enabled in a `gradle.properties` file, it can be disabled on the command line for one build invocation:
@@ -215,7 +215,7 @@ Select `Templates > Gradle` and add the necessary system properties to the `VM o
 For example to enable the configuration cache, turning problems into warnings, add the following:
 
 ----
--Dorg.gradle.unsafe.configuration-cache=true -Dorg.gradle.unsafe.configuration-cache-problems=warn
+-Dorg.gradle.unsafe.configuration-cache=on -Dorg.gradle.unsafe.configuration-cache-problems=warn
 ----
 
 You can also choose to only enable it for a given run configuration.
@@ -238,7 +238,7 @@ To enable it globally, go to `Preferences > Gradle`.
 You can use the properties described above as system properties.
 For example to enable the configuration cache, turning problems into warnings, add the following JVM arguments:
 
-* `-Dorg.gradle.unsafe.configuration-cache=true`
+* `-Dorg.gradle.unsafe.configuration-cache=on`
 * `-Dorg.gradle.unsafe.configuration-cache-problems=warn`
 
 To enable it for a given run configuration, go to `Run configurations...`, find the one you want to change, go to `Project Settings`, tick the `Override project settings` checkbox and add the same system properties as a `JVM argument`.


### PR DESCRIPTION
Change all references that indicate to use `true` instead of `on` to enable Configuration cache.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
