### PR TITLE
Fix missing reference in composite build user guide

### DIFF
--- a/buildSrc/subprojects/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/buildSrc/subprojects/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -270,7 +270,6 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("toc-title", "Contents");
             attributes.put("groovyDslPath", "../dsl");
             attributes.put("javadocPath", "../javadoc");
-            attributes.put("samplesPath", "../samples");
             attributes.put("kotlinDslPath", "https://gradle.github.io/kotlin-dsl-docs/api");
             // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
             // TODO: This breaks the provider

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -751,6 +751,6 @@ publishing credentials to be present. On the other hand, if the build needs to e
 at some point, Gradle will check for credential presence first thing and will not start running any of the tasks
 if it knows that the build will fail at a later point because of missing credentials.
 
-Here is a link:{samplesPath}/sample_publishing_credentials.html[downloadable sample] that demonstrates the concept in more detail.
+Here is a link:../samples/sample_publishing_credentials.html[downloadable sample] that demonstrates the concept in more detail.
 
 The same rules apply for supplying link:{javadocPath}/org/gradle/api/credentials/AwsCredentials.html[AwsCredentials].


### PR DESCRIPTION
[This change](https://github.com/gradle/gradle/commit/7487089b6176690ad4c06802d0e36453cd4c2f26#diff-9ca716396957b5a73c7148091988283dR273) accidentally modified the `samplesPath` asciidoctor variable, which broke the file references in the composite build user guide:
```
Unresolved directive in composite_builds.adoc - include::../samples/build-organization/composite-builds/basic/tests/basicCli.out[]
```