### PR TITLE
Fix incremental annotation processing

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -63,6 +63,22 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    def "incremental processing works on subsequent incremental compilations"() {
+        given:
+        def a = java "@Helper class A {}"
+        java "class Unrelated {}"
+        run "compileJava"
+        a.text = "@Helper class A { public void foo() {} }"
+        outputs.snapshot { run "compileJava" }
+
+        when:
+        a.text = "@Helper class A { public void bar() {} }"
+        run "compileJava"
+
+        then:
+        outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
+    }
+
     def "annotated files are not recompiled on unrelated changes"() {
         given:
         java "@Helper class A {}"

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringCompiler.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathSnap
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingData;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.GeneratedResource;
+import org.gradle.api.internal.tasks.compile.incremental.recomp.IncrementalCompilationResult;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilationData;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.tasks.WorkResult;
@@ -76,6 +77,9 @@ class IncrementalResultStoringCompiler<T extends JavaCompileSpec> implements Com
         Set<AnnotationProcessorDeclaration> processors = spec.getEffectiveAnnotationProcessors();
         if (processors == null || processors.isEmpty()) {
             return new AnnotationProcessingData();
+        }
+        if (result instanceof IncrementalCompilationResult) {
+            result = ((IncrementalCompilationResult) result).getCompilerResult();
         }
         if (result instanceof JdkJavaCompilerResult) {
             AnnotationProcessingResult processingResult = ((JdkJavaCompilerResult) result).getAnnotationProcessingResult();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationNotNecessary.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationNotNecessary.java
@@ -24,4 +24,9 @@ public class RecompilationNotNecessary implements WorkResult, IncrementalCompila
     public boolean getDidWork() {
         return false;
     }
+
+    @Override
+    public WorkResult getCompilerResult() {
+        return this;
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -80,8 +80,7 @@ class SelectiveCompiler<T extends JavaCompileSpec> implements org.gradle.languag
 
         try {
             WorkResult result = recompilationSpecProvider.decorateResult(recompilationSpec, cleaningCompiler.getCompiler().execute(spec));
-            return result
-                .or(WorkResults.didWork(cleanedOutput));
+            return result.or(WorkResults.didWork(cleanedOutput));
         } finally {
             Collection<String> classesToCompile = recompilationSpec.getClassesToCompile();
             LOG.info("Incremental compilation of {} classes completed in {}.", classesToCompile.size(), clock.getElapsed());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/DefaultIncrementalCompileResult.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/DefaultIncrementalCompileResult.java
@@ -23,8 +23,11 @@ import org.gradle.workers.internal.DefaultWorkResult;
  * Marks compilation as beeing performed incrementally.
  */
 public class DefaultIncrementalCompileResult extends DefaultWorkResult implements IncrementalCompilationResult {
-    public DefaultIncrementalCompileResult(WorkResult workResult) {
-        super(workResult.getDidWork(), maybeException(workResult));
+    private final WorkResult compilerResult;
+
+    public DefaultIncrementalCompileResult(WorkResult compilerResult) {
+        super(compilerResult.getDidWork(), maybeException(compilerResult));
+        this.compilerResult = compilerResult;
     }
 
     private static Throwable maybeException(WorkResult workResult) {
@@ -32,5 +35,10 @@ public class DefaultIncrementalCompileResult extends DefaultWorkResult implement
             return ((DefaultWorkResult) workResult).getException();
         }
         return null;
+    }
+
+    @Override
+    public WorkResult getCompilerResult() {
+        return compilerResult;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/IncrementalCompilationResult.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/IncrementalCompilationResult.java
@@ -16,8 +16,11 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
+import org.gradle.api.tasks.WorkResult;
+
 /**
  * A marker interface for incremental compilation result.
  */
-public interface IncrementalCompilationResult {
+public interface IncrementalCompilationResult extends WorkResult {
+    WorkResult getCompilerResult();
 }


### PR DESCRIPTION
### Context
Incremental annotation processing was broken since Gradle 6.0, due to the changes in #9964.
This went undetected because there was no test asserting that incremental processing works
when the previous build was incremental.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
