### PR TITLE
Remove annotations for internal APIs that TD no longer uses

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.internal.reflect.TypeValidationContext;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 @NonNullApi
 public class TaskPropertyUtils {
@@ -29,7 +28,6 @@ public class TaskPropertyUtils {
      * Visits both properties declared via annotations on the properties of the task type as well as
      * properties declared via the runtime API ({@link org.gradle.api.tasks.TaskInputs} etc.).
      */
-    @UsedByScanPlugin("test-distribution")
     public static void visitProperties(PropertyWalker propertyWalker, TaskInternal task, PropertyVisitor visitor) {
         visitProperties(propertyWalker, task, TypeValidationContext.NOOP, visitor);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.internal.tasks.properties;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
-@UsedByScanPlugin("test-distribution")
 public enum InputFilePropertyType {
     FILE(ValidationActions.INPUT_FILE_VALIDATOR),
     DIRECTORY(ValidationActions.INPUT_DIRECTORY_VALIDATOR),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
@@ -17,9 +17,7 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.internal.file.TreeType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
-@UsedByScanPlugin("test-distribution")
 public enum  OutputFilePropertyType {
     FILE(TreeType.FILE, ValidationActions.OUTPUT_FILE_VALIDATOR),
     DIRECTORY(TreeType.DIRECTORY, ValidationActions.OUTPUT_DIRECTORY_VALIDATOR),
@@ -34,7 +32,6 @@ public enum  OutputFilePropertyType {
         this.validationAction = validationAction;
     }
 
-    @UsedByScanPlugin("test-distribution")
     public TreeType getOutputType() {
         return outputType;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
@@ -17,14 +17,12 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.tasks.FileNormalizer;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 
 /**
  * Visits properties of beans which are inputs, outputs, destroyables or local state.
  */
-@UsedByScanPlugin("test-distribution")
 public interface PropertyVisitor {
     void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType);
 
@@ -36,10 +34,8 @@ public interface PropertyVisitor {
 
     void visitLocalStateProperty(Object value);
 
-    @UsedByScanPlugin("test-distribution")
     class Adapter implements PropertyVisitor {
         @Override
-        @UsedByScanPlugin("test-distribution")
         public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
         }
 
@@ -48,7 +44,6 @@ public interface PropertyVisitor {
         }
 
         @Override
-        @UsedByScanPlugin("test-distribution")
         public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
@@ -17,12 +17,10 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.internal.reflect.TypeValidationContext;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Walks properties declared by the type.
  */
-@UsedByScanPlugin("test-distribution")
 public interface PropertyWalker {
     void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
 }


### PR DESCRIPTION
Test distribution now retrieves the input- and output-files of a test task directly. Therefore several accesses to internal Gradle classes/methods are now longer required. (see https://github.com/gradle/dotcom/pull/6598)

This PR removes the corresponding annotations.
