### PR TITLE
Support detecting native JDK installations on macOS

### DIFF
--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
@@ -66,7 +66,7 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
 
                 void apply(Project project) {
                     project.tasks.register("show") {
-                        println registry.listInstallations()
+                       registry.listInstallations().each { println it }
                     }
                 }
             }
@@ -79,6 +79,7 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
             .withEnvironmentVars([JDK1: "/unknown/env", JDK2: firstJavaHome])
             .withArgument("-Porg.gradle.java.installations.paths=/unknown/path," + secondJavaHome)
             .withArgument("-Porg.gradle.java.installations.fromEnv=JDK1,JDK2")
+            .withArgument("--info")
             .withTasks("show")
             .run()
         then:

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -48,6 +48,7 @@ import org.gradle.jvm.toolchain.internal.JavaInstallationProbe;
 import org.gradle.jvm.toolchain.internal.JavaToolchainFactory;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
 import org.gradle.model.internal.manage.schema.ModelSchemaStore;
@@ -78,6 +79,7 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
         registration.add(CurrentInstallationSupplier.class);
         registration.add(SdkmanInstallationSupplier.class);
         registration.add(AutoInstalledInstallationSupplier.class);
+        registration.add(OsXInstallationSupplier.class);
         registration.add(JdkCacheDirectory.class);
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.os.OperatingSystem;
+import org.gradle.process.internal.ExecHandleBuilder;
+import org.gradle.process.internal.ExecHandleFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OsXInstallationSupplier extends AutoDetectingInstallationSupplier {
+
+    private final ExecHandleFactory execHandleFactory;
+    private final OperatingSystem os;
+
+    public OsXInstallationSupplier(ExecHandleFactory execHandleFactory, ProviderFactory providerFactory, OperatingSystem os) {
+        super(providerFactory);
+        this.execHandleFactory = execHandleFactory;
+        this.os = os;
+    }
+
+    @Override
+    protected Set<InstallationLocation> findCandidates() {
+        if (os.isMacOsX()) {
+            final Reader output = executeJavaHome();
+            final Set<File> javaHomes = new OsXJavaHomeOutputParser().parse(output);
+            return javaHomes.stream().map(this::asInstallation).collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+
+    private InstallationLocation asInstallation(File javaHome) {
+        return new InstallationLocation(javaHome, "macOS java_home");
+    }
+
+    private Reader executeJavaHome() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        executeCommand(outputStream);
+        return new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray()));
+    }
+
+    void executeCommand(ByteArrayOutputStream outputStream) {
+        ExecHandleBuilder execHandleBuilder = execHandleFactory.newExec();
+        execHandleBuilder.workingDir(new File(".").getAbsoluteFile());
+        execHandleBuilder.commandLine("/usr/libexec/java_home", "-V");
+        // verbose output is written to stderr
+        execHandleBuilder.setErrorOutput(outputStream);
+        execHandleBuilder.setStandardOutput(new ByteArrayOutputStream());
+        execHandleBuilder.build().start().waitForFinish().assertNormalExitValue();
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/OsXJavaHomeOutputParser.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/OsXJavaHomeOutputParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.Reader;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class OsXJavaHomeOutputParser {
+
+    private static final Pattern INSTALLATION_PATTERN = Pattern.compile(".+\\s+(/.+)");
+
+    public Set<File> parse(Reader output) {
+        BufferedReader reader = new BufferedReader(output);
+        return reader.lines().flatMap(line -> {
+            Matcher matcher = INSTALLATION_PATTERN.matcher(line);
+            if (matcher.matches()) {
+                String javaHome = matcher.group(1);
+                return Stream.of(javaHome);
+            }
+            return Stream.empty();
+        }).map(File::new).collect(Collectors.toSet());
+    }
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXInstallationSupplierTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.internal.ExecHandleFactory
+import spock.lang.Specification
+
+class OsXInstallationSupplierTest extends Specification {
+
+    def "is marked as auto-detecting"() {
+        createSupplier() instanceof AutoDetectingInstallationSupplier
+    }
+
+    def "supplies no installations for absent output"() {
+        given:
+        def supplier = createSupplier("")
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+
+    def "supplies no installations for wrong os"() {
+        given:
+        def supplier = createSupplier(null, OperatingSystem.WINDOWS)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies single installations for single candidate"() {
+        given:
+        def supplier = createSupplier("""
+Matching Java Virtual Machines (1):
+    1.7.0_80, x86_64:\t"Java SE 7"\t/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home
+""")
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories*.location == [new File("/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home")]
+        directories*.source == ["macOS java_home"]
+    }
+
+    def "supplies multiple installations for multiple paths"() {
+        given:
+        def supplier = createSupplier("""
+Matching Java Virtual Machines (3):
+    9, x86_64:\t"Java SE 9-ea"\t/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home
+    1.8.0, x86_64:\t"Java SE 8"\t/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home
+    1.7.0_17, x86_64:\t"Java SE 7"\t/Library/Java/JavaVirtualMachines/jdk1.7.0_17.jdk/Contents/Home
+
+""")
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories*.location.containsAll([
+            new File("/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/jdk1.7.0_17.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home")
+        ])
+        directories*.source == ["macOS java_home", "macOS java_home", "macOS java_home"]
+    }
+
+    OsXInstallationSupplier createSupplier(String output, OperatingSystem os = OperatingSystem.MAC_OS) {
+        new OsXInstallationSupplier(Mock(ExecHandleFactory), createProviderFactory(), os) {
+            @Override
+            def void executeCommand(ByteArrayOutputStream outputStream) {
+                outputStream.writeBytes(output.bytes)
+            }
+        }
+    }
+
+    ProviderFactory createProviderFactory() {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable("true")
+        providerFactory
+    }
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXInstallationSupplierTest.groovy
@@ -92,7 +92,7 @@ Matching Java Virtual Machines (3):
         new OsXInstallationSupplier(Mock(ExecHandleFactory), createProviderFactory(), os) {
             @Override
             def void executeCommand(ByteArrayOutputStream outputStream) {
-                outputStream.writeBytes(output.bytes)
+                outputStream.write(output.bytes, 0, output.bytes.size())
             }
         }
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXJavaHomeOutputParserTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/OsXJavaHomeOutputParserTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+
+import spock.lang.Specification
+
+class OsXJavaHomeOutputParserTest extends Specification {
+
+    def "parses new format output"() {
+        given:
+        def parser = new OsXJavaHomeOutputParser()
+        def output = """
+Matching Java Virtual Machines (11):
+    9, x86_64:\t"Java SE 9-ea"\t/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home
+    1.8.0, x86_64:\t"Java SE 8"\t/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home
+    1.7.0_17, x86_64:\t"Java SE 7"\t/Library/Java/JavaVirtualMachines/jdk1.7.0_17.jdk/Contents/Home
+    1.7.0_07, x86_64:\t"Java SE 7"\t/Library/Java/JavaVirtualMachines/jdk1.7.0_07.jdk/Contents/Home
+    1.7.0_06, x86_64:\t"Java SE 7"\t/Library/Java/JavaVirtualMachines/jdk1.7.0_06.jdk/Contents/Home
+    1.7.0-ea-b223-ea-b223-ea-b223, x86_64:\t"Java SE 7 Developer Preview"\t/Library/Java/JavaVirtualMachines/JDK 1.7.0 Developer Preview.jdk/Contents/Home
+    1.7.0-ea-b223-ea-b223-ea-b223, i386:\t"Java SE 7 Developer Preview"\t/Library/Java/JavaVirtualMachines/JDK 1.7.0 Developer Preview.jdk/Contents/Home
+    1.7.0, x86_64:\t"OpenJDK 7"\t/Library/Java/JavaVirtualMachines/1.7.0.jdk/Contents/Home
+    1.7.0, i386:\t"OpenJDK 7"\t/Library/Java/JavaVirtualMachines/1.7.0.jdk/Contents/Home
+    1.6.0_65-b14-462, x86_64:\t"Java SE 6"\t/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+    1.6.0_65-b14-462, i386:\t"Java SE 6"\t/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+"""
+
+        when:
+        def result = parser.parse(new StringReader(output))
+
+        then:
+        result.containsAll([
+            new File("/Library/Java/JavaVirtualMachines/1.7.0.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/JDK 1.7.0 Developer Preview.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/jdk1.7.0_17.jdk/Contents/Home"),
+            new File("/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home"),
+            new File("/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home"),
+        ])
+        result.size() == 8
+    }
+
+    def "parses old format output"() {
+        given:
+        def parser = new OsXJavaHomeOutputParser()
+        def output = """
+Matching Java Virtual Machines (2):
+    1.6.0_17 (x86_64):\t/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home
+    1.6.0_17 (x86_64):\t/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home
+"""
+        when:
+        def result = parser.parse(new StringReader(output))
+
+        then:
+        result.containsAll([
+            new File("/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home"),
+        ])
+        result.size() == 1
+    }
+
+    def "can parse output with no installations"() {
+        given:
+        def parser = new OsXJavaHomeOutputParser()
+        def output = """
+Unable to find any JVMs matching version "(null)".
+Matching Java Virtual Machines (0):
+
+Default Java Virtual Machines (0):
+
+No Java runtime present, try --request to install.
+"""
+        when:
+        def result = parser.parse(new StringReader(output))
+
+        then:
+        result.isEmpty()
+    }
+
+}


### PR DESCRIPTION
This adds support for macOS as part of #13871


It uses macOs native `java_home` tool to detect those installations.