### PR TITLE
Detect Java installations on Windows

### DIFF
--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":diagnostics"))
     implementation(project(":normalization-java"))
     implementation(project(":resources"))
+    implementation(project(":native"))
 
     implementation(libs.groovy)
     implementation(libs.guava)

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -52,6 +52,7 @@ import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
+import org.gradle.jvm.toolchain.internal.WindowsInstallationSupplier;
 import org.gradle.model.internal.manage.schema.ModelSchemaStore;
 
 import java.util.Collection;
@@ -86,6 +87,7 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
         registration.add(JabbaInstallationSupplier.class);
         registration.add(AutoInstalledInstallationSupplier.class);
         registration.add(OsXInstallationSupplier.class);
+        registration.add(WindowsInstallationSupplier.class);
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import com.google.common.collect.Lists;
+import net.rubygrapefruit.platform.MissingRegistryEntryException;
+import net.rubygrapefruit.platform.WindowsRegistry;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.os.OperatingSystem;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class WindowsInstallationSupplier extends AutoDetectingInstallationSupplier {
+
+    private final WindowsRegistry windowsRegistry;
+    private final OperatingSystem os;
+
+    public WindowsInstallationSupplier(WindowsRegistry registry, OperatingSystem os, ProviderFactory providerFactory) {
+        super(providerFactory);
+        this.windowsRegistry = registry;
+        this.os = os;
+    }
+
+    @Override
+    protected Set<InstallationLocation> findCandidates() {
+        if (os.isWindows()) {
+            return findInstallationsInRegistry();
+        }
+        return Collections.emptySet();
+    }
+
+    private Set<InstallationLocation> findInstallationsInRegistry() {
+        final Stream<String> openJdkInstallations = findAdoptOpenJdk().stream();
+        final Stream<String> jvms = Lists.newArrayList(
+            "SOFTWARE\\JavaSoft\\JDK",
+            "SOFTWARE\\JavaSoft\\Java Development Kit",
+            "SOFTWARE\\JavaSoft\\Java Runtime Environment",
+            "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Development Kit",
+            "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Runtime Environment"
+        ).stream().map(this::findJvms).flatMap(List::stream);
+        return Stream.concat(openJdkInstallations, jvms)
+            .map(javaHome -> new InstallationLocation(new File(javaHome), "windows registry"))
+            .collect(Collectors.toSet());
+    }
+
+    private List<String> find(String sdkSubkey, String path, String value) {
+        try {
+            return getVersions(sdkSubkey).stream()
+                .map(version -> getValue(sdkSubkey, path, value, version)).collect(Collectors.toList());
+        } catch (MissingRegistryEntryException e) {
+            // Ignore
+            return Collections.emptyList();
+        }
+    }
+
+    private List<String> getVersions(String sdkSubkey) {
+        return windowsRegistry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, sdkSubkey);
+    }
+
+    private String getValue(String sdkSubkey, String path, String value, String version) {
+        return windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, sdkSubkey + '\\' + version + path, value);
+    }
+
+    private List<String> findAdoptOpenJdk() {
+        return find("SOFTWARE\\AdoptOpenJDK\\JDK", "\\hotspot\\MSI", "Path");
+    }
+
+    private List<String> findJvms(String sdkSubkey) {
+        return find(sdkSubkey, "", "JavaHome");
+    }
+
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplierTest.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import net.rubygrapefruit.platform.MissingRegistryEntryException
+import net.rubygrapefruit.platform.WindowsRegistry
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.internal.os.OperatingSystem
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WindowsInstallationSupplierTest extends Specification {
+
+    def registry = Mock(WindowsRegistry)
+
+    def "no detection for non-windows os"() {
+        given:
+        def supplier = createSupplier(OperatingSystem.MAC_OS)
+
+        when:
+        supplier.get()
+
+        then:
+        0 * registry._
+    }
+
+    def "finds adoptopenjdk homes"() {
+        given:
+        registry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, "SOFTWARE\\AdoptOpenJDK\\JDK") >> [
+            "8.0",
+            "9.0-abc"
+        ]
+        registry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, "SOFTWARE\\AdoptOpenJDK\\JDK\\8.0\\hotspot\\MSI", "Path") >> "c:\\jdk8"
+        registry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, "SOFTWARE\\AdoptOpenJDK\\JDK\\9.0-abc\\hotspot\\MSI", "Path") >> "d:\\jdk9"
+        registry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, _) >> { throw new MissingRegistryEntryException() }
+        def supplier = createSupplier()
+
+        when:
+        def locations = supplier.get()
+
+        then:
+        locations*.location.path.containsAll("c:\\jdk8", "d:\\jdk9")
+        locations*.source == ["windows registry", "windows registry"]
+    }
+
+    def "handles absent adoptopenjdk keys"() {
+        given:
+        registry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, "SOFTWARE\\AdoptOpenJDK\\JDK") >> { throw new MissingRegistryEntryException() }
+        def supplier = createSupplier(OperatingSystem.MAC_OS)
+
+        when:
+        def locations = supplier.get()
+
+        then:
+        locations.isEmpty()
+    }
+
+    @Unroll
+    def "finds java homes #home via #key"() {
+        given:
+        registry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, key) >> [
+            "8.0",
+            "9.0-abc"
+        ]
+        registry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, key + "\\8.0", "JavaHome") >> home + "/8.0-home"
+        registry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, key + "\\9.0-abc", "JavaHome") >> home + "/9.0-home"
+        registry.getSubkeys(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, _) >> { throw new MissingRegistryEntryException() }
+        def supplier = createSupplier()
+
+        when:
+        def locations = supplier.get()
+
+        then:
+        locations*.location.path.containsAll(home + "${File.separator}8.0-home", home + "${File.separator}9.0-home")
+        locations*.source == ["windows registry", "windows registry"]
+
+        where:
+        key                                                         | home
+        "SOFTWARE\\JavaSoft\\JDK"                                   | "c:\\javasoft-jdk"
+        "SOFTWARE\\JavaSoft\\Java Development Kit"                  | "c:\\javasoft-jadevel"
+        "SOFTWARE\\JavaSoft\\Java Runtime Environment"              | "c:\\javasoft-jre"
+        "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Development Kit"     | "c:\\wow-jdk"
+        "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Runtime Environment" | "c:\\wow-jre"
+    }
+
+    WindowsInstallationSupplier createSupplier(OperatingSystem os = OperatingSystem.WINDOWS) {
+        new WindowsInstallationSupplier(registry, os, createProviderFactory())
+    }
+
+    ProviderFactory createProviderFactory(String propertyValue) {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.notDefined()
+        providerFactory
+    }
+
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -220,7 +220,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         then:
         def compileTask = project.tasks.named("compileCustomJava", JavaCompile).get()
         def configuredToolchain = compileTask.javaCompiler.get().javaToolchain
-        configuredToolchain.displayName == someJdk.javaHome.canonicalPath
+        configuredToolchain.displayName.contains(someJdk.javaHome.canonicalPath)
     }
 
     void "wires toolchain for test if toolchain is configured"() {
@@ -237,7 +237,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def configuredJavaLauncher = testTask.javaLauncher.get()
 
         then:
-        configuredJavaLauncher.javaExecutable == someJdk.javaExecutable.canonicalPath
+        new File(configuredJavaLauncher.javaExecutable).canonicalPath == someJdk.javaExecutable.canonicalPath
     }
 
     void tasksReflectChangesToSourceSetConfiguration() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -220,7 +220,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         then:
         def compileTask = project.tasks.named("compileCustomJava", JavaCompile).get()
         def configuredToolchain = compileTask.javaCompiler.get().javaToolchain
-        configuredToolchain.displayName == someJdk.javaHome.absolutePath
+        configuredToolchain.displayName == someJdk.javaHome.canonicalPath
     }
 
     void "wires toolchain for test if toolchain is configured"() {
@@ -237,7 +237,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def configuredJavaLauncher = testTask.javaLauncher.get()
 
         then:
-        configuredJavaLauncher.javaExecutable == someJdk.javaExecutable.absolutePath
+        configuredJavaLauncher.javaExecutable == someJdk.javaExecutable.canonicalPath
     }
 
     void tasksReflectChangesToSourceSetConfiguration() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -220,7 +220,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         then:
         def compileTask = project.tasks.named("compileCustomJava", JavaCompile).get()
         def configuredToolchain = compileTask.javaCompiler.get().javaToolchain
-        configuredToolchain.displayName.contains(someJdk.javaHome.canonicalPath)
+        configuredToolchain.displayName.contains(someJdk.javaVersion.getMajorVersion())
     }
 
     void "wires toolchain for test if toolchain is configured"() {
@@ -237,7 +237,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def configuredJavaLauncher = testTask.javaLauncher.get()
 
         then:
-        new File(configuredJavaLauncher.javaExecutable).canonicalPath == someJdk.javaExecutable.canonicalPath
+        configuredJavaLauncher.javaExecutable.contains(someJdk.javaVersion.getMajorVersion())
     }
 
     void tasksReflectChangesToSourceSetConfiguration() {


### PR DESCRIPTION
Most of the code was reused from the existing windows locator for `AvailableJavaHomes` which is going to replaced with the installation registry going forward.

Part of #13871