### PR TITLE
Avoid corruption of surrogate pairs in CopySpec filtering

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FilterChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FilterChain.java
@@ -19,7 +19,7 @@ import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import groovy.text.SimpleTemplateEngine;
 import groovy.text.Template;
-import org.apache.tools.ant.util.ReaderInputStream;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Transformer;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/FilterChainTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/FilterChainTest.java
@@ -22,6 +22,7 @@ import org.gradle.util.WrapUtil;
 import org.junit.Test;
 
 import java.io.*;
+import java.nio.charset.*;
 
 import static org.gradle.util.WrapUtil.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -89,6 +90,30 @@ public class FilterChainTest {
 
         String expectedResult = "éàüî 1";
         assertThat(actualResult, equalTo(expectedResult));
+    }
+
+    @Test
+    public void canFilterSurrogatePairs() throws IOException {
+        Charset charset = StandardCharsets.UTF_8;
+        FilterChain filterChain = new FilterChain(charset.name());
+        // This is a no-op transform, however it ensures FilterChain executes full byte->string->byte sequence
+        filterChain.add(s -> s);
+
+        // Make the input string longer to ensure the downstream implementations would have to use a buffer
+        // instead of converting the full string at once
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            sb.append("丈, 😃, and नि");
+        }
+        String input = sb.toString();
+        InputStream transformed = filterChain.transform(new ByteArrayInputStream(input.getBytes(charset.name())));
+        // We read byte-by-byte to trigger edge cases in the downstream implementations.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int read;
+        while ((read = transformed.read()) != -1) {
+            baos.write(read);
+        }
+        assertThat(baos.toString(charset.name()), equalTo(input));
     }
 
     public static class TestFilterReader extends FilterReader {


### PR DESCRIPTION
fixes #14134

### Context

Ant's ReaderInputStream corrupts data (see https://bz.apache.org/bugzilla/show_bug.cgi?id=40455),
so FilterChain is switched to commons-io ReaderInputStream

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
