### PR TITLE
Fix inputs for JavaCompile using toolchain

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainUpToDateIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainUpToDateIntegrationTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
+import org.gradle.test.fixtures.file.TestFile
+
+class JavaToolchainUpToDateIntegrationTest extends AbstractPluginIntegrationTest {
+
+    def "compile and test reacting to toolchains are up-to-date without changes"() {
+        def someJdk = AvailableJavaHomes.getDifferentJdk()
+        buildscriptWithToolchain(someJdk)
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+        file("src/test/java/FooTest.java") << testClass("FooTest")
+
+        when:
+        runWithToolchainConfigured(someJdk)
+        runWithToolchainConfigured(someJdk)
+
+        then:
+        outputContains("Task :compileJava UP-TO-DATE")
+        outputContains("Task :compileTestJava UP-TO-DATE")
+        outputContains("Task :test UP-TO-DATE")
+    }
+
+    def "compile and test not up-to-date once toolchain changed"() {
+        def someJdk = AvailableJavaHomes.getDifferentJdk()
+        buildscriptWithToolchain(someJdk)
+        file("src/main/java/Foo.java") << """
+            /** foo */
+            public class Foo {
+            }
+            """
+
+        file("src/test/java/FooTest.java") << testClass("FooTest")
+
+        when:
+        runWithToolchainConfigured(someJdk)
+        runWithToolchainConfigured(someJdk)
+
+        then:
+        outputContains("Task :compileJava UP-TO-DATE")
+        outputContains("Task :compileTestJava UP-TO-DATE")
+        outputContains("Task :test UP-TO-DATE")
+        outputContains("Task :javadoc UP-TO-DATE")
+
+        when:
+        println "3rd time"
+        buildscriptWithToolchain(Jvm.current())
+        runWithToolchainConfigured(Jvm.current())
+
+
+        then:
+        outputDoesNotContain("Task :compileJava UP-TO-DATE")
+        outputDoesNotContain("Task :compileTestJava UP-TO-DATE")
+        outputDoesNotContain("Task :test UP-TO-DATE")
+        outputDoesNotContain("Task :javadoc UP-TO-DATE")
+        outputDoesNotContain("UnsupportedClassVersionError")
+    }
+
+    private TestFile buildscriptWithToolchain(Jvm someJdk) {
+        buildFile << """
+            apply plugin: "java"
+
+            ${jcenterRepository()}
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            java {
+                toolchain {
+                    languageVersion = JavaVersion.toVersion(${someJdk.javaVersion.majorVersion})
+                }
+            }
+        """
+    }
+
+    def runWithToolchainConfigured(Jvm jvm) {
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            .withArgument("-Porg.gradle.java.installations.paths=" + jvm.javaHome.absolutePath)
+            .withTasks("check", "javadoc")
+            .run()
+    }
+
+    private static String testClass(String className) {
+        return """
+            import org.junit.*;
+
+            public class $className {
+               @Test
+               public void test() {
+                  Assert.assertEquals(1,1);
+               }
+            }
+        """.stripIndent()
+    }
+
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -53,6 +53,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.LocalState;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -171,6 +172,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      */
     @Incubating
     @Nested
+    @Optional
     public Property<JavaCompiler> getJavaCompiler() {
         return javaCompiler;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -170,7 +170,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      * @since 6.7
      */
     @Incubating
-    @Internal
+    @Nested
     public Property<JavaCompiler> getJavaCompiler() {
         return javaCompiler;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.language.base.internal.compile.CompileSpec;
@@ -34,6 +35,7 @@ public class DefaultToolchainJavaCompiler implements JavaCompiler {
         this.compilerFactory = compilerFactory;
     }
 
+    @Nested
     public JavaToolchain getJavaToolchain() {
         return javaToolchain;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -18,6 +18,8 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallation;
 import org.gradle.jvm.toolchain.JavaLauncher;
@@ -36,22 +38,27 @@ public class JavaToolchain implements Describable {
         this.compilerFactory = compilerFactory;
     }
 
+    @Internal
     public JavaCompiler getJavaCompiler() {
         return new DefaultToolchainJavaCompiler(this, compilerFactory);
     }
 
+    @Internal
     public JavaLauncher getJavaLauncher() {
         return new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile());
     }
 
+    @Input
     public JavaVersion getJavaMajorVersion() {
         return installation.getJavaVersion();
     }
 
+    @Internal
     public File getJavaHome() {
         return installation.getInstallationDirectory().getAsFile();
     }
 
+    @Internal
     @Override
     public String getDisplayName() {
         return getJavaHome().getAbsolutePath();


### PR DESCRIPTION
Fix JavaCompile to take the toolchain into account as `@Input`