### PR TITLE
Increase Gradle client -Xmx from 64m to 128m

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
@@ -79,7 +79,7 @@ class ForkingGradleSession implements GradleSession {
 
     private void run(BuildExperimentInvocationInfo invocationInfo, GradleInvocationSpec invocation, List<String> tasks) {
         String jvmArgs = invocation.jvmOpts.join(' ')
-        Map<String, String> env = [:]
+        Map<String, String> env = [JAVA_OPTS: '-Xmx128m -Xms128m']
         List<String> args = []
         if (OperatingSystem.current().isWindows()) {
             args << "cmd.exe" << "/C"


### PR DESCRIPTION
We observed in some huge build, the client might be OOM because
of huge amount of log event objects from daemon. Let's double
the Xmx for now.
