### PR TITLE
Add support for asdf-vm and linux java installations

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -49,6 +49,7 @@ import org.gradle.jvm.toolchain.internal.JabbaInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe;
 import org.gradle.jvm.toolchain.internal.JavaToolchainFactory;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
+import org.gradle.jvm.toolchain.internal.LinuxInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
@@ -81,15 +82,16 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
     }
 
     private void registerJavaInstallationSuppliers(ServiceRegistration registration) {
-        registration.add(LocationListInstallationSupplier.class);
-        registration.add(EnvironmentVariableListInstallationSupplier.class);
-        registration.add(CurrentInstallationSupplier.class);
-        registration.add(SdkmanInstallationSupplier.class);
-        registration.add(JabbaInstallationSupplier.class);
-        registration.add(AutoInstalledInstallationSupplier.class);
-        registration.add(OsXInstallationSupplier.class);
-        registration.add(WindowsInstallationSupplier.class);
         registration.add(AsdfInstallationSupplier.class);
+        registration.add(AutoInstalledInstallationSupplier.class);
+        registration.add(CurrentInstallationSupplier.class);
+        registration.add(EnvironmentVariableListInstallationSupplier.class);
+        registration.add(JabbaInstallationSupplier.class);
+        registration.add(LinuxInstallationSupplier.class);
+        registration.add(LocationListInstallationSupplier.class);
+        registration.add(OsXInstallationSupplier.class);
+        registration.add(SdkmanInstallationSupplier.class);
+        registration.add(WindowsInstallationSupplier.class);
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -40,6 +40,7 @@ import org.gradle.jvm.toolchain.install.internal.AdoptOpenJdkDownloader;
 import org.gradle.jvm.toolchain.install.internal.AdoptOpenJdkRemoteBinary;
 import org.gradle.jvm.toolchain.install.internal.DefaultJavaToolchainProvisioningService;
 import org.gradle.jvm.toolchain.install.internal.JdkCacheDirectory;
+import org.gradle.jvm.toolchain.internal.AsdfInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.AutoInstalledInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.CurrentInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.DefaultJavaInstallationRegistry;
@@ -88,6 +89,7 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
         registration.add(AutoInstalledInstallationSupplier.class);
         registration.add(OsXInstallationSupplier.class);
         registration.add(WindowsInstallationSupplier.class);
+        registration.add(AsdfInstallationSupplier.class);
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
@@ -24,9 +24,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
 
 public class AsdfInstallationSupplier extends AutoDetectingInstallationSupplier {
 
@@ -43,19 +40,9 @@ public class AsdfInstallationSupplier extends AutoDetectingInstallationSupplier 
 
     private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {
         return candidatesDir -> {
-            final File[] javaCandidates = new File(candidatesDir, "installs/java").listFiles();
-            if (javaCandidates == null) {
-                return Collections.emptySet();
-            }
-            return Stream.of(javaCandidates)
-                .filter(File::isDirectory)
-                .map(this::asInstallation)
-                .collect(toSet());
+            final File root = new File(candidatesDir, "installs/java");
+            return FileBasedInstallationFactory.fromDirectory(root, "asdf-vm");
         };
-    }
-
-    private InstallationLocation asInstallation(File file) {
-        return new InstallationLocation(file, "asdf-vm");
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+public class AsdfInstallationSupplier extends AutoDetectingInstallationSupplier {
+
+    @Inject
+    public AsdfInstallationSupplier(ProviderFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    protected Set<InstallationLocation> findCandidates() {
+        final Provider<String> asdfHome = getEnvironmentProperty("ASDF_DIR");
+        return asdfHome.map(findJavaCandidates()).getOrElse(Collections.emptySet());
+    }
+
+    private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {
+        return candidatesDir -> {
+            final File[] javaCandidates = new File(candidatesDir, "installs/java").listFiles();
+            if (javaCandidates == null) {
+                return Collections.emptySet();
+            }
+            return Stream.of(javaCandidates)
+                .filter(File::isDirectory)
+                .map(this::asInstallation)
+                .collect(toSet());
+        };
+    }
+
+    private InstallationLocation asInstallation(File file) {
+        return new InstallationLocation(file, "asdf-vm");
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/FileBasedInstallationFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/FileBasedInstallationFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+public class FileBasedInstallationFactory {
+
+    public static Set<InstallationLocation> fromDirectory(File rootDirectory, String supplierName) {
+        final File[] javaCandidates = rootDirectory.listFiles();
+        if (javaCandidates == null) {
+            return Collections.emptySet();
+        }
+        return Stream.of(javaCandidates)
+            .filter(File::isDirectory)
+            .map(d -> new InstallationLocation(d, supplierName))
+            .collect(toSet());
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JabbaInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JabbaInstallationSupplier.java
@@ -24,9 +24,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
 
 public class JabbaInstallationSupplier extends AutoDetectingInstallationSupplier {
 
@@ -43,19 +40,9 @@ public class JabbaInstallationSupplier extends AutoDetectingInstallationSupplier
 
     private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {
         return jabbaHome -> {
-            final File[] javaCandidates = new File(jabbaHome, "jdk").listFiles();
-            if (javaCandidates == null) {
-                return Collections.emptySet();
-            }
-            return Stream.of(javaCandidates)
-                .filter(File::isDirectory)
-                .map(this::asInstallation)
-                .collect(toSet());
+            final File root = new File(jabbaHome, "jdk");
+            return FileBasedInstallationFactory.fromDirectory(root, "jabba");
         };
-    }
-
-    private InstallationLocation asInstallation(File file) {
-        return new InstallationLocation(file, "jabba");
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
@@ -33,7 +33,7 @@ public class LinuxInstallationSupplier extends AutoDetectingInstallationSupplier
         this(factory, "/usr/lib/jvm", "/usr/java");
     }
 
-    public LinuxInstallationSupplier(ProviderFactory factory, String... roots) {
+    private LinuxInstallationSupplier(ProviderFactory factory, String... roots) {
         super(factory);
         this.roots = roots;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
@@ -17,33 +17,40 @@
 package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.os.OperatingSystem;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class LinuxInstallationSupplier extends AutoDetectingInstallationSupplier {
 
     private final String[] roots;
+    private final OperatingSystem os;
 
     @Inject
     public LinuxInstallationSupplier(ProviderFactory factory) {
-        this(factory, "/usr/lib/jvm", "/usr/java");
+        this(factory, OperatingSystem.current(), "/usr/lib/jvm", "/usr/java");
     }
 
-    private LinuxInstallationSupplier(ProviderFactory factory, String... roots) {
+    private LinuxInstallationSupplier(ProviderFactory factory, OperatingSystem os, String... roots) {
         super(factory);
         this.roots = roots;
+        this.os = os;
     }
 
     @Override
     protected Set<InstallationLocation> findCandidates() {
-        return Arrays.stream(roots)
-            .map(root -> FileBasedInstallationFactory.fromDirectory(new File(root), "linux"))
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        if (os.isLinux()) {
+            return Arrays.stream(roots)
+                .map(root -> FileBasedInstallationFactory.fromDirectory(new File(root), "linux"))
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LinuxInstallationSupplier extends AutoDetectingInstallationSupplier {
+
+    private final String[] roots;
+
+    @Inject
+    public LinuxInstallationSupplier(ProviderFactory factory) {
+        this(factory, "/usr/lib/jvm", "/usr/java");
+    }
+
+    public LinuxInstallationSupplier(ProviderFactory factory, String... roots) {
+        super(factory);
+        this.roots = roots;
+    }
+
+    @Override
+    protected Set<InstallationLocation> findCandidates() {
+        return Arrays.stream(roots)
+            .map(root -> FileBasedInstallationFactory.fromDirectory(new File(root), "linux"))
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java
@@ -24,9 +24,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
 
 public class SdkmanInstallationSupplier extends AutoDetectingInstallationSupplier {
 
@@ -43,19 +40,9 @@ public class SdkmanInstallationSupplier extends AutoDetectingInstallationSupplie
 
     private Transformer<Set<InstallationLocation>, String> findJavaCandidates() {
         return candidatesDir -> {
-            final File[] javaCandidates = new File(candidatesDir, "java").listFiles();
-            if (javaCandidates == null) {
-                return Collections.emptySet();
-            }
-            return Stream.of(javaCandidates)
-                .filter(File::isDirectory)
-                .map(this::asInstallation)
-                .collect(toSet());
+            final File root = new File(candidatesDir, "java");
+            return FileBasedInstallationFactory.fromDirectory(root, "SDKMAN");
         };
-    }
-
-    private InstallationLocation asInstallation(File file) {
-        return new InstallationLocation(file, "SDKMAN");
     }
 
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplierTest.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
+
+class AsdfInstallationSupplierTest extends Specification {
+
+    @Rule
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
+
+    def asdfHomeDirectory = temporaryFolder.createDir("asdf")
+
+    def "supplies no installations for absent property"() {
+        given:
+        def supplier = createSupplier(null)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+
+    def "supplies no installations for empty property"() {
+        given:
+        def supplier = createSupplier("")
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations for non-existing directory"() {
+        assert asdfHomeDirectory.delete()
+
+        given:
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations for empty directory"() {
+        given:
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies single installations for single candidate"() {
+        given:
+        asdfHomeDirectory.createDir("installs/java/11.0.6.hs-adpt")
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([new File(asdfHomeDirectory, "installs/java/11.0.6.hs-adpt").absolutePath])
+        directories*.source == ["asdf-vm"]
+    }
+
+    def "supplies multiple installations for multiple paths"() {
+        given:
+        asdfHomeDirectory.createDir("installs/java/11.0.6.hs-adpt")
+        asdfHomeDirectory.createDir("installs/java/14")
+        asdfHomeDirectory.createDir("installs/java/8.0.262.fx-librca")
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(asdfHomeDirectory, "installs/java/11.0.6.hs-adpt").absolutePath,
+            new File(asdfHomeDirectory, "installs/java/14").absolutePath,
+            new File(asdfHomeDirectory, "installs/java/8.0.262.fx-librca").absolutePath
+        ])
+        directories*.source == ["asdf-vm", "asdf-vm", "asdf-vm"]
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "supplies installations with symlinked candidate"() {
+        given:
+        def otherLocation = temporaryFolder.createDir("other")
+        def javaCandidates = asdfHomeDirectory.createDir("installs/java")
+        javaCandidates.createDir("14-real")
+        javaCandidates.file("other-symlinked").createLink(otherLocation.canonicalFile)
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(asdfHomeDirectory, "installs/java/14-real").absolutePath,
+            new File(asdfHomeDirectory, "installs/java/other-symlinked").absolutePath
+        ])
+        directories*.source == ["asdf-vm", "asdf-vm"]
+    }
+
+    def directoriesAsStablePaths(Set<InstallationLocation> actualDirectories) {
+        actualDirectories*.location.absolutePath.sort()
+    }
+
+    def stablePaths(List<String> expectedPaths) {
+        expectedPaths.replaceAll({ String s -> systemSpecificAbsolutePath(s) })
+        expectedPaths
+    }
+
+    AsdfInstallationSupplier createSupplier(String propertyValue) {
+        new AsdfInstallationSupplier(createProviderFactory(propertyValue))
+    }
+
+    ProviderFactory createProviderFactory(String propertyValue) {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.environmentVariable("ASDF_DIR") >> Providers.ofNullable(propertyValue)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
+        providerFactory
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplierTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.jvm.toolchain.internal
 
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
@@ -57,12 +58,24 @@ class LinuxInstallationSupplierTest extends Specification {
         def directories = supplier.get()
 
         then:
-        directories.isEmpty()
+        directories != null
     }
 
     def "supplies no installations for empty directory"() {
         given:
         def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations non-linux operating system"() {
+        given:
+        candidates.createDir("11.0.6.hs-adpt")
+        def supplier = new LinuxInstallationSupplier(createProviderFactory(), OperatingSystem.WINDOWS, candidates.absolutePath)
 
         when:
         def directories = supplier.get()
@@ -149,7 +162,7 @@ class LinuxInstallationSupplierTest extends Specification {
     }
 
     InstallationSupplier createSupplier(String... roots) {
-        new LinuxInstallationSupplier(createProviderFactory(), roots)
+        new LinuxInstallationSupplier(createProviderFactory(), OperatingSystem.LINUX, roots)
     }
 
     ProviderFactory createProviderFactory(String propertyValue) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplierTest.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
+
+@CleanupTestDirectory
+class LinuxInstallationSupplierTest extends Specification {
+
+    @Rule
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
+
+    def candidates = temporaryFolder.createDir("linux")
+    def otherCandidates = temporaryFolder.createDir("centos")
+
+    def "supplies no installations for non-existing directory"() {
+        assert candidates.delete()
+
+        given:
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "detects installations in default roots"() {
+        given:
+        def supplier = new LinuxInstallationSupplier(createProviderFactory())
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies no installations for empty directory"() {
+        given:
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+    }
+
+    def "supplies single installations for single candidate"() {
+        given:
+        candidates.createDir("11.0.6.hs-adpt")
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([new File(candidates, "11.0.6.hs-adpt").absolutePath])
+        directories*.source == ["linux"]
+    }
+
+    def "supplies multiple installations for multiple paths"() {
+        given:
+        candidates.createDir("11.0.6.hs-adpt")
+        candidates.createDir("14")
+        candidates.createDir("8.0.262.fx-librca")
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(candidates, "11.0.6.hs-adpt").absolutePath,
+            new File(candidates, "14").absolutePath,
+            new File(candidates, "8.0.262.fx-librca").absolutePath
+        ])
+        directories*.source == ["linux", "linux", "linux"]
+    }
+
+    def "supplies installations for multiple locations"() {
+        given:
+        candidates.createDir("11.0.6.hs-adpt")
+        otherCandidates.createDir("8.0.262.fx-librca")
+        def supplier = createSupplier(candidates.absolutePath, otherCandidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(otherCandidates, "8.0.262.fx-librca").absolutePath,
+            new File(candidates, "11.0.6.hs-adpt").absolutePath
+        ])
+        directories*.source == ["linux", "linux"]
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "supplies installations with symlinked candidate"() {
+        given:
+        def otherLocation = temporaryFolder.createDir("other")
+        candidates.createDir("14-real")
+        candidates.file("other-symlinked").createLink(otherLocation.canonicalFile)
+        def supplier = createSupplier(candidates.absolutePath)
+
+        when:
+        def directories = supplier.get()
+
+        then:
+        directoriesAsStablePaths(directories) == stablePaths([
+            new File(candidates, "14-real").absolutePath,
+            new File(candidates, "other-symlinked").absolutePath
+        ])
+        directories*.source == ["linux", "linux"]
+    }
+
+    def directoriesAsStablePaths(Set<InstallationLocation> actualDirectories) {
+        actualDirectories*.location.absolutePath.sort()
+    }
+
+    def stablePaths(List<String> expectedPaths) {
+        expectedPaths.replaceAll({ String s -> systemSpecificAbsolutePath(s) })
+        expectedPaths
+    }
+
+    InstallationSupplier createSupplier(String... roots) {
+        new LinuxInstallationSupplier(createProviderFactory(), roots)
+    }
+
+    ProviderFactory createProviderFactory(String propertyValue) {
+        def providerFactory = Mock(ProviderFactory)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
+        providerFactory
+    }
+}


### PR DESCRIPTION
Support for the asdf package manager.
Support for ubuntu and centos. These use the common location for package managers (yum, apt) as well as
using local rpm packages.

Fixes #13871