### PR TITLE
Check if `requireIsolatedDaemons()` is used correctly

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -153,6 +153,9 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             return createGradleHandle().waitForFinish();
         }
 
+        if (!isSharedDaemons() && !isDaemonExplicitlyRequired()) {
+            throw new UnsupportedOperationException("Cannot use isolated daemons with the in-process executer without requiring a daemon.");
+        }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
         BuildListenerImpl buildListener = new BuildListenerImpl();


### PR DESCRIPTION
`requireIsolatedDaemons()` only has an effect when the executor creates an actual daemon. The `InProcessGradleExecuter` does not create a daemon.