### PR TITLE
Deprecate set/getMainClassName

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -69,7 +69,9 @@ class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec imple
     def "outputs are correctly loaded from cache"() {
         buildFile << """
             apply plugin: "application"
-            mainClassName = "Hello"
+            application {
+                mainClass = "Hello"
+            }
         """
         withBuildCache().run "run"
         withBuildCache().run "clean"

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GroovyApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GroovyApplicationProjectInitDescriptor.java
@@ -40,7 +40,7 @@ public class GroovyApplicationProjectInitDescriptor extends GroovyProjectInitDes
             .plugin(
                 "Apply the application plugin to add support for building a CLI application.",
                 "application")
-            .block(null, "application", b -> b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "App")));
+            .block(null, "application", b -> b.methodInvocation("Define the main class for the application.", "mainClass.set", withPackage(settings, "App")));
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
@@ -47,7 +47,7 @@ public class JavaApplicationProjectInitDescriptor extends JavaProjectInitDescrip
                 "application")
             .implementationDependency("This dependency is used by the application.",
                 "com.google.guava:guava:" + libraryVersionProvider.getVersion("guava"))
-            .block(null, "application", b -> b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "App")));
+            .block(null, "application", b -> b.methodInvocation("Define the main class for the application.", "mainClass.set", withPackage(settings, "App")));
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
@@ -66,7 +66,7 @@ public class KotlinApplicationProjectInitDescriptor extends JvmProjectInitDescri
             .plugin("Apply the application plugin to add support for building a CLI application.", "application")
             .block(null,
                 "application",
-                b -> b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "AppKt")));
+                b -> b.methodInvocation("Define the main class for the application.", "mainClass.set", withPackage(settings, "AppKt")));
 
         TemplateOperation kotlinSourceTemplate = templateFactory.fromSourceTemplate("kotlinapp/App.kt.template", "main");
         TemplateOperation kotlinTestTemplate = templateFactory.fromSourceTemplate("kotlinapp/AppTest.kt.template", "test");

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -92,7 +92,9 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
             apply plugin: 'java'
             apply plugin: 'application'
             group = 'com.example'
-            mainClassName = 'com.example.Main'
+            application {
+                mainClass = 'com.example.Main'
+            }
             dependencies {
                 implementation 'org.test:library:0.1'
             }
@@ -212,7 +214,9 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
                 apply plugin: 'java'
                 apply plugin: 'application'
                 group = 'com.example'
-                mainClassName = 'com.example.' + name + '.Main'
+                application {
+                   mainClass = 'com.example.' + name + '.Main'
+                }
                 dependencies {
                     implementation 'org.test:library:0.1'
                 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheJavaIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheJavaIntegrationTest.groovy
@@ -460,7 +460,7 @@ class ConfigurationCacheJavaIntegrationTest extends AbstractConfigurationCacheIn
         """
         buildFile << """
             plugins { id 'application' }
-            application.mainClassName = 'Thing'
+            application.mainClass = 'Thing'
         """
         file("src/main/java/Thing.java") << """
             class Thing {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -148,7 +148,9 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
     def "outputs are correctly loaded from cache"() {
         buildFile << """
             apply plugin: "application"
-            mainClassName = "Hello"
+            application {
+                mainClass = "Hello"
+            }
         """
         withBuildCache().run "run"
         withBuildCache().run "clean"
@@ -281,7 +283,9 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         given:
         buildFile << """
             apply plugin: "application"
-            mainClassName = "Hello"
+            application {
+                mainClass = "Hello"
+            }
         """
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -272,7 +272,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
 
             application {
                 // Define the main class for the application.
-                mainClassName = 'artifact.transform.sample.App'
+                mainClass = 'artifact.transform.sample.App'
             }
 
             abstract class SomeTransform implements TransformAction<TransformParameters.None> {

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
@@ -25,7 +25,7 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         buildFile << """
             apply plugin: "application"
 
-            application.mainClassName = "Main"
+            application.mainClass = "Main"
         """
 
         def mainSourceFileRelativePath = "src/main/java/Main.java"
@@ -126,7 +126,7 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         buildFile << """
             apply plugin: "application"
 
-            application.mainClassName = "Main"
+            application.mainClass = "Main"
         """
 
         def mainSourceFile = file("src/main/java/Main.java")
@@ -150,7 +150,7 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         buildFile << """
             apply plugin: "application"
 
-            application.mainClassName = "Main"
+            application.mainClass = "Main"
         """
 
         def mainSourceFile = file("src/main/java/Main.java")

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -42,7 +42,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         buildFile << """
             apply plugin: "application"
 
-            application.mainClassName = "Main"
+            application.mainClass = "Main"
         """
 
         def mainSourceFileRelativePath = "src/main/java/Main.java"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -34,7 +34,9 @@ class ApplicationIntegrationSpec extends AbstractIntegrationSpec {
 
         buildFile << """
             apply plugin: 'application'
-            mainClassName = 'org.gradle.test.Main'
+            application {
+               mainClass = 'org.gradle.test.Main'
+            }
         """
     }
 

--- a/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle.kts
+++ b/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 application {
-    mainClassName = "org.gradle.performance.android.Main"
+    mainClass.set("org.gradle.performance.android.Main")
     applicationName = "android-test-app"
 }
 

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -548,10 +548,10 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
         withBuildScript("""
             plugins { application }
 
-            application { mainClassName = "App" }
+            application { mainClass.set("App") }
 
             task("mainClassName") {
-                doLast { println("*" + application.mainClassName + "*") }
+                doLast { println("*" + application.mainClass.get() + "*") }
             }
         """)
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -58,7 +58,7 @@ class JavaExecToolchainIntegrationTest extends AbstractPluginIntegrationTest {
             apply plugin: ApplyTestToolchain
 
             application {
-                mainClassName = 'App'
+                mainClass = 'App'
             }
         """
 
@@ -98,7 +98,7 @@ class JavaExecToolchainIntegrationTest extends AbstractPluginIntegrationTest {
             }
 
             application {
-                mainClassName = 'App'
+                mainClass = 'App'
             }
         """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
@@ -44,7 +44,7 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
                 id("application")
             }
             application {
-                mainClassName = "test.Main"
+                mainClass = "test.Main"
             }
         """
 
@@ -101,6 +101,9 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
         }
 
         when:
+        if (deprecation) {
+            executer.expectDocumentedDeprecationWarning("The JavaApplication.setMainClassName(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead. See https://docs.gradle.org/current/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.")
+        }
         run("installDist")
 
         def out = new ByteArrayOutputStream()
@@ -114,10 +117,10 @@ class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationS
         out.toString() == TextUtil.toPlatformLineSeparators("Module: $expectedModule\n")
 
         where:
-        configClass                   | configModule                  | expectedModule
-        "mainClassName = 'test.Main'" | ''                            | 'null'
-        "mainClass.set('test.Main')"  | ''                            | 'null'
-        "mainClass.set('test.Main')"  | "mainModule.set('test.main')" | 'test.main'
-        ''                            | "mainModule.set('test.main')" | 'test.main'
+        configClass                   | configModule                  | expectedModule | deprecation
+        "mainClassName = 'test.Main'" | ''                            | 'null'         | true
+        "mainClass.set('test.Main')"  | ''                            | 'null'         | false
+        "mainClass.set('test.Main')"  | "mainModule.set('test.main')" | 'test.main'    | false
+        ''                            | "mainModule.set('test.main')" | 'test.main'    | false
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -546,7 +546,9 @@ public class Main {
         buildFile << """
 apply plugin: 'application'
 
-mainClassName = 'org.gradle.test.Main'
+application {
+    mainClass = 'org.gradle.test.Main'
+}
 """
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
@@ -442,7 +442,10 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
         buildFile << """
             apply plugin: 'application'
             apply plugin: 'java'
-            mainClassName = "Main"
+
+            application {
+                mainClass = "Main"
+            }
         """
         file("src/main/java/Main.java") << "public class Main {}"
         settingsFile << """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
@@ -33,7 +33,9 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
                 id 'application'
             }
 
-            mainClassName = "Hello"
+            application {
+                mainClass = "Hello"
+            }
 
             ${mavenCentralRepository()}
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -121,7 +121,10 @@ public class ThingTest {
         given:
         buildFile << """
 apply plugin: 'application'
-mainClassName = 'Main'
+
+application {
+    mainClass = 'Main'
+}
 """
 
         file("src/main/java/Main.java") << """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -75,7 +75,10 @@ abstract class BasicJavaCompilerIntegrationSpec extends AbstractIntegrationSpec 
         and:
         buildFile << '''
             apply plugin: 'application'
-            mainClassName = 'Main'
+
+            application {
+                mainClass = 'Main'
+            }
             compileJava.options.encoding = \'ISO8859_7\'
 '''
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
@@ -32,7 +32,9 @@ class CachedJavaCompileIntegrationTest extends AbstractCachedCompileIntegrationT
                 id 'application'
             }
 
-            mainClassName = "Hello"
+            application {
+                mainClass = "Hello"
+            }
 
             ${mavenCentralRepository()}
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
@@ -63,18 +63,23 @@ public interface JavaApplication {
      *
      * @since 6.4
      */
-    @Incubating
     Property<String> getMainClass();
 
     /**
      * The fully qualified name of the application's main class.
+     *
+     * @deprecated Use {@link #getMainClass()} instead.
      */
+    @Deprecated
     @ReplacedBy("mainClass")
     String getMainClassName();
 
     /**
      * The fully qualified name of the application's main class.
+     *
+     * @deprecated Set via {@link #getMainClass()} instead.
      */
+    @Deprecated
     void setMainClassName(String mainClassName);
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
@@ -22,6 +22,7 @@ import org.gradle.api.plugins.ApplicationPluginConvention;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 public class DefaultJavaApplication implements JavaApplication {
     private final ApplicationPluginConvention convention;
@@ -56,11 +57,21 @@ public class DefaultJavaApplication implements JavaApplication {
 
     @Override
     public String getMainClassName() {
+        DeprecationLogger.deprecateMethod(JavaApplication.class, "getMainClassName()")
+            .withAdvice("Use #getMainClass() instead.")
+            .willBeRemovedInGradle8()
+            .withDslReference(JavaApplication.class, "mainClass")
+            .nagUser();
         return mainClass.getOrNull();
     }
 
     @Override
     public void setMainClassName(String mainClassName) {
+        DeprecationLogger.deprecateMethod(JavaApplication.class, "setMainClassName(String)")
+            .withAdvice("Use #getMainClass().set(...) instead.")
+            .willBeRemovedInGradle8()
+            .withDslReference(JavaApplication.class, "mainClass")
+            .nagUser();
         mainClass.set(mainClassName);
         convention.setMainClassName(mainClassName);
     }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
                 id 'application'
             }
 
-            mainClassName = "Hello"
+            application.mainClass = "Hello"
 
             ${mavenCentralRepository()}
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -207,7 +207,7 @@ compileScala.scalaCompileOptions.failOnError = false
         buildFile <<
             """
 apply plugin: "application"
-mainClassName = "Main"
+application.mainClass = "Main"
 compileScala.scalaCompileOptions.encoding = "ISO8859_7"
 """
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -185,7 +185,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
                 id "com.bmuschko.docker-java-application" version "${TestedVersions.docker}"
             }
 
-            mainClassName = 'org.gradle.JettyMain'
+            application.mainClass = 'org.gradle.JettyMain'
 
             docker {
                 javaApplication {

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-example/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-example/build.gradle
@@ -13,7 +13,9 @@ buildscript {
 apply plugin: 'kotlin'
 apply plugin: 'application'
 
-mainClassName = "pkg.MainKt"
+application {
+    mainClass = "pkg.MainKt"
+}
 
 repositories {
     mavenCentral()

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -201,7 +201,7 @@ allprojects {
                 runtimeOnly 'org.slf4j:slf4j-simple:1.7.10'
             }
 
-            mainClassName = 'Main'
+            application.mainClass = 'Main'
 
             run {
                 args = ["${TextUtil.escapeString(gradleHomeDirPath)}", "${TextUtil.escapeString(gradleUserHomeDirPath)}"]


### PR DESCRIPTION

Fixes #13855


The only reason this PR is on top of #13977 is because it uses the new method to warn of removal in 8.0.
