### PR TITLE
Cleanup license headers from snippets and samples

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -1,19 +1,4 @@
 
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import gradlebuild.integrationtests.model.GradleDistribution
 import org.gradle.docs.samples.internal.tasks.InstallSample
 

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-app/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-app/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-app/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-app/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/groovy/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/groovy/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/kotlin/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/kotlin/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/src/main/java/org/sample/myapp/Main.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/src/main/java/org/sample/myapp/Main.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample.myapp;
 
 import org.sample.numberutils.Numbers;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample;
 
 import org.gradle.api.Plugin;

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.sample;
 
 import org.gradle.api.Plugin;

--- a/subprojects/docs/src/samples/templates/groovy-list-library/src/main/groovy/org/gradle/sample/list/LinkedList.groovy
+++ b/subprojects/docs/src/samples/templates/groovy-list-library/src/main/groovy/org/gradle/sample/list/LinkedList.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.gradle.sample.list
 
 class LinkedList {

--- a/subprojects/docs/src/snippets/base/buildDashboard/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/base/buildDashboard/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-build-dashboard-plugin[]
 plugins {
     id 'build-dashboard'

--- a/subprojects/docs/src/snippets/base/buildDashboard/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/base/buildDashboard/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-build-dashboard-plugin[]
 plugins {
     `build-dashboard`

--- a/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/buildSrc/src/main/groovy/org/gradle/samples/ProductModulePlugin.groovy
+++ b/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/buildSrc/src/main/groovy/org/gradle/samples/ProductModulePlugin.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2009 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.gradle.samples
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/buildSrc/src/main/groovy/org/gradle/samples/ProductPlugin.groovy
+++ b/subprojects/docs/src/snippets/base/customBuildLanguage/groovy/buildSrc/src/main/groovy/org/gradle/samples/ProductPlugin.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2009 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.gradle.samples
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
@@ -1,20 +1,5 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'configure-built-in-caches'
+
 // tag::configure-directory-build-cache[]
 buildCache {
     local {

--- a/subprojects/docs/src/snippets/buildCache/configure-by-init-script/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/buildCache/configure-by-init-script/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/developer-ci-setup/groovy/settings.gradle
@@ -1,20 +1,5 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'developer-ci-setup'
+
 // tag::developer-ci-setup[]
 boolean isCiServer = System.getenv().containsKey("CI")
 

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
@@ -1,20 +1,5 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'http-build-cache'
+
 // tag::http-build-cache[]
 buildCache {
     remote(HttpBuildCache) {

--- a/subprojects/docs/src/snippets/cpp/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/cpp/basic/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-cpp-plugin[]
 plugins {
     id 'cpp-application' // or 'cpp-library'
@@ -73,7 +57,7 @@ application {
 application {
     targetMachines = [
         machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64
     ]
 }

--- a/subprojects/docs/src/snippets/cpp/basic/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/cpp/basic/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"
 
 include 'common'

--- a/subprojects/docs/src/snippets/cpp/cppApplication/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppApplication/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'cpp-application'
@@ -24,7 +8,7 @@ plugins {
 application {
     targetMachines = [
         machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64
     ]
 }

--- a/subprojects/docs/src/snippets/cpp/cppApplication/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppApplication/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/cpp/cppApplication/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppApplication/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     `cpp-application`
@@ -23,7 +7,7 @@ plugins {
 // tag::configure-target-machines[]
 application {
     targetMachines.set(listOf(machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64))
 }
 // end::configure-target-machines[]

--- a/subprojects/docs/src/snippets/cpp/cppApplication/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppApplication/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/cpp/cppLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppLibrary/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'cpp-library'
@@ -33,7 +17,7 @@ library {
 library {
     targetMachines = [
         machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64
     ]
 }

--- a/subprojects/docs/src/snippets/cpp/cppLibrary/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppLibrary/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/cpp/cppLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppLibrary/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     `cpp-library`
@@ -32,7 +16,7 @@ library {
 // tag::configure-target-machines[]
 library {
     targetMachines.set(listOf(machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64))
 }
 // end::configure-target-machines[]

--- a/subprojects/docs/src/snippets/cpp/cppLibrary/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppLibrary/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/cpp/cppUnitTest/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppUnitTest/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'cpp-unit-test'
@@ -24,7 +8,7 @@ plugins {
 unitTest {
     targetMachines = [
         machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64
     ]
 }

--- a/subprojects/docs/src/snippets/cpp/cppUnitTest/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/cpp/cppUnitTest/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/cpp/cppUnitTest/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppUnitTest/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     `cpp-unit-test`
@@ -23,7 +7,7 @@ plugins {
 // tag::configure-target-machines[]
 unitTest {
     targetMachines.set(listOf(machines.linux.x86_64,
-        machines.windows.x86, machines.windows.x86_64, 
+        machines.windows.x86, machines.windows.x86_64,
         machines.macOS.x86_64))
 }
 // end::configure-target-machines[]

--- a/subprojects/docs/src/snippets/cpp/cppUnitTest/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/cpp/cppUnitTest/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-cpp"

--- a/subprojects/docs/src/snippets/customModel/componentType/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/customModel/componentType/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 @Managed
 interface ImageComponent extends LibrarySpec {
     String getTitle()

--- a/subprojects/docs/src/snippets/customModel/internalViews/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/customModel/internalViews/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::type-declaration[]
 @Managed interface MyComponent extends ComponentSpec {
     String getPublicData()

--- a/subprojects/docs/src/snippets/customModel/internalViews/tests/softwareModelExtend-iv-model.out
+++ b/subprojects/docs/src/snippets/customModel/internalViews/tests/softwareModelExtend-iv-model.out
@@ -7,17 +7,17 @@ Root project
       | Type:   	org.gradle.platform.base.ComponentSpecContainer
       | Creator: 	ComponentBasePlugin.PluginRules#components(ComponentSpecContainer)
       | Rules:
-         ⤷ components { ... } @ build.gradle line 53, column 5
+         ⤷ components { ... } @ build.gradle line 37, column 5
          ⤷ MyPlugin#mutateMyComponents(ModelMap<MyComponentInternal>)
     + my
           | Type:   	MyComponent
-          | Creator: 	components { ... } @ build.gradle line 53, column 5 > create(my)
+          | Creator: 	components { ... } @ build.gradle line 37, column 5 > create(my)
           | Rules:
              ⤷ MyPlugin#mutateMyComponents(ModelMap<MyComponentInternal>) > all()
         + publicData
               | Type:   	java.lang.String
               | Value:  	Some PUBLIC data
-              | Creator: 	components { ... } @ build.gradle line 53, column 5 > create(my)
+              | Creator: 	components { ... } @ build.gradle line 37, column 5 > create(my)
 + tasks
       | Type:   	org.gradle.model.ModelMap<org.gradle.api.Task>
       | Creator: 	Project.<init>.tasks()

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::build-script[]
 import sample.documentation.DocumentationComponent
 import sample.documentation.TextSourceSet

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'groovy'
 }

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationBinary.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationBinary.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.documentation
 
 import org.gradle.model.Managed

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationComponent.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationComponent.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.documentation
 
 import org.gradle.model.Managed

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationPlugin.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/DocumentationPlugin.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package sample.documentation
 
 import org.gradle.api.Task

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/TextSourceSet.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/documentation/TextSourceSet.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.documentation
 
 import org.gradle.language.base.LanguageSourceSet

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownHtmlCompile.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownHtmlCompile.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.markdown
 
 import org.gradle.api.tasks.Input

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownPlugin.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.markdown
 
 import org.gradle.api.Task

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownSourceSet.groovy
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/src/main/groovy/sample/markdown/MarkdownSourceSet.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.markdown
 
 import org.gradle.language.base.LanguageSourceSet

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 
 import org.gradle.api.artifacts.transform.TransformParameters

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'artifact-transforms-unzip'

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 
 import org.gradle.api.artifacts.transform.TransformParameters

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "artifact-transforms-incremental"

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/groovy/settings.gradle
@@ -1,18 +1,2 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'artifact-transforms-minify'
 include('producer')

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import java.io.BufferedOutputStream
 import java.io.FileOutputStream
 import java.util.jar.JarOutputStream

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-minify/kotlin/settings.gradle.kts
@@ -1,18 +1,2 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "artifact-transforms-minify"
 include("producer")

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import me.lucko.jarrelocator.JarRelocator
 import me.lucko.jarrelocator.Relocation
 import java.util.function.Predicate

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'artifact-transforms-relocate'

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import me.lucko.jarrelocator.JarRelocator
 import me.lucko.jarrelocator.Relocation
 import java.util.jar.JarFile

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "artifact-transforms-relocate"

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/build.gradle
@@ -1,20 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'artifact-transforms-unzip'

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import java.io.File
 import java.nio.file.Files
 import java.util.zip.ZipEntry

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "artifact-transforms-unzip"

--- a/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/groovy/build.gradle
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'snippets'
 
 include("lib")

--- a/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/build.gradle.kts
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "snippets"
 
 include("lib")

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/lib/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
     id 'java-test-fixtures'

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/lib/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/lib/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'lib'

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/lib/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
     `java-test-fixtures`

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/lib/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/lib/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "lib"

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/lib/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::file-dependencies[]
 configurations {
     antContrib

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::repository-filter[]
 repositories {
     maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "filtering-repository"

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::repository-filter[]
 repositories {
     maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "filtering-repository"

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockModeSelection/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockModeSelection/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingClasspathConfiguration/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingClasspathConfiguration/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::locking-classpath[]
 buildscript {
     configurations.classpath {

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingClasspathConfiguration/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingClasspathConfiguration/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'locking-classpath-configurations'

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingSingleConfiguration/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingSingleConfiguration/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingSingleFilePerProject/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-lockingSingleFilePerProject/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'unlocking-one-configuration'

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     java
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyLocking-unlockingSingleConfiguration/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "unlocking-one-configuration"

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 repositories {
     mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "disabling-verification"

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 repositories {
     mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "disabling-verification"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
@@ -1,21 +1,5 @@
 import groovy.transform.CompileStatic
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "declaring-capabilities"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "declaring-capabilities"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "dependency-alignment"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignment/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "dependency-alignment"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/build.gradle
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 allprojects {
     group = 'com.acme'
     version = '1.0'

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/core/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/core/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }
@@ -22,7 +6,7 @@ plugins {
 dependencies {
     // Each project has a dependency on the platform
     api(platform(project(":platform")))
-    
+
     // And any additional dependency required
     implementation(project(":lib"))
     implementation(project(":utils"))

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/platform/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/platform/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::platform[]
 plugins {
     id 'java-platform'

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "dependency-alignment-with-platform"
 
 include "core", "lib", "utils", "platform"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/utils/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy/utils/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/build.gradle.kts
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 allprojects {
     group = "com.acme"
     version = "1.0"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/core/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/core/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }
@@ -22,7 +6,7 @@ plugins {
 dependencies {
     // Each project has a dependency on the platform
     api(platform(project(":platform")))
-    
+
     // And any additional dependency required
     implementation(project(":lib"))
     implementation(project(":utils"))

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/lib/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/platform/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/platform/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::platform[]
 plugins {
     `java-platform`

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "dependency-alignment-with-platform"
 
 include("core", "lib", "utils", "platform")

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/utils/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-dependencyAlignmentWithPlatform/kotlin/utils/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-enforcedConstraintsFromBOM/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-enforcedConstraintsFromBOM/groovy/build.gradle
@@ -6,22 +6,6 @@ repositories {
     mavenCentral()
 }
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::dependency-on-bom[]
 dependencies {
     // import a BOM. The versions used in this file will override any other version found in the graph

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-enforcedConstraintsFromBOM/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-enforcedConstraintsFromBOM/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "resolution-strategy"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
    `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "resolution-strategy"

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-versionsWithConstraints/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-versionsWithConstraints/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "dependency-constraints"

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'groovy'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/src/main/groovy/com/acme/InstrumentedJarsPlugin.groovy
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/src/main/groovy/com/acme/InstrumentedJarsPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme
 
 import groovy.transform.CompileStatic

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/producer/build.gradle
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     id 'java-library'
     id 'maven-publish'

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include "producer"

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `kotlin-dsl`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/src/main/kotlin/com/acme/InstrumentedJarsPlugin.kt
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/src/main/kotlin/com/acme/InstrumentedJarsPlugin.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme
 
 import org.gradle.api.JavaVersion

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/consumer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/producer/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
     `maven-publish`

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/settings.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include("producer")

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/producer/build.gradle
@@ -1,21 +1,5 @@
 import org.gradle.api.attributes.java.TargetJvmVersion
 
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include "producer"

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/consumer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/producer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include("producer")

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/producer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include "producer"

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/consumer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/producer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-simple/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "cross-project-publications"
 
 include("producer")

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
     id 'maven-publish'

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "my-library"

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
     `maven-publish`

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-outgoingCapabilities/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "my-library"

--- a/subprojects/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/settings.gradle
@@ -1,17 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 rootProject.name = 'earCustomized'
+
 include 'war', 'ear'

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'war'
 }

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/src/main/java/org/gradle/sample/SimpleGreeter.java
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/src/main/java/org/gradle/sample/SimpleGreeter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.apache.log4j.LogManager;

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/war/src/main/java/org/gradle/sample/SimpleGreeter.java
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/war/src/main/java/org/gradle/sample/SimpleGreeter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.apache.log4j.LogManager;

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/settings.gradle
@@ -1,17 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 rootProject.name = 'earWithWar'
+
 include 'war'

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'war'
 }

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/src/main/java/org/gradle/sample/SimpleGreeter.java
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/src/main/java/org/gradle/sample/SimpleGreeter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.apache.log4j.LogManager;

--- a/subprojects/docs/src/snippets/ear/earWithWar/kotlin/war/src/main/java/org/gradle/sample/SimpleGreeter.java
+++ b/subprojects/docs/src/snippets/ear/earWithWar/kotlin/war/src/main/java/org/gradle/sample/SimpleGreeter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.apache.log4j.LogManager;

--- a/subprojects/docs/src/snippets/groovy/compilationAvoidance/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/groovy/compilationAvoidance/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 subprojects {
     apply plugin: 'groovy'
     repositories {

--- a/subprojects/docs/src/snippets/groovy/compilationAvoidance/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/groovy/compilationAvoidance/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 subprojects {
     apply(plugin = "groovy")
     repositories {

--- a/subprojects/docs/src/snippets/ide/visualStudio/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ide/visualStudio/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'visual-studio'

--- a/subprojects/docs/src/snippets/ide/visualStudio/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ide/visualStudio/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "visual-studio"

--- a/subprojects/docs/src/snippets/ide/xcode/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ide/xcode/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'xcode'

--- a/subprojects/docs/src/snippets/ide/xcode/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/ide/xcode/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "xcode"

--- a/subprojects/docs/src/snippets/initScripts/plugins/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/initScripts/plugins/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::show-repos-task[]
 repositories{
     mavenCentral()

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = 'org.gradle.demo'
     version = '1.0'

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"
 
 include "producer"

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = "org.gradle.demo"
     version = "1.0"

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/consumer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/settings.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"
 
 include("producer")

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'producer'

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "producer"

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugins[]
 plugins {
     id 'java-library'

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'producer'

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugins[]
 plugins {
     `java-library`

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "producer"

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/settings.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = 'org.gradle.demo'
     version = '1.0'

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"
 
 include "producer"

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = "org.gradle.demo"
     version = "1.0"

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/consumer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "requiring-features"
 
 include("producer")

--- a/subprojects/docs/src/snippets/java-library/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-library/quickstart/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     id 'java-library'

--- a/subprojects/docs/src/snippets/java-library/quickstart/groovy/src/main/java/org/gradle/HttpClientWrapper.java
+++ b/subprojects/docs/src/snippets/java-library/quickstart/groovy/src/main/java/org/gradle/HttpClientWrapper.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::sample[]
 // The following types can appear anywhere in the code
 // but say nothing about API or implementation usage

--- a/subprojects/docs/src/snippets/java-library/quickstart/kotlin/src/main/java/org/gradle/HttpClientWrapper.java
+++ b/subprojects/docs/src/snippets/java-library/quickstart/kotlin/src/main/java/org/gradle/HttpClientWrapper.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::sample[]
 // The following types can appear anywhere in the code
 // but say nothing about API or implementation usage

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = "com.acme"
     version = "1.0"

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/core/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/core/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/platform/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/platform/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-platform'
     id 'maven-publish'

--- a/subprojects/docs/src/snippets/java-platform/multiproject/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/groovy/settings.gradle
@@ -1,20 +1,5 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'multiproject'
+
 include 'core'
 include 'lib'
 include 'platform'

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 allprojects {
     group = "com.acme"
     version = "1.0"

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/core/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/core/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/lib/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/platform/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/platform/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-platform`
     `maven-publish`

--- a/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/multiproject/kotlin/settings.gradle.kts
@@ -1,36 +1,5 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "multiproject"
+
 include("core")
 include("lib")
 include("platform")

--- a/subprojects/docs/src/snippets/java-platform/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/quickstart/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     id 'java-platform'

--- a/subprojects/docs/src/snippets/java-platform/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/quickstart/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     `java-platform`

--- a/subprojects/docs/src/snippets/java-platform/recommender/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/recommender/groovy/consumer/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java-platform/recommender/groovy/platform/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/recommender/groovy/platform/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-platform'
 }

--- a/subprojects/docs/src/snippets/java-platform/recommender/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java-platform/recommender/groovy/settings.gradle
@@ -1,19 +1,4 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'recommender'
+
 include 'platform'
 include 'consumer'

--- a/subprojects/docs/src/snippets/java-platform/recommender/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/recommender/kotlin/consumer/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java-platform/recommender/kotlin/platform/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/recommender/kotlin/platform/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-platform`
 }

--- a/subprojects/docs/src/snippets/java-platform/recommender/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/recommender/kotlin/settings.gradle.kts
@@ -1,35 +1,4 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "recommender"
+
 include("platform")
 include("consumer")

--- a/subprojects/docs/src/snippets/java/application/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/application/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     id 'application'

--- a/subprojects/docs/src/snippets/java/apt/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/apt/groovy/build.gradle
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/java/basic/kotlin/src/intTest/java/org/gradle/PersonIntTest.java
+++ b/subprojects/docs/src/snippets/java/basic/kotlin/src/intTest/java/org/gradle/PersonIntTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/java/basic/kotlin/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/java/basic/kotlin/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/java/crossCompilation/groovy/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/java/crossCompilation/groovy/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/java/crossCompilation/kotlin/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/java/crossCompilation/kotlin/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "custom-dirs"

--- a/subprojects/docs/src/snippets/java/fixtures/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/java/fixtures/groovy/lib/build.gradle
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/lib/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     // A Java Library

--- a/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/main/java/com/acme/Person.java
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/main/java/com/acme/Person.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme;
 
 // tag::sample[]

--- a/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme;
 
 import java.util.List;

--- a/subprojects/docs/src/snippets/java/fixtures/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java/fixtures/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'sample-fixtures'
 
 include 'lib'

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
@@ -1,21 +1,5 @@
 import org.gradle.api.internal.component.SoftwareComponentInternal
 
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     // A Java Library

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/main/java/com/acme/Person.java
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/main/java/com/acme/Person.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme;
 
 // tag::sample[]

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.acme;
 
 import java.util.List;

--- a/subprojects/docs/src/snippets/java/fixtures/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java/fixtures/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "sample-fixtures"
 
 include("lib")

--- a/subprojects/docs/src/snippets/java/javaGradlePlugin/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/javaGradlePlugin/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-java-gradle-plugin-plugin[]
 plugins {
     id 'java-gradle-plugin'

--- a/subprojects/docs/src/snippets/java/javaGradlePlugin/groovy/src/main/java/org/gradle/sample/SimplePlugin.java
+++ b/subprojects/docs/src/snippets/java/javaGradlePlugin/groovy/src/main/java/org/gradle/sample/SimplePlugin.java
@@ -1,20 +1,4 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
- 
- package org.gradle.sample;
+package org.gradle.sample;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/subprojects/docs/src/snippets/java/javaGradlePlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/javaGradlePlugin/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-java-gradle-plugin-plugin[]
 plugins {
     `java-gradle-plugin`

--- a/subprojects/docs/src/snippets/java/javaGradlePlugin/kotlin/src/main/java/org/gradle/sample/SimplePlugin.java
+++ b/subprojects/docs/src/snippets/java/javaGradlePlugin/kotlin/src/main/java/org/gradle/sample/SimplePlugin.java
@@ -1,20 +1,4 @@
-/*
- * Copyright 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
- 
- package org.gradle.sample;
+package org.gradle.sample;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/subprojects/docs/src/snippets/maven/quickstart/groovy/src/main/java/org/MyClass.java
+++ b/subprojects/docs/src/snippets/maven/quickstart/groovy/src/main/java/org/MyClass.java
@@ -1,20 +1,5 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org;
 
 public class MyClass {
-    
+
 }

--- a/subprojects/docs/src/snippets/maven/quickstart/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/maven/quickstart/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "quickstart"

--- a/subprojects/docs/src/snippets/maven/quickstart/kotlin/src/main/java/org/MyClass.java
+++ b/subprojects/docs/src/snippets/maven/quickstart/kotlin/src/main/java/org/MyClass.java
@@ -1,20 +1,5 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org;
 
 public class MyClass {
-    
+
 }

--- a/subprojects/docs/src/snippets/mavenMigration/basic/kotlin/src/intTest/java/org/gradle/PersonIntTest.java
+++ b/subprojects/docs/src/snippets/mavenMigration/basic/kotlin/src/intTest/java/org/gradle/PersonIntTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/mavenMigration/basic/kotlin/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/mavenMigration/basic/kotlin/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/multiproject/dependencies-java/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/multiproject/dependencies-java/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 subprojects {
     apply plugin: 'java'
     group = 'org.gradle.sample'

--- a/subprojects/docs/src/snippets/native-binaries/assembler/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/assembler/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'assembler'

--- a/subprojects/docs/src/snippets/native-binaries/c/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/c/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'c'

--- a/subprojects/docs/src/snippets/native-binaries/custom-check/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/custom-check/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::custom-check[]
 plugins {
     id "cpp"

--- a/subprojects/docs/src/snippets/native-binaries/custom-layout/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/custom-layout/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'cpp'
     id 'c'

--- a/subprojects/docs/src/snippets/native-binaries/pre-compiled-headers/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/pre-compiled-headers/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'cpp'

--- a/subprojects/docs/src/snippets/native-binaries/target-platforms/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/target-platforms/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'cpp'
 }

--- a/subprojects/docs/src/snippets/play/advanced/groovy/app/controllers/hello/HelloController.java
+++ b/subprojects/docs/src/snippets/play/advanced/groovy/app/controllers/hello/HelloController.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package controllers.hello;
 
 import play.*;

--- a/subprojects/docs/src/snippets/plugins/buildService/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildService/groovy/buildSrc/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id('java-gradle-plugin')
 }

--- a/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::buildscript_block[]
 buildscript {
     repositories {

--- a/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::buildscript_block[]
 buildscript {
     repositories {

--- a/subprojects/docs/src/snippets/plugins/dsl/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/dsl/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 // tag::use-community-plugin[]
 plugins {

--- a/subprojects/docs/src/snippets/plugins/dsl/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/dsl/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 // tag::use-community-plugin[]
 plugins {

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     id 'my-plugin'

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::main-block[]
 plugins {
     id 'java-gradle-plugin'

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/src/main/java/my/MyPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/src/main/java/my/MyPlugin.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package my;
 
 import org.gradle.api.*;

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::use-plugin[]
 plugins {
     id("my-plugin")

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::main-block[]
 plugins {
     `java-gradle-plugin`

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/src/main/java/my/MyPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/src/main/java/my/MyPlugin.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package my;
 
 import org.gradle.api.*;

--- a/subprojects/docs/src/snippets/plugins/multiproject/groovy/project/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/multiproject/groovy/project/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugins-on-subprojects[]
 plugins {
     id 'com.example.hello' version '1.0.0' apply false

--- a/subprojects/docs/src/snippets/plugins/multiproject/groovy/project/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/multiproject/groovy/project/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 pluginManagement {
   repositories {
       maven {

--- a/subprojects/docs/src/snippets/plugins/multiproject/kotlin/project/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/multiproject/kotlin/project/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugins-on-subprojects[]
 plugins {
     id("com.example.hello") version "1.0.0" apply false

--- a/subprojects/docs/src/snippets/plugins/multiproject/kotlin/project/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/multiproject/kotlin/project/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 pluginManagement {
   repositories {
       maven(url = "../maven-repo")

--- a/subprojects/docs/src/snippets/plugins/pluginVersions/groovy/project/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/pluginVersions/groovy/project/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'com.example.hello'
 }

--- a/subprojects/docs/src/snippets/plugins/pluginVersions/groovy/project/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/pluginVersions/groovy/project/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::configure-plugin-version[]
 pluginManagement {
   plugins {

--- a/subprojects/docs/src/snippets/plugins/pluginVersions/kotlin/project/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/pluginVersions/kotlin/project/build.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id("com.example.hello")
 }

--- a/subprojects/docs/src/snippets/plugins/pluginVersions/kotlin/project/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/pluginVersions/kotlin/project/settings.gradle.kts
@@ -1,35 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::configure-plugin-version[]
 pluginManagement {
   val helloPluginVersion: String by settings

--- a/subprojects/docs/src/snippets/plugins/resolutionRules/groovy/project/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/resolutionRules/groovy/project/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugin-resolution-strategy[]
 pluginManagement {
     resolutionStrategy {

--- a/subprojects/docs/src/snippets/plugins/resolutionRules/kotlin/project/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/resolutionRules/kotlin/project/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::plugin-resolution-strategy[]
 pluginManagement {
     resolutionStrategy {

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/src/main/java/org/gradle/HttpClientWrapper.java
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/src/main/java/org/gradle/HttpClientWrapper.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.gradle;
 
 // The following types can appear anywhere in the code

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/src/main/java/org/gradle/HttpClientWrapper.java
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/src/main/java/org/gradle/HttpClientWrapper.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.gradle;
 
 // The following types can appear anywhere in the code

--- a/subprojects/docs/src/snippets/swift/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/basic/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-swift-plugin[]
 plugins {
     id 'swift-application' // or 'swift-library'

--- a/subprojects/docs/src/snippets/swift/basic/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/basic/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"
 
 include 'common'

--- a/subprojects/docs/src/snippets/swift/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/basic/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-swift-plugin[]
 plugins {
     `swift-application` // or `swift-library`
@@ -60,7 +44,7 @@ application {
 
 project(":common") {
     apply(plugin = "swift-library")
-    
+
     // tag::swift-source-set[]
     extensions.configure<SwiftLibrary> {
         source.from(file("Sources/Common"))

--- a/subprojects/docs/src/snippets/swift/basic/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/basic/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"
 
 include("common")

--- a/subprojects/docs/src/snippets/swift/basicTest/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/basicTest/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-swift-plugin[]
 plugins {
     id 'swift-application' // or 'swift-library'

--- a/subprojects/docs/src/snippets/swift/basicTest/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/basicTest/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"
 
 include 'common'

--- a/subprojects/docs/src/snippets/swift/basicTest/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/basicTest/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-swift-plugin[]
 plugins {
     `swift-application` // or `swift-library`
@@ -60,7 +44,7 @@ application {
 
 project(":common") {
     apply(plugin = "swift-library")
-    
+
     // tag::swift-source-set[]
     extensions.configure<SwiftLibrary> {
         source.from(file("Sources/Common"))

--- a/subprojects/docs/src/snippets/swift/basicTest/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/basicTest/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"
 
 include("common")

--- a/subprojects/docs/src/snippets/swift/swiftApplication/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftApplication/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'swift-application'

--- a/subprojects/docs/src/snippets/swift/swiftApplication/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftApplication/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/swiftApplication/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftApplication/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     `swift-application`

--- a/subprojects/docs/src/snippets/swift/swiftApplication/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftApplication/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/swiftLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftLibrary/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'swift-library'
@@ -32,8 +16,8 @@ library {
 
 // tag::configure-target-machines[]
 library {
-    targetMachines = [ 
-        machines.linux.x86_64, 
+    targetMachines = [
+        machines.linux.x86_64,
         machines.macOS.x86_64
     ]
 }

--- a/subprojects/docs/src/snippets/swift/swiftLibrary/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftLibrary/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/swiftLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftLibrary/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     `swift-library`

--- a/subprojects/docs/src/snippets/swift/swiftLibrary/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftLibrary/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/swiftXCTest/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftXCTest/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     id 'xctest'

--- a/subprojects/docs/src/snippets/swift/swiftXCTest/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/swiftXCTest/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/swiftXCTest/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftXCTest/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     xctest

--- a/subprojects/docs/src/snippets/swift/swiftXCTest/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/swiftXCTest/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "basic-swift"

--- a/subprojects/docs/src/snippets/swift/testFiltering/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/swift/testFiltering/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'xctest'
 }

--- a/subprojects/docs/src/snippets/swift/testFiltering/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/testFiltering/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'testing'

--- a/subprojects/docs/src/snippets/swift/testFiltering/groovy/src/test/swift/SomeIntegTest.swift
+++ b/subprojects/docs/src/snippets/swift/testFiltering/groovy/src/test/swift/SomeIntegTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class SomeIntegTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testFiltering/groovy/src/test/swift/SomeOtherTest.swift
+++ b/subprojects/docs/src/snippets/swift/testFiltering/groovy/src/test/swift/SomeOtherTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class SomeOtherTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testFiltering/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/testFiltering/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     xctest
 }

--- a/subprojects/docs/src/snippets/swift/testFiltering/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/testFiltering/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "testing"

--- a/subprojects/docs/src/snippets/swift/testFiltering/kotlin/src/test/swift/SomeIntegTest.swift
+++ b/subprojects/docs/src/snippets/swift/testFiltering/kotlin/src/test/swift/SomeIntegTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class SomeIntegTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testFiltering/kotlin/src/test/swift/SomeOtherTest.swift
+++ b/subprojects/docs/src/snippets/swift/testFiltering/kotlin/src/test/swift/SomeOtherTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class SomeOtherTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testReport/groovy/core/src/test/swift/CoreTest.swift
+++ b/subprojects/docs/src/snippets/swift/testReport/groovy/core/src/test/swift/CoreTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class CoreTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testReport/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/swift/testReport/groovy/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "testing"
 
 include 'util'

--- a/subprojects/docs/src/snippets/swift/testReport/groovy/util/src/test/swift/UtilTest.swift
+++ b/subprojects/docs/src/snippets/swift/testReport/groovy/util/src/test/swift/UtilTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class UtilTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testReport/kotlin/core/src/test/swift/CoreTest.swift
+++ b/subprojects/docs/src/snippets/swift/testReport/kotlin/core/src/test/swift/CoreTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class CoreTest: XCTestCase {

--- a/subprojects/docs/src/snippets/swift/testReport/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/swift/testReport/kotlin/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "testing"
 
 include("util")

--- a/subprojects/docs/src/snippets/swift/testReport/kotlin/util/src/test/swift/UtilTest.swift
+++ b/subprojects/docs/src/snippets/swift/testReport/kotlin/util/src/test/swift/UtilTest.swift
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import XCTest
 
 class UtilTest: XCTestCase {

--- a/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/groovy/buildSrc/src/main/java/UrlProcess.java
+++ b/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/groovy/buildSrc/src/main/java/UrlProcess.java
@@ -1,20 +1,4 @@
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/kotlin/buildSrc/src/main/java/UrlProcess.java
+++ b/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/kotlin/buildSrc/src/main/java/UrlProcess.java
@@ -1,20 +1,4 @@
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/subprojects/docs/src/snippets/tasks/commandLineOption-stringOption/groovy/buildSrc/src/main/java/UrlVerify.java
+++ b/subprojects/docs/src/snippets/tasks/commandLineOption-stringOption/groovy/buildSrc/src/main/java/UrlVerify.java
@@ -1,20 +1,4 @@
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;

--- a/subprojects/docs/src/snippets/tasks/commandLineOption-stringOption/kotlin/buildSrc/src/main/java/UrlVerify.java
+++ b/subprojects/docs/src/snippets/tasks/commandLineOption-stringOption/kotlin/buildSrc/src/main/java/UrlVerify.java
@@ -1,20 +1,4 @@
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;

--- a/subprojects/docs/src/snippets/tasks/inputNormalization/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/inputNormalization/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/functionalTest/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/functionalTest/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/functionalTest/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/functionalTest/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/gradleVersion/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/gradleVersion/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 // tag::functional-test-spock-gradle-version[]

--- a/subprojects/docs/src/snippets/testKit/junitQuickstart/groovy/src/test/java/org/gradle/sample/BuildLogicFunctionalTest.java
+++ b/subprojects/docs/src/snippets/testKit/junitQuickstart/groovy/src/test/java/org/gradle/sample/BuildLogicFunctionalTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 // tag::functional-test-junit[]

--- a/subprojects/docs/src/snippets/testKit/junitQuickstart/kotlin/src/test/kotlin/org/gradle/sample/BuildLogicFunctionalTest.kt
+++ b/subprojects/docs/src/snippets/testKit/junitQuickstart/kotlin/src/test/kotlin/org/gradle/sample/BuildLogicFunctionalTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 // tag::functional-test-junit[]

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/groovy/org/gradle/sample/HelloWorld.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/groovy/org/gradle/sample/HelloWorld.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.DefaultTask

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/groovy/org/gradle/sample/HelloWorld.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/groovy/org/gradle/sample/HelloWorld.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.DefaultTask

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/manualClasspathInjection/kotlin/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testKit/spockQuickstart/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/spockQuickstart/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 // tag::functional-test-spock[]

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/groovy/org/gradle/sample/HelloWorldPlugin.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.Plugin

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/groovy/org/gradle/sample/MyCacheableTask.groovy
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/groovy/org/gradle/sample/MyCacheableTask.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.api.DefaultTask

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/main/resources/META-INF/gradle-plugins/org.gradle.sample.helloworld.properties
@@ -1,17 +1,1 @@
-#
-# Copyright 2017 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 implementation-class=org.gradle.sample.HelloWorldPlugin

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample
 
 import org.gradle.testkit.runner.GradleRunner

--- a/subprojects/docs/src/snippets/testing/filtering/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/filtering/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/testing/jacoco-application/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-application/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::application-configuration[]
 plugins {
     id 'application'

--- a/subprojects/docs/src/snippets/testing/jacoco-application/groovy/src/main/java/org/gradle/MyMain.java
+++ b/subprojects/docs/src/snippets/testing/jacoco-application/groovy/src/main/java/org/gradle/MyMain.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import java.lang.String;

--- a/subprojects/docs/src/snippets/testing/jacoco-application/kotlin/src/main/java/org/gradle/MyMain.java
+++ b/subprojects/docs/src/snippets/testing/jacoco-application/kotlin/src/main/java/org/gradle/MyMain.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import java.lang.String;

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
@@ -1,20 +1,4 @@
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::apply-plugin[]
 plugins {
     // end::apply-plugin[]

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/src/test/java/org/gradle/PersonTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategorizedJUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategorizedJUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategoryA.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategoryA.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 public interface CategoryA{

--- a/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategoryB.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/CategoryB.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 public interface CategoryB{

--- a/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/SimpleJUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/groovy/src/test/java/org/gradle/junit/SimpleJUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategorizedJUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategorizedJUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategoryA.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategoryA.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 public interface CategoryA{

--- a/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategoryB.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/CategoryB.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 public interface CategoryB{

--- a/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/SimpleJUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/junit-categories/kotlin/src/test/java/org/gradle/junit/SimpleJUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junit;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/build.gradle
@@ -6,22 +6,6 @@ repositories {
     mavenCentral()
 }
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::jupiter-dependencies[]
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'

--- a/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/src/test/java/org/gradle/junitplatform/JupiterTest.java
+++ b/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/src/test/java/org/gradle/junitplatform/JupiterTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junitplatform;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/subprojects/docs/src/snippets/testing/junitplatform-jupiter/kotlin/src/test/java/org/gradle/junitplatform/JupiterTest.java
+++ b/subprojects/docs/src/snippets/testing/junitplatform-jupiter/kotlin/src/test/java/org/gradle/junitplatform/JupiterTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.junitplatform;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/subprojects/docs/src/snippets/testing/junitplatform-mix/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-mix/groovy/build.gradle
@@ -1,18 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     id 'java'
 }

--- a/subprojects/docs/src/snippets/testing/testReport/kotlin/core/src/test/java/org/gradle/sample/CoreTest.java
+++ b/subprojects/docs/src/snippets/testing/testReport/kotlin/core/src/test/java/org/gradle/sample/CoreTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/testReport/kotlin/util/src/test/java/org/gradle/sample/UtilTest.java
+++ b/subprojects/docs/src/snippets/testing/testReport/kotlin/util/src/test/java/org/gradle/sample/UtilTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.sample;
 
 import org.junit.Test;

--- a/subprojects/docs/src/snippets/testing/testng-groupbyinstances/groovy/src/test/java/org/gradle/testng/TestFactory.java
+++ b/subprojects/docs/src/snippets/testing/testng-groupbyinstances/groovy/src/test/java/org/gradle/testng/TestFactory.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.AfterClass;

--- a/subprojects/docs/src/snippets/testing/testng-groupbyinstances/kotlin/src/test/java/org/gradle/testng/TestFactory.java
+++ b/subprojects/docs/src/snippets/testing/testng-groupbyinstances/kotlin/src/test/java/org/gradle/testng/TestFactory.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.AfterClass;

--- a/subprojects/docs/src/snippets/testing/testng-groups/groovy/src/test/java/org/gradle/testng/SimpleIntegrationTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-groups/groovy/src/test/java/org/gradle/testng/SimpleIntegrationTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.BeforeMethod;

--- a/subprojects/docs/src/snippets/testing/testng-groups/groovy/src/test/java/org/gradle/testng/SimpleUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-groups/groovy/src/test/java/org/gradle/testng/SimpleUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.BeforeMethod;

--- a/subprojects/docs/src/snippets/testing/testng-groups/kotlin/src/test/java/org/gradle/testng/SimpleIntegrationTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-groups/kotlin/src/test/java/org/gradle/testng/SimpleIntegrationTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.BeforeMethod;

--- a/subprojects/docs/src/snippets/testing/testng-groups/kotlin/src/test/java/org/gradle/testng/SimpleUnitTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-groups/kotlin/src/test/java/org/gradle/testng/SimpleUnitTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.BeforeMethod;

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/AbstractTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/AbstractTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.testng.annotations.Test;

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/ConcreteTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/ConcreteTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 public class ConcreteTest extends AbstractTest {

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/OkTest.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/OkTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 public class OkTest {

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/SuiteCleanup.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/SuiteCleanup.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.testng.annotations.AfterSuite;

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/SuiteSetup.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/SuiteSetup.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.testng.annotations.BeforeSuite;

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/TestCleanup.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/TestCleanup.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.testng.annotations.AfterTest;

--- a/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/TestSetup.java
+++ b/subprojects/docs/src/snippets/testing/testng-java-passing/groovy/src/test/java/org/gradle/TestSetup.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle;
 
 import org.testng.annotations.BeforeTest;

--- a/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/build.gradle
@@ -10,22 +10,6 @@ dependencies {
     testImplementation 'org.testng:testng:6.9.4'
 }
 
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // tag::test-config[]
 test {
     useTestNG {

--- a/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/src/test/java/org/gradle/testng/Test1.java
+++ b/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/src/test/java/org/gradle/testng/Test1.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.AfterClass;

--- a/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/src/test/java/org/gradle/testng/Test2.java
+++ b/subprojects/docs/src/snippets/testing/testng-preserveorder/groovy/src/test/java/org/gradle/testng/Test2.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import java.io.Serializable;

--- a/subprojects/docs/src/snippets/testing/testng-preserveorder/kotlin/src/test/java/org/gradle/testng/Test1.java
+++ b/subprojects/docs/src/snippets/testing/testng-preserveorder/kotlin/src/test/java/org/gradle/testng/Test1.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import org.testng.annotations.AfterClass;

--- a/subprojects/docs/src/snippets/testing/testng-preserveorder/kotlin/src/test/java/org/gradle/testng/Test2.java
+++ b/subprojects/docs/src/snippets/testing/testng-preserveorder/kotlin/src/test/java/org/gradle/testng/Test2.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.testng;
 
 import java.io.Serializable;

--- a/subprojects/docs/src/snippets/tutorial/projectReports/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tutorial/projectReports/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 defaultTasks 'dists'
 
 allprojects {

--- a/subprojects/docs/src/snippets/tutorial/properties/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tutorial/properties/groovy/settings.gradle
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = 'properties'

--- a/subprojects/docs/src/snippets/workerApi/noIsolation/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/noIsolation/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 // tag::unit-of-work[]
 // The parameters for a single unit of work

--- a/subprojects/docs/src/snippets/workerApi/waitForCompletion/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/waitForCompletion/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 
 // The parameters for a single unit of work

--- a/subprojects/docs/src/snippets/workerApi/workerDaemon/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/workerDaemon/groovy/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 
 // The parameters for a single unit of work

--- a/subprojects/docs/src/snippets/workerApi/workerDaemon/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/workerDaemon/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import javax.inject.Inject
 
 // The parameters for a single unit of work

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -42,17 +42,17 @@ class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
                   | Type:   \torg.gradle.platform.base.ComponentSpecContainer
                   | Creator: \tComponentBasePlugin.PluginRules#components(ComponentSpecContainer)
                   | Rules:
-                     ⤷ components { ... } @ build.gradle line 53, column 5
+                     ⤷ components { ... } @ build.gradle line 37, column 5
                      ⤷ MyPlugin#mutateMyComponents(ModelMap<MyComponentInternal>)
                 + my
                       | Type:   \tMyComponent
-                      | Creator: \tcomponents { ... } @ build.gradle line 53, column 5 > create(my)
+                      | Creator: \tcomponents { ... } @ build.gradle line 37, column 5 > create(my)
                       | Rules:
                          ⤷ MyPlugin#mutateMyComponents(ModelMap<MyComponentInternal>) > all()
                     + publicData
                           | Type:   \tjava.lang.String
                           | Value:  \tSome PUBLIC data
-                          | Creator: \tcomponents { ... } @ build.gradle line 53, column 5 > create(my)
+                          | Creator: \tcomponents { ... } @ build.gradle line 37, column 5 > create(my)
             """.stripIndent().trim()
     }
 }


### PR DESCRIPTION
The snippets and samples sporadically define the apache license header. We probably add it because Idea automatically pastes it in every new source files. It is not required though and makes the snippets/samples database inconsistent. 