### PR TITLE
Define rootProject.name in all snippets and samples

### DIFF
--- a/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'customBuildLanguage'
 include 'billing'
 include 'identityManagement'
 include 'reporting'

--- a/subprojects/docs/src/snippets/bestPractices/conditionalLogic-do/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/conditionalLogic-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'conditionalLogic-do'

--- a/subprojects/docs/src/snippets/bestPractices/conditionalLogic-do/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/conditionalLogic-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "conditionalLogic-do"

--- a/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'conditionalLogic-dont'

--- a/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/conditionalLogic-dont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "conditionalLogic-dont"

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'logicDuringConfiguration-do'

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "logicDuringConfiguration-do"

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'logicDuringConfiguration-dont'

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "logicDuringConfiguration-dont"

--- a/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+rootProject.name = 'configure-built-in-caches'
 // tag::configure-directory-build-cache[]
 buildCache {
     local {

--- a/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "configure-built-in-caches"
 // tag::configure-directory-build-cache[]
 buildCache {
     local {

--- a/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/settings.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+rootProject.name = 'developer-ci-setup'
 // tag::developer-ci-setup[]
 boolean isCiServer = System.getenv().containsKey("CI")
 

--- a/subprojects/docs/src/snippets/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "developer-ci-setup"
 // tag::developer-ci-setup[]
 val isCiServer = System.getenv().containsKey("CI")
 

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+rootProject.name = 'http-build-cache'
 // tag::http-build-cache[]
 buildCache {
     remote(HttpBuildCache) {

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "http-build-cache"
 // tag::http-build-cache[]
 buildCache {
     remote<HttpBuildCache> {

--- a/subprojects/docs/src/snippets/buildlifecycle/basic/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildlifecycle/basic/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'basic'
 println 'This is executed during the initialization phase.'

--- a/subprojects/docs/src/snippets/buildlifecycle/basic/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildlifecycle/basic/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "basic"
 println("This is executed during the initialization phase.")

--- a/subprojects/docs/src/snippets/buildlifecycle/projectEvaluateEvents/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildlifecycle/projectEvaluateEvents/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'projectEvaluateEvents'
 include 'projectA', 'projectB'
 
 project(':projectA').buildFileName = '../projectA.gradle'

--- a/subprojects/docs/src/snippets/buildlifecycle/projectEvaluateEvents/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildlifecycle/projectEvaluateEvents/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "projectEvaluateEvents"
 include("projectA", "projectB")
 
 project(":projectA").buildFileName = "../projectA.gradle.kts"

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypes/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypes/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'disallowedTypes'

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypes/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypes/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "disallowedTypes"

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypesFixed/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypesFixed/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'disallowedTypesFixed'

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypesFixed/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypesFixed/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "disallowedTypesFixed"

--- a/subprojects/docs/src/snippets/configurationCache/noProblem/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/noProblem/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'noProblem'

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'problemsFixed'

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "problemsFixed"

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'problemsFixedReuse'

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "problemsFixedReuse"

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'problemsGroovy'

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "problemsKotlin"

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecution/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecution/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'projectAtExecution'

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecution/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecution/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "projectAtExecution"

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'projectAtExecutionFixed'

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "projectAtExecutionFixed"

--- a/subprojects/docs/src/snippets/dependencyManagement/clientModuleDependencies/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/clientModuleDependencies/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'clientModuleDependencies'
 include 'api', 'shared'

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'customizingResolution-conditionalSubstitutionRule'
 ext.projectNames = ["project1", "project2", "project3"]
 
 projectNames.each { name ->

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "customizingResolution-conditionalSubstitutionRule"
 val projectNames = listOf("project1", "project2", "project3")
 
 projectNames.forEach { name ->

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/settings.gradle
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+rootProject.name = 'earCustomized'
 include 'war', 'ear'

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "earCustomized"
 include("war", "ear")

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/settings.gradle
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+rootProject.name = 'earWithWar'
 include 'war'

--- a/subprojects/docs/src/snippets/ear/earWithWar/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earWithWar/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "earWithWar"
 include("war")

--- a/subprojects/docs/src/snippets/groovy/compilationAvoidance/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/groovy/compilationAvoidance/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'compilationAvoidance'
 include("astTransformation")
 include("astTransformationConsumer")
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")

--- a/subprojects/docs/src/snippets/groovy/compilationAvoidance/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/groovy/compilationAvoidance/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "compilationAvoidance"
 include("astTransformation")
 include("astTransformationConsumer")
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")

--- a/subprojects/docs/src/snippets/groovy/incrementalCompilation/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/groovy/incrementalCompilation/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'incrementalCompilation'
 include("library")
 include("app")
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")

--- a/subprojects/docs/src/snippets/groovy/incrementalCompilation/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/groovy/incrementalCompilation/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "incrementalCompilation"
 include("app")
 include("library")
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")

--- a/subprojects/docs/src/snippets/groovy/multiproject/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/groovy/multiproject/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'multiproject'
 include 'groovycDetector', 'testproject'

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/settings.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+rootProject.name = 'multiproject'
 include 'core'
 include 'lib'
 include 'platform'

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/settings.gradle.kts
@@ -30,6 +30,7 @@
  * limitations under the License.
  */
 
+rootProject.name = "multiproject"
 include("core")
 include("lib")
 include("platform")

--- a/subprojects/docs/src/snippets/java-platform/recommender/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-platform/recommender/groovy/settings.gradle
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+rootProject.name = 'recommender'
 include 'platform'
 include 'consumer'

--- a/subprojects/docs/src/snippets/java-platform/recommender/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/recommender/kotlin/settings.gradle.kts
@@ -30,5 +30,6 @@
  * limitations under the License.
  */
 
+rootProject.name = "recommender"
 include("platform")
 include("consumer")

--- a/subprojects/docs/src/snippets/java/base/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java/base/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'base'
 include "prod", "test"

--- a/subprojects/docs/src/snippets/java/incrementalAnnotationProcessing/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java/incrementalAnnotationProcessing/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'incrementalAnnotationProcessing'
 include "library"
 include "processor"
 include "user"

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "accessors"

--- a/subprojects/docs/src/snippets/kotlinDsl/containers-api/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/containers-api/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "containers-api"

--- a/subprojects/docs/src/snippets/kotlinDsl/containers-delegated-properties/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/containers-delegated-properties/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "containers-delegated-properties"

--- a/subprojects/docs/src/snippets/kotlinDsl/containers-scope/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/containers-scope/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "containers-scope"

--- a/subprojects/docs/src/snippets/kotlinDsl/containers-string-invoke/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/containers-string-invoke/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "containers-string-invoke"

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-closure-of/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-closure-of/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interoperability-closure-of"

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-delegate-closure-of/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-delegate-closure-of/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interoperability-delegate-closure-of"

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-groovy-builder/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-groovy-builder/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interoperability-groovy-builder"

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-kotlinClosure/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-kotlinClosure/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interoperability-kotlinClosure"

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-static-extensions/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-static-extensions/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interoperability-static-extensions"

--- a/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "noAccessors"

--- a/subprojects/docs/src/snippets/kotlinDsl/sourceSetConvention/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/sourceSetConvention/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sourceSetConvention"

--- a/subprojects/docs/src/snippets/multiproject/dependencies-firstMessages/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-firstMessages/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'dependencies-firstMessages'
 include 'consumer', 'producer'

--- a/subprojects/docs/src/snippets/multiproject/dependencies-firstMessages/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-firstMessages/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "dependencies-firstMessages"
 include("consumer", "producer")

--- a/subprojects/docs/src/snippets/multiproject/dependencies-java/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-java/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'dependencies-java'
 include 'api', 'shared', 'services:personService'

--- a/subprojects/docs/src/snippets/multiproject/dependencies-java/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-java/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "dependencies-java"
 include("api", "shared", "services:personService")

--- a/subprojects/docs/src/snippets/multiproject/dependencies-javaWithCustomConf/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-javaWithCustomConf/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'dependencies-javaWithCustomConf'
 include 'api', 'shared', 'services:personService'

--- a/subprojects/docs/src/snippets/multiproject/dependencies-javaWithCustomConf/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-javaWithCustomConf/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "dependencies-javaWithCustomConf"
 include("api", "shared", "services:personService")

--- a/subprojects/docs/src/snippets/multiproject/dependencies-messagesHack/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-messagesHack/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'dependencies-messagesHack'
 include 'consumer', 'aProducer'

--- a/subprojects/docs/src/snippets/multiproject/dependencies-messagesHack/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-messagesHack/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "dependencies-messagesHack"
 include("consumer", "aProducer")

--- a/subprojects/docs/src/snippets/multiproject/dependencies-outgoingArtifact/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-outgoingArtifact/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'dependencies-outgoingArtifact'
 include 'consumer', 'producer'

--- a/subprojects/docs/src/snippets/multiproject/dependencies-outgoingArtifact/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-outgoingArtifact/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "dependencies-outgoingArtifact"
 include("consumer", "producer")

--- a/subprojects/docs/src/snippets/multiproject/flat/groovy/master/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/flat/groovy/master/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'master'
 includeFlat('dolphin', 'shark')

--- a/subprojects/docs/src/snippets/multiproject/flatWithNoDefaultMaster/groovy/water/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/flatWithNoDefaultMaster/groovy/water/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'master'
 includeFlat('dolphin', 'shark')

--- a/subprojects/docs/src/snippets/multiproject/standardLayouts/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/standardLayouts/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'standardLayouts'
 // tag::hierarchical-layout[]
 include 'project1', 'project2:child', 'project3:child1'
 // end::hierarchical-layout[]

--- a/subprojects/docs/src/snippets/multiproject/standardLayouts/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/standardLayouts/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "standardLayouts"
 // tag::hierarchical-layout[]
 include("project1", "project2:child", "project3:child1")
 // end::hierarchical-layout[]

--- a/subprojects/docs/src/snippets/native-binaries/multi-project/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/multi-project/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'multi-project'
 include "exe", "lib"

--- a/subprojects/docs/src/snippets/organizingGradleProjects/customGradleDistribution/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/organizingGradleProjects/customGradleDistribution/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customGradleDistribution'

--- a/subprojects/docs/src/snippets/play/multiproject/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/play/multiproject/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'multiproject'
 include 'admin', 'user', 'util'
 
 project(':admin').projectDir = new File(settingsDir, 'modules/admin')

--- a/subprojects/docs/src/snippets/plugins/pluginManagement/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/pluginManagement/groovy/settings.gradle
@@ -1,4 +1,3 @@
-rootProject.name = 'pluginManagement'
 pluginManagement {
     plugins {
     }
@@ -7,3 +6,4 @@ pluginManagement {
     repositories {
     }
 }
+rootProject.name = 'pluginManagement'

--- a/subprojects/docs/src/snippets/plugins/pluginManagement/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/pluginManagement/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'pluginManagement'
 pluginManagement {
     plugins {
     }

--- a/subprojects/docs/src/snippets/plugins/pluginManagement/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/pluginManagement/kotlin/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "pluginManagement"
 pluginManagement {
     plugins {
     }

--- a/subprojects/docs/src/snippets/plugins/pluginManagement/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/pluginManagement/kotlin/settings.gradle.kts
@@ -1,4 +1,3 @@
-rootProject.name = "pluginManagement"
 pluginManagement {
     plugins {
     }
@@ -7,3 +6,4 @@ pluginManagement {
     repositories {
     }
 }
+rootProject.name = "pluginManagement"

--- a/subprojects/docs/src/snippets/tasks/addDependencyUsingPath/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tasks/addDependencyUsingPath/groovy/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'addDependencyUsingPath'
 include 'projectA', 'projectB'

--- a/subprojects/docs/src/snippets/tasks/addDependencyUsingPath/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/addDependencyUsingPath/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
+rootProject.name = "addDependencyUsingPath"
 include("projectA", "projectB")

--- a/subprojects/docs/src/snippets/testing/testReport/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/testing/testReport/groovy/settings.gradle
@@ -1,2 +1,3 @@
+rootProject.name = 'testReport'
 include 'util'
 include 'core'

--- a/subprojects/docs/src/snippets/testing/testReport/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/testReport/kotlin/settings.gradle.kts
@@ -1,2 +1,3 @@
+rootProject.name = "testReport"
 include("util")
 include("core")

--- a/subprojects/docs/src/snippets/tutorial/projectReports/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tutorial/projectReports/groovy/settings.gradle
@@ -1,3 +1,4 @@
+rootProject.name = 'projectReports'
 include 'api', 'webapp'
 
 rootProject.children.each {

--- a/subprojects/docs/src/snippets/valueProviders/envVarsDo/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/envVarsDo/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'envVarsDo'

--- a/subprojects/docs/src/snippets/valueProviders/envVarsDo/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/envVarsDo/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "envVarsDo"

--- a/subprojects/docs/src/snippets/valueProviders/envVarsDont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/envVarsDont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'envVarsDont'

--- a/subprojects/docs/src/snippets/valueProviders/envVarsDont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/envVarsDont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "envVarsDont"

--- a/subprojects/docs/src/snippets/valueProviders/fileContentsDo/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/fileContentsDo/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'fileContentsDo'

--- a/subprojects/docs/src/snippets/valueProviders/fileContentsDo/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/fileContentsDo/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "fileContentsDo"

--- a/subprojects/docs/src/snippets/valueProviders/fileContentsDont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/fileContentsDont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'fileContentsDont'

--- a/subprojects/docs/src/snippets/valueProviders/fileContentsDont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/fileContentsDont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "fileContentsDont"

--- a/subprojects/docs/src/snippets/valueProviders/gradlePropsDo/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/gradlePropsDo/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradlePropsDo'

--- a/subprojects/docs/src/snippets/valueProviders/gradlePropsDo/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/gradlePropsDo/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gradlePropsDo"

--- a/subprojects/docs/src/snippets/valueProviders/gradlePropsDont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/gradlePropsDont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradlePropsDont'

--- a/subprojects/docs/src/snippets/valueProviders/gradlePropsDont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/gradlePropsDont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gradlePropsDont"

--- a/subprojects/docs/src/snippets/valueProviders/sysPropsDo/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/sysPropsDo/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sysPropsDo'

--- a/subprojects/docs/src/snippets/valueProviders/sysPropsDo/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/sysPropsDo/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sysPropsDo"

--- a/subprojects/docs/src/snippets/valueProviders/sysPropsDont/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/sysPropsDont/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sysPropsDont'

--- a/subprojects/docs/src/snippets/valueProviders/sysPropsDont/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/sysPropsDont/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sysPropsDont"


### PR DESCRIPTION
This is a first step for cleaning up our snippets and samples. The PR ensures that all snippets/samples have a settings file with a `rootProject.name` configuration. 