### PR TITLE
Smoke Test Kotlin 1.4.0

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -97,7 +97,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(*AGP_VERSIONS.latestsPlusNightly)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of('1.3.21', '1.3.31', '1.3.41', '1.3.50', '1.3.61', '1.3.72')
+        static kotlin = Versions.of('1.3.21', '1.3.31', '1.3.41', '1.3.50', '1.3.61', '1.3.72', '1.4.0')
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "3.0.3"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
@@ -50,7 +50,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],
@@ -101,7 +101,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
@@ -54,7 +54,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
@@ -51,14 +51,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
@@ -14,13 +14,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
@@ -51,14 +51,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
@@ -14,13 +14,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
@@ -51,14 +51,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
@@ -14,13 +14,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
@@ -51,14 +51,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
@@ -14,13 +14,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
@@ -45,14 +45,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
@@ -45,14 +45,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
@@ -47,14 +47,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.0"
           }
         }
       ],

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull-request adds Kotlin v1.4.0 to the set of smoke tested Kotlin plugin versions.

https://github.com/JetBrains/kotlin/releases/tag/v1.4.0