### PR TITLE
Fix missing category attribute on plugin classpath

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmVersion;
@@ -122,8 +123,11 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
+            // should ideally reuse the `JvmEcosystemUtilities` but this code is too low level
+            // and this service is therefore not available!
             AttributeContainer attributes = classpathConfiguration.getAttributes();
             attributes.attribute(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage.class, Usage.JAVA_RUNTIME));
+            attributes.attribute(Category.CATEGORY_ATTRIBUTE, instantiator.named(Category.class, Category.LIBRARY));
             attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
             attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import spock.lang.Issue
+import spock.lang.Unroll
+
+class PluginVariantResolveIntegrationTest extends AbstractPluginIntegrationTest {
+
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/13659")
+    def "should report an incompatible Java version of a plugin properly (#id)"() {
+        withDummyPlugin(true)
+        executer.inDirectory(file("my-plugin"))
+        run 'publishAllPublicationsToBuildRepository'
+        def repoLoc = file("my-plugin/build/repo").toURI().toURL().toString()
+
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    maven { url = "$repoLoc" }
+                }
+            }
+
+            rootProject.name = 'test'
+        """
+
+        buildFile << """
+            ${pluginsBlock.replace('%repoloc%', repoLoc)}
+        """
+
+        when:
+        fails ':help'
+
+        then:
+        failure.assertHasErrorOutput("Incompatible because this component declares an API of a component compatible with Java 2099 and the consumer needed a runtime of a component compatible with Java ${JavaVersion.current().majorVersion}")
+
+        where:
+        id                  | pluginsBlock
+        "plugins block"     | """
+            plugins {
+                id 'com.acme.my.plugin' version '1.0'
+            }
+        """
+
+        "buildscript block" | """
+                buildscript {
+                    repositories {
+                        maven {
+                            url "%repoloc%"
+                        }
+                    }
+                    dependencies {
+                        classpath 'com.acme:my-plugin:1.0'
+                    }
+                }
+            """
+    }
+
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/13659")
+    def "should report an incompatible Java version of a plugin properly (#id) using composite builds"() {
+        settingsFile << """
+            rootProject.name = 'test-plugin'
+
+            includeBuild('my-plugin') {
+                $substitution
+            }
+        """
+        withDummyPlugin()
+        buildFile << pluginsBlock
+
+        when:
+        fails ':help'
+
+        then:
+        failure.assertHasErrorOutput("Incompatible because this component declares an API of a component compatible with Java 2099 and the consumer needed a runtime of a component compatible with Java ${JavaVersion.current().majorVersion}")
+
+        where:
+        id                  | pluginsBlock       | substitution
+        "plugins block"     | """
+            plugins {
+                id 'com.acme.my.plugin'
+            }
+        """     | ""
+
+        "buildscript block" | """
+                buildscript {
+                    dependencies {
+                        classpath 'com.acme:my-plugin:1.0'
+                    }
+                }
+            """ | """dependencySubstitution {
+                    substitute(module("com.acme:my-plugin")).with(project(":"))
+                }"""
+
+    }
+
+    private void withDummyPlugin(boolean withPublication = false) {
+        def publishPlugin = withPublication ? "id 'maven-publish'" : ''
+        def publishConfig = ''
+        if (withPublication) {
+            publishConfig = '''
+                publishing {
+                    repositories {
+                       maven {
+                           name 'build'
+                           url "\$buildDir/repo"
+                       }
+                    }
+                }
+            '''
+        }
+        file('my-plugin/settings.gradle') << '''
+            rootProject.name = 'my-plugin'
+        '''
+        file('my-plugin/build.gradle') << """
+            plugins {
+                id 'java-gradle-plugin'
+                $publishPlugin
+            }
+
+            group = 'com.acme'
+            version = '1.0'
+
+            gradlePlugin {
+                plugins {
+                    greeting {
+                        id = 'com.acme.my.plugin'
+                        implementationClass = 'com.acme.MyPlugin'
+                    }
+                }
+            }
+
+            configurations.all {
+                if (it.canBeConsumed && it.name != 'sourcesElements' ) {
+                    // let's pretend it was built with a newer Java version
+                    attributes {
+                        // This test is not Artic Code Vault safe
+                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 2099)
+                    }
+                }
+            }
+
+            java {
+               // make sure we add a sources variant like in the bug report
+               // because this is this variant which causes the problem: because there's
+               // a mismatch on the Java version for the other variants, this one ended up
+               // being selected!
+               withSourcesJar()
+            }
+
+            $publishConfig
+        """
+
+        file('my-plugin/src/main/java/com/acme/MyPlugin.java') << """
+            package com.acme;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+
+            public class MyPlugin implements Plugin<Project> {
+                public void apply(Project p) {
+                }
+            }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -25,6 +26,7 @@ class PluginVariantResolveIntegrationTest extends AbstractPluginIntegrationTest 
 
     @Unroll
     @Issue("https://github.com/gradle/gradle/issues/13659")
+    @ToBeFixedForInstantExecution(because = "Publish plugin plugin is not compatible")
     def "should report an incompatible Java version of a plugin properly (#id)"() {
         withDummyPlugin(true)
         executer.inDirectory(file("my-plugin"))


### PR DESCRIPTION
The plugin compile classpath configuration was missing the `category`
attribute. The consequence is that if a plugin was published with
Gradle metadata, and that for some reason one of the attributes like
the target JVM version didn't match on the library variants, then we
would fallback on the "sources" variant because it has less attributes
and is compatible with all the requested attributes!

Fixes #13659
