### PR TITLE
Introduce @SafeUnroll

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/SafeUnroll.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/SafeUnroll.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testfixtures;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The intention of this annotation is to get rid of https://github.com/gradle/gradle/issues/8787
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(SafeUnrollExtension.class)
+@Inherited
+public @interface SafeUnroll {
+    String value() default "";
+}

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/SafeUnrollExtension.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/SafeUnrollExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testfixtures;
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.IterationInfo;
+import org.spockframework.runtime.model.NameProvider;
+import org.spockframework.runtime.model.SpecInfo;
+
+public class SafeUnrollExtension extends AbstractAnnotationDrivenExtension<SafeUnroll> {
+
+    @Override
+    public void visitSpecAnnotation(SafeUnroll unroll, SpecInfo spec) {
+        spec.getFeatures()
+            .stream()
+            .filter(FeatureInfo::isParameterized)
+            .forEach(feature -> visitFeatureAnnotation(unroll, feature));
+    }
+
+    @Override
+    public void visitFeatureAnnotation(SafeUnroll unroll, FeatureInfo feature) {
+        if (feature.isParameterized()) {
+            feature.setReportIterations(true);
+            feature.setIterationNameProvider(chooseNameProvider(unroll, feature));
+        }
+    }
+
+    private NameProvider<IterationInfo> chooseNameProvider(SafeUnroll unroll, FeatureInfo feature) {
+        if (unroll.value().length() > 0) {
+            return new UniqueNameProvider(feature, unroll.value());
+        } else if (feature.getName().contains("#")) {
+            return new UniqueNameProvider(feature, feature.getName());
+        } else {
+            return null;
+        }
+    }
+}
+
+
+

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/UniqueNameProvider.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/UniqueNameProvider.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testfixtures
+
+import org.spockframework.runtime.SpockAssertionError
+import org.spockframework.runtime.extension.builtin.UnrollNameProvider
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.IterationInfo
+import org.spockframework.runtime.model.NameProvider
+
+class UniqueNameProvider implements NameProvider<IterationInfo> {
+
+    private final Set<String> testMethodNames = new HashSet<>()
+    private final NameProvider<IterationInfo> delegate
+
+    UniqueNameProvider(FeatureInfo feature, String namePattern) {
+        delegate = new UnrollNameProvider(feature, namePattern)
+    }
+
+    @Override
+    String getName(IterationInfo iterationInfo) {
+        def name = delegate.getName(iterationInfo)
+        if (!testMethodNames.add(name)) {
+            throw new SpockAssertionError("Test method name '$name' is not unique")
+        }
+
+        name
+    }
+}

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
@@ -20,15 +20,15 @@ import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.IgnoreIf
 import spock.lang.Issue
-import spock.lang.Unroll
 
 import java.nio.charset.Charset
 
 class BuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
 
-    @Unroll("default locale for gradle build switched to #locale")
+    @SafeUnroll("default locale for gradle build switched to #locale")
     def "builds can be executed with different default locales"() {
         given:
         executer.withDefaultLocale(locale)
@@ -143,7 +143,7 @@ task check {
         }
     }
 
-    @Unroll("build default encoding matches specified - input = #inputEncoding, expectedEncoding: #expectedEncoding")
+    @SafeUnroll("build default encoding matches specified - input = #inputEncoding, expectedEncoding: #expectedEncoding")
     def "build default encoding matches specified"(String inputEncoding, String expectedEncoding) {
         given:
         executerEncoding inputEncoding
@@ -170,7 +170,7 @@ task check {
         null          | Charset.defaultCharset().name()
     }
 
-    @Unroll("forked java processes inherit default encoding - input = #inputEncoding, expectedEncoding: #expectedEncoding")
+    @SafeUnroll("forked java processes inherit default encoding - input = #inputEncoding, expectedEncoding: #expectedEncoding")
     def "forked java processes inherit default encoding"() {
         given:
         executerEncoding inputEncoding

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
@@ -20,16 +20,16 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
 import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.testfixtures.SafeUnroll
 import org.junit.Rule
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
     @Rule
     JDWPUtil jdwpClient = new JDWPUtil(5005)
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
-    @Unroll
+    @SafeUnroll
     def "reasonable failure message when --max-workers=#value"() {
         given:
         executer.requireDaemon().requireIsolatedDaemons()  // otherwise exception gets thrown in testing infrastructure
@@ -47,7 +47,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
         value << ["-1", "0", "foo", " 1"]
     }
 
-    @Unroll
+    @SafeUnroll
     def "reasonable failure message when org.gradle.workers.max=#value"() {
         given:
         executer.requireDaemon().requireIsolatedDaemons() // otherwise exception gets thrown in testing infrastructure

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -19,15 +19,15 @@ package org.gradle.launcher
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 @Requires(adhoc = { AvailableJavaHomes.getJdks("1.6", "1.7") })
 class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
 
-    @Unroll
+    @SafeUnroll
     @IgnoreIf({ GradleContextualExecuter.embedded }) // This test requires to start Gradle from scratch with the wrong Java version
     def "provides reasonable failure message when attempting to run under java #jdk.javaVersion"() {
         given:
@@ -41,7 +41,7 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         jdk << AvailableJavaHomes.getJdks("1.6", "1.7")
     }
 
-    @Unroll
+    @SafeUnroll
     def "fails when build is configured to use Java #jdk.javaVersion"() {
         given:
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationLoggingSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationLoggingSpec.groovy
@@ -17,11 +17,11 @@
 package org.gradle.launcher.cli
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Unroll
+import org.gradle.testfixtures.SafeUnroll
 
 class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
 
-    @Unroll
+    @SafeUnroll
     def "Set logging level using org.gradle.logging.level=#logLevel"() {
         def message = 'Expected message in the output'
         buildFile << """
@@ -51,7 +51,7 @@ class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
         'debug'     | ''          | ['-Dorg.gradle.logging.level=debug']
     }
 
-    @Unroll
+    @SafeUnroll
     def "Set log level using org.gradle.logging.level in GRADLE_OPTS to #logLevel"() {
         setup:
         executer.requireIsolatedDaemons()
@@ -86,7 +86,7 @@ class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
     }
 
 
-    @Unroll
+    @SafeUnroll
     def "Command line switches override properly: #flags #options"() {
         setup:
         executer.requireIsolatedDaemons()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Ignore
+import spock.lang.Unroll
 
 @TestReproducibleArchives
 class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
@@ -69,7 +70,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         executedAndNotSkipped(":zip")
     }
 
-    @SafeUnroll
+    @Unroll
     def "using compressed files as inputs - #type #packType #source - readonly #readonly"() {
         given:
         def packDir = file("pack").createDir()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -70,7 +70,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
     }
 
     @SafeUnroll
-    def "using compressed files as inputs - #source - readonly #readonly"() {
+    def "using compressed files as inputs - #type #packType #source - readonly #readonly"() {
         given:
         def packDir = file("pack").createDir()
         def outputDir = file("unpack")

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.launcher.continuous
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Ignore
-import spock.lang.Unroll
 
 @TestReproducibleArchives
 class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
@@ -69,7 +69,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         executedAndNotSkipped(":zip")
     }
 
-    @Unroll
+    @SafeUnroll
     def "using compressed files as inputs - #source - readonly #readonly"() {
         given:
         def packDir = file("pack").createDir()
@@ -126,7 +126,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
     }
 
     @Ignore("inputs from resources are ignored")
-    @Unroll
+    @SafeUnroll
     def "using compressed files as inputs from resources - #source"() {
         given:
         def packDir = file("pack").createDir()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
@@ -21,15 +21,14 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.process.internal.worker.WorkerProcessFactory
 import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider
-import spock.lang.Unroll
-
+import org.gradle.testfixtures.SafeUnroll
 
 class BuildSessionServiceReuseContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def cleanup() {
         gradle.cancel()
     }
 
-    @Unroll
+    @SafeUnroll
     @ToBeFixedForInstantExecution
     def "reuses #service across continuous builds" () {
         def triggerFileName = "trigger"

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -181,7 +181,7 @@ jar.dependsOn postCompile
     }
 
     @SafeUnroll
-    def "check build executing and failing in task :c - change in :#changingInput"(changingInput, shouldTrigger) {
+    def "check build executing and failing in task :c - change in :#changingInput #shouldTrigger"(changingInput, shouldTrigger) {
         given:
         ['a', 'b', 'c', 'd'].each { file(it).createDir() }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.TestPrecondition
 import spock.lang.Retry
-import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.RetryConditions.cleanProjectDir
 import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
@@ -180,7 +180,7 @@ jar.dependsOn postCompile
         changingInput << ['a', 'b', 'c', 'd']
     }
 
-    @Unroll
+    @SafeUnroll
     def "check build executing and failing in task :c - change in :#changingInput"(changingInput, shouldTrigger) {
         given:
         ['a', 'b', 'c', 'd'].each { file(it).createDir() }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.TestPrecondition
 import spock.lang.Retry
+import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.RetryConditions.cleanProjectDir
 import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
@@ -180,7 +180,7 @@ jar.dependsOn postCompile
         changingInput << ['a', 'b', 'c', 'd']
     }
 
-    @SafeUnroll
+    @Unroll
     def "check build executing and failing in task :c - change in :#changingInput #shouldTrigger"(changingInput, shouldTrigger) {
         given:
         ['a', 'b', 'c', 'd'].each { file(it).createDir() }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -19,8 +19,8 @@ package org.gradle.launcher.daemon
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 class DaemonJvmSettingsIntegrationTest extends DaemonIntegrationSpec {
     def "uses current JVM and default JVM args when none specified"() {
@@ -57,7 +57,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         stopDaemonsNow()
     }
 
-    @Unroll
+    @SafeUnroll
     def "uses defaults for max/min heap size when JAVA_TOOL_OPTIONS is set (#javaToolOptions)"() {
         setup:
         executer.requireDaemon().requireIsolatedDaemons()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.launcher.daemon
 
 import org.apache.commons.lang.LocaleUtils
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.GradleVersion
 import spock.lang.Issue
-import spock.lang.Unroll
 
 @Issue("https://issues.gradle.org/browse/GRADLE-3142")
 class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
@@ -87,12 +87,12 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4973")
-    @Unroll
+    @SafeUnroll
     def "can use a locale without region (#overrideVersion)"() {
         Locale locale = Locale.ENGLISH
         buildScript """
             import org.gradle.util.GradleVersion
-            
+
             task printLocale {
                 doFirst {
                     println "GradleVersion: " + GradleVersion.current()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -21,11 +21,11 @@ import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.launcher.daemon.client.SingleUseDaemonClient
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.GFileUtils
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 @IntegrationTestTimeout(300)
 class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
@@ -81,7 +81,7 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         daemon?.abort()
     }
 
-    @Unroll
+    @SafeUnroll
     def "a daemon expiration listener receives expiration reasons continuous:#continuous"() {
         given:
         buildFile << """

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/testing/DaemonsEventSequence.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/testing/DaemonsEventSequence.groovy
@@ -15,10 +15,10 @@
  */
 package org.gradle.launcher.daemon.testing
 
-import org.gradle.launcher.daemon.registry.DaemonRegistry
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.concurrent.Stoppable
+import org.gradle.launcher.daemon.registry.DaemonRegistry
 
 import java.util.concurrent.LinkedBlockingQueue
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/bootstrap/EntryPointTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/bootstrap/EntryPointTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.launcher.bootstrap
 
-import spock.lang.Specification
 import org.gradle.api.Action
+import spock.lang.Specification
 
 class EntryPointTest extends Specification {
     final Action<ExecutionListener> action = Mock()

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -21,15 +21,15 @@ import org.gradle.internal.build.event.BuildEventSubscriptions
 import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.launcher.cli.action.BuildActionSerializer
 import org.gradle.launcher.cli.action.ExecuteBuildAction
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.test.internal.DefaultDebugOptions
 import org.gradle.tooling.internal.provider.BuildModelAction
 import org.gradle.tooling.internal.provider.ClientProvidedBuildAction
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload
-import spock.lang.Unroll
 
-@Unroll
+@SafeUnroll
 class BuildActionSerializerTest extends SerializerSpec {
     def "serializes ExecuteBuildAction with all defaults"() {
         def action = new ExecuteBuildAction(new StartParameterInternal())

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.cli.CommandLineParser
 import org.gradle.launcher.configuration.BuildLayoutResult
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.launcher.daemon.configuration.DaemonParameters
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DaemonCommandLineConverterTest extends Specification {
-    @Unroll
+    @SafeUnroll
     def "converts daemon options - #options"() {
         when:
         def converted = convert(options)
@@ -43,7 +43,7 @@ class DaemonCommandLineConverterTest extends Specification {
         ['--no-daemon', '--daemon']     | true
     }
 
-    @Unroll
+    @SafeUnroll
     def "can convert foreground option - #options"() {
         when:
         def converted = convert(options)
@@ -59,7 +59,7 @@ class DaemonCommandLineConverterTest extends Specification {
         ['--foreground', '--daemon']    | true
     }
 
-    @Unroll
+    @SafeUnroll
     def "can convert stop option - #options"() {
         when:
         def converted = convert(options)
@@ -73,7 +73,7 @@ class DaemonCommandLineConverterTest extends Specification {
         ['--stop'] | true
     }
 
-    @Unroll
+    @SafeUnroll
     def "can convert status option - #options"() {
         when:
         def converted = convert(options)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -22,9 +22,9 @@ import org.gradle.launcher.configuration.BuildLayoutResult
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.launcher.daemon.configuration.DaemonParameters
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.testfixtures.SafeUnroll
 import org.junit.Rule
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class PropertiesToDaemonParametersConverterTest extends Specification {
     @Rule
@@ -125,7 +125,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         ex.message.contains 'bogus'
     }
 
-    @Unroll
+    @SafeUnroll
     def "explicitly sets daemon usage if daemon system property is specified"() {
         when:
         converter.convert((DaemonBuildOptions.DaemonOption.GRADLE_PROPERTY): enabled.toString(), params)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/bootstrap/DaemonGreeterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/bootstrap/DaemonGreeterTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.launcher.daemon.bootstrap
 
 import org.gradle.api.GradleException
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.internal.remote.internal.inet.MultiChoiceAddress
 import org.gradle.launcher.daemon.client.DaemonGreeter
 import org.gradle.launcher.daemon.logging.DaemonMessages
-import org.gradle.internal.remote.internal.inet.MultiChoiceAddress
 import org.gradle.process.ExecResult
 import spock.lang.Specification
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonCancelForwarderTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonCancelForwarderTest.groovy
@@ -16,8 +16,8 @@
 package org.gradle.launcher.daemon.client
 
 import org.gradle.initialization.DefaultBuildCancellationToken
-import org.gradle.launcher.daemon.protocol.Cancel
 import org.gradle.internal.dispatch.Dispatch
+import org.gradle.launcher.daemon.protocol.Cancel
 import org.gradle.util.ConcurrentSpecification
 
 import java.util.concurrent.LinkedBlockingQueue

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientInputForwarderTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientInputForwarderTest.groovy
@@ -15,9 +15,9 @@
  */
 package org.gradle.launcher.daemon.client
 
+import org.gradle.internal.dispatch.Dispatch
 import org.gradle.launcher.daemon.protocol.CloseInput
 import org.gradle.launcher.daemon.protocol.ForwardInput
-import org.gradle.internal.dispatch.Dispatch
 import org.gradle.util.ConcurrentSpecification
 
 import java.util.concurrent.LinkedBlockingQueue

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonStartupMessageTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonStartupMessageTest.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.launcher.daemon.client
 
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DaemonStartupMessageTest extends Specification {
-    @Unroll
+    @SafeUnroll
     def "starting message contains number of busy and incompatible daemons (#numBusy busy, #numIncompatible incompatible, #numStopped stopped)"() {
         given:
         def message = DaemonStartupMessage.generate(numBusy, numIncompatible, numStopped)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonJvmOptionsTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonJvmOptionsTest.groovy
@@ -18,12 +18,12 @@ package org.gradle.launcher.daemon.configuration
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.internal.JvmOptions
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DaemonJvmOptionsTest extends Specification {
 
-    @Unroll
+    @SafeUnroll
     def "#propDescr is immutable system property"() {
         when:
         def opts = createOpts()
@@ -44,7 +44,7 @@ class DaemonJvmOptionsTest extends Specification {
         "ssl truststore type"     | DaemonJvmOptions.SSL_TRUSTSTORETYPE_KEY   | "-D${DaemonJvmOptions.SSL_TRUSTSTORETYPE_KEY}=jks"
     }
 
-    @Unroll
+    @SafeUnroll
     def "#propDescr can be set as systemproperty"() {
         JvmOptions opts = createOpts()
         when:

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryUpdaterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryUpdaterTest.groovy
@@ -16,13 +16,15 @@
 
 package org.gradle.launcher.daemon.registry
 
+import org.gradle.internal.remote.Address
 import org.gradle.launcher.daemon.context.DaemonContext
 import org.gradle.launcher.daemon.registry.DaemonRegistry.EmptyRegistryException
 import org.gradle.launcher.daemon.server.DaemonRegistryUpdater
-import org.gradle.internal.remote.Address
 import spock.lang.Specification
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Busy
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Canceled
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idle
 
 public class DaemonRegistryUpdaterTest extends Specification {
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/EmbeddedDaemonRegistry.java
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/EmbeddedDaemonRegistry.java
@@ -26,8 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.*;
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*;
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State;
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Canceled;
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idle;
 
 /**
  * A daemon registry for daemons running in the same JVM.

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/EmbeddedDaemonRegistrySpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/EmbeddedDaemonRegistrySpec.groovy
@@ -15,11 +15,12 @@
  */
 package org.gradle.launcher.daemon.registry
 
-import org.gradle.launcher.daemon.context.DaemonContext
 import org.gradle.internal.remote.Address
+import org.gradle.launcher.daemon.context.DaemonContext
 import spock.lang.Specification
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Busy
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idle
 
 class EmbeddedDaemonRegistrySpec extends Specification {
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonExpirationStrategyTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.launcher.daemon.server
 
 import org.gradle.internal.remote.Address
+import org.gradle.internal.time.MockClock
 import org.gradle.launcher.daemon.context.DaemonContext
 import org.gradle.launcher.daemon.registry.DaemonInfo
 import org.gradle.launcher.daemon.registry.DaemonRegistry
 import org.gradle.launcher.daemon.registry.EmbeddedDaemonRegistry
 import org.gradle.launcher.daemon.server.api.DaemonStateControl
-import org.gradle.internal.time.MockClock
 import spock.lang.Specification
 
 import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Busy

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonIdleTimeoutExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonIdleTimeoutExpirationStrategyTest.groovy
@@ -22,7 +22,8 @@ import spock.lang.Specification
 import javax.annotation.Nullable
 import java.util.concurrent.TimeUnit
 
-import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.*
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.DO_NOT_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.QUIET_EXPIRE
 
 class DaemonIdleTimeoutExpirationStrategyTest extends Specification {
     final Daemon daemon = Mock(Daemon)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonStateCoordinatorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonStateCoordinatorTest.groovy
@@ -19,7 +19,10 @@ import org.gradle.launcher.daemon.server.api.DaemonStoppedException
 import org.gradle.launcher.daemon.server.api.DaemonUnavailableException
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Busy
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idle
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.StopRequested
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Stopped
 
 class DaemonStateCoordinatorTest extends ConcurrentSpec {
     final Runnable onStartCommand = Mock(Runnable)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DefaultDaemonConnectionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DefaultDaemonConnectionTest.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.launcher.daemon.server
 
+import org.gradle.internal.remote.internal.MessageIOException
+import org.gradle.internal.remote.internal.RemoteConnection
 import org.gradle.launcher.daemon.protocol.CloseInput
 import org.gradle.launcher.daemon.protocol.ForwardInput
 import org.gradle.launcher.daemon.server.api.StdinHandler
-import org.gradle.internal.remote.internal.MessageIOException
-import org.gradle.internal.remote.internal.RemoteConnection
 import org.gradle.util.ConcurrentSpecification
 
 import java.util.concurrent.CountDownLatch

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AllDaemonExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AllDaemonExpirationStrategyTest.groovy
@@ -19,7 +19,10 @@ package org.gradle.launcher.daemon.server.expiry
 
 import spock.lang.Specification
 
-import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.*
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.DO_NOT_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.IMMEDIATE_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.QUIET_EXPIRE
 
 class AllDaemonExpirationStrategyTest extends Specification {
     private DaemonExpirationStrategy c1;

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategyTest.groovy
@@ -19,7 +19,10 @@ package org.gradle.launcher.daemon.server.expiry
 
 import spock.lang.Specification
 
-import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.*
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.DO_NOT_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.IMMEDIATE_EXPIRE
+import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.QUIET_EXPIRE
 
 class AnyDaemonExpirationStrategyTest extends Specification {
     private DaemonExpirationStrategy c1;

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/DaemonMemoryStatusTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/DaemonMemoryStatusTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.launcher.daemon.server.health
 
 import org.gradle.launcher.daemon.server.health.gc.GarbageCollectionStats
+import org.gradle.testfixtures.SafeUnroll
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification
-import spock.lang.Unroll
 
 
 class DaemonMemoryStatusTest extends Specification {
@@ -32,7 +32,7 @@ class DaemonMemoryStatusTest extends Specification {
         return new DaemonMemoryStatus(stats, heapUsageThreshold, heapRateThreshold, nonHeapUsageThreshold, thrashingThreshold)
     }
 
-    @Unroll
+    @SafeUnroll
     def "knows when heap space is exhausted (#rateThreshold <= #rate, #usageThreshold <= #usage)"(double rateThreshold, int usageThreshold, double rate, int usage, boolean unhealthy) {
         when:
         def status = create(usageThreshold, rateThreshold, 100, 100)
@@ -58,7 +58,7 @@ class DaemonMemoryStatusTest extends Specification {
         1.0           | 75             | 1.0  | 100   | true
     }
 
-    @Unroll
+    @SafeUnroll
     def "knows when metaspace is exhausted (#usageThreshold <= #usage, #usageThreshold <= #usage)"() {
         when:
         def status = create(100, 100, usageThreshold, 100)
@@ -80,8 +80,8 @@ class DaemonMemoryStatusTest extends Specification {
         100            | 100   | true
     }
 
-    @Unroll
-    def "knows when gc is thrashing (#rateThreshold <= #rate)"(double rateThreshold, int usageThreshold, double rate, int usage, boolean thrashing) {
+    @SafeUnroll
+    def "knows when gc is thrashing (#rateThreshold <= #rate #usageThreshold #usage #thrashing)"(double rateThreshold, int usageThreshold, double rate, int usage, boolean thrashing) {
         when:
         def status = create(usageThreshold, 100, 100, rateThreshold)
         stats.getHeapStats() >> {

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FailsafePhasedActionResultListenerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FailsafePhasedActionResultListenerTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.tooling.internal.provider
 
 import org.gradle.internal.event.ListenerNotificationException
-import spock.lang.Specification
 import org.gradle.tooling.internal.protocol.PhasedActionResult
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener
+import spock.lang.Specification
 
 class FailsafePhasedActionResultListenerTest extends Specification {
     def delegateListener = Mock(PhasedActionResultListener)

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -24,10 +24,10 @@ import org.gradle.internal.invocation.BuildController
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
+import org.gradle.testfixtures.SafeUnroll
 import spock.lang.Specification
-import spock.lang.Unroll
 
-@Unroll
+@SafeUnroll
 class FileSystemWatchingBuildActionRunnerTest extends Specification {
 
     def watchingHandler = Mock(BuildLifecycleAwareVirtualFileSystem)

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuterTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.tooling.internal.provider
 import org.gradle.api.logging.LogLevel
 import org.gradle.initialization.BuildRequestContext
 import org.gradle.internal.invocation.BuildAction
+import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.launcher.exec.BuildActionExecuter
-import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters
 import spock.lang.Specification
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/PhasedActionEventConsumerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/PhasedActionEventConsumerTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.tooling.internal.provider
 
 import org.gradle.initialization.BuildEventConsumer
-import spock.lang.Specification
 import org.gradle.tooling.internal.protocol.PhasedActionResult
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload
+import spock.lang.Specification
 
 class PhasedActionEventConsumerTest extends Specification {
     def phasedActionResultListener = Mock(PhasedActionResultListener)


### PR DESCRIPTION
We came across https://github.com/gradle/gradle/issues/8787 again. As the first step
to get rid of this issue, now we introduce UniqueNameProvider and @SafeUnroll to
find out duplicate test ids in launcher module.

This can be a first step of better `@Unroll` handing: https://github.com/gradle/gradle/pull/13693