### PR TITLE
Deprecate older toolchain APIs

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -334,6 +334,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
      */
     @Nested
     @SuppressWarnings("deprecation")
+    @Deprecated
     protected org.gradle.jvm.toolchain.JavaToolChain getJavaToolChain() {
         return getJavaToolChainFactory().forCompileOptions(getOptions());
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -145,6 +145,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      * @return The tool chain.
      */
     @Nested
+    @Deprecated
     public JavaToolChain getToolChain() {
         if (toolChain != null) {
             return toolChain;
@@ -157,6 +158,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      *
      * @param toolChain The tool chain.
      */
+    @Deprecated
     public void setToolChain(JavaToolChain toolChain) {
         this.toolChain = toolChain;
     }
@@ -313,6 +315,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
     }
 
     @Nested
+    @Deprecated
     protected JavaPlatform getPlatform() {
         return new DefaultJavaPlatform(JavaVersion.toVersion(getTargetCompatibility()));
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -207,6 +207,7 @@ public class Javadoc extends SourceTask {
      * Returns the tool chain that will be used to generate the Javadoc.
      */
     @Inject
+    @Deprecated
     public JavaToolChain getToolChain() {
         // Implementation is generated
         throw new UnsupportedOperationException();
@@ -215,6 +216,7 @@ public class Javadoc extends SourceTask {
     /**
      * Sets the tool chain to use to generate the Javadoc.
      */
+    @Deprecated
     public void setToolChain(@SuppressWarnings("unused") JavaToolChain toolChain) {
         // Implementation is generated
         throw new UnsupportedOperationException();

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/platform/JavaPlatform.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/platform/JavaPlatform.java
@@ -23,6 +23,7 @@ import org.gradle.platform.base.Platform;
 /**
  * Defines and configures a Java SE runtime environment, consisting of a JVM runtime and a set of class libraries.
  */
+@Deprecated
 public interface JavaPlatform extends Platform {
     @Internal
     JavaVersion getTargetCompatibility();


### PR DESCRIPTION
These are leftover accessors for the toolchain APIs for toolchains. Most of these types have been deprecated already.