### PR TITLE
Add watched hierarchies as custom value to build scans

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/gradlebuild/buildscan.gradle.kts
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/gradlebuild/buildscan.gradle.kts
@@ -204,6 +204,7 @@ open class FileSystemWatchingBuildOperationListener(private val buildOperationLi
                         buildScan.value("watchFsRetainedDirectories", it.retainedDirectories.toString())
                         buildScan.value("watchFsRetainedFiles", it.retainedRegularFiles.toString())
                         buildScan.value("watchFsRetainedMissingFiles", it.retainedMissingFiles.toString())
+                        buildScan.value("watchFsWatchedHierarchies", it.numberOfWatchedHierarchies.toString())
                     }
                 }
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.7-20200812093124+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.7-20200817160929+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The file system watching build finished build operation now exposes the number of watched hierarchies. We can capture the value as custom value in build scans to get better insights what is going on with file system watching.