### PR TITLE
Let Javadoc task support toolchains

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.javadoc
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "can manually set javadoc tool via  #type toolchain on javadoc task #jdk"() {
+        buildFile << """
+            import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService
+            import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
+
+            plugins {
+                id 'java'
+            }
+
+            abstract class ApplyTestToolchain implements Plugin<Project> {
+                @javax.inject.Inject
+                abstract JavaToolchainQueryService getQueryService()
+
+                void apply(Project project) {
+                    def filter = project.objects.newInstance(DefaultToolchainSpec)
+                    filter.languageVersion = JavaVersion.${jdk.javaVersion.name()}
+                    def toolchain = getQueryService().findMatchingToolchain(filter)
+
+                    project.tasks.withType(JavaCompile) {
+                        javaCompiler = toolchain.map({it.javaCompiler})
+                    }
+                    project.tasks.withType(Javadoc) {
+                        javadocTool = toolchain.map({it.javadocTool})
+                    }
+                }
+            }
+
+            apply plugin: ApplyTestToolchain
+
+            // need to do as separate task as -version stop javadoc generation
+            task javadocVersionOutput(type: Javadoc) {
+                options.jFlags("-version")
+            }
+
+        """
+
+        file('src/main/java/Lib.java') << testLib()
+
+        when:
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath)
+            .withArgument("--info")
+            .withTasks("javadoc", "javadocVersionOutput")
+            .run()
+        then:
+
+        file("build/docs/javadoc/Lib.html").text.contains("Some API documentation.")
+        outputContains(jdk.javaVersion.majorVersion)
+        noExceptionThrown()
+
+        where:
+        type           | jdk
+        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_11)
+        'current'      | Jvm.current()
+    }
+
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "JavaExec task is configured using default toolchain"() {
+        def someJdk = AvailableJavaHomes.getDifferentJdk()
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            java {
+                toolchain {
+                    languageVersion = JavaVersion.toVersion(${someJdk.javaVersion.majorVersion})
+                }
+            }
+
+            // need to do as separate task as -version stop javadoc generation
+            task javadocVersionOutput(type: Javadoc) {
+                options.jFlags("-version")
+            }
+        """
+
+        file('src/main/java/Lib.java') << testLib()
+
+        when:
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + someJdk.javaHome.absolutePath)
+            .withArgument("--info")
+            .withTasks("javadoc", "javadocVersionOutput")
+            .run()
+
+        then:
+        file("build/docs/javadoc/Lib.html").text.contains("Some API documentation.")
+        outputContains(someJdk.javaVersion.majorVersion)
+        noExceptionThrown()
+    }
+
+    private static String testLib() {
+        return """
+            public class Lib {
+               /**
+                * Some API documentation.
+                */
+               public void foo() {
+               }
+            }
+        """.stripIndent()
+    }
+
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
-    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    @IgnoreIf({ AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) == null })
     def "can manually set javadoc tool via  #type toolchain on javadoc task #jdk"() {
         buildFile << """
             import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/AbstractJavaToolChain.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/AbstractJavaToolChain.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
-import org.gradle.api.tasks.javadoc.internal.JavadocGenerator;
+import org.gradle.api.tasks.javadoc.internal.JavadocCompilerAdapter;
 import org.gradle.api.tasks.javadoc.internal.JavadocSpec;
 import org.gradle.internal.logging.text.DiagnosticsVisitor;
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal;
@@ -74,7 +74,7 @@ public abstract class AbstractJavaToolChain implements JavaToolChainInternal {
                 return compiler;
             }
             if (JavadocSpec.class.isAssignableFrom(spec)) {
-                @SuppressWarnings("unchecked") Compiler<T> compiler = (Compiler<T>) new JavadocGenerator(execActionFactory);
+                @SuppressWarnings("unchecked") Compiler<T> compiler = (Compiler<T>) new JavadocCompilerAdapter(execActionFactory);
                 return compiler;
             }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocCompilerAdapter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocCompilerAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.javadoc.internal;
+
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.process.internal.ExecActionFactory;
+
+public class JavadocCompilerAdapter implements Compiler<JavadocSpec> {
+
+    private final JavadocGenerator generator;
+
+    public JavadocCompilerAdapter(ExecActionFactory execActionFactory) {
+        this.generator = new JavadocGenerator(execActionFactory);
+    }
+
+    @Override
+    public WorkResult execute(JavadocSpec spec) {
+        return generator.execute(spec);
+    }
+
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
@@ -20,7 +20,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.external.javadoc.internal.JavadocExecHandleBuilder;
-import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.internal.ExecAction;
 import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecException;
@@ -28,7 +27,7 @@ import org.gradle.util.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JavadocGenerator implements Compiler<JavadocSpec> {
+public class JavadocGenerator {
 
     private final static Logger LOG = LoggerFactory.getLogger(JavadocGenerator.class);
 
@@ -38,7 +37,6 @@ public class JavadocGenerator implements Compiler<JavadocSpec> {
         this.execActionFactory = execActionFactory;
     }
 
-    @Override
     public WorkResult execute(JavadocSpec spec) {
         JavadocExecHandleBuilder javadocExecHandleBuilder = new JavadocExecHandleBuilder(execActionFactory);
         javadocExecHandleBuilder.setExecutable(spec.getExecutable());

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocToolAdapter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocToolAdapter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.javadoc.internal;
+
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.jvm.toolchain.JavadocTool;
+import org.gradle.jvm.toolchain.internal.JavaToolchain;
+import org.gradle.process.internal.ExecActionFactory;
+
+public class JavadocToolAdapter implements JavadocTool {
+
+    private final JavadocGenerator generator;
+    private final JavaToolchain toolchain;
+
+    public JavadocToolAdapter(ExecActionFactory execActionFactory, JavaToolchain toolchain) {
+        this.generator = new JavadocGenerator(execActionFactory);
+        this.toolchain = toolchain;
+    }
+
+    public WorkResult execute(JavadocSpec spec) {
+        spec.setExecutable(toolchain.findExecutable("javadoc"));
+        return generator.execute(spec);
+    }
+
+
+}

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetec
 import org.gradle.api.internal.tasks.compile.tooling.JavaCompileTaskSuccessResultPostProcessor;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.api.tasks.javadoc.internal.JavadocToolAdapter;
 import org.gradle.cache.internal.FileContentCacheFactory;
 import org.gradle.internal.build.event.OperationResultPostProcessorFactory;
 import org.gradle.internal.hash.FileHasher;
@@ -35,7 +36,11 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.jvm.JvmLibrary;
+import org.gradle.jvm.toolchain.JavadocTool;
+import org.gradle.jvm.toolchain.internal.JavaToolchain;
+import org.gradle.jvm.toolchain.internal.ToolchainToolFactory;
 import org.gradle.language.java.artifact.JavadocArtifact;
+import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.tooling.events.OperationType;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +86,18 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
     private static class JavaProjectScopeServices {
         public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, GeneralCompileCaches compileCaches, BuildOperationExecutor buildOperationExecutor, StringInterner interner, FileSystemAccess fileSystemAccess, FileHasher fileHasher) {
             return new IncrementalCompilerFactory(fileOperations, streamHasher, compileCaches, buildOperationExecutor, interner, fileSystemAccess, fileHasher);
+        }
+
+        public ToolchainToolFactory createToolFactory(ExecActionFactory generator) {
+            return new ToolchainToolFactory() {
+                @Override
+                public <T> T create(Class<T> toolType, JavaToolchain toolchain) {
+                    if (toolType == JavadocTool.class) {
+                        return toolType.cast(new JavadocToolAdapter(generator, toolchain));
+                    }
+                    return null;
+                }
+            };
         }
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/AbstractJavaToolChainTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/AbstractJavaToolChainTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.tasks
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec
-import org.gradle.api.tasks.javadoc.internal.JavadocGenerator
+import org.gradle.api.tasks.javadoc.internal.JavadocCompilerAdapter
 import org.gradle.api.tasks.javadoc.internal.JavadocSpec
 import org.gradle.internal.logging.text.DiagnosticsVisitor
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal
@@ -59,7 +59,7 @@ abstract class AbstractJavaToolChainTest extends Specification {
 
     def "creates compiler for JavadocSpec"() {
         expect:
-        toolChain.select(platform(toolChainJavaVersion)).newCompiler(JavadocSpec.class) instanceof JavadocGenerator
+        toolChain.select(platform(toolChainJavaVersion)).newCompiler(JavadocSpec.class) instanceof JavadocCompilerAdapter
     }
 
     def "creates available tool provider for earlier platform"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.jvm.toolchain.JavaInstallation
 import org.gradle.jvm.toolchain.JavaToolChain
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory
 import org.gradle.jvm.toolchain.internal.JavaToolchain
+import org.gradle.jvm.toolchain.internal.ToolchainToolFactory
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import spock.lang.Issue
 
@@ -88,7 +89,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         installDir.asFile >> javaHome
         installation.installationDirectory >> installDir
         installation.getJavaVersion() >> JavaVersion.VERSION_12
-        def toolchain = new JavaToolchain(installation, Mock(JavaCompilerFactory))
+        def toolchain = new JavaToolchain(installation, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory))
         javaCompile.setDestinationDir(new File("tmp"))
 
         when:

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.javadoc
 
 import org.apache.commons.io.FileUtils
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.tasks.javadoc.internal.JavadocToolAdapter
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.platform.base.internal.toolchain.ToolProvider
@@ -55,6 +56,21 @@ class JavadocTest extends AbstractProjectBuilderSpec {
         1 * toolChain.select(_) >> toolProvider
         1 * toolProvider.newCompiler(!null) >> generator
         1 * generator.execute(_)
+    }
+
+    def usesToolchainIfConfigured() {
+        def tool = Mock(JavadocToolAdapter)
+        task.setDestinationDir(destDir)
+        task.source(srcDir)
+
+        when:
+        task.javadocTool.set(tool)
+
+        and:
+        execute(task)
+
+        then:
+        1 * tool.execute(!null)
     }
 
     def executionWithOptionalAttributes() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavadocTool.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavadocTool.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A java compiler used by compile tasks.
+ *
+ * @since 6.7
+ */
+@Incubating
+public interface JavadocTool {
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavadocTool.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavadocTool.java
@@ -19,7 +19,7 @@ package org.gradle.jvm.toolchain;
 import org.gradle.api.Incubating;
 
 /**
- * A java compiler used by compile tasks.
+ * Generates HTML API documentation for Java classes.
  *
  * @since 6.7
  */

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -51,6 +51,7 @@ public class JavaToolchain implements Describable {
         return new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile());
     }
 
+    @Internal
     public JavadocTool getJavadocTool() {
         return toolFactory.create(JavadocTool.class, this);
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
 import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavadocTool;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -31,11 +32,13 @@ public class JavaToolchain implements Describable {
 
     private final JavaInstallation installation;
     private JavaCompilerFactory compilerFactory;
+    private final ToolchainToolFactory toolFactory;
 
     @Inject
-    public JavaToolchain(JavaInstallation installation, JavaCompilerFactory compilerFactory) {
+    public JavaToolchain(JavaInstallation installation, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
         this.installation = installation;
         this.compilerFactory = compilerFactory;
+        this.toolFactory = toolFactory;
     }
 
     @Internal
@@ -46,6 +49,10 @@ public class JavaToolchain implements Describable {
     @Internal
     public JavaLauncher getJavaLauncher() {
         return new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile());
+    }
+
+    public JavadocTool getJavadocTool() {
+        return toolFactory.create(JavadocTool.class, this);
     }
 
     @Input
@@ -64,4 +71,7 @@ public class JavaToolchain implements Describable {
         return getJavaHome().getAbsolutePath();
     }
 
+    public String findExecutable(String toolname) {
+        return new File(getJavaHome(), "bin/javadoc").getAbsolutePath();
+    }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
@@ -25,20 +25,22 @@ import java.io.File;
 
 public class JavaToolchainFactory {
 
-    private FileFactory fileFactory;
-    private JavaInstallationRegistry installationRegistry;
-    private JavaCompilerFactory compilerFactory;
+    private final FileFactory fileFactory;
+    private final JavaInstallationRegistry installationRegistry;
+    private final JavaCompilerFactory compilerFactory;
+    private final ToolchainToolFactory toolFactory;
 
     @Inject
-    public JavaToolchainFactory(FileFactory fileFactory, JavaInstallationRegistry installationRegistry, JavaCompilerFactory compilerFactory) {
+    public JavaToolchainFactory(FileFactory fileFactory, JavaInstallationRegistry installationRegistry, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
         this.fileFactory = fileFactory;
         this.installationRegistry = installationRegistry;
         this.compilerFactory = compilerFactory;
+        this.toolFactory = toolFactory;
     }
 
     public JavaToolchain newInstance(File javaHome) {
         final JavaInstallation installation = installationRegistry.installationForDirectory(fileFactory.dir(javaHome)).get();
-        return new JavaToolchain(installation, compilerFactory);
+        return new JavaToolchain(installation, compilerFactory, toolFactory);
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainToolFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainToolFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+public interface ToolchainToolFactory {
+
+    <T> T create(Class<T> toolType, JavaToolchain javaToolchain);
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -134,9 +134,10 @@ class JavaToolchainQueryServiceTest extends Specification {
 
     private JavaToolchainFactory newToolchainFactory() {
         def compilerFactory = Mock(JavaCompilerFactory)
-        def toolchainFactory = new JavaToolchainFactory(Mock(FileFactory), Mock(JavaInstallationRegistry), Mock(JavaCompilerFactory)) {
+        def toolFactory = Mock(ToolchainToolFactory)
+        def toolchainFactory = new JavaToolchainFactory(Mock(FileFactory), Mock(JavaInstallationRegistry), compilerFactory, toolFactory) {
             JavaToolchain newInstance(File javaHome) {
-                return new JavaToolchain(newInstallation(javaHome), compilerFactory)
+                return new JavaToolchain(newInstallation(javaHome), compilerFactory, toolFactory)
             }
         }
         toolchainFactory

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -325,6 +325,7 @@ public class JavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             javadoc.getConventionMapping().map("destinationDir", () -> new File(convention.getDocsDir(), "javadoc"));
             javadoc.getConventionMapping().map("title", () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
+            javadoc.getJavadocTool().convention(getToolchainTool(project, JavaToolchain::getJavadocTool));
         });
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1165,7 +1165,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     }
 
     /**
-     * Configures the java exectuable to be used to run the tests.
+     * Configures the java executable to be used to run the tests.
      *
      * @since 6.7
      */

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1170,7 +1170,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @since 6.7
      */
     @Incubating
-    @Internal // getJavaVersion() is used as @Input
+    @Internal("getJavaVersion() is used as @Input")
     public Property<JavaLauncher> getJavaLauncher() {
         return javaLauncher;
     }


### PR DESCRIPTION
Handled in parallel with the existing toolchain support, refactored to
have independent adapters for both worlds. THat makes it easier to
remove the legacy toolchain support in 7.0
 
Given javadoc resists in `languageJava` while core toolchain support
in `platformJvm`, we have to go through a tool factory instantiating the
Javadoc toolchain implementation. This will be needed anyone at some
point to form a proper toolchain API as plugins may request unsupported
tools (e.g. jlink). 

Fixes #14139