### PR TITLE
Allow configuring the maximum number of hierarchies to watch

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -124,8 +124,18 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
      */
     public static final String VFS_DROP_PROPERTY = "org.gradle.unsafe.vfs.drop";
 
+    private static final int DEFAULT_MAX_HIERARCHIES_TO_WATCH = 50;
+    public static final String MAX_HIERARCHIES_TO_WATCH_PROPERTY = "org.gradle.vfs.watch.hierarchies.max";
+
     public static boolean isDropVfs(StartParameter startParameter) {
         return isSystemPropertyEnabled(VFS_DROP_PROPERTY, startParameter.getSystemPropertiesArgs());
+    }
+
+    public static int getMaximumNumberOfWatchedHierarchies(StartParameter startParameter) {
+        String fromProperty = getSystemProperty(MAX_HIERARCHIES_TO_WATCH_PROPERTY, startParameter.getSystemPropertiesArgs());
+        return fromProperty != null && !fromProperty.isEmpty()
+            ? Integer.parseInt(fromProperty, 10)
+            : DEFAULT_MAX_HIERARCHIES_TO_WATCH;
     }
 
     public static boolean isDeprecatedVfsRetentionPropertyPresent(StartParameter startParameter) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -67,7 +67,7 @@ public interface FileWatcherRegistry extends Closeable {
      * @return the snapshot hierarchy without snapshots which can't be kept till the next build.
      */
     @CheckReturnValue
-    SnapshotHierarchy buildFinished(SnapshotHierarchy root);
+    SnapshotHierarchy buildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies);
 
     /**
      * Get statistics about the received changes.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -41,10 +41,10 @@ public interface FileWatcherUpdater {
     /**
      * Remove everything from the root which can't be kept after the current build finished.
      *
-     * @see FileWatcherRegistry#buildFinished(SnapshotHierarchy)
+     * @see FileWatcherRegistry#buildFinished(SnapshotHierarchy, int)
      */
     @CheckReturnValue
-    SnapshotHierarchy buildFinished(SnapshotHierarchy root);
+    SnapshotHierarchy buildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies);
 
     int getNumberOfWatchedHierarchies();
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
@@ -29,7 +29,6 @@ import java.util.function.Predicate;
 
 public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileEventFunctions> implements FileWatcherRegistryFactory {
     private static final int FILE_EVENT_QUEUE_SIZE = 4096;
-    private static final int DEFAULT_MAX_HIERARCHIES_TO_WATCH = 50;
 
     protected final T fileEventFunctions;
     private final Predicate<String> watchFilter;
@@ -44,7 +43,7 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileE
         BlockingQueue<FileWatchEvent> fileEvents = new ArrayBlockingQueue<>(FILE_EVENT_QUEUE_SIZE);
         try {
             FileWatcher watcher = createFileWatcher(fileEvents);
-            FileWatcherUpdater fileWatcherUpdater = createFileWatcherUpdater(watcher, watchFilter, DEFAULT_MAX_HIERARCHIES_TO_WATCH);
+            FileWatcherUpdater fileWatcherUpdater = createFileWatcherUpdater(watcher, watchFilter);
             return new DefaultFileWatcherRegistry(
                 watcher,
                 handler,
@@ -59,5 +58,5 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractFileE
 
     protected abstract FileWatcher createFileWatcher(BlockingQueue<FileWatchEvent> fileEvents) throws InterruptedException;
 
-    protected abstract FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch);
+    protected abstract FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter);
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -45,8 +45,8 @@ public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistr
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
-        return new HierarchicalFileWatcherUpdater(watcher, DarwinFileWatcherRegistryFactory::validateLocationToWatch, watchFilter, maxHierarchiesToWatch);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
+        return new HierarchicalFileWatcherUpdater(watcher, DarwinFileWatcherRegistryFactory::validateLocationToWatch, watchFilter);
     }
 
     private static void validateLocationToWatch(File location) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -124,8 +124,8 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
     }
 
     @Override
-    public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
-        return fileWatcherUpdater.buildFinished(root);
+    public SnapshotHierarchy buildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies) {
+        return fileWatcherUpdater.buildFinished(root, maximumNumberOfWatchedHierarchies);
     }
 
     private static Type convertType(FileWatchEvent.ChangeType type) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -63,10 +63,10 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     private final WatchableHierarchies watchableHierarchies;
     private final WatchedHierarchies watchedHierarchies = new WatchedHierarchies();
 
-    public HierarchicalFileWatcherUpdater(FileWatcher fileWatcher, FileSystemLocationToWatchValidator locationToWatchValidator, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+    public HierarchicalFileWatcherUpdater(FileWatcher fileWatcher, FileSystemLocationToWatchValidator locationToWatchValidator, Predicate<String> watchFilter) {
         this.fileWatcher = fileWatcher;
         this.locationToWatchValidator = locationToWatchValidator;
-        this.watchableHierarchies = new WatchableHierarchies(watchFilter, maxHierarchiesToWatch);
+        this.watchableHierarchies = new WatchableHierarchies(watchFilter);
     }
 
     @Override
@@ -93,11 +93,12 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
+    public SnapshotHierarchy buildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies) {
         WatchableHierarchies.Invalidator invalidator = (location, currentRoot) -> currentRoot.invalidate(location, SnapshotHierarchy.NodeDiffListener.NOOP);
         SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
             root,
             watchedHierarchies::contains,
+            maximumNumberOfWatchedHierarchies,
             invalidator
         );
         newRoot = watchableHierarchies.removeUnwatchedSnapshots(
@@ -151,5 +152,4 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
         void validateLocationToWatch(File location);
     }
-
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
@@ -39,7 +39,7 @@ public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistry
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
-        return new NonHierarchicalFileWatcherUpdater(watcher, watchFilter, maxHierarchiesToWatch);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
+        return new NonHierarchicalFileWatcherUpdater(watcher, watchFilter);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -51,9 +51,9 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
     private final WatchableHierarchies watchableHierarchies;
 
-    public NonHierarchicalFileWatcherUpdater(FileWatcher fileWatcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
+    public NonHierarchicalFileWatcherUpdater(FileWatcher fileWatcher, Predicate<String> watchFilter) {
         this.fileWatcher = fileWatcher;
-        this.watchableHierarchies = new WatchableHierarchies(watchFilter, maxHierarchiesToWatch);
+        this.watchableHierarchies = new WatchableHierarchies(watchFilter);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public SnapshotHierarchy buildFinished(SnapshotHierarchy root) {
+    public SnapshotHierarchy buildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies) {
         WatchableHierarchies.Invalidator invalidator = (location, currentRoot) -> {
             SnapshotCollectingDiffListener diffListener = new SnapshotCollectingDiffListener();
             SnapshotHierarchy invalidatedRoot = currentRoot.invalidate(location, diffListener);
@@ -93,7 +93,10 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
             return invalidatedRoot;
         };
         SnapshotHierarchy newRoot = watchableHierarchies.removeWatchedHierarchiesOverLimit(
-            root, hierarchy -> containsSnapshots(hierarchy, root), invalidator
+            root,
+            hierarchy -> containsSnapshots(hierarchy, root),
+            maximumNumberOfWatchedHierarchies,
+            invalidator
         );
         newRoot = watchableHierarchies.removeUnwatchedSnapshots(
             newRoot,

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -45,7 +45,7 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
     }
 
     @Override
-    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
-        return new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter, maxHierarchiesToWatch);
+    protected FileWatcherUpdater createFileWatcherUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
+        return new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter);
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -43,5 +43,5 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is finished.
      */
-    void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner);
+    void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -79,7 +79,7 @@ public class WatchingNotSupportedVirtualFileSystem implements BuildLifecycleAwar
     }
 
     @Override
-    public void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner) {
+    public void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
         rootReference.update(vfsRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -161,7 +161,7 @@ public class WatchingVirtualFileSystem implements BuildLifecycleAwareVirtualFile
     }
 
     @Override
-    public void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner) {
+    public void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {
@@ -179,7 +179,7 @@ public class WatchingVirtualFileSystem implements BuildLifecycleAwareVirtualFile
                     SnapshotHierarchy newRoot = stopWatchingIfProblemsWhenReceivingFileChanges(currentRoot, statistics);
                     if (watchRegistry != null) {
                         SnapshotHierarchy rootAfterEvents = newRoot;
-                        newRoot = withWatcherChangeErrorHandling(newRoot, () -> watchRegistry.buildFinished(rootAfterEvents));
+                        newRoot = withWatcherChangeErrorHandling(newRoot, () -> watchRegistry.buildFinished(rootAfterEvents, maximumNumberOfWatchedHierarchies));
                     }
                     boolean stoppedWatchingDuringTheBuild = watchRegistry == null;
                     FileSystemWatchingStatistics fileSystemWatchingStatistics = statistics == null ? null : new DefaultFileSystemWatchingStatistics(statistics, newRoot);

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -70,10 +70,10 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     }
 
     def setup() {
-        updater = createUpdater(watcher, watchFilter, Integer.MAX_VALUE)
+        updater = createUpdater(watcher, watchFilter)
     }
 
-    abstract FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch)
+    abstract FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter)
 
     def "does not watch directories outside of hierarchies to watch"() {
         def watchableHierarchies = ["first", "second", "third"].collect { file(it).createDir() }
@@ -192,7 +192,6 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
 
     def "stops watching hierarchies when maximum number of hierarchies to watch has been reached"() {
         int maxHierarchiesToWatch = 4
-        updater = createUpdater(watcher, watchFilter, maxHierarchiesToWatch)
         def oldestRegisteredWatchableHierarchy = file("oldestWatchable").createDir()
         def watchableHierarchies = (1..maxHierarchiesToWatch - 1).collect { index -> file("watchable${index}").createDir() }
         def newestRegisteredWatchableHierarchy = file("newestWatchable").createDir()
@@ -217,7 +216,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         1 * watcher.startWatching({ equalIgnoringOrder(it, [newestRegisteredWatchableHierarchy]) })
 
         when:
-        buildFinished()
+        buildFinished(maxHierarchiesToWatch)
         then:
         1 * watcher.stopWatching({ equalIgnoringOrder(it, [oldestRegisteredWatchableHierarchy]) })
 
@@ -286,9 +285,9 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         }
     }
 
-    void buildFinished() {
+    void buildFinished(int maximumNumberOfWatchedHierarchies = Integer.MAX_VALUE) {
         virtualFileSystem.update { root, diffListener ->
-            updater.buildFinished(root)
+            updater.buildFinished(root, maximumNumberOfWatchedHierarchies)
         }
     }
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -29,8 +29,8 @@ import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpd
 class HierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
-    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
-        new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter, maxHierarchiesToWatch)
+    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
+        new HierarchicalFileWatcherUpdater(watcher, NO_VALIDATION, watchFilter)
     }
 
     def "does not watch hierarchy to watch if no snapshot is inside"() {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -24,8 +24,8 @@ import java.util.function.Predicate
 class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 
     @Override
-    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter, int maxHierarchiesToWatch) {
-        new NonHierarchicalFileWatcherUpdater(watcher, watchFilter, maxHierarchiesToWatch)
+    FileWatcherUpdater createUpdater(FileWatcher watcher, Predicate<String> watchFilter) {
+        new NonHierarchicalFileWatcherUpdater(watcher, watchFilter)
     }
 
     def "only watches directories in hierarchies to watch"() {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -40,7 +40,7 @@ class WatchingNotSupportedVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingNotSupportedHandler.beforeBuildFinished(retentionEnabled, buildOperationRunner)
+        watchingNotSupportedHandler.beforeBuildFinished(retentionEnabled, buildOperationRunner, Integer.MAX_VALUE)
         then:
         rootReference.getRoot() == emptySnapshotHierarchy
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -55,7 +55,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.beforeBuildFinished(false, buildOperationRunner)
+        watchingVirtualFileSystem.beforeBuildFinished(false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         0 * _
 
@@ -70,10 +70,10 @@ class WatchingVirtualFileSystemTest extends Specification {
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner)
+        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
-        1 * watcherRegistry.buildFinished(_) >> rootReference.getRoot()
+        1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
         0 * _
 
         when:
@@ -94,10 +94,10 @@ class WatchingVirtualFileSystemTest extends Specification {
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner)
+        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
-        1 * watcherRegistry.buildFinished(_) >> rootReference.getRoot()
+        1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
         0 * _
 
         when:
@@ -133,10 +133,10 @@ class WatchingVirtualFileSystemTest extends Specification {
         1 * watcherRegistry.registerWatchableHierarchy(anotherWatchableHierarchy, _)
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner)
+        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
-        1 * watcherRegistry.buildFinished(_) >> rootReference.getRoot()
+        1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
         0 * _
 
         when:

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -54,7 +54,8 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         try {
             return delegate.run(action, buildController);
         } finally {
-            virtualFileSystem.beforeBuildFinished(watchFileSystem, buildOperationRunner);
+            int maximumNumberOfWatchedHierarchies = VirtualFileSystemServices.getMaximumNumberOfWatchedHierarchies(startParameter);
+            virtualFileSystem.beforeBuildFinished(watchFileSystem, buildOperationRunner, maximumNumberOfWatchedHierarchies);
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -60,7 +60,7 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
         1 * delegate.run(buildAction, buildController)
 
         then:
-        1 * watchingHandler.beforeBuildFinished(watchFsEnabled, buildOperationRunner)
+        1 * watchingHandler.beforeBuildFinished(watchFsEnabled, buildOperationRunner, _)
 
         where:
         watchFsEnabled << [true, false]


### PR DESCRIPTION
This PR introduces the system property `org.gradle.vfs.watch.hierarchies.max` which controls the maximum number of hierarchies to watch.

Fixes #14114 .
