### PR TITLE
Add support for ignored dependencies in lock state

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 /**
@@ -68,5 +69,18 @@ public interface DependencyLockingHandler {
      */
     @Incubating
     RegularFileProperty getLockFile();
+
+    /**
+     * Allows to configure dependencies that will be ignored in the lock state.
+     * <p>
+     * The format of the entry is {@code <group>:<artifact>} where both can end with a {@code *} as a wildcard character.
+     * <p>
+     * These dependencies will not be written to the lock state and any references to them in lock state will be ignored at runtime.
+     * It is thus not possible to set this property but still lock a matching entry by manually adding it to the lock state.
+     *
+     * @since 6.7
+     */
+    @Incubating
+    ListProperty<String> getIgnoredDependencies();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 import java.util.Set;
@@ -34,4 +35,6 @@ public interface DependencyLockingProvider {
     void buildFinished();
 
     RegularFileProperty getLockFile();
+
+    ListProperty<String> getIgnoredDependencies();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
@@ -47,4 +47,6 @@ public interface DependencyLockingState {
      * @see #mustValidateLockState()
      */
     Set<ModuleComponentIdentifier> getLockedDependencies();
+
+    LockEntryFilter getIgnoredEntryFilter();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/LockEntryFilter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/LockEntryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.locking;
+package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.specs.Spec;
 
-interface LockEntryFilter extends Spec<ModuleComponentIdentifier> {
+public interface LockEntryFilter extends Spec<ModuleComponentIdentifier> {
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public class DefaultDependencyLockingHandler implements DependencyLockingHandler {
@@ -59,5 +60,10 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
     @Override
     public RegularFileProperty getLockFile() {
         return dependencyLockingProvider.getLockFile();
+    }
+
+    @Override
+    public ListProperty<String> getIgnoredDependencies() {
+        return dependencyLockingProvider.getIgnoredDependencies();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
+import org.gradle.api.internal.artifacts.dsl.dependencies.LockEntryFilter;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.ArtifactSelectionDetailsInternal;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
@@ -44,6 +45,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.resource.local.FileResourceListener;
@@ -66,14 +68,17 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private final LockFileReaderWriter lockFileReaderWriter;
     private final boolean writeLocks;
     private final boolean partialUpdate;
-    private final LockEntryFilter lockEntryFilter;
+    private final LockEntryFilter updateLockEntryFilter;
     private final DomainObjectContext context;
     private final DependencySubstitutionRules dependencySubstitutionRules;
     private final boolean uniqueLockStateEnabled;
     private final Property<LockMode> lockMode;
     private final RegularFileProperty lockFile;
+    private final ListProperty<String> ignoredDependencies;
     private boolean uniqueLockStateLoaded;
     private Map<String, List<String>> allLockState;
+    private LockEntryFilter compoundLockEntryFilter;
+    private LockEntryFilter ignoredEntryFilter;
 
     public DefaultDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, DependencySubstitutionRules dependencySubstitutionRules, FeaturePreviews featurePreviews, PropertyFactory propertyFactory, FilePropertyFactory filePropertyFactory, FileResourceListener listener) {
         this.context = context;
@@ -84,11 +89,12 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         }
         List<String> lockedDependenciesToUpdate = startParameter.getLockedDependenciesToUpdate();
         partialUpdate = !lockedDependenciesToUpdate.isEmpty();
-        lockEntryFilter = LockEntryFilterFactory.forParameter(lockedDependenciesToUpdate);
+        updateLockEntryFilter = LockEntryFilterFactory.forParameter(lockedDependenciesToUpdate, "Update lock");
         uniqueLockStateEnabled = featurePreviews.isFeatureEnabled(ONE_LOCKFILE_PER_PROJECT);
         lockMode = propertyFactory.property(LockMode.class);
         lockMode.convention(LockMode.DEFAULT);
         lockFile = filePropertyFactory.newFileProperty();
+        ignoredDependencies = propertyFactory.listProperty(String.class);
         this.lockFileReaderWriter = new LockFileReaderWriter(fileResolver, context, lockFile, listener);
     }
 
@@ -113,7 +119,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                 Set<ModuleComponentIdentifier> results = Sets.newHashSetWithExpectedSize(lockedModules.size());
                 for (String module : lockedModules) {
                     ModuleComponentIdentifier lockedIdentifier = parseLockNotation(configurationName, module);
-                    if (!lockEntryFilter.isSatisfiedBy(lockedIdentifier) && !isSubstitutedInComposite(lockedIdentifier)) {
+                    if (!getCompoundLockEntryFilter().isSatisfiedBy(lockedIdentifier) && !isSubstitutedInComposite(lockedIdentifier)) {
                         results.add(lockedIdentifier);
                     }
                 }
@@ -123,10 +129,24 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                     LOGGER.info("Loaded lock state for configuration '{}'", context.identityPath(configurationName));
                 }
                 boolean strictlyValidate = !partialUpdate && lockMode.get() != LockMode.LENIENT;
-                return new DefaultDependencyLockingState(strictlyValidate, results);
+                return new DefaultDependencyLockingState(strictlyValidate, results, getIgnoredEntryFilter());
             }
         }
         return DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT;
+    }
+
+    private LockEntryFilter getCompoundLockEntryFilter() {
+        if (compoundLockEntryFilter == null) {
+            compoundLockEntryFilter = LockEntryFilterFactory.combine(getIgnoredEntryFilter(), updateLockEntryFilter);
+        }
+        return compoundLockEntryFilter;
+    }
+
+    private LockEntryFilter getIgnoredEntryFilter() {
+        if (ignoredEntryFilter == null) {
+            ignoredEntryFilter = LockEntryFilterFactory.forParameter(ignoredDependencies.getOrElse(Collections.emptyList()), "Ignored dependencies");
+        }
+        return ignoredEntryFilter;
     }
 
     @Nullable
@@ -155,6 +175,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private void recordUsage() {
         lockMode.finalizeValue();
         lockFile.finalizeValue();
+        ignoredDependencies.finalizeValue();
     }
 
     private boolean isSubstitutedInComposite(ModuleComponentIdentifier lockedIdentifier) {
@@ -212,7 +233,9 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private List<String> getModulesOrdered(Collection<ModuleComponentIdentifier> resolvedComponents) {
         List<String> modules = Lists.newArrayListWithCapacity(resolvedComponents.size());
         for (ModuleComponentIdentifier identifier : resolvedComponents) {
-            modules.add(converter.convertToLockNotation(identifier));
+            if (!getIgnoredEntryFilter().isSatisfiedBy(identifier)) {
+                modules.add(converter.convertToLockNotation(identifier));
+            }
         }
         Collections.sort(modules);
         return modules;
@@ -226,6 +249,11 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     @Override
     public RegularFileProperty getLockFile() {
         return lockFile;
+    }
+
+    @Override
+    public ListProperty<String> getIgnoredDependencies() {
+        return ignoredDependencies;
     }
 
     private static class LockingDependencySubstitution implements DependencySubstitutionInternal {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
@@ -18,6 +18,7 @@ package org.gradle.internal.locking;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
+import org.gradle.api.internal.artifacts.dsl.dependencies.LockEntryFilter;
 
 import java.util.Set;
 
@@ -29,14 +30,17 @@ public class DefaultDependencyLockingState implements DependencyLockingState {
 
     private final boolean strictlyValidate;
     private final Set<ModuleComponentIdentifier> constraints;
+    private final LockEntryFilter ignoredEntryFilter;
 
     private DefaultDependencyLockingState() {
         strictlyValidate = false;
         constraints = emptySet();
+        ignoredEntryFilter = LockEntryFilterFactory.FILTERS_NONE;
     }
-    public DefaultDependencyLockingState(boolean strictlyValidate, Set<ModuleComponentIdentifier> constraints) {
+    public DefaultDependencyLockingState(boolean strictlyValidate, Set<ModuleComponentIdentifier> constraints, LockEntryFilter ignoredEntryFilter) {
         this.strictlyValidate = strictlyValidate;
         this.constraints = constraints;
+        this.ignoredEntryFilter = ignoredEntryFilter;
     }
 
     @Override
@@ -47,5 +51,9 @@ public class DefaultDependencyLockingState implements DependencyLockingState {
     @Override
     public Set<ModuleComponentIdentifier> getLockedDependencies() {
         return constraints;
+    }
+
+    public LockEntryFilter getIgnoredEntryFilter() {
+        return ignoredEntryFilter;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -97,7 +97,9 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
                     if (dependencyLockingState.mustValidateLockState()) {
                         ModuleComponentIdentifier lockedId = modulesToBeLocked.remove(id.getModuleIdentifier());
                         if (lockedId == null) {
-                            extraModules.add(id);
+                            if (!dependencyLockingState.getIgnoredEntryFilter().isSatisfiedBy(id)) {
+                                extraModules.add(id);
+                            }
                         } else if (!lockedId.getVersion().equals(id.getVersion()) && !isNodeRejected(node)) {
                             // Need to check that versions do match, mismatch indicates a force was used
                             forcedModules.put(lockedId, id.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
@@ -16,7 +16,9 @@
 
 package org.gradle.internal.locking;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.LockEntryFilter;
 
 import java.util.HashSet;
 import java.util.List;
@@ -24,13 +26,13 @@ import java.util.Set;
 
 class LockEntryFilterFactory {
 
-    private static final LockEntryFilter FILTERS_NONE = element -> false;
+    protected static final LockEntryFilter FILTERS_NONE = element -> false;
     private static final LockEntryFilter FILTERS_ALL = element -> true;
 
     private static final String WILDCARD_SUFFIX = "*";
     public static final String MODULE_SEPARATOR = ":";
 
-    static LockEntryFilter forParameter(List<String> lockedDependenciesToUpdate) {
+    static LockEntryFilter forParameter(List<String> lockedDependenciesToUpdate, String context) {
         if (lockedDependenciesToUpdate.isEmpty()) {
             return FILTERS_NONE;
         }
@@ -38,12 +40,12 @@ class LockEntryFilterFactory {
         for (String lockExcludes : lockedDependenciesToUpdate) {
             for (String lockExclude : lockExcludes.split(",")) {
                 String[] split = lockExclude.split(MODULE_SEPARATOR);
-                validateNotation(lockExclude, split);
+                validateNotation(lockExclude, split, context);
 
                 lockEntryFilters.add(createFilter(split[0], split[1]));
             }
             if (lockEntryFilters.isEmpty()) {
-                throwInvalid(lockExcludes);
+                throwInvalid(lockExcludes, context);
             }
         }
 
@@ -54,8 +56,8 @@ class LockEntryFilterFactory {
         }
     }
 
-    private static void throwInvalid(String lockExclude) {
-        throw new IllegalArgumentException("Update lock format must be <group>:<artifact> but '" + lockExclude + "' is invalid.");
+    private static void throwInvalid(String lockExclude, String context) {
+        throw new IllegalArgumentException(context + " format must be <group>:<artifact> but '" + lockExclude + "' is invalid.");
     }
 
     private static LockEntryFilter createFilter(final String group, final String module) {
@@ -66,17 +68,34 @@ class LockEntryFilterFactory {
         return new GroupModuleLockEntryFilter(group, module);
     }
 
-    private static void validateNotation(String lockExclude, String[] split) {
+    private static void validateNotation(String lockExclude, String[] split, String context) {
         if (split.length != 2) {
-            throwInvalid(lockExclude);
+            throwInvalid(lockExclude, context);
         }
         String group = split[0];
         String module = split[1];
 
         if ((group.contains(WILDCARD_SUFFIX) && !group.endsWith(WILDCARD_SUFFIX)) || (module.contains(WILDCARD_SUFFIX) && !module.endsWith(WILDCARD_SUFFIX))) {
-            throwInvalid(lockExclude);
+            throwInvalid(lockExclude, context);
         }
 
+    }
+
+    public static LockEntryFilter combine(LockEntryFilter firstFilter, LockEntryFilter secondFilter) {
+        if (firstFilter == FILTERS_NONE) {
+            return secondFilter;
+        }
+        if (secondFilter == FILTERS_NONE) {
+            return firstFilter;
+        }
+        if (firstFilter == FILTERS_ALL) {
+            return firstFilter;
+        }
+        if (secondFilter == FILTERS_ALL) {
+            return secondFilter;
+        }
+
+        return new AggregateLockEntryFilter(ImmutableSet.of(firstFilter, secondFilter));
     }
 
     private static class AggregateLockEntryFilter implements LockEntryFilter {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.dsl.LockMode;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 import java.util.Set;
@@ -60,5 +61,10 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     @Override
     public void buildFinished() {
         // No-op
+    }
+
+    @Override
+    public ListProperty<String> getIgnoredDependencies() {
+        throw new IllegalStateException("Should not be invoked on the no-op instance");
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -36,7 +36,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     def 'locking constraints are attached to a configuration and not its children'() {
         given:
         def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
-        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(true, [constraint] as Set)
+        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(true, [constraint] as Set, {entry -> false })
         dependencyLockingHandler.loadLockState("child") >> DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT
         addConfiguration('conf').enableLocking()
         addConfiguration('child', ['conf']).enableLocking()
@@ -53,7 +53,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     def 'locking constraints are not transitive'() {
         given:
         def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
-        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(true, [constraint] as Set)
+        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(true, [constraint] as Set, {entry -> false })
         addConfiguration('conf').enableLocking()
 
         when:
@@ -70,7 +70,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     def 'provides useful reason for locking constraints (#strict)'() {
         given:
         def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
-        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(strict, [constraint] as Set)
+        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(strict, [constraint] as Set, {entry -> false })
         addConfiguration('conf').enableLocking()
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -49,6 +49,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     TestFile lockDir = tmpDir.createDir(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER)
+    TestFile uniqueLockFile = tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
 
     FileResolver resolver = Mock()
     StartParameter startParameter = Mock()
@@ -67,7 +68,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
         context.getProjectPath() >> Path.path(':')
         resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
-        resolver.resolve(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) >> tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+        resolver.resolve(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) >> uniqueLockFile
         startParameter.getLockedDependenciesToUpdate() >> []
         provider = newProvider()
     }
@@ -273,6 +274,30 @@ empty=
 
         where:
         unique << [true, false]
+    }
+
+    @Unroll
+    def 'fails with invalid ignored dependencies notation #notation'() {
+        uniqueLockFile << """
+org:foo:1.0=conf
+empty=
+"""
+        featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
+        provider = newProvider()
+        provider.ignoredDependencies.add(notation)
+
+        when:
+        provider.loadLockState('conf')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "Ignored dependencies format must be <group>:<artifact> but '$invalid' is invalid."
+
+        where:
+        notation        | invalid
+        'invalid'       | 'invalid'
+        ',org:foo'      | ''
+        'org:foo:1.0'   | 'org:foo:1.0'
     }
 
     private DefaultDependencyLockingProvider newProvider() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
+import org.gradle.api.internal.artifacts.dsl.dependencies.LockEntryFilter
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
@@ -213,6 +214,21 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     }
 
+    def 'ignores visited node that is to be ignored'() {
+        given:
+        def identifier = newId(mid, '1.1')
+        def ignoredIdentifier = newId(DefaultModuleIdentifier.newId('org', 'ignored'), '1.0')
+        startWithState([identifier], LockEntryFilterFactory.forParameter(['org:ignored'], "Update lock"))
+        addVisitedNode(identifier)
+        addVisitedNode(ignoredIdentifier)
+
+        when:
+        def failures = visitor.collectLockingFailures()
+
+        then:
+        failures.isEmpty()
+    }
+
 
     private void addVisitedNode(ModuleComponentIdentifier module) {
         DependencyGraphNode node = Mock()
@@ -245,11 +261,12 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         visitor.startArtifacts(rootNode)
     }
 
-    private startWithState(List<ModuleComponentIdentifier> locks) {
+    private startWithState(List<ModuleComponentIdentifier> locks, LockEntryFilter ignoredEntries = LockEntryFilterFactory.FILTERS_NONE) {
         rootNode.metadata >> metadata
         metadata.dependencyLockingState >> lockState
         lockState.mustValidateLockState() >> true
         lockState.lockedDependencies >> locks
+        lockState.ignoredEntryFilter >> ignoredEntries
 
         visitor.startArtifacts(rootNode)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
@@ -27,7 +27,7 @@ class LockEntryFilterFactoryTest extends Specification {
     @Unroll
     def "filters #filteredValues and accept #acceptedValues for filter with #filters"() {
         when:
-        def filter = LockEntryFilterFactory.forParameter(filters)
+        def filter = LockEntryFilterFactory.forParameter(filters, "Update lock")
 
         then:
         filteredValues.each {
@@ -61,7 +61,7 @@ class LockEntryFilterFactoryTest extends Specification {
     @Unroll
     def "fails for invalid filter #filters"() {
         when:
-        LockEntryFilterFactory.forParameter(filters)
+        LockEntryFilterFactory.forParameter(filters, "Update lock")
 
         then:
         thrown(IllegalArgumentException)


### PR DESCRIPTION
This enables locking to be configured to ignore a set of module
identifiers. These identifiers will then be fully ignored from the
locking logic perspective: neither loaded nor written from/to lock
files, ignored when found in results. Note that these ignored module can
 also be totally absent from resolution.
The granularity of the set of ignored modules is per project.
