### PR TITLE
Improve performance of updating the watched hierarchies when using hierarchical watchers

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -79,7 +79,7 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     @Override
     public void virtualFileSystemContentsChanged(Collection<CompleteFileSystemLocationSnapshot> removedSnapshots, Collection<CompleteFileSystemLocationSnapshot> addedSnapshots, SnapshotHierarchy root) {
         boolean directoriesToWatchChanged = watchableHierarchies.getWatchableHierarchies().stream().anyMatch(watchableHierarchy -> {
-            boolean hasSnapshotsToWatch = root.hasDescendantSnapshot(watchableHierarchy.toString());
+            boolean hasSnapshotsToWatch = root.hasDescendantsUnder(watchableHierarchy.toString());
             if (watchedHierarchies.contains(watchableHierarchy.toString())) {
                 // Need to stop watching this hierarchy
                 return !hasSnapshotsToWatch;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchedHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchedHierarchies.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.registry.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.internal.file.DefaultFileHierarchySet;
+import org.gradle.internal.file.FileHierarchySet;
+import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
+import org.gradle.internal.snapshot.SnapshotHierarchy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class WatchedHierarchies {
+    private Set<Path> watchedRoots = new HashSet<>();
+    private FileHierarchySet watchedHierarchies = DefaultFileHierarchySet.of();
+
+    public boolean contains(Path watchableHierarchy) {
+        return watchedHierarchies.contains(watchableHierarchy.toString());
+    }
+
+    public Set<Path> getWatchedRoots() {
+        return watchedRoots;
+    }
+
+    public void updateWatchedHierarchies(WatchableHierarchies watchableHierarchies, SnapshotHierarchy vfsRoot) {
+        watchedHierarchies = DefaultFileHierarchySet.of();
+        Stream<Path> hierarchiesWithSnapshots = watchableHierarchies.getWatchableHierarchies().stream()
+            .flatMap(watchableHierarchy -> {
+                if (watchedHierarchies.contains(watchableHierarchy.toString())) {
+                    return Stream.empty();
+                }
+                CheckIfNonEmptySnapshotVisitor checkIfNonEmptySnapshotVisitor = new CheckIfNonEmptySnapshotVisitor(watchableHierarchies);
+                vfsRoot.visitSnapshotRoots(watchableHierarchy.toString(), new FilterAlreadyCoveredSnapshotsVisitor(checkIfNonEmptySnapshotVisitor, watchedHierarchies));
+                if (checkIfNonEmptySnapshotVisitor.isEmpty()) {
+                    return Stream.empty();
+                }
+                watchedHierarchies = watchedHierarchies.plus(watchableHierarchy.toFile());
+                return checkIfNonEmptySnapshotVisitor.containsOnlyMissingFiles()
+                    ? Stream.of(locationOrFirstExistingAncestor(watchableHierarchy))
+                    : Stream.of(watchableHierarchy);
+            });
+
+        watchedRoots = resolveHierarchiesToWatch(hierarchiesWithSnapshots);
+    }
+
+    private Path locationOrFirstExistingAncestor(Path watchableHierarchy) {
+        if (Files.isDirectory(watchableHierarchy)) {
+            return watchableHierarchy;
+        }
+        return SnapshotWatchedDirectoryFinder.findFirstExistingAncestor(watchableHierarchy);
+    }
+
+    /**
+     * Filters out directories whose ancestor is also among the watched directories.
+     *
+     * The Stream of directories must not contain duplicates.
+     */
+    @VisibleForTesting
+    static Set<Path> resolveHierarchiesToWatch(Stream<Path> directories) {
+        Set<Path> hierarchies = new HashSet<>();
+        directories
+            .sorted(Comparator.comparingInt(Path::getNameCount))
+            .filter(path -> {
+                Path parent = path;
+                while (true) {
+                    parent = parent.getParent();
+                    if (parent == null) {
+                        break;
+                    }
+                    if (hierarchies.contains(parent)) {
+                        return false;
+                    }
+                }
+                return true;
+            })
+            .forEach(hierarchies::add);
+        return hierarchies;
+    }
+
+    private static class FilterAlreadyCoveredSnapshotsVisitor implements SnapshotHierarchy.SnapshotVisitor {
+        private final SnapshotHierarchy.SnapshotVisitor delegate;
+        private final FileHierarchySet alreadyCoveredSnapshots;
+
+        public FilterAlreadyCoveredSnapshotsVisitor(SnapshotHierarchy.SnapshotVisitor delegate, FileHierarchySet alreadyCoveredSnapshots) {
+            this.delegate = delegate;
+            this.alreadyCoveredSnapshots = alreadyCoveredSnapshots;
+        }
+
+        @Override
+        public void visitSnapshotRoot(CompleteFileSystemLocationSnapshot snapshot) {
+            if (!alreadyCoveredSnapshots.contains(snapshot.getAbsolutePath())) {
+                delegate.visitSnapshotRoot(snapshot);
+            }
+        }
+    }
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchedHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchedHierarchies.java
@@ -71,8 +71,6 @@ public class WatchedHierarchies {
 
     /**
      * Filters out directories whose ancestor is also among the watched directories.
-     *
-     * The Stream of directories must not contain duplicates.
      */
     @VisibleForTesting
     static Set<Path> resolveHierarchiesToWatch(Stream<Path> directories) {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -21,10 +21,7 @@ import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.snapshot.MissingFileSnapshot
 import org.gradle.internal.watch.registry.FileWatcherUpdater
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 
-import java.nio.file.Paths
 import java.util.function.Predicate
 
 import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.FileSystemLocationToWatchValidator.NO_VALIDATION
@@ -309,42 +306,6 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         0 * _
     }
 
-    @Requires(TestPrecondition.UNIX_DERIVATIVE)
-    def "resolves recursive UNIX roots #directories to #resolvedRoots"() {
-        expect:
-        resolveRecursiveRoots(directories) == resolvedRoots
-
-        where:
-        directories        | resolvedRoots
-        []                 | []
-        ["/a"]             | ["/a"]
-        ["/a", "/b"]       | ["/a", "/b"]
-        ["/a", "/a/b"]     | ["/a"]
-        ["/a/b", "/a"]     | ["/a"]
-        ["/a", "/a/b/c/d"] | ["/a"]
-        ["/a/b/c/d", "/a"] | ["/a"]
-        ["/a", "/b/a"]     | ["/a", "/b/a"]
-        ["/b/a", "/a"]     | ["/a", "/b/a"]
-    }
-
-    @Requires(TestPrecondition.WINDOWS)
-    def "resolves recursive Windows roots #directories to #resolvedRoots"() {
-        expect:
-        resolveRecursiveRoots(directories) == resolvedRoots
-
-        where:
-        directories                 | resolvedRoots
-        []                          | []
-        ["C:\\a"]                   | ["C:\\a"]
-        ["C:\\a", "C:\\b"]          | ["C:\\a", "C:\\b"]
-        ["C:\\a", "C:\\a\\b"]       | ["C:\\a"]
-        ["C:\\a\\b", "C:\\a"]       | ["C:\\a"]
-        ["C:\\a", "C:\\a\\b\\c\\d"] | ["C:\\a"]
-        ["C:\\a\\b\\c\\d", "C:\\a"] | ["C:\\a"]
-        ["C:\\a", "C:\\b\\a"]       | ["C:\\a", "C:\\b\\a"]
-        ["C:\\b\\a", "C:\\a"]       | ["C:\\a", "C:\\b\\a"]
-    }
-
     MissingFileSnapshot missingFileSnapshot(File location) {
         new MissingFileSnapshot(location.getAbsolutePath(), AccessType.DIRECT)
     }
@@ -355,11 +316,5 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
             addSnapshot(snapshotRegularFile(fileInside))
             return fileInside.parentFile
         }
-    }
-
-    private static List<String> resolveRecursiveRoots(List<String> directories) {
-        HierarchicalFileWatcherUpdater.resolveHierarchiesToWatch(directories.collect { Paths.get(it) } as Set)
-            .collect { it.toString() }
-            .sort()
     }
 }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -301,6 +301,7 @@ class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest 
         when:
         missingFile.createFile()
         addSnapshot(snapshotRegularFile(missingFile))
+        buildFinished()
         then:
         1 * watcher.stopWatching({ equalIgnoringOrder(it, [rootDir]) })
         then:

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/WatchedHierarchiesTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/WatchedHierarchiesTest.groovy
@@ -30,16 +30,17 @@ class WatchedHierarchiesTest extends Specification {
         resolveRecursiveRoots(directories) == resolvedRoots
 
         where:
-        directories        | resolvedRoots
-        []                 | []
-        ["/a"]             | ["/a"]
-        ["/a", "/b"]       | ["/a", "/b"]
-        ["/a", "/a/b"]     | ["/a"]
-        ["/a/b", "/a"]     | ["/a"]
-        ["/a", "/a/b/c/d"] | ["/a"]
-        ["/a/b/c/d", "/a"] | ["/a"]
-        ["/a", "/b/a"]     | ["/a", "/b/a"]
-        ["/b/a", "/a"]     | ["/a", "/b/a"]
+        directories          | resolvedRoots
+        []                   | []
+        ["/a"]               | ["/a"]
+        ["/a", "/b"]         | ["/a", "/b"]
+        ["/a", "/a/b"]       | ["/a"]
+        ["/a/b", "/a"]       | ["/a"]
+        ["/a", "/a/b/c/d"]   | ["/a"]
+        ["/a/b/c/d", "/a"]   | ["/a"]
+        ["/a", "/b/a"]       | ["/a", "/b/a"]
+        ["/b/a", "/a"]       | ["/a", "/b/a"]
+        ["/a", "/b/a", "/a"] | ["/a", "/b/a"]
     }
 
     @Requires(TestPrecondition.WINDOWS)
@@ -49,15 +50,16 @@ class WatchedHierarchiesTest extends Specification {
 
         where:
         directories                 | resolvedRoots
-        []                          | []
-        ["C:\\a"]                   | ["C:\\a"]
-        ["C:\\a", "C:\\b"]          | ["C:\\a", "C:\\b"]
-        ["C:\\a", "C:\\a\\b"]       | ["C:\\a"]
-        ["C:\\a\\b", "C:\\a"]       | ["C:\\a"]
-        ["C:\\a", "C:\\a\\b\\c\\d"] | ["C:\\a"]
-        ["C:\\a\\b\\c\\d", "C:\\a"] | ["C:\\a"]
-        ["C:\\a", "C:\\b\\a"]       | ["C:\\a", "C:\\b\\a"]
-        ["C:\\b\\a", "C:\\a"]       | ["C:\\a", "C:\\b\\a"]
+        []                             | []
+        ["C:\\a"]                      | ["C:\\a"]
+        ["C:\\a", "C:\\b"]             | ["C:\\a", "C:\\b"]
+        ["C:\\a", "C:\\a\\b"]          | ["C:\\a"]
+        ["C:\\a\\b", "C:\\a"]          | ["C:\\a"]
+        ["C:\\a", "C:\\a\\b\\c\\d"]    | ["C:\\a"]
+        ["C:\\a\\b\\c\\d", "C:\\a"]    | ["C:\\a"]
+        ["C:\\a", "C:\\b\\a"]          | ["C:\\a", "C:\\b\\a"]
+        ["C:\\b\\a", "C:\\a"]          | ["C:\\a", "C:\\b\\a"]
+        ["C:\\a", "C:\\b\\a", "C:\\a"] | ["C:\\a", "C:\\b\\a"]
     }
 
     private static List<String> resolveRecursiveRoots(List<String> directories) {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/WatchedHierarchiesTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/WatchedHierarchiesTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.registry.impl
+
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Specification
+
+import java.nio.file.Paths
+
+class WatchedHierarchiesTest extends Specification {
+
+    @Requires(TestPrecondition.UNIX_DERIVATIVE)
+    def "resolves recursive UNIX roots #directories to #resolvedRoots"() {
+        expect:
+        resolveRecursiveRoots(directories) == resolvedRoots
+
+        where:
+        directories        | resolvedRoots
+        []                 | []
+        ["/a"]             | ["/a"]
+        ["/a", "/b"]       | ["/a", "/b"]
+        ["/a", "/a/b"]     | ["/a"]
+        ["/a/b", "/a"]     | ["/a"]
+        ["/a", "/a/b/c/d"] | ["/a"]
+        ["/a/b/c/d", "/a"] | ["/a"]
+        ["/a", "/b/a"]     | ["/a", "/b/a"]
+        ["/b/a", "/a"]     | ["/a", "/b/a"]
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "resolves recursive Windows roots #directories to #resolvedRoots"() {
+        expect:
+        resolveRecursiveRoots(directories) == resolvedRoots
+
+        where:
+        directories                 | resolvedRoots
+        []                          | []
+        ["C:\\a"]                   | ["C:\\a"]
+        ["C:\\a", "C:\\b"]          | ["C:\\a", "C:\\b"]
+        ["C:\\a", "C:\\a\\b"]       | ["C:\\a"]
+        ["C:\\a\\b", "C:\\a"]       | ["C:\\a"]
+        ["C:\\a", "C:\\a\\b\\c\\d"] | ["C:\\a"]
+        ["C:\\a\\b\\c\\d", "C:\\a"] | ["C:\\a"]
+        ["C:\\a", "C:\\b\\a"]       | ["C:\\a", "C:\\b\\a"]
+        ["C:\\b\\a", "C:\\a"]       | ["C:\\a", "C:\\b\\a"]
+    }
+
+    private static List<String> resolveRecursiveRoots(List<String> directories) {
+        WatchedHierarchies.resolveHierarchiesToWatch(
+            directories.stream().map(Paths.&get)
+        ).collect { it.toString() }
+            .sort()
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
@@ -66,6 +66,11 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
     }
 
     @Override
+    public boolean hasDescendantSnapshot() {
+        return true;
+    }
+
+    @Override
     public FileSystemNode asFileSystemNode(String pathToParent) {
         return getPathToParent().equals(pathToParent)
             ? this
@@ -133,6 +138,11 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
         @Override
         public Optional<MetadataSnapshot> getSnapshot(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
             return delegate.getSnapshot(relativePath, caseSensitivity);
+        }
+
+        @Override
+        public boolean hasDescendantSnapshot() {
+            return delegate.hasDescendantSnapshot();
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractCompleteFileSystemLocationSnapshot.java
@@ -66,7 +66,7 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
     }
 
     @Override
-    public boolean hasDescendantSnapshot() {
+    public boolean hasDescendants() {
         return true;
     }
 
@@ -141,8 +141,8 @@ public abstract class AbstractCompleteFileSystemLocationSnapshot implements Comp
         }
 
         @Override
-        public boolean hasDescendantSnapshot() {
-            return delegate.hasDescendantSnapshot();
+        public boolean hasDescendants() {
+            return delegate.hasDescendants();
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteSnapshotWithChildren.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteSnapshotWithChildren.java
@@ -131,4 +131,14 @@ public abstract class AbstractIncompleteSnapshotWithChildren extends AbstractFil
             child.accept(snapshotVisitor);
         }
     }
+
+    @Override
+    public boolean hasDescendantSnapshot() {
+        for (FileSystemNode child : children) {
+            if (child.hasDescendantSnapshot()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteSnapshotWithChildren.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteSnapshotWithChildren.java
@@ -133,9 +133,9 @@ public abstract class AbstractIncompleteSnapshotWithChildren extends AbstractFil
     }
 
     @Override
-    public boolean hasDescendantSnapshot() {
+    public boolean hasDescendants() {
         for (FileSystemNode child : children) {
-            if (child.hasDescendantSnapshot()) {
+            if (child.hasDescendants()) {
                 return true;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ReadOnlyFileSystemNode.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ReadOnlyFileSystemNode.java
@@ -27,6 +27,11 @@ public interface ReadOnlyFileSystemNode {
         }
 
         @Override
+        public boolean hasDescendantSnapshot() {
+            return false;
+        }
+
+        @Override
         public ReadOnlyFileSystemNode getNode(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
             return EMPTY;
         }
@@ -47,6 +52,8 @@ public interface ReadOnlyFileSystemNode {
      * When calling this method, the caller needs to make sure the the snapshot is a child of this node.
      */
     Optional<MetadataSnapshot> getSnapshot(VfsRelativePath relativePath, CaseSensitivity caseSensitivity);
+
+    boolean hasDescendantSnapshot();
 
     ReadOnlyFileSystemNode getNode(VfsRelativePath relativePath, CaseSensitivity caseSensitivity);
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ReadOnlyFileSystemNode.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ReadOnlyFileSystemNode.java
@@ -27,7 +27,7 @@ public interface ReadOnlyFileSystemNode {
         }
 
         @Override
-        public boolean hasDescendantSnapshot() {
+        public boolean hasDescendants() {
             return false;
         }
 
@@ -53,7 +53,7 @@ public interface ReadOnlyFileSystemNode {
      */
     Optional<MetadataSnapshot> getSnapshot(VfsRelativePath relativePath, CaseSensitivity caseSensitivity);
 
-    boolean hasDescendantSnapshot();
+    boolean hasDescendants();
 
     ReadOnlyFileSystemNode getNode(VfsRelativePath relativePath, CaseSensitivity caseSensitivity);
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotHierarchy.java
@@ -41,6 +41,8 @@ public interface SnapshotHierarchy {
             .map(CompleteFileSystemLocationSnapshot.class::cast);
     }
 
+    boolean hasDescendantSnapshot(String absolutePath);
+
     /**
      * Returns a hierarchy augmented by the information of the snapshot at the absolute path.
      */

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotHierarchy.java
@@ -41,7 +41,7 @@ public interface SnapshotHierarchy {
             .map(CompleteFileSystemLocationSnapshot.class::cast);
     }
 
-    boolean hasDescendantSnapshot(String absolutePath);
+    boolean hasDescendantsUnder(String absolutePath);
 
     /**
      * Returns a hierarchy augmented by the information of the snapshot at the absolute path.

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
@@ -68,8 +68,8 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
     }
 
     @Override
-    public boolean hasDescendantSnapshot(String absolutePath) {
-        return getNodeForLocation(absolutePath).hasDescendantSnapshot();
+    public boolean hasDescendantsUnder(String absolutePath) {
+        return getNodeForLocation(absolutePath).hasDescendants();
     }
 
     @Override
@@ -121,7 +121,7 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
         }
 
         @Override
-        public boolean hasDescendantSnapshot(String absolutePath) {
+        public boolean hasDescendantsUnder(String absolutePath) {
             return false;
         }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
@@ -68,6 +68,11 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
     }
 
     @Override
+    public boolean hasDescendantSnapshot(String absolutePath) {
+        return getNodeForLocation(absolutePath).hasDescendantSnapshot();
+    }
+
+    @Override
     public SnapshotHierarchy store(String absolutePath, MetadataSnapshot snapshot, NodeDiffListener diffListener) {
         VfsRelativePath relativePath = VfsRelativePath.of(absolutePath);
         return new DefaultSnapshotHierarchy(storeSingleChild(rootNode, relativePath, caseSensitivity, snapshot, diffListener), caseSensitivity);
@@ -93,7 +98,11 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
 
     @Override
     public void visitSnapshotRoots(String absolutePath, SnapshotVisitor snapshotVisitor) {
-        SnapshotUtil.getNodeFromChild(rootNode, VfsRelativePath.of(absolutePath), caseSensitivity).orElse(ReadOnlyFileSystemNode.EMPTY).accept(snapshotVisitor);
+        getNodeForLocation(absolutePath).accept(snapshotVisitor);
+    }
+
+    private ReadOnlyFileSystemNode getNodeForLocation(String absolutePath) {
+        return SnapshotUtil.getNodeFromChild(rootNode, VfsRelativePath.of(absolutePath), caseSensitivity).orElse(ReadOnlyFileSystemNode.EMPTY);
     }
 
     private enum EmptySnapshotHierarchy implements SnapshotHierarchy {
@@ -109,6 +118,11 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
         @Override
         public Optional<MetadataSnapshot> getMetadata(String absolutePath) {
             return Optional.empty();
+        }
+
+        @Override
+        public boolean hasDescendantSnapshot(String absolutePath) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
We first determine if we should start/stop watching any of the watchable hierarchies. If we don't, we also don't try to update the watches.

Fixes #14158.
Fixes #13429.
Supersedes #14157.