### PR TITLE
Address some deadlocks when using artifact transforms

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -75,11 +75,6 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     }
 
     @Override
-    public void withLenientState(Runnable runnable) {
-        runnable.run();
-    }
-
-    @Override
     public Path getBuildPath() {
         return Path.ROOT;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -19,10 +19,12 @@ package org.gradle.api.internal.initialization;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.Factory;
+import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 public class RootScriptDomainObjectContext implements DomainObjectContext, ModelContainer {
 
@@ -85,5 +87,44 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     @Override
     public boolean isScript() {
         return true;
+    }
+
+    @Override
+    public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
+        return new CalculatedModelValueImpl<>(initialValue);
+    }
+
+    private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
+        private T value;
+
+        CalculatedModelValueImpl(@Nullable T initialValue) {
+            value = initialValue;
+        }
+
+        @Override
+        public T get() throws IllegalStateException {
+            T currentValue = getOrNull();
+            if (currentValue == null) {
+                throw new IllegalStateException("No value is available.");
+            }
+            return currentValue;
+        }
+
+        @Override
+        public T getOrNull() {
+            return value;
+        }
+
+        @Override
+        public void set(T newValue) {
+            value = newValue;
+        }
+
+        @Override
+        public T update(Function<T, T> updateFunction) {
+            T newValue = updateFunction.apply(value);
+            value = newValue;
+            return newValue;
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -293,7 +293,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry {
         public T get() throws IllegalStateException {
             T currentValue = getOrNull();
             if (currentValue == null) {
-                throw new IllegalStateException("No value is available for " + owner);
+                throw new IllegalStateException("No calculated value is available for " + owner);
             }
             return currentValue;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -63,6 +63,9 @@ public interface ProjectState extends ModelContainer {
      */
     ProjectComponentIdentifier getComponentIdentifier();
 
+    /**
+     * This state object should own the project instantiation. This method is currently here to allow transition towards that.
+     */
     void attachMutableModel(ProjectInternal project);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -75,20 +75,4 @@ public interface ProjectStateRegistry {
      * deprecated practices that we eventually want to retire.
      */
     <T> T withLenientState(Factory<T> factory);
-
-    /**
-     * Returns a {@link SafeExclusiveLock}.
-     */
-    SafeExclusiveLock newExclusiveOperationLock();
-
-    /**
-     * Represents a lock that can be used to perform safe concurrent execution in light of the possibility that a project
-     * lock might be released during execution.  Specifically, it avoids blocking on the lock while holding the project lock.
-     */
-    interface SafeExclusiveLock {
-        /**
-         * Safely waits for the lock before executing the given action.
-         */
-        void withLock(Runnable runnable);
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -65,12 +65,16 @@ public interface ProjectStateRegistry {
     void registerProject(BuildState owner, DefaultProjectDescriptor projectDescriptor);
 
     /**
-     * Allows a section of code to run with all of the projects locked. Any attempt to lock a project by some other thread will fail while the given action is running.
+     * Allows a section of code to run against the mutable state of all projects. No other thread will be able to access the state of any project while the given action is running.
+     *
+     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#withMutableState(Runnable)}.
      */
     void withMutableStateOfAllProjects(Runnable runnable);
 
     /**
-     * Allows a section of code to run with all of the projects locked. Any attempt to lock a project by some other thread will fail while the given action is running.
+     * Allows a section of code to run against the mutable state of all projects. No other thread will be able to access the state of any project while the given action is running.
+     *
+     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#withMutableState(Runnable)}.
      */
     <T> T withMutableStateOfAllProjects(Factory<T> factory);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -65,14 +65,12 @@ public interface ProjectStateRegistry {
     void registerProject(BuildState owner, DefaultProjectDescriptor projectDescriptor);
 
     /**
-     * Allows a section of code to be run with state locking disabled.  This should be used to allow
-     * deprecated practices that we eventually want to retire.
+     * Allows a section of code to run with all of the projects locked. Any attempt to lock a project by some other thread will fail while the given action is running.
      */
-    void withLenientState(Runnable runnable);
+    void withMutableStateOfAllProjects(Runnable runnable);
 
     /**
-     * Creates the object with state locking disabled.  This should be used to allow
-     * deprecated practices that we eventually want to retire.
+     * Allows a section of code to run with all of the projects locked. Any attempt to lock a project by some other thread will fail while the given action is running.
      */
-    <T> T withLenientState(Factory<T> factory);
+    <T> T withMutableStateOfAllProjects(Factory<T> factory);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultBuildConfigurationActionExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultBuildConfigurationActionExecuter.java
@@ -36,13 +36,10 @@ public class DefaultBuildConfigurationActionExecuter implements BuildConfigurati
 
     @Override
     public void select(final GradleInternal gradle) {
-        // We know that we're running single-threaded here, so we can use lenient project locking
-        projectStateRegistry.withLenientState(new Runnable() {
-            @Override
-            public void run() {
-                List<BuildConfigurationAction> processingBuildActions = CollectionUtils.flattenCollections(BuildConfigurationAction.class, configurationActions, taskSelectors);
-                configure(processingBuildActions, gradle, 0);
-            }
+        // We know that we're running single-threaded here, so we can use coarse grained locks
+        projectStateRegistry.withMutableStateOfAllProjects(() -> {
+            List<BuildConfigurationAction> processingBuildActions = CollectionUtils.flattenCollections(BuildConfigurationAction.class, configurationActions, taskSelectors);
+            configure(processingBuildActions, gradle, 0);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -19,6 +19,7 @@ package org.gradle.execution.plan;
 import org.gradle.api.Action;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.resources.ResourceLock;
 
@@ -50,6 +51,11 @@ public class ActionNode extends Node implements SelfExecutingNode {
 
     @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
+        TaskDependencyContainer dependencies = action::visitDependencies;
+        for (Node node : dependencyResolver.resolveDependenciesFor(null, dependencies)) {
+            addDependencySuccessor(node);
+            processHardSuccessor.execute(node);
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -48,7 +48,7 @@ public abstract class Node implements Comparable<Node> {
     private Throwable executionFailure;
     private final NavigableSet<Node> dependencySuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> dependencyPredecessors = Sets.newTreeSet();
-    private MutationInfo mutationInfo = new MutationInfo(this);
+    private final MutationInfo mutationInfo = new MutationInfo(this);
 
     public Node() {
         this.state = ExecutionState.UNKNOWN;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -160,8 +160,8 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     public void populate() {
         ensurePopulated();
         if (!hasFiredWhenReady) {
-            // We know that we're running single-threaded here, so we can use lenient project locking
-            projectStateRegistry.withLenientState(() -> buildOperationExecutor.run(new NotifyTaskGraphWhenReady(DefaultTaskExecutionGraph.this, graphListeners.getSource(), gradleInternal)));
+            // We know that we're running single-threaded here, so we can use coarse grained project locks
+            projectStateRegistry.withMutableStateOfAllProjects(() -> buildOperationExecutor.run(new NotifyTaskGraphWhenReady(DefaultTaskExecutionGraph.this, graphListeners.getSource(), gradleInternal)));
             hasFiredWhenReady = true;
         } else if (!graphListeners.isEmpty()) {
             LOGGER.warn("Ignoring listeners of task graph ready event, as this build (" + gradleInternal.getIdentityPath() + ") has already executed work.");

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.model;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Function;
+
+/**
+ * Represents a value that is calculated from some mutable state managed by a {@link ModelContainer}, where the calculated value may
+ * be used by multiple threads.
+ */
+@ThreadSafe
+public interface CalculatedModelValue<T> {
+    /**
+     * Returns the current value, failing if not present.
+     *
+     * <p>May be called by any thread, except any thread currently inside {@link #update(Function)}.
+     * This method does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
+     */
+    T get() throws IllegalStateException;
+
+    /**
+     * Returns the current value, failing if not present.
+     *
+     * <p>May be called by any thread, except any thread currently inside {@link #update(Function)}.
+     * This method does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
+     */
+    @Nullable
+    T getOrNull();
+
+    /**
+     * Updates the current value. The function is passed the current value or null if there is no value and the return value is
+     * used as the new value.
+     *
+     * <p>The current thread must hold the lock for the mutable state from which the value is calculated. At most a single thread
+     * will run the update function at a given time. This additional guarantee is because the mutable state lock may be released
+     * while the function is running or while waiting to access the value.
+     */
+    T update(Function<T, T> updateFunction);
+
+    /**
+     * Sets the current value.
+     */
+    void set(T newValue);
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
@@ -18,6 +18,8 @@ package org.gradle.internal.model;
 
 import org.gradle.internal.Factory;
 
+import javax.annotation.Nullable;
+
 /**
  * Encapsulates some mutable model, and provides synchronized access to the model.
  */
@@ -51,4 +53,10 @@ public interface ModelContainer {
      * Returns whether or not the current thread has access to the mutable model.
      */
     boolean hasMutableState();
+
+    /**
+     * Creates a new container for a value that is calculated from the mutable state of this container, and then
+     * reused by multiple threads.
+     */
+    <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
@@ -29,7 +29,9 @@ public interface ModelContainer {
      * Runs the given action against the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
      * However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
      *
-     * Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
+     * <p>It is usually a better option to use {@link #newCalculatedValue(Object)} instead of this method.</p>
+     *
+     * <p>Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
      */
     <T> T withMutableState(Factory<? extends T> factory);
 
@@ -37,17 +39,9 @@ public interface ModelContainer {
      * Runs the given action against the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
      * However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
      *
-     * Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
+     * <p>Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
      */
     void withMutableState(Runnable runnable);
-
-    /**
-     * Accesses the public mutable model without any synchronization. Please do not use this method, except for backwards compatibility (and deprecate the behaviour that requires this).
-     * Use {@link #withMutableState(Runnable)} instead.
-     *
-     * Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
-     */
-    void withLenientState(Runnable runnable);
 
     /**
      * Returns whether or not the current thread has access to the mutable model.
@@ -55,8 +49,7 @@ public interface ModelContainer {
     boolean hasMutableState();
 
     /**
-     * Creates a new container for a value that is calculated from the mutable state of this container, and then
-     * reused by multiple threads.
+     * Creates a new container for a value that is calculated from the mutable state of this container, and then reused by multiple threads.
      */
     <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue);
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
@@ -98,7 +98,7 @@ public class DefaultToolingModelBuilderRegistry implements ToolingModelBuilderRe
             return buildOperationExecutor.call(new CallableBuildOperation<Object>() {
                 @Override
                 public Object call(BuildOperationContext context) {
-                    return projectStateRegistry.withLenientState(new Factory<Object>() {
+                    return projectStateRegistry.withMutableStateOfAllProjects(new Factory<Object>() {
                         @Nullable
                         @Override
                         public Object create() {
@@ -134,7 +134,7 @@ public class DefaultToolingModelBuilderRegistry implements ToolingModelBuilderRe
             return buildOperationExecutor.call(new CallableBuildOperation<Object>() {
                 @Override
                 public Object call(BuildOperationContext context) {
-                    return projectStateRegistry.withLenientState(new Factory<Object>() {
+                    return projectStateRegistry.withMutableStateOfAllProjects(new Factory<Object>() {
                         @Nullable
                         @Override
                         public Object create() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultBuildConfigurationActionExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultBuildConfigurationActionExecuterTest.groovy
@@ -25,7 +25,7 @@ class DefaultBuildConfigurationActionExecuterTest extends Specification {
     final ProjectStateRegistry projectStateRegistry = Stub()
 
     def setup() {
-        _ * projectStateRegistry.withLenientState(_) >> { args -> args[0].run() }
+        _ * projectStateRegistry.withMutableStateOfAllProjects(_) >> { args -> args[0].run() }
     }
 
     def "select method calls configure method on first configuration action"() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -91,7 +91,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
                 return false
             }
         }
-        _ * projectStateRegistry.withLenientState(_) >> { Runnable r -> r.run() }
+        _ * projectStateRegistry.withMutableStateOfAllProjects(_) >> { Runnable r -> r.run() }
     }
 
     def cleanup() {

--- a/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
@@ -19,14 +19,14 @@ package org.gradle.tooling.provider.model.internal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.operations.TestBuildOperationExecutor
-import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder
+import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.UnknownModelException
 import spock.lang.Specification
 
 class DefaultToolingModelBuilderRegistryTest extends Specification {
     final def projectStateRegistry = Stub(ProjectStateRegistry) {
-        withLenientState(_) >> { args -> args[0].create() }
+        withMutableStateOfAllProjects(_) >> { args -> args[0].create() }
     }
     final def registry = new DefaultToolingModelBuilderRegistry(new TestBuildOperationExecutor(), projectStateRegistry)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
@@ -90,20 +90,20 @@ task copyFiles(type:Copy) {
         mavenRepo.module('org.test', 'module2', '1.0').publish()
 
         given:
-        buildFile << """            
-            plugins { 
+        buildFile << """
+            plugins {
                 id 'java'
             }
-            
+
             repositories {
                 maven { url '${mavenRepo.uri}' }
             }
-            
+
             dependencies {
                 implementation('org.test:module1:1.0')
                 testImplementation('org.test:module2:1.0')
             }
-            
+
             configurations.all { configuration ->
                 configuration.incoming.beforeResolve { resolvableDependencies ->
                     resolvableDependencies.dependencies.each { dependency ->
@@ -111,7 +111,7 @@ task copyFiles(type:Copy) {
                     }
                 }
             }
-            
+
             task resolveDependencies {
                 doLast {
                     configurations.compileClasspath.files
@@ -181,7 +181,7 @@ task resolveDependencies {
         mavenRepo.module('org.test', 'module1', '1.0').publish()
         mavenRepo.module('org.test', 'module2', '1.0').publish()
         settingsFile << """
-           include ":lib" 
+           include ":lib"
         """
         buildFile << """
             allprojects {
@@ -195,13 +195,13 @@ task resolveDependencies {
                     incoming.beforeResolve {
                         println "resolving foo..."
                         foo.resolve()
-                        // bar should still be in an unresolved state, so we should be able to modify the 
+                        // bar should still be in an unresolved state, so we should be able to modify the
                         // things like dependency constraints here
                         bar.validateMutation(${MutationValidator.MutationType.class.name}.DEPENDENCIES)
                     }
                 }
             }
-            dependencies { 
+            dependencies {
                 foo project(path: ':lib', configuration: 'foo')
                 bar "org.test:module2:1.0"
             }
@@ -209,20 +209,20 @@ task resolveDependencies {
                 inputs.files configurations.bar
                 doLast {
                     configurations.bar.each { println it }
-                }    
+                }
             }
             task b {
                 inputs.files configurations.bar
                 doLast {
                     configurations.bar.each { println it }
-                }    
+                }
             }
         """
-        file('lib/build.gradle') << """  
+        file('lib/build.gradle') << """
             configurations {
-                foo 
+                foo
             }
-                      
+
             dependencies {
                 foo "org.test:module1:1.0"
             }
@@ -233,6 +233,6 @@ task resolveDependencies {
         succeeds "a", "b"
 
         and:
-        outputContains("resolving foo")
+        output.count("resolving foo") == 1
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -2118,7 +2118,7 @@ Found the following transforms:
         when:
         fails "resolve"
         then:
-        Matcher<String> matchesCannotIsolate = matchesRegexp("Cannot isolate parameters Custom\\\$Parameters_Decorated@.* of artifact transform Custom")
+        Matcher<String> matchesCannotIsolate = matchesRegexp("Could not isolate parameters Custom\\\$Parameters_Decorated@.* of artifact transform Custom")
         if (scheduled) {
             failure.assertThatDescription(matchesCannotIsolate)
         } else {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -379,7 +379,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         fails(":a:resolve")
 
         then:
-        failure.assertThatDescription(matchesRegexp('Cannot isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
+        failure.assertThatDescription(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('Some problems were found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         assertPropertyValidationErrors(
             absolutePathSensitivity: 'is declared to be sensitive to absolute paths. This is not allowed for cacheable transforms',
@@ -465,7 +465,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         fails(":a:resolve")
 
         then:
-        failure.assertThatDescription(matchesRegexp('Cannot isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
+        failure.assertThatDescription(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('Some problems were found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         failure.assertHasCause("Type 'MakeGreen.Parameters': Cannot use @CacheableTask on type. This annotation can only be used with Task types.")
         failure.assertHasCause("Type 'MakeGreen.Parameters': Cannot use @CacheableTransform on type. This annotation can only be used with TransformAction types.")
@@ -508,7 +508,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         fails(":a:resolve")
 
         then:
-        failure.assertThatDescription(matchesRegexp('Cannot isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
+        failure.assertThatDescription(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('A problem was found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         assertPropertyValidationErrors(bad: "is annotated with invalid property type @${annotation.simpleName}")
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -410,7 +410,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
                 TransformerInvocationFactory transformerInvocationFactory,
                 ValueSnapshotter valueSnapshotter,
-                ProjectStateRegistry projectStateRegistry,
                 DomainObjectContext domainObjectContext,
                 ArtifactTransformParameterScheme parameterScheme,
                 ArtifactTransformActionScheme actionScheme,
@@ -429,7 +428,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                     fileLookup,
                     fileCollectionFingerprinterRegistry,
                     domainObjectContext,
-                    projectStateRegistry,
                     parameterScheme,
                     actionScheme,
                     internalServices

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -109,10 +109,11 @@ import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.CollectionUtils;
@@ -130,7 +131,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED;
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED;
@@ -195,7 +195,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final Set<Object> excludeRules = new LinkedHashSet<>();
     private Set<ExcludeRule> parsedExcludeRules;
 
-    private final ProjectStateRegistry.SafeExclusiveLock resolutionLock;
     private final Object observationLock = new Object();
     private volatile InternalState observedState = UNRESOLVED;
     private boolean insideBeforeResolve;
@@ -221,7 +220,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private List<String> declarationAlternatives;
     private List<String> consumptionAlternatives;
     private List<String> resolutionAlternatives;
-    private final AtomicReference<ResolveState> currentResolveState = new AtomicReference<>(ResolveState.NOT_RESOLVED);
+
+    private final CalculatedModelValue<ResolveState> currentResolveState;
 
     public DefaultConfiguration(DomainObjectContext domainObjectContext,
                                 String name,
@@ -266,7 +266,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.domainObjectContext = domainObjectContext;
         this.intrinsicFiles = new ConfigurationFileCollection(Specs.satisfyAll());
         this.documentationRegistry = documentationRegistry;
-        this.resolutionLock = projectStateRegistry.newExclusiveOperationLock();
         this.resolvableDependencies = instantiator.newInstance(ConfigurationResolvableDependencies.class, this);
 
         displayName = Describables.memoize(new ConfigurationDescription(identityPath));
@@ -287,6 +286,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory);
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilder;
         this.owner = owner;
+        this.currentResolveState = owner.getModel().newCalculatedValue(ResolveState.NOT_RESOLVED);
         path = domainObjectContext.projectPath(name);
     }
 
@@ -562,18 +562,15 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 // Error if we are executing in a user-managed thread.
                 throw new IllegalStateException("The configuration " + identityPath.toString() + " was resolved from a thread not managed by Gradle.");
             } else {
-                // We don't have mutable access to the project, so we throw a deprecation warning and then continue with
-                // lenient locking.
+                // We don't currently have mutable access to the project, so report a deprecation warning and then continue by attempting to lock
                 DeprecationLogger.deprecateBehaviour("The configuration " + identityPath.toString() + " was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a different project.")
                     .willBeRemovedInGradle7()
                     .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")
                     .nagUser();
-                owner.getModel().withLenientState(() -> resolveExclusively(requestedState));
-                return currentResolveState.get();
+                return owner.getModel().withMutableState(() -> resolveExclusively(requestedState));
             }
-        } else {
-            return resolveExclusively(requestedState);
         }
+        return resolveExclusively(requestedState);
     }
 
     private void warnIfConfigurationIsDeprecatedForResolving() {
@@ -586,31 +583,32 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private ResolveState resolveExclusively(InternalState requestedState) {
-        resolutionLock.withLock(() -> {
+        return currentResolveState.update(initial -> {
+            ResolveState current = initial;
             if (requestedState == GRAPH_RESOLVED || requestedState == ARTIFACTS_RESOLVED) {
-                resolveGraphIfRequired(requestedState, currentResolveState.get());
+                current = resolveGraphIfRequired(requestedState, current);
             }
             if (requestedState == ARTIFACTS_RESOLVED) {
-                resolveArtifactsIfRequired(currentResolveState.get());
+                current = resolveArtifactsIfRequired(current);
             }
+            return current;
         });
-        return currentResolveState.get();
     }
 
     /**
      * Must be called from {@link #resolveExclusively(InternalState)} only.
      */
-    private void resolveGraphIfRequired(final InternalState requestedState, ResolveState currentState) {
+    private ResolveState resolveGraphIfRequired(final InternalState requestedState, ResolveState currentState) {
         if (currentState.state == ARTIFACTS_RESOLVED || currentState.state == GRAPH_RESOLVED) {
             if (dependenciesModified) {
                 throw new InvalidUserDataException(String.format("Attempted to resolve %s that has been resolved previously.", getDisplayName()));
             }
-            return;
+            return currentState;
         }
 
-        buildOperationExecutor.run(new RunnableBuildOperation() {
+        return buildOperationExecutor.call(new CallableBuildOperation<ResolveState>() {
             @Override
-            public void run(BuildOperationContext context) {
+            public ResolveState call(BuildOperationContext context) {
                 runDependencyActions();
                 preventFromFurtherMutation();
 
@@ -619,7 +617,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 DefaultResolverResults results = new DefaultResolverResults();
                 resolver.resolveGraph(DefaultConfiguration.this, results);
                 dependenciesModified = false;
+
                 ResolveState newState = new GraphResolved(results);
+
+                // Make the new state visible in case a dependency resolution listener queries the result, which requires the new state
                 currentResolveState.set(newState);
 
                 // Mark all affected configurations as observed
@@ -630,8 +631,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                     dependencyResolutionListeners.getSource().afterResolve(incoming);
                     // Discard listeners
                     dependencyResolutionListeners.removeAll();
+
+                    // Use the current state, which may have changed if the listener queried the result
+                    newState = currentResolveState.get();
                 }
                 captureBuildOperationResult(context, results);
+                return newState;
             }
 
             private void captureBuildOperationResult(BuildOperationContext context, ResolverResults results) {
@@ -689,17 +694,16 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     /**
      * Must be called from {@link #resolveExclusively(InternalState)} only.
      */
-    private void resolveArtifactsIfRequired(ResolveState currentState) {
+    private ResolveState resolveArtifactsIfRequired(ResolveState currentState) {
         if (currentState.state == ARTIFACTS_RESOLVED) {
-            return;
+            return currentState;
         }
         if (currentState.state != GRAPH_RESOLVED) {
             throw new IllegalStateException("Cannot resolve artifacts before graph has been resolved.");
         }
         ResolverResults results = currentState.getCachedResolverResults();
         resolver.resolveArtifacts(DefaultConfiguration.this, results);
-        ResolveState newState = new ArtifactsResolved(results);
-        currentResolveState.set(newState);
+        return new ArtifactsResolved(results);
     }
 
     @Override
@@ -722,15 +726,15 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
             return resolveToStateOrLater(GRAPH_RESOLVED).getCachedResolverResults();
         }
 
-        ResolveState currentState = currentResolveState.get();
-        if (currentState.state == UNRESOLVED) {
-            // Traverse graph
-            ResolverResults results = new DefaultResolverResults();
-            resolver.resolveBuildDependencies(DefaultConfiguration.this, results);
-            BuildDependenciesResolved newState = new BuildDependenciesResolved(results);
-            currentResolveState.set(newState);
-            return newState.getCachedResolverResults();
-        }
+        ResolveState currentState = currentResolveState.update(initial -> {
+            if (initial.state == UNRESOLVED) {
+                // Traverse graph
+                ResolverResults results = new DefaultResolverResults();
+                resolver.resolveBuildDependencies(DefaultConfiguration.this, results);
+                return new BuildDependenciesResolved(results);
+            } // Otherwise, already have a result, so reuse it
+            return initial;
+        });
 
         // Otherwise, already have a result, so reuse it
         return currentState.getCachedResolverResults();
@@ -1869,6 +1873,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         @Override
         public Project getProject() {
             return configuration.owner.getProject();
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -78,6 +78,9 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         ProjectComponentIdentifier projectId = module.getProjectId();
         if (projectId != null) {
             ProjectState projectState = projectStateRegistry.stateFor(projectId);
+            if (!projectState.hasMutableState()) {
+                throw new IllegalStateException("Thread should hold project lock for " + projectId);
+            }
             return projectState.withMutableState(new Factory<DefaultLocalComponentMetadata>() {
                 @Override
                 public DefaultLocalComponentMetadata create() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -30,12 +30,9 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
-
-import javax.annotation.Nullable;
 
 /**
  * Provides the metadata for a component consumed from the same build that produces it.
@@ -86,23 +83,14 @@ public class DefaultProjectLocalComponentProvider implements LocalComponentProvi
     }
 
     private LocalComponentMetadata getLocalComponentMetadata(final ProjectComponentIdentifier projectIdentifier) {
-        // TODO - the project model should be reachable from ProjectState without another lookup
-        final ProjectInternal project = projectRegistry.getProject(projectIdentifier.getProjectPath());
-        if (project == null) {
-            throw new IllegalArgumentException(projectIdentifier + " not found.");
-        }
-        final ProjectState projectState = projectStateRegistry.stateFor(project);
-        return projectState.withMutableState(new Factory<LocalComponentMetadata>() {
-            @Nullable
-            @Override
-            public LocalComponentMetadata create() {
-                LocalComponentMetadata metadata = projects.getIfPresent(projectIdentifier);
-                if (metadata == null) {
-                    metadata = getLocalComponentMetadata(projectState, project);
-                    projects.put(projectIdentifier, metadata);
-                }
-                return metadata;
+        ProjectState projectState = projectStateRegistry.stateFor(projectIdentifier);
+        return projectState.withMutableState(() -> {
+            LocalComponentMetadata metadata = projects.getIfPresent(projectIdentifier);
+            if (metadata == null) {
+                metadata = getLocalComponentMetadata(projectState, projectState.getMutableModel());
+                projects.put(projectIdentifier, metadata);
             }
+            return metadata;
         });
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
@@ -48,13 +48,11 @@ public class ProjectArtifactResolver implements ArtifactResolver {
     public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
         final LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
         ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) artifact.getComponentId();
-        projectStateRegistry.stateFor(projectId).withMutableState(() -> {
-            File localArtifactFile = projectArtifact.getFile();
-            if (localArtifactFile != null) {
-                result.resolved(localArtifactFile);
-            } else {
-                result.notFound(projectArtifact.getId());
-            }
-        });
+        File localArtifactFile = projectStateRegistry.stateFor(projectId).withMutableState(() -> projectArtifact.getFile());
+        if (localArtifactFile != null) {
+            result.resolved(localArtifactFile);
+        } else {
+            result.notFound(projectArtifact.getId());
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
@@ -73,6 +73,10 @@ public abstract class AbstractTransformedArtifactSet implements ResolvedArtifact
         if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
             return visitor -> visitor.endVisitCollection(this);
         }
+
+        // Isolate the transformation parameters, if not already done
+        transformation.isolateParameters();
+
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
         Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, actions, artifactResults, dependenciesResolver, transformationNodeRegistry));
         return new TransformCompletion(result, targetVariantAttributes, artifactResults);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
-import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.properties.FileParameterUtils;
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
@@ -69,7 +68,6 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
     private final FileLookup fileLookup;
     private final FileCollectionFingerprinterRegistry fileCollectionFingerprinterRegistry;
     private final DomainObjectContext owner;
-    private final ProjectStateRegistry projectRegistry;
     private final InstantiationScheme actionInstantiationScheme;
     private final InstantiationScheme legacyActionInstantiationScheme;
 
@@ -83,7 +81,6 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
         FileLookup fileLookup,
         FileCollectionFingerprinterRegistry fileCollectionFingerprinterRegistry,
         DomainObjectContext owner,
-        ProjectStateRegistry projectRegistry,
         ArtifactTransformParameterScheme parameterScheme,
         ArtifactTransformActionScheme actionScheme,
         ServiceLookup internalServices
@@ -97,7 +94,6 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
         this.fileLookup = fileLookup;
         this.fileCollectionFingerprinterRegistry = fileCollectionFingerprinterRegistry;
         this.owner = owner;
-        this.projectRegistry = projectRegistry;
         this.actionInstantiationScheme = actionScheme.getInstantiationScheme();
         this.actionMetadataStore = actionScheme.getInspectionScheme().getMetadataStore();
         this.legacyActionInstantiationScheme = actionScheme.getLegacyInstantiationScheme();
@@ -159,16 +155,17 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
             fileLookup,
             parametersPropertyWalker,
             actionInstantiationScheme,
+            owner.getModel(),
             internalServices);
 
-        return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvocationFactory, owner, projectRegistry, fileCollectionFingerprinterRegistry));
+        return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvocationFactory, owner, fileCollectionFingerprinterRegistry));
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends org.gradle.api.artifacts.transform.ArtifactTransform> implementation, Object[] params) {
         Transformer transformer = new LegacyTransformer(implementation, params, legacyActionInstantiationScheme, from, classLoaderHierarchyHasher, isolatableFactory);
-        return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvocationFactory, owner, projectRegistry, fileCollectionFingerprinterRegistry));
+        return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvocationFactory, owner, fileCollectionFingerprinterRegistry));
     }
 
     private static class DefaultArtifactTransformRegistration implements ArtifactTransformRegistration {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
@@ -38,6 +38,7 @@ public class DefaultTransformedVariantFactory implements TransformedVariantFacto
 
     @Override
     public ResolvedArtifactSet transformedExternalArtifacts(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, ImmutableAttributes target, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
+        transformation.isolateParameters();
         VariantResolveMetadata.Identifier identifier = sourceVariant.getIdentifier();
         if (identifier == null) {
             // An ad hoc variant, do not cache the result

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
@@ -38,7 +38,6 @@ public class DefaultTransformedVariantFactory implements TransformedVariantFacto
 
     @Override
     public ResolvedArtifactSet transformedExternalArtifacts(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, ImmutableAttributes target, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
-        transformation.isolateParameters();
         VariantResolveMetadata.Identifier identifier = sourceVariant.getIdentifier();
         if (identifier == null) {
             // An ad hoc variant, do not cache the result

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -42,7 +42,7 @@ public interface Transformation extends Describable {
     CacheableInvocation<TransformationSubject> createInvocation(TransformationSubject subjectToTransform, ExecutionGraphDependenciesResolver dependenciesResolver, @Nullable NodeExecutionContext context);
 
     /**
-     * Whether the transformation requires dependencies of the transformed artifact to be injected.
+     * Whether the transformation requires upstream dependencies of the transformed artifact to be injected.
      */
     boolean requiresDependencies();
 
@@ -50,4 +50,6 @@ public interface Transformation extends Describable {
      * Extract the transformation steps from this transformation.
      */
     void visitTransformationSteps(Action<? super TransformationStep> action);
+
+    void isolateParameters();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -51,5 +51,8 @@ public interface Transformation extends Describable {
      */
     void visitTransformationSteps(Action<? super TransformationStep> action);
 
+    /**
+     * Isolates the parameters of this transformation, if not already.
+     */
     void isolateParameters();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
@@ -85,4 +85,10 @@ public class TransformationChain implements Transformation {
         first.visitTransformationSteps(action);
         second.visitTransformationSteps(action);
     }
+
+    @Override
+    public void isolateParameters() {
+        first.isolateParameters();
+        second.isolateParameters();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -157,7 +157,7 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
 
     @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
-        processDependencies(processHardSuccessor, dependencyResolver.resolveDependenciesFor(null, transformationStep.getDependencies()));
+        processDependencies(processHardSuccessor, dependencyResolver.resolveDependenciesFor(null, transformationStep));
         processDependencies(processHardSuccessor, dependencyResolver.resolveDependenciesFor(null, dependenciesResolver.computeDependencyNodes(transformationStep)));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -84,7 +84,6 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         }
 
         FileCollectionFingerprinterRegistry fingerprinterRegistry = context != null ? context.getService(FileCollectionFingerprinterRegistry.class) : globalFingerprinterRegistry;
-        isolateTransformerParameters(fingerprinterRegistry);
 
         Try<ArtifactTransformDependencies> resolvedDependencies = dependenciesResolver.computeArtifacts(transformer);
         return resolvedDependencies

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -23,14 +23,12 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.Try;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
-import org.gradle.internal.model.ModelContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,37 +46,16 @@ public class TransformationStep implements Transformation, TaskDependencyContain
 
     private final Transformer transformer;
     private final TransformerInvocationFactory transformerInvocationFactory;
-    private final ProjectStateRegistry.SafeExclusiveLock isolationLock;
     private final WorkNodeAction isolateAction;
     private final ProjectInternal owningProject;
     private final FileCollectionFingerprinterRegistry globalFingerprinterRegistry;
-    private final ModelContainer owner;
 
-    public TransformationStep(Transformer transformer, TransformerInvocationFactory transformerInvocationFactory, DomainObjectContext owner, ProjectStateRegistry projectRegistry, FileCollectionFingerprinterRegistry globalFingerprinterRegistry) {
+    public TransformationStep(Transformer transformer, TransformerInvocationFactory transformerInvocationFactory, DomainObjectContext owner, FileCollectionFingerprinterRegistry globalFingerprinterRegistry) {
         this.transformer = transformer;
         this.transformerInvocationFactory = transformerInvocationFactory;
         this.globalFingerprinterRegistry = globalFingerprinterRegistry;
-        this.isolationLock = projectRegistry.newExclusiveOperationLock();
         this.owningProject = owner.getProject();
-        this.owner = owner.getModel();
-        this.isolateAction = transformer.isIsolated() ? null : new WorkNodeAction() {
-            @Override
-            public String toString() {
-                return "isolate parameters of transform " + transformer.getDisplayName();
-            }
-
-            @Nullable
-            @Override
-            public Project getProject() {
-                return owningProject;
-            }
-
-            @Override
-            public void run(NodeExecutionContext context) {
-                FileCollectionFingerprinterRegistry fingerprinterRegistry = context.getService(FileCollectionFingerprinterRegistry.class);
-                isolateTransformerParameters(fingerprinterRegistry);
-            }
-        };
+        this.isolateAction = transformer.isIsolated() ? null : new IsolateTransformerParametersNode(this);
     }
 
     public Transformer getTransformer() {
@@ -141,22 +118,15 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         return Try.successful(subjectToTransform.createSubjectFromResult(builder.build()));
     }
 
-    private void isolateTransformerParameters(FileCollectionFingerprinterRegistry fingerprinterRegistry) {
-        if (!transformer.isIsolated()) {
-            if (!owner.hasMutableState()) {
-                owner.withLenientState(() -> isolateExclusively(fingerprinterRegistry));
-            } else {
-                isolateExclusively(fingerprinterRegistry);
-            }
-        }
+    @Override
+    public void isolateParameters() {
+        isolateTransformerParameters(globalFingerprinterRegistry);
     }
 
-    private void isolateExclusively(FileCollectionFingerprinterRegistry fingerprinterRegistry) {
-        isolationLock.withLock(() -> {
-            if (!transformer.isIsolated()) {
-                transformer.isolateParameters(fingerprinterRegistry);
-            }
-        });
+    private void isolateTransformerParameters(FileCollectionFingerprinterRegistry fingerprinterRegistry) {
+        if (!transformer.isIsolated()) {
+            transformer.isolateParameters(fingerprinterRegistry);
+        }
     }
 
     @Override
@@ -183,15 +153,45 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         return String.format("%s@%s", transformer.getDisplayName(), transformer.getSecondaryInputHash());
     }
 
-    public TaskDependencyContainer getDependencies() {
-        return transformer;
-    }
-
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         if (!transformer.isIsolated()) {
             context.add(isolateAction);
         }
         transformer.visitDependencies(context);
+    }
+
+    public static class IsolateTransformerParametersNode implements WorkNodeAction {
+        private final TransformationStep transformationStep;
+
+        public IsolateTransformerParametersNode(TransformationStep transformationStep) {
+            this.transformationStep = transformationStep;
+        }
+
+        public TransformationStep getTransformationStep() {
+            return transformationStep;
+        }
+
+        @Override
+        public String toString() {
+            return "isolate parameters of transform " + transformationStep.transformer.getDisplayName();
+        }
+
+        @Nullable
+        @Override
+        public Project getProject() {
+            return transformationStep.owningProject;
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            transformationStep.transformer.visitDependencies(context);
+        }
+
+        @Override
+        public void run(NodeExecutionContext context) {
+            FileCollectionFingerprinterRegistry fingerprinterRegistry = context.getService(FileCollectionFingerprinterRegistry.class);
+            transformationStep.isolateTransformerParameters(fingerprinterRegistry);
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
@@ -56,6 +56,8 @@ public class TransformedExternalArtifactSet extends AbstractTransformedArtifactS
     }
 
     public List<File> calculateResult() {
+        getTransformation().isolateParameters();
+
         List<File> files = new ArrayList<>();
         delegate.visitExternalArtifacts(artifact -> {
             TransformationSubject subject = TransformationSubject.initial(artifact.getId(), artifact.getFile());

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.configuration.internal.UserCodeApplicationContext
@@ -80,6 +81,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
+        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
         def compile = configurationContainer.create("compile")
@@ -110,6 +112,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "configures and finds"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
+        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
         def compile = configurationContainer.create("compile") {
@@ -125,6 +128,8 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "creates detached"() {
         given:
         1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
+        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
         def dependency2 = new DefaultExternalModuleDependency("group", "name2", "version")
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
@@ -57,6 +57,9 @@ class ChainedTransformerTest extends Specification {
         void visitTransformationSteps(Action<? super TransformationStep> action) {
         }
 
+        @Override
+        void isolateParameters() {
+        }
 
         @Override
         boolean endsWith(Transformation otherTransform) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileLookup
-import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.internal.tasks.properties.InspectionScheme
 import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.api.plugins.ExtensionAware
@@ -64,6 +64,10 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def inspectionScheme = Stub(InspectionScheme) {
         getPropertyWalker() >> propertyWalker
     }
+    def domainObjectContext = Mock(DomainObjectContext) {
+        getModel() >> RootScriptDomainObjectContext.INSTANCE
+    }
+
     def isolatableFactory = new TestIsolatableFactory()
     def classLoaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def attributesFactory = AttributeTestUtil.attributesFactory()
@@ -76,8 +80,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         fileCollectionFactory,
         Mock(FileLookup),
         fileCollectionFingerprinterRegistry,
-        Mock(DomainObjectContext),
-        Mock(ProjectStateRegistry),
+        domainObjectContext,
         new ArtifactTransformParameterScheme(
             instantiatorFactory.injectScheme(),
             inspectionScheme

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationMatchingSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationMatchingSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.transform
 
 import org.gradle.api.internal.DomainObjectContext
-import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
 import spock.lang.Specification
 
@@ -97,6 +96,6 @@ class TransformationMatchingSpec extends Specification {
     }
 
     private TransformationStep step() {
-        new TransformationStep(Mock(Transformer), Mock(TransformerInvocationFactory), Mock(DomainObjectContext), Mock(ProjectStateRegistry), Mock(FileCollectionFingerprinterRegistry))
+        new TransformationStep(Mock(Transformer), Mock(TransformerInvocationFactory), Mock(DomainObjectContext), Mock(FileCollectionFingerprinterRegistry))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -28,7 +28,6 @@ class TransformationNodeSpec extends Specification {
 
     def artifact = Mock(ResolvedArtifactSet.LocalArtifactSet)
     def dependencyResolver = Mock(TaskDependencyResolver)
-    def transformerDependencies = Mock(TaskDependencyContainer)
     def hardSuccessor = Mock(Action)
     def transformationStep = Mock(TransformationStep)
     def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
@@ -55,10 +54,10 @@ class TransformationNodeSpec extends Specification {
         1 * graphDependenciesResolver.computeDependencyNodes(transformationStep) >> artifactDependencyDependencies
         1 * dependencyResolver.resolveDependenciesFor(null, artifactDependencyDependencies) >> [additionalNode]
         1 * hardSuccessor.execute(additionalNode)
-        1 * transformationStep.dependencies >> transformerDependencies
-        1 * dependencyResolver.resolveDependenciesFor(null, transformerDependencies) >> [isolationNode]
+        1 * dependencyResolver.resolveDependenciesFor(null, transformationStep) >> [isolationNode]
         1 * hardSuccessor.execute(isolationNode)
         0 * hardSuccessor._
+        0 * dependencyResolver._
     }
 
     def "chained node with empty extra resolver only adds dependency on previous step and dependencies"() {
@@ -74,14 +73,14 @@ class TransformationNodeSpec extends Specification {
         node.resolveDependencies(dependencyResolver, hardSuccessor)
 
         then:
-        1 * transformationStep.dependencies >> transformerDependencies
-        1 * dependencyResolver.resolveDependenciesFor(null, transformerDependencies) >> [isolationNode]
+        1 * dependencyResolver.resolveDependenciesFor(null, transformationStep) >> [isolationNode]
         1 * hardSuccessor.execute(isolationNode)
         1 * graphDependenciesResolver.computeDependencyNodes(transformationStep) >> container
         1 * dependencyResolver.resolveDependenciesFor(null, container) >> [additionalNode]
         1 * hardSuccessor.execute(additionalNode)
         1 * hardSuccessor.execute(initialNode)
         0 * hardSuccessor._
+        0 * dependencyResolver._
     }
 
     private Node node() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -43,7 +43,6 @@ import org.gradle.plugins.ide.internal.resolver.IdeDependencySet;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencyVisitor;
 import org.gradle.plugins.ide.internal.resolver.UnresolvedIdeDependencyHandler;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -112,7 +111,6 @@ public class IdeaDependenciesProvider {
 
         final IdeaDependenciesVisitor visitor = new IdeaDependenciesVisitor(ideaModule, scope.name());
         return projectInternal.getMutationState().withMutableState(new Factory<IdeaDependenciesVisitor>() {
-            @Nullable
             @Override
             public IdeaDependenciesVisitor create() {
                 new IdeDependencySet(handler, javaModuleDetector, plusConfigurations, minusConfigurations, false, gradleApiSourcesResolver).visit(visitor);

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -197,7 +197,7 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun writeInstantExecutionState(stateFile: File) {
-        service<ProjectStateRegistry>().withLenientState {
+        service<ProjectStateRegistry>().withMutableStateOfAllProjects {
             withWriteContextFor(stateFile) {
                 instantExecutionState().run {
                     writeState()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ActionNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ActionNodeCodec.kt
@@ -16,37 +16,21 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
-import org.gradle.api.Project
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
-import org.gradle.api.internal.tasks.NodeExecutionContext
 import org.gradle.api.internal.tasks.WorkNodeAction
 import org.gradle.execution.plan.ActionNode
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.logNotImplemented
+import org.gradle.instantexecution.serialization.readNonNull
 
 
 object ActionNodeCodec : Codec<ActionNode> {
     override suspend fun WriteContext.encode(value: ActionNode) {
-        if (value.action is DefaultConfiguration.ResolveGraphAction) {
-            // Can ignore
-            return
-        } else {
-            logNotImplemented(value.action.javaClass)
-        }
+        write(value.action)
     }
 
     override suspend fun ReadContext.decode(): ActionNode? {
-        // TODO - should discard from graph instead
-        return ActionNode(object : WorkNodeAction {
-            override fun run(context: NodeExecutionContext) {
-                // Ignore
-            }
-
-            override fun getProject(): Project? {
-                return null
-            }
-        })
+        val action = readNonNull<WorkNodeAction>()
+        return ActionNode(action)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -76,6 +76,7 @@ class ArtifactCollectionCodec(private val fileCollectionFactory: FileCollectionF
                     element.nodes.flatMap { it.transformedSubject.get().files }
                 }
                 is TransformedLocalArtifactSpec -> Callable {
+                    element.transformation.isolateParameters()
                     element.transformation.createInvocation(TransformationSubject.initial(element.origin), FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty())), null).invoke().get().files
                 }
                 is TransformedExternalArtifactSet -> Callable {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -47,6 +47,7 @@ import org.gradle.instantexecution.serialization.codecs.jos.JavaObjectSerializat
 import org.gradle.instantexecution.serialization.codecs.transform.ChainedTransformationNodeCodec
 import org.gradle.instantexecution.serialization.codecs.transform.DefaultTransformerCodec
 import org.gradle.instantexecution.serialization.codecs.transform.InitialTransformationNodeCodec
+import org.gradle.instantexecution.serialization.codecs.transform.IsolateTransformerParametersNodeCodec
 import org.gradle.instantexecution.serialization.codecs.transform.LegacyTransformerCodec
 import org.gradle.instantexecution.serialization.codecs.transform.TransformDependenciesCodec
 import org.gradle.instantexecution.serialization.codecs.transform.TransformationChainCodec
@@ -146,7 +147,7 @@ class Codecs(
         bind(ImmutableAttributesCodec(attributesFactory, managedFactoryRegistry))
         bind(AttributeContainerCodec(attributesFactory, managedFactoryRegistry))
         bind(TransformationNodeReferenceCodec)
-        bind(TransformationStepCodec(projectStateRegistry, fingerprinterRegistry))
+        bind(TransformationStepCodec(fingerprinterRegistry))
         bind(TransformationChainCodec())
         bind(DefaultTransformerCodec(buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, parameterScheme, actionScheme))
         bind(LegacyTransformerCodec(actionScheme))
@@ -219,6 +220,8 @@ class Codecs(
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
         bind(ChainedTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
+        bind(IsolateTransformerParametersNodeCodec(userTypesCodec))
+        bind(WorkNodeActionCodec)
         bind(ActionNodeCodec)
 
         bind(ResolvableArtifactCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -91,6 +91,7 @@ class FileCollectionCodec(
                             element.calculateResult()
                         }
                         is TransformedLocalFileSpec -> Callable {
+                            element.transformation.isolateParameters()
                             element.transformation.createInvocation(TransformationSubject.initial(element.origin), noDependencies, null).invoke().get().files
                         }
                         else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/WorkNodeActionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/WorkNodeActionCodec.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.Project
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
+import org.gradle.api.internal.tasks.NodeExecutionContext
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.internal.tasks.WorkNodeAction
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.logNotImplemented
+
+
+object WorkNodeActionCodec : Codec<WorkNodeAction> {
+    override suspend fun WriteContext.encode(value: WorkNodeAction) {
+        if (value is DefaultConfiguration.ResolveGraphAction) {
+            // Can ignore
+            return
+        } else {
+            logNotImplemented(value.javaClass)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): WorkNodeAction {
+        // TODO - should discard from graph instead
+        return object : WorkNodeAction {
+            override fun getProject(): Project? {
+                return null
+            }
+
+            override fun visitDependencies(context: TaskDependencyResolveContext) {
+            }
+
+            override fun run(context: NodeExecutionContext) {
+                // Ignore
+            }
+        }
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/DefaultTransformerCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/DefaultTransformerCodec.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.transform.DefaultTransformer
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileLookup
+import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.tasks.FileNormalizer
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
@@ -105,6 +106,7 @@ class DefaultTransformerCodec(
             fileLookup,
             parameterScheme.inspectionScheme.propertyWalker,
             actionScheme.instantiationScheme,
+            RootScriptDomainObjectContext.INSTANCE.model,
             isolate.owner.service(ServiceRegistry::class.java)
         )
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/IsolateTransformerParametersNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/IsolateTransformerParametersNodeCodec.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs.transform
+
+import org.gradle.api.internal.artifacts.transform.TransformationStep
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.codecs.BindingsBackedCodec
+import org.gradle.instantexecution.serialization.readNonNull
+import org.gradle.instantexecution.serialization.withCodec
+
+
+class IsolateTransformerParametersNodeCodec(
+    val userTypesCodec: BindingsBackedCodec
+) : Codec<TransformationStep.IsolateTransformerParametersNode> {
+    override suspend fun WriteContext.encode(value: TransformationStep.IsolateTransformerParametersNode) {
+        withCodec(userTypesCodec) {
+            write(value.transformationStep)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): TransformationStep.IsolateTransformerParametersNode? {
+        val step = withCodec(userTypesCodec) { readNonNull<TransformationStep>() }
+        return TransformationStep.IsolateTransformerParametersNode(step)
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/TransformationStepCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/transform/TransformationStepCodec.kt
@@ -20,7 +20,6 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.transform.TransformationStep
 import org.gradle.api.internal.artifacts.transform.Transformer
 import org.gradle.api.internal.artifacts.transform.TransformerInvocationFactory
-import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
@@ -32,7 +31,6 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
 
 internal
 class TransformationStepCodec(
-    private val projectStateRegistry: ProjectStateRegistry,
     private val fingerprinterRegistry: FileCollectionFingerprinterRegistry
 ) : Codec<TransformationStep> {
 
@@ -54,7 +52,6 @@ class TransformationStepCodec(
                 transformer,
                 services[TransformerInvocationFactory::class.java],
                 services[DomainObjectContext::class.java],
-                projectStateRegistry,
                 fingerprinterRegistry
             )
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/WorkNodeAction.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/WorkNodeAction.java
@@ -30,6 +30,8 @@ public interface WorkNodeAction {
     @Nullable
     Project getProject();
 
+    void visitDependencies(TaskDependencyResolveContext context);
+
     /**
      * Run the action, throwing any failure.
      */


### PR DESCRIPTION
### Context

Ensure that a worker thread never attempts to acquire any project locks while it is executing an artifact transform. Previously, it was possible for transform execution to attempt to resolve dependencies and use other project state, while isolating the transform parameters. It was also possible for multiple threads to perform this isolation work concurrently. This would sometimes lead to deadlocks, and is also not particularly efficient.

Now, transform parameter isolation is always performed prior to starting execution of a transform on some worker thread. For scheduled transform nodes, this is done as a separate isolation node, and for on-demand execution, this is done by the visiting thread prior to starting the transform.

Also:
- Remove the concept of 'lenient' project access, so that all access is strict and no more than one thread is granted access to the state of a given project at any given time.
- Replace the "safe exclusive lock" concept with a "calculated model value" concept, as each of the "exclusive lock" consumers would use this lock plus some other thread safety code (or not) to produce some value calculated from a project and shared by multiple consuming threads. A "calculated model value" concept captures this use case more clearly and allows thread safety and performance fixes to happen in one place.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
