### PR TITLE
Limit the number of directories to watch

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -433,8 +433,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
             .with { it as List<BuildOperationRecord.Progress> }
             .findAll { OutputEvent.isAssignableFrom(it.detailsType) }
         // Watching the file system is an incubating feature.
-        // Watching 20 directories to track changes
-        def watchFsExtraEvents = GradleContextualExecuter.watchFs ? 2 : 0
+        def watchFsExtraEvents = GradleContextualExecuter.watchFs ? 1 : 0
         assert progressOutputEvents
             .size() == 14 + watchFsExtraEvents // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed" +
     }

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
@@ -59,7 +59,7 @@ class BuildOperationsFileSystemWatchingIntegrationTest extends AbstractFileSyste
         def finishedResult = buildFinishedResult()
         finishedResult.watchingEnabled
         !finishedResult.stoppedWatchingDuringTheBuild
-        finishedResult.statistics
+        finishedResult.statistics.numberOfWatchedHierarchies == 1
         retainedFiles(finishedResult)
 
         when:
@@ -76,7 +76,7 @@ class BuildOperationsFileSystemWatchingIntegrationTest extends AbstractFileSyste
 
         finishedResult.watchingEnabled
         !finishedResult.stoppedWatchingDuringTheBuild
-        finishedResult.statistics
+        finishedResult.statistics.numberOfWatchedHierarchies == 1
         retainedFiles(finishedResult)
     }
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -84,5 +84,6 @@ public interface FileWatcherRegistry extends Closeable {
         Optional<Throwable> getErrorWhileReceivingFileChanges();
         boolean isUnknownEventEncountered();
         int getNumberOfReceivedEvents();
+        int getNumberOfWatchedHierarchies();
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -45,4 +45,6 @@ public interface FileWatcherUpdater {
      */
     @CheckReturnValue
     SnapshotHierarchy buildFinished(SnapshotHierarchy root);
+
+    int getNumberOfWatchedHierarchies();
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 
 public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileEventFunctions> implements FileWatcherRegistryFactory {
     private static final int FILE_EVENT_QUEUE_SIZE = 4096;
+    private static final int DEFAULT_MAX_HIERARCHIES_TO_WATCH = 50;
 
     protected final T fileEventFunctions;
     private final Predicate<String> watchFilter;
@@ -43,7 +44,7 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileE
         BlockingQueue<FileWatchEvent> fileEvents = new ArrayBlockingQueue<>(FILE_EVENT_QUEUE_SIZE);
         try {
             FileWatcher watcher = createFileWatcher(fileEvents);
-            FileWatcherUpdater fileWatcherUpdater = createFileWatcherUpdater(watcher, watchFilter);
+            FileWatcherUpdater fileWatcherUpdater = createFileWatcherUpdater(watcher, watchFilter, DEFAULT_MAX_HIERARCHIES_TO_WATCH);
             return new DefaultFileWatcherRegistry(
                 watcher,
                 handler,
@@ -58,5 +59,5 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileE
 
     protected abstract FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException;
 
-    protected abstract FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter);
+    protected abstract FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch);
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -45,8 +45,8 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
-        return new HierarchicalFileWatcherUpdater(watcher, DarwinFileWatcherRegistryFactory::validateLocationToWatch, watchFilter);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+        return new HierarchicalFileWatcherUpdater(watcher, DarwinFileWatcherRegistryFactory::validateLocationToWatch, watchFilter, maxHierarchiesToWatch);
     }
 
     private static void validateLocationToWatch(File location) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -145,7 +145,29 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
 
     @Override
     public FileWatchingStatistics getAndResetStatistics() {
-        return fileWatchingStatistics.getAndSet(new MutableFileWatchingStatistics());
+        MutableFileWatchingStatistics currentStatistics = fileWatchingStatistics.getAndSet(new MutableFileWatchingStatistics());
+        int numberOfWatchedHierarchies = fileWatcherUpdater.getNumberOfWatchedHierarchies();
+        return new FileWatchingStatistics() {
+            @Override
+            public Optional<Throwable> getErrorWhileReceivingFileChanges() {
+                return currentStatistics.getErrorWhileReceivingFileChanges();
+            }
+
+            @Override
+            public boolean isUnknownEventEncountered() {
+                return currentStatistics.isUnknownEventEncountered();
+            }
+
+            @Override
+            public int getNumberOfReceivedEvents() {
+                return currentStatistics.getNumberOfReceivedEvents();
+            }
+
+            @Override
+            public int getNumberOfWatchedHierarchies() {
+                return numberOfWatchedHierarchies;
+            }
+        };
     }
 
     @Override
@@ -165,22 +187,19 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
         }
     }
 
-    private static class MutableFileWatchingStatistics implements FileWatchingStatistics {
+    private static class MutableFileWatchingStatistics {
         private boolean unknownEventEncountered;
         private int numberOfReceivedEvents;
         private Throwable errorWhileReceivingFileChanges;
 
-        @Override
         public Optional<Throwable> getErrorWhileReceivingFileChanges() {
             return Optional.ofNullable(errorWhileReceivingFileChanges);
         }
 
-        @Override
         public boolean isUnknownEventEncountered() {
             return unknownEventEncountered;
         }
 
-        @Override
         public int getNumberOfReceivedEvents() {
             return numberOfReceivedEvents;
         }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -67,10 +67,10 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private final FileSystemLocationToWatchValidator locationToWatchValidator;
     private final WatchableHierarchies watchableHierarchies;
 
-    public HierarchicalFileWatcherUpdater(FileWatcher fileWatcher, FileSystemLocationToWatchValidator locationToWatchValidator, Predicate<String> watchFilter) {
+    public HierarchicalFileWatcherUpdater(FileWatcher fileWatcher, FileSystemLocationToWatchValidator locationToWatchValidator, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
         this.fileWatcher = fileWatcher;
         this.locationToWatchValidator = locationToWatchValidator;
-        this.watchableHierarchies = new WatchableHierarchies(watchFilter);
+        this.watchableHierarchies = new WatchableHierarchies(watchFilter, maxHierarchiesToWatch);
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -94,9 +94,13 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         );
 
         determineAndUpdateWatchedHierarchies(newRoot);
-        LOGGER.warn("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
         LOGGER.info("Watched directory hierarchies: {}", watchedHierarchies);
         return newRoot;
+    }
+
+    @Override
+    public int getNumberOfWatchedHierarchies() {
+        return watchedHierarchies.size();
     }
 
     private void determineAndUpdateWatchedHierarchies(SnapshotHierarchy root) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -86,11 +86,16 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
     @Override
     public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
+        WatchableHierarchies.Invalidator invalidator = (location, currentRoot) -> currentRoot.invalidate(location, SnapshotHierarchy.NodeDiffListener.NOOP);
         Set<File> watchedFiles = watchedHierarchies.stream().map(Path::toFile).collect(Collectors.toSet());
-        SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchedSnapshots(
+        SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
+            invalidator,
             watchedFiles::contains,
-            root,
-            (location, currentRoot) -> currentRoot.invalidate(location, SnapshotHierarchy.NodeDiffListener.NOOP)
+            root
+        );
+        newRoot = watchableHierarchies.removeUnwatchedSnapshots(
+            newRoot,
+            invalidator
         );
 
         determineAndUpdateWatchedHierarchies(newRoot);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -88,9 +88,7 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
         WatchableHierarchies.Invalidator invalidator = (location, currentRoot) -> currentRoot.invalidate(location, SnapshotHierarchy.NodeDiffListener.NOOP);
         SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
-            invalidator,
-            watchedHierarchies::contains,
-            root
+            root, watchedHierarchies::contains, invalidator
         );
         newRoot = watchableHierarchies.removeUnwatchedSnapshots(
             newRoot,

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -87,10 +87,9 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     @Override
     public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
         WatchableHierarchies.Invalidator invalidator = (location, currentRoot) -> currentRoot.invalidate(location, SnapshotHierarchy.NodeDiffListener.NOOP);
-        Set<File> watchedFiles = watchedHierarchies.stream().map(Path::toFile).collect(Collectors.toSet());
         SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
             invalidator,
-            watchedFiles::contains,
+            watchedHierarchies::contains,
             root
         );
         newRoot = watchableHierarchies.removeUnwatchedSnapshots(
@@ -113,13 +112,13 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         Set<Path> hierarchiesWithSnapshots = watchableHierarchies.getWatchableHierarchies().stream()
             .flatMap(watchableHierarchy -> {
                 CheckIfNonEmptySnapshotVisitor checkIfNonEmptySnapshotVisitor = new CheckIfNonEmptySnapshotVisitor(watchableHierarchies);
-                root.visitSnapshotRoots(watchableHierarchy.getAbsolutePath(), new FilterAlreadyCoveredSnapshotsVisitor(checkIfNonEmptySnapshotVisitor, snapshotsAlreadyCoveredByOtherHierarchies));
+                root.visitSnapshotRoots(watchableHierarchy.toString(), new FilterAlreadyCoveredSnapshotsVisitor(checkIfNonEmptySnapshotVisitor, snapshotsAlreadyCoveredByOtherHierarchies));
                 if (checkIfNonEmptySnapshotVisitor.isEmpty()) {
                     return Stream.empty();
                 }
                 return checkIfNonEmptySnapshotVisitor.containsOnlyMissingFiles()
-                    ? Stream.of(locationOrFirstExistingAncestor(watchableHierarchy.toPath()))
-                    : Stream.of(watchableHierarchy.toPath());
+                    ? Stream.of(locationOrFirstExistingAncestor(watchableHierarchy))
+                    : Stream.of(watchableHierarchy);
             })
             .collect(Collectors.toSet());
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
@@ -39,7 +39,7 @@ public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistry
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
-        return new NonHierarchicalFileWatcherUpdater(watcher, watchFilter);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+        return new NonHierarchicalFileWatcherUpdater(watcher, watchFilter, maxHierarchiesToWatch);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -100,6 +100,11 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         return newRoot;
     }
 
+    @Override
+    public int getNumberOfWatchedHierarchies() {
+        return watchableHierarchies.getWatchableHierarchies().size();
+    }
+
     private boolean containsSnapshots(File location, SnapshotHierarchy root) {
         CheckIfNonEmptySnapshotVisitor checkIfNonEmptySnapshotVisitor = new CheckIfNonEmptySnapshotVisitor(watchableHierarchies);
         root.visitSnapshotRoots(location.getAbsolutePath(), checkIfNonEmptySnapshotVisitor);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -51,9 +51,9 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
     private final WatchableHierarchies watchableHierarchies;
 
-    public NonHierarchicalFileWatcherUpdater(FileWatcher fileWatcher, Predicate<String> watchFilter) {
+    public NonHierarchicalFileWatcherUpdater(FileWatcher fileWatcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
         this.fileWatcher = fileWatcher;
-        this.watchableHierarchies = new WatchableHierarchies(watchFilter);
+        this.watchableHierarchies = new WatchableHierarchies(watchFilter, maxHierarchiesToWatch);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private boolean containsSnapshots(File location, SnapshotHierarchy root) {
         CheckIfNonEmptySnapshotVisitor checkIfNonEmptySnapshotVisitor = new CheckIfNonEmptySnapshotVisitor(watchableHierarchies);
         root.visitSnapshotRoots(location.getAbsolutePath(), checkIfNonEmptySnapshotVisitor);
-        return checkIfNonEmptySnapshotVisitor.isEmpty();
+        return !checkIfNonEmptySnapshotVisitor.isEmpty();
     }
 
     private void updateWatchedDirectories(Map<String, Integer> changedWatchDirectories) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -93,9 +93,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
             return invalidatedRoot;
         };
         SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
-            invalidator,
-            hierarchy -> containsSnapshots(hierarchy, root),
-            root
+            root, hierarchy -> containsSnapshots(hierarchy, root), invalidator
         );
         newRoot = watchableHierarchies.removeUnwatchedSnapshots(
             newRoot,

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -110,9 +110,9 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         return watchableHierarchies.getWatchableHierarchies().size();
     }
 
-    private boolean containsSnapshots(File location, SnapshotHierarchy root) {
+    private boolean containsSnapshots(Path location, SnapshotHierarchy root) {
         CheckIfNonEmptySnapshotVisitor checkIfNonEmptySnapshotVisitor = new CheckIfNonEmptySnapshotVisitor(watchableHierarchies);
-        root.visitSnapshotRoots(location.getAbsolutePath(), checkIfNonEmptySnapshotVisitor);
+        root.visitSnapshotRoots(location.toString(), checkIfNonEmptySnapshotVisitor);
         return !checkIfNonEmptySnapshotVisitor.isEmpty();
     }
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -76,7 +76,7 @@ public class WatchableHierarchies {
     }
 
     @CheckReturnValue
-    public SnapshotHierarchy removeWatchedHierarchiesOverLimit(Invalidator invalidator, Predicate<Path> isWatchedHierarchy, SnapshotHierarchy root) {
+    public SnapshotHierarchy removeWatchedHierarchiesOverLimit(SnapshotHierarchy root, Predicate<Path> isWatchedHierarchy, Invalidator invalidator) {
         recentlyUsedHierarchies.removeIf(hierarchy -> !isWatchedHierarchy.test(hierarchy));
         SnapshotHierarchy result = root;
         int toRemove = recentlyUsedHierarchies.size() - maxHierarchiesToWatch;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -81,7 +81,7 @@ public class WatchableHierarchies {
         SnapshotHierarchy result = root;
         int toRemove = recentlyUsedHierarchies.size() - maxHierarchiesToWatch;
         if (toRemove > 0) {
-            LOGGER.warn("Watching {} hierarchies, removing {} to limit the number of watched directories", recentlyUsedHierarchies.size(), toRemove);
+            LOGGER.warn("Watching too many directories in the file system (watching {}, limit {}), dropping some state from the virtual file system", recentlyUsedHierarchies.size(), maxHierarchiesToWatch);
             for (int i = 0; i < toRemove; i++) {
                 File locationToRemove = recentlyUsedHierarchies.removeLast();
                 result = invalidator.invalidate(locationToRemove.getAbsolutePath(), result);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -45,7 +45,7 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
-        return new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+        return new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter, maxHierarchiesToWatch);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/FileSystemWatchingStatistics.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/FileSystemWatchingStatistics.java
@@ -18,6 +18,7 @@ package org.gradle.internal.watch.vfs;
 
 public interface FileSystemWatchingStatistics {
     int getNumberOfReceivedEvents();
+    int getNumberOfWatchedHierarchies();
 
     int getRetainedRegularFiles();
     int getRetainedDirectories();

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultFileSystemWatchingStatistics.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultFileSystemWatchingStatistics.java
@@ -44,6 +44,11 @@ public class DefaultFileSystemWatchingStatistics implements FileSystemWatchingSt
     }
 
     @Override
+    public int getNumberOfWatchedHierarchies() {
+        return fileWatchingStatistics.getNumberOfWatchedHierarchies();
+    }
+
+    @Override
     public int getRetainedRegularFiles() {
         return vfsStatistics.getRetained(FileType.RegularFile);
     }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -32,8 +32,8 @@ import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpd
 class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
-    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
-        new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter)
+    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+        new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter, maxHierarchiesToWatch)
     }
 
     def "does not watch hierarchy to watch if no snapshot is inside"() {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -173,7 +173,7 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         def directoryWithinFirst = file("first/within").createDir()
 
         when:
-        registerWatchableHierarchies([firstDir, directoryWithinFirst, secondDir])
+        registerWatchableHierarchies([directoryWithinFirst, firstDir, secondDir])
         addSnapshotsInWatchableHierarchies([secondDir, directoryWithinFirst])
         then:
         [firstDir, secondDir].each { watchableHierarchy ->
@@ -188,7 +188,7 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         def directoryWithinFirst = file("first/within").createDir()
 
         when:
-        registerWatchableHierarchies([firstDir, directoryWithinFirst, secondDir])
+        registerWatchableHierarchies([directoryWithinFirst, firstDir, secondDir])
         addSnapshotsInWatchableHierarchies([secondDir, directoryWithinFirst])
         then:
         [firstDir, secondDir].each { watchableHierarchy ->

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -173,8 +173,8 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         def directoryWithinFirst = file("first/within").createDir()
 
         when:
-        registerWatchableHierarchies([directoryWithinFirst, firstDir, secondDir])
-        addSnapshotsInWatchableHierarchies([secondDir, directoryWithinFirst])
+        registerWatchableHierarchies([firstDir, directoryWithinFirst, secondDir])
+        addSnapshotsInWatchableHierarchies([secondDir, firstDir, directoryWithinFirst])
         then:
         [firstDir, secondDir].each { watchableHierarchy ->
             1 * watcher.startWatching({ equalIgnoringOrder(it, [watchableHierarchy]) })

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -167,18 +167,16 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         0 * _
     }
 
-    def "only adds watches for the roots of the hierarchies to watch"() {
-        def firstDir = file("first").createDir()
-        def secondDir = file("second").createDir()
-        def directoryWithinFirst = file("first/within").createDir()
+    def "watch only outermost hierarchy"() {
+        def outerDir = file("outer").createDir()
+        def innerDirBefore = file("outer/inner1").createDir()
+        def innerDirAfter = file("outer/inner2").createDir()
 
         when:
-        registerWatchableHierarchies([firstDir, directoryWithinFirst, secondDir])
-        addSnapshotsInWatchableHierarchies([secondDir, firstDir, directoryWithinFirst])
+        registerWatchableHierarchies([innerDirBefore, outerDir, innerDirAfter])
+        addSnapshotsInWatchableHierarchies([outerDir, innerDirAfter, innerDirBefore])
         then:
-        [firstDir, secondDir].each { watchableHierarchy ->
-            1 * watcher.startWatching({ equalIgnoringOrder(it, [watchableHierarchy]) })
-        }
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [outerDir]) })
         0 * _
     }
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -24,8 +24,8 @@ import java.util.function.Predicate
 class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
-    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
-        new NonHierarchicalFileWatcherUpdater(watcher, watchFilter)
+    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+        new NonHierarchicalFileWatcherUpdater(watcher, watchFilter, maxHierarchiesToWatch)
     }
 
     def "only watches directories in hierarchies to watch"() {


### PR DESCRIPTION
Stop watching hierarchies after a maximum limit of watchable hierarchies has been reached. This is especially important for Windows an macOS, since both operating systems have problems watching more than 100 directories.

Fixes #13513