### PR TITLE
Generalize heuristic for using display names in XML reports

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -30,19 +30,17 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
     String testClassName
     boolean checked
     String testClassDisplayName
-    boolean hasDisplayNameAnnotation
     TestResultOutputAssociation outputAssociation
 
-    JUnitTestClassExecutionResult(GPathResult testClassNode, String testClassName, String testClassDisplayName, boolean hasDisplayNameAnnotation, TestResultOutputAssociation outputAssociation) {
+    JUnitTestClassExecutionResult(GPathResult testClassNode, String testClassName, String testClassDisplayName, TestResultOutputAssociation outputAssociation) {
         this.outputAssociation = outputAssociation
         this.testClassNode = testClassNode
         this.testClassName = testClassName
         this.testClassDisplayName = testClassDisplayName
-        this.hasDisplayNameAnnotation = hasDisplayNameAnnotation
     }
 
-    JUnitTestClassExecutionResult(String content, String testClassName, String testClassDisplayName, boolean hasDisplayNameAnnotation, TestResultOutputAssociation outputAssociation) {
-        this(new XmlSlurper().parse(new StringReader(content)), testClassName, testClassDisplayName, hasDisplayNameAnnotation, outputAssociation)
+    JUnitTestClassExecutionResult(String content, String testClassName, String testClassDisplayName, TestResultOutputAssociation outputAssociation) {
+        this(new XmlSlurper().parse(new StringReader(content)), testClassName, testClassDisplayName, outputAssociation)
     }
 
     TestClassExecutionResult assertTestsExecuted(String... testNames) {
@@ -205,15 +203,9 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
     }
 
     private def findTests() {
-        String className
-        if(hasDisplayNameAnnotation) {
-            className = testClassDisplayName
-        } else {
-            className = testClassName
-        }
         if (!checked) {
             Assert.assertThat(testClassNode.name(), CoreMatchers.equalTo('testsuite'))
-            Assert.assertThat(testClassNode.@name.text(), CoreMatchers.equalTo(className))
+            Assert.assertThat(testClassNode.@name.text(), CoreMatchers.equalTo(testClassDisplayName))
             Assert.assertThat(testClassNode.@tests.text(), CoreMatchers.not(CoreMatchers.equalTo('')))
             Assert.assertThat(testClassNode.@skipped.text(), CoreMatchers.not(CoreMatchers.equalTo('')))
             Assert.assertThat(testClassNode.@failures.text(), CoreMatchers.not(CoreMatchers.equalTo('')))

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
@@ -56,12 +56,12 @@ class JUnitXmlTestExecutionResult implements TestExecutionResult {
     }
 
     TestClassExecutionResult testClass(String testClass) {
-        return new JUnitTestClassExecutionResult(findTestClass(testClass), testClass, testClass, false, outputAssociation)
+        return new JUnitTestClassExecutionResult(findTestClass(testClass), testClass, testClass, outputAssociation)
     }
 
     TestClassExecutionResult testClassStartsWith(String testClass) {
         def matching = findTestClassStartsWith(testClass)
-        return new JUnitTestClassExecutionResult(matching[1], matching[0], matching[0], false, outputAssociation)
+        return new JUnitTestClassExecutionResult(matching[1], matching[0], matching[0], outputAssociation)
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -41,7 +41,7 @@ public class JUnitXmlResultWriter {
      * @param output The destination, unbuffered
      */
     public void write(TestClassResult result, OutputStream output) {
-        String className = result.getClassDisplayName();
+        String className = result.hasDefaultDisplayName() ? result.getClassName() : result.getClassDisplayName();
         long classId = result.getId();
 
         try {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -41,13 +41,12 @@ public class JUnitXmlResultWriter {
      * @param output The destination, unbuffered
      */
     public void write(TestClassResult result, OutputStream output) {
-        String className = result.hasDefaultDisplayName() ? result.getClassName() : result.getClassDisplayName();
         long classId = result.getId();
 
         try {
             SimpleXmlWriter writer = new SimpleXmlWriter(output, "  ");
             writer.startElement("testsuite")
-                    .attribute("name", className)
+                    .attribute("name", result.getXmlTestSuiteName())
                     .attribute("tests", String.valueOf(result.getTestsCount()))
                     .attribute("skipped", String.valueOf(result.getSkippedCount()))
                     .attribute("failures", String.valueOf(result.getFailuresCount()))

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
@@ -102,4 +102,10 @@ public class TestClassResult {
     public void setStartTime(long startTime) {
         this.startTime = startTime;
     }
+
+    public boolean hasDefaultDisplayName() {
+        // both JUnit Jupiter and Vintage use the simple class name as the default display name
+        // so we use this as a heuristic to determine whether the display name was customized
+        return className.endsWith("." + classDisplayName) || className.endsWith("$" + classDisplayName);
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
@@ -103,7 +103,11 @@ public class TestClassResult {
         this.startTime = startTime;
     }
 
-    public boolean hasDefaultDisplayName() {
+    String getXmlTestSuiteName() {
+        return hasDefaultDisplayName() ? className : classDisplayName;
+    }
+
+    private boolean hasDefaultDisplayName() {
         // both JUnit Jupiter and Vintage use the simple class name as the default display name
         // so we use this as a heuristic to determine whether the display name was customized
         return className.endsWith("." + classDisplayName) || className.endsWith("$" + classDisplayName);

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.fixtures.TestResultOutputAssociation
 import org.gradle.internal.SystemProperties
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static TestOutputAssociation.WITH_SUITE
 import static TestOutputAssociation.WITH_TESTCASE
@@ -57,7 +58,7 @@ class JUnitXmlResultWriterSpec extends Specification {
         def xml = getXml(result)
 
         then:
-        new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", "com.foo.FooTest", false, TestResultOutputAssociation.WITH_SUITE)
+        new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", "com.foo.FooTest", TestResultOutputAssociation.WITH_SUITE)
                 .assertTestCount(4, 1, 1, 0)
                 .assertTestFailed("some failing test", equalTo('failure message'))
                 .assertTestsSkipped("some skipped test")
@@ -181,9 +182,10 @@ class JUnitXmlResultWriterSpec extends Specification {
 """
     }
 
+    @Unroll
     @Issue("gradle/gradle#11445")
-    def "writes xml JUnit result displayName"() {
-        TestClassResult result = new TestClassResult(1, "com.foo.FooTest", "com.foo.FooTest displayName", startTime)
+    def "writes #writtenName as class display name when #displayName is specified"() {
+        TestClassResult result = new TestClassResult(1, "com.foo.FooTest", displayName, startTime)
         result.add(new TestMethodResult(1, "some test", "some test displayName", SUCCESS, 15, startTime + 25))
         result.add(new TestMethodResult(2, "some test two", "some test two displayName", SUCCESS, 15, startTime + 30))
         result.add(new TestMethodResult(3, "some failing test", "some failing test displayName", FAILURE, 10, startTime + 40).addFailure("failure message", "[stack-trace]", "ExceptionType"))
@@ -196,7 +198,7 @@ class JUnitXmlResultWriterSpec extends Specification {
         def xml = getXml(result)
 
         then:
-        new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", "com.foo.FooTest displayName", true, TestResultOutputAssociation.WITH_SUITE)
+        new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", writtenName, TestResultOutputAssociation.WITH_SUITE)
             .assertTestCount(4, 1, 1, 0)
             .assertTestFailed("some failing test displayName", equalTo('failure message'))
             .assertTestsSkipped("some skipped test displayName")
@@ -208,7 +210,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         and:
         xml == """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="com.foo.FooTest displayName" tests="4" skipped="1" failures="1" errors="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.045">
+<testsuite name="$writtenName" tests="4" skipped="1" failures="1" errors="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.045">
   <properties/>
   <testcase name="some test displayName" classname="com.foo.FooTest" time="0.015"/>
   <testcase name="some test two displayName" classname="com.foo.FooTest" time="0.015"/>
@@ -224,6 +226,11 @@ class JUnitXmlResultWriterSpec extends Specification {
   <system-err><![CDATA[err]]></system-err>
 </testsuite>
 """
+
+        where:
+        displayName           | writtenName
+        'FooTest'             | 'com.foo.FooTest'
+        'custom display name' | 'custom display name'
     }
 
     def getXml(TestClassResult result) {

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -81,7 +81,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
-        if (testIdentifier.isTest() || isClass(testIdentifier)) {
+        if (testIdentifier.isTest() || hasClassSource(testIdentifier)) {
             reportStartedUnlessAlreadyStarted(testIdentifier);
         }
     }
@@ -121,10 +121,10 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     private void reportSkipped(TestIdentifier testIdentifier) {
         currentTestPlan.getChildren(testIdentifier).stream()
             .filter(child -> !wasStarted(child))
-            .forEach(child -> executionSkipped(child));
+            .forEach(this::executionSkipped);
         if (testIdentifier.isTest()) {
             resultProcessor.completed(getId(testIdentifier), completeEvent(SKIPPED));
-        } else if (isClass(testIdentifier)) {
+        } else if (hasClassSource(testIdentifier)) {
             resultProcessor.completed(getId(testIdentifier), completeEvent());
         }
     }
@@ -160,8 +160,8 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         MutableBoolean wasCreated = new MutableBoolean(false);
         descriptorsByUniqueId.computeIfAbsent(node.getUniqueId(), uniqueId -> {
             wasCreated.set(true);
-            if (node.getType() == CONTAINER || isClass(node) && !hasSameSourceAsAncestor(node)) {
-                TestIdentifier classIdentifier = findClassSource(node);
+            if (node.getType() == CONTAINER || isTestClassIdentifier(node)) {
+                TestIdentifier classIdentifier = findTestClassIdentifier(node);
                 String className = className(classIdentifier);
                 String classDisplayName = classDisplayName(classIdentifier);
                 return new DefaultTestClassDescriptor(idGenerator.generateId(), className, classDisplayName);
@@ -178,7 +178,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private TestDescriptorInternal createTestDescriptor(TestIdentifier test, String name, String displayName) {
-        TestIdentifier classIdentifier = findClassSource(test);
+        TestIdentifier classIdentifier = findTestClassIdentifier(test);
         String className = className(classIdentifier);
         String classDisplayName = classDisplayName(classIdentifier);
         return new DefaultTestDescriptor(idGenerator.generateId(), className, name, classDisplayName, displayName);
@@ -199,28 +199,13 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         return result;
     }
 
-    private static boolean isClass(TestIdentifier test) {
-        return test.getSource().isPresent() && test.getSource().get() instanceof ClassSource;
-    }
-
-    private boolean hasSameSourceAsAncestor(TestIdentifier node) {
-        Optional<TestIdentifier> parent = currentTestPlan.getParent(node);
-        while (parent.isPresent()) {
-            if (Objects.equals(parent.get().getSource(), node.getSource())) {
-                return true;
-            }
-            parent = currentTestPlan.getParent(parent.get());
-        }
-        return false;
-    }
-
-    private TestIdentifier findClassSource(TestIdentifier testIdentifier) {
+    private TestIdentifier findTestClassIdentifier(TestIdentifier testIdentifier) {
         // For tests in default method of interface,
         // we might not be able to get the implementation class directly.
         // In this case, we need to retrieve test plan to get the real implementation class.
         TestIdentifier current = testIdentifier;
         while (current != null) {
-            if (isClass(current)) {
+            if (isTestClassIdentifier(current)) {
                 return current;
             }
             current = current.getParentId().map(currentTestPlan::getTestIdentifier).orElse(null);
@@ -228,20 +213,46 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         return null;
     }
 
+    private boolean isTestClassIdentifier(TestIdentifier testIdentifier) {
+        return hasClassSource(testIdentifier) && hasDifferentSourceThanAncestor(testIdentifier);
+    }
+
     private String className(TestIdentifier testClassIdentifier) {
-        if (testClassIdentifier != null && isClass(testClassIdentifier)) {
-            return ((ClassSource) testClassIdentifier.getSource().get()).getClassName();
-        } else {
-            return "UnknownClass";
+        if (testClassIdentifier != null) {
+            Optional<ClassSource> classSource = getClassSource(testClassIdentifier);
+            if (classSource.isPresent()) {
+                return classSource.get().getClassName();
+            }
         }
+        return "UnknownClass";
     }
 
     private String classDisplayName(TestIdentifier testClassIdentifier) {
         if (testClassIdentifier != null) {
             return testClassIdentifier.getDisplayName();
-        } else {
-            return "UnknownClass";
         }
+        return "UnknownClass";
+    }
+
+    private static boolean hasClassSource(TestIdentifier testIdentifier) {
+        return getClassSource(testIdentifier).isPresent();
+    }
+
+    private static Optional<ClassSource> getClassSource(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+            .filter(source -> source instanceof ClassSource)
+            .map(source -> (ClassSource) source);
+    }
+
+    private boolean hasDifferentSourceThanAncestor(TestIdentifier testIdentifier) {
+        Optional<TestIdentifier> parent = currentTestPlan.getParent(testIdentifier);
+        while (parent.isPresent()) {
+            if (Objects.equals(parent.get().getSource(), testIdentifier.getSource())) {
+                return false;
+            }
+            parent = currentTestPlan.getParent(parent.get());
+        }
+        return true;
     }
 
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
@@ -94,7 +94,7 @@ abstract class JUnitMultiVersionIntegrationSpec extends MultiVersionIntegrationS
         if (isJupiter()) {
             return "org.junit.jupiter:junit-jupiter-api:${dependencyVersion}','org.junit.jupiter:junit-jupiter-engine:${dependencyVersion}"
         } else if (isVintage()) {
-            return "org.junit.vintage:junit-vintage-engine:${dependencyVersion}','junit:junit:4.13','org.junit.jupiter:junit-jupiter-api:${dependencyVersion}"
+            return "org.junit.vintage:junit-vintage-engine:${dependencyVersion}','junit:junit:4.13"
         } else {
             return "junit:junit:${version}"
         }


### PR DESCRIPTION
### Context

This change partially reverts #13250, in particular the changes done to
`JUnitPlatformTestExecutionListener` which tried to determine whether a
custom display name was used based on the `DisplayName` annotation from
JUnit Jupiter. There were a couple of problems with that approach: it
did not support other test engines which might have other annotations,
it did not support composed annotations or other ways of setting the
display name (e.g. Jupiter's `DisplayNameGenerator` API).

We now use a simple heuristic that checks whether the class display name
is the simple name of the test class which is used as the default
display name for Jupiter, Vintage, and other test engines. Instead of
applying this heuristic eagerly and disposing the display name, we now
do it in `JUnitXmlResultWriter` which allows to reuse it for the
test-distribution plugin.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
