### PR TITLE
Fix bottleneck around VFS update, take 2

### DIFF
--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 141 * 1024 * 1024
+        return 142 * 1024 * 1024
     }
 
     def allZipContents() {

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -35,7 +35,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 44 * 1024 * 1024
+        return 45 * 1024 * 1024
     }
 
     @Override

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -71,12 +71,12 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         invalidate(snapshotsInsideWatchableHierarchies[0].absolutePath)
         then:
-        1 * watcher.stopWatching({ equalIgnoringOrder(it, [watchableHierarchies[0]]) })
         0 * _
 
         when:
         buildFinished()
         then:
+        1 * watcher.stopWatching({ equalIgnoringOrder(it, [watchableHierarchies[0]]) })
         0 * _
 
         when:
@@ -153,12 +153,12 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         invalidate(snapshotsInsideFirstWatchableHierarchy[0].absolutePath)
         then:
-        1 * watcher.stopWatching({ equalIgnoringOrder(it, [file("first")]) })
         0 * _
 
         when:
         buildFinished()
         then:
+        1 * watcher.stopWatching({ equalIgnoringOrder(it, [file("first")]) })
         0 * _
 
         when:
@@ -253,13 +253,11 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         invalidate(snapshotInRootDir)
         then:
-        1 * watcher.stopWatching({ equalIgnoringOrder(it, [watchableHierarchy]) })
         0 * _
 
         when:
         addSnapshot(snapshotInRootDir)
         then:
-        1 * watcher.startWatching({ equalIgnoringOrder(it, ([watchableHierarchy])) })
         0 * _
     }
 
@@ -284,6 +282,11 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         invalidate(rootDirSnapshot.children[2])
         then:
+        0 * _
+
+        when:
+        buildFinished()
+        then:
         1 * watcher.stopWatching({ equalIgnoringOrder(it, [rootDir.parentFile]) })
         0 * _
     }
@@ -303,6 +306,11 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         missingFile.createFile()
         addSnapshot(snapshotRegularFile(missingFile))
+        then:
+        0 * _
+
+        when:
+        buildFinished()
         then:
         1 * watcher.stopWatching({ equalIgnoringOrder(it, [rootDir]) })
         then:


### PR DESCRIPTION
Fixes: #14158

The idea is to only update watched hierarchies when we need to start watching something. For the vast majority of changes this will be enough, as:

1) the change either happens in an already watched hierarchy, typically the project root directory (applies to most changes)
2) it happens in an unwatchable directory (like native headers)
3) it happens in a watchable directory not being watched already (there are a small number of watchable directories, so we can only have a few of these events during each build)

With 1) and 2) we did a lot of work previously (including a lot of allocation for the `Set` elements) only to conclude that we don't need to change the set of watched hierarchies. With this change we can now short-circuit these cases with no allocation and relatively little work. In case of 3) we still need to do the work, but that should happen only a handful of times each build.

This has the side effect that we will potentially keep watching hierarchies that became empty during the build until the end of the build. This seems acceptable.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
