### PR TITLE
Allow running performance tests on Windows

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -354,7 +354,7 @@ tasks.register("k9AndroidBuild", RemoteProject) {
 tasks.register("largeAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
     // From android-35 branch
-    ref = "36143205842725fb1bd33f5ffc4667ccd0336641"
+    ref = "ea980c1d903491aae18ecdea2abb9c60cc520239"
 }
 
 tasks.register("santaTrackerAndroidBuild", RemoteProject) {
@@ -463,7 +463,7 @@ tasks.register("excludeRuleMergingBuild", RemoteProject) {
 tasks.register("springBootApp", RemoteProject) {
     remoteUri = 'https://github.com/gradle/performance-comparisons.git'
     // From master branch
-    ref = "13739fa299e485c079335b0cd5b30da1cff92234"
+    ref = "cbfe4c63fa570200624575c75bafb556d3eb4bdd"
     subdirectory = 'parallel-downloads'
 }
 

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
@@ -68,17 +68,20 @@ abstract class RemoteProject extends DefaultTask {
         moveToOutputDir(checkoutDir, outputDirectory, subdirectory.getOrNull())
     }
 
-    private static File cleanTemporaryDir(Task task) {
-        File tmpDir = task.getTemporaryDir()
+    private static File cleanTemporaryDir(Task task, File tmpDir) {
         if (tmpDir.exists()) {
             task.project.delete(tmpDir)
         }
         return tmpDir
     }
 
-    @TypeChecked(TypeCheckingMode.SKIP)
     static File checkout(Task task, String remoteUri, String ref) {
-        File checkoutDir = cleanTemporaryDir(task)
+        checkout(task, remoteUri, ref, task.getTemporaryDir())
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    static File checkout(Task task, String remoteUri, String ref, File checkoutDir) {
+        cleanTemporaryDir(task, checkoutDir)
         task.project.exec {
             commandLine = ["git", "clone", "--no-checkout", remoteUri, checkoutDir.absolutePath]
             errorOutput = System.out

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -270,7 +270,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             createDistributedPerformanceTestTask(name, clazz, performanceSourceSet, prepareSamplesTask).configure(configure)
         }
 
-        val channelSuffix = if (OperatingSystem.current().isLinux) "" else "-${OperatingSystem.current().name.toLowerCase()}"
+        val channelSuffix = if (OperatingSystem.current().isLinux) "" else "-${OperatingSystem.current().familyName.toLowerCase()}"
 
         create("distributedPerformanceTest", DistributedPerformanceTest::class) {
             includeCategories(performanceRegressionTestCategory)

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.caching.http.HttpBuildCache
+import org.gradle.internal.os.OperatingSystem
 import java.io.File
 
 
@@ -73,7 +74,7 @@ abstract class BuildCommitDistribution : DefaultTask() {
     fun getBuildCommands(): Array<String> {
         project.delete(commitDistributionHome.get().asFile)
         val buildCommands = mutableListOf(
-            "./gradlew",
+            "./gradlew" + (if (OperatingSystem.current().isWindows()) ".bat" else ""),
             "clean",
             ":distributions-full:install",
             "-Pgradle_installPath=" + commitDistributionHome.get().asFile.absolutePath,

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
 import javax.inject.Inject
 
@@ -50,7 +51,7 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
             determinedBaselines.set(defaultBaseline)
         } else if (configuredBaselines.getOrElse("") == flakinessDetectionCommitBaseline) {
             determinedBaselines.set(determineFlakinessDetectionBaseline())
-        } else if (!currentBranchIsMasterOrRelease() && configuredBaselines.isDefaultValue()) {
+        } else if (!currentBranchIsMasterOrRelease() && !OperatingSystem.current().isWindows && configuredBaselines.isDefaultValue()) {
             determinedBaselines.set(forkPointCommitBaseline())
         } else {
             determinedBaselines.set(configuredBaselines)
@@ -78,7 +79,11 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
     private
     fun forkPointCommitBaseline(): String {
         val upstream = tryGetUpstream()
-        val source = if (upstream == null) { "origin" } else { upstream }
+        val source = if (upstream == null) {
+            "origin"
+        } else {
+            upstream
+        }
         project.execAndGetStdout("git", "fetch", source, "master", "release")
         val masterForkPointCommit = project.execAndGetStdout("git", "merge-base", "origin/master", "HEAD")
         val releaseForkPointCommit = project.execAndGetStdout("git", "merge-base", "origin/release", "HEAD")

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -24,6 +24,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
 
 

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -19,13 +19,12 @@ package gradlebuild.performance.tasks
 import gradlebuild.basics.kotlindsl.execAndGetStdout
 import gradlebuild.identity.extension.ModuleIdentityExtension
 import gradlebuild.performance.Config
-import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
+import javax.inject.Inject
 
 
 const val defaultBaseline = "defaults"

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -52,6 +52,7 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
         } else if (configuredBaselines.getOrElse("") == flakinessDetectionCommitBaseline) {
             determinedBaselines.set(determineFlakinessDetectionBaseline())
         } else if (!currentBranchIsMasterOrRelease() && !OperatingSystem.current().isWindows && configuredBaselines.isDefaultValue()) {
+            // Windows git complains "long path" so we don't build commit distribution on Windows
             determinedBaselines.set(forkPointCommitBaseline())
         } else {
             determinedBaselines.set(configuredBaselines)

--- a/buildSrc/subprojects/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/buildSrc/subprojects/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -22,9 +22,11 @@ import gradlebuild.identity.extension.ModuleIdentityExtension
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 
@@ -69,6 +71,7 @@ class DetermineBaselinesTest {
 
     @Test
     fun `determines fork point commit on feature branch and default configuration`() {
+        Assume.assumeFalse(OperatingSystem.current().isWindows)
         // given
         setCurrentBranch("my-branch")
         mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")
@@ -83,6 +86,7 @@ class DetermineBaselinesTest {
 
     @Test
     fun `determines fork point commit on feature branch and empty configuration`() {
+        Assume.assumeFalse(OperatingSystem.current().isWindows)
         // given
         setCurrentBranch("my-branch")
         mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")

--- a/buildSrc/subprojects/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/buildSrc/subprojects/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -71,6 +71,7 @@ class DetermineBaselinesTest {
 
     @Test
     fun `determines fork point commit on feature branch and default configuration`() {
+        // Windows git complains "long path" so we don't build commit distribution on Windows
         Assume.assumeFalse(OperatingSystem.current().isWindows)
         // given
         setCurrentBranch("my-branch")
@@ -86,6 +87,7 @@ class DetermineBaselinesTest {
 
     @Test
     fun `determines fork point commit on feature branch and empty configuration`() {
+        // Windows git complains "long path" so we don't build commit distribution on Windows
         Assume.assumeFalse(OperatingSystem.current().isWindows)
         // given
         setCurrentBranch("my-branch")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AbstractRealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AbstractRealLifeAndroidBuildPerformanceTest.groovy
@@ -27,7 +27,7 @@ class AbstractRealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGr
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         // AGP 3.6 requires 5.6.1+
         // forUseAtConfigurationTime API used in this senario
         runner.minimumBaseVersion = "6.5"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -28,7 +28,7 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
         experiment(testProject) {
             // AGP 3.5 requires 5.4.1+
             minimumBaseVersion = "5.4.1"
-            targetVersions = ["6.7-20200816220041+0000"]
+            targetVersions = ["6.7-20200824220048+0000"]
             action('org.gradle.performance.android.SyncAction') {
                 jvmArguments = ["-Xms5g", "-Xmx5g"]
             }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -43,7 +43,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumBaseVersion = "3.5"
-        runner.targetVersions = ["6.7-20200804220106+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     def "clean #tasks on #testProject with remote http cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
@@ -17,13 +17,16 @@
 package org.gradle.performance.regression.buildcache
 
 import org.gradle.initialization.ParallelismBuildOptions
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class TaskOutputCachingNativePerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
     def setup() {
         runner.minimumBaseVersion = "4.3"
-        runner.targetVersions = ["6.7-20200804220106+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args += ["-Dorg.gradle.caching.native=true", "--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -23,7 +23,7 @@ class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPer
 
     def setup() {
         runner.minimumBaseVersion = "4.5"
-        runner.targetVersions = ["6.7-20200804220106+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.performance.regression.buildcache
 
 import org.gradle.initialization.ParallelismBuildOptions
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
-
     def setup() {
         runner.minimumBaseVersion = "4.5"
         runner.targetVersions = ["6.7-20200824220048+0000"]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
 
 class ArchiveTreePerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     def "visiting zip trees"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -25,7 +25,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionGradleProfil
 
     def setup() {
         runner.minimumBaseVersion = '4.9'
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     def "merge exclude rules"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
@@ -30,7 +30,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionGradleProfilerPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['eclipse']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()
@@ -50,7 +50,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionGradleProfilerPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['idea']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -29,7 +29,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionGradleProf
 
     def setup() {
         runner.minimumBaseVersion = '4.8'
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     def "resolve large dependency graph from file repo"() {
@@ -55,7 +55,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionGradleProf
         given:
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = [MIN_MEMORY, MAX_MEMORY]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", '-PnoExcludes']
         if (parallel) {
             runner.args += '--parallel'

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -155,3 +155,4 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionGradleInterna
     }
 
 }
+

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
@@ -38,7 +38,7 @@ class RichConsolePerformanceTest extends AbstractCrossVersionGradleProfilerPerfo
         runner.gradleOpts = ["-Xms${daemonMemory}", "-Xmx${daemonMemory}"]
         runner.warmUpRuns = 5
         runner.runs = 8
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
@@ -25,7 +25,7 @@ class TaskCreationPerformanceTest extends AbstractCrossVersionGradleProfilerPerf
         runner.testProject = "createLotsOfTasks"
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.runs = 60
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
@@ -28,7 +28,7 @@ class VerboseTestOutputPerformanceTest extends AbstractCrossVersionGradleProfile
         runner.tasksToRun = ['cleanTest', 'test']
         runner.args = ['-q']
         runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/WorkerApiPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/WorkerApiPerformanceTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 class WorkerApiPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '5.0'
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.testProject = "workerApiProject"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -35,7 +35,7 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPer
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         if (testProject.name().contains("GROOVY")) {
             runner.minimumBaseVersion = '5.0'
         }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -34,7 +34,7 @@ class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionGradleInterna
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         runner.tasksToRun = ["clean", "assemble"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.minimumBaseVersion = minimumBaseVersion
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionGradleProfile
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaDependencyReportPerformanceTest extends AbstractCrossVersionGradleProf
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ["${subProject}dependencyReport"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["6.7-20200823220030+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -34,7 +34,7 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternal
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         if (testProject.name().contains("GROOVY")) {
             runner.minimumBaseVersion = '5.0'
         }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaTasksPerformanceTest extends AbstractCrossVersionGradleProfilerPerform
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()
@@ -50,7 +50,7 @@ class JavaTasksPerformanceTest extends AbstractCrossVersionGradleProfilerPerform
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks', '--all']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
@@ -35,7 +35,7 @@ class JavaTestChangePerformanceTest extends AbstractCrossVersionGradleInternalPe
         runner.runs = runs
         runner.tasksToRun = ['test']
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['test']))
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -33,7 +33,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionGradleProfilerPerf
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args += ["-Dorg.gradle.parallel=$parallel"]
 
         when:
@@ -55,7 +55,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionGradleProfilerPerf
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.minimumBaseVersion = "3.5"
         runner.args += ["-Dorg.gradle.parallel=$parallel", "-D${StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY}=true"]
         def cacheDir = temporaryFolder.file("local-cache")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/GradleKotlinDslBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/GradleKotlinDslBuildPerformanceTest.groovy
@@ -29,7 +29,7 @@ class GradleKotlinDslBuildPerformanceTest extends AbstractCrossVersionGradleProf
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()
@@ -49,7 +49,7 @@ class GradleKotlinDslBuildPerformanceTest extends AbstractCrossVersionGradleProf
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/KotlinDslVsGroovyDslPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/KotlinDslVsGroovyDslPerformanceTest.groovy
@@ -35,8 +35,8 @@ class KotlinDslVsGroovyDslPerformanceTest extends AbstractCrossBuildPerformanceT
 
         given:
         runner.testGroup = 'Kotlin DSL vs Groovy DSL'
-        def groovyDslBuildName = 'Groovy DSL build'
-        def kotlinDslBuildName = 'Kotlin DSL build'
+        def groovyDslBuildName = 'Groovy_DSL_build'
+        def kotlinDslBuildName = 'Kotlin_DSL_build'
 
         and:
         def warmupBuilds = 1

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
@@ -17,12 +17,15 @@
 package org.gradle.performance.regression.nativeplatform
 
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.minimumBaseVersion = "4.0"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -18,12 +18,15 @@ package org.gradle.performance.regression.nativeplatform
 
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
 import org.gradle.profiler.mutations.ApplyChangeToNativeSourceFileMutator
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class NativeBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
-        runner.targetVersions = ["6.7-20200806220106+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -18,14 +18,17 @@ package org.gradle.performance.regression.nativeplatform
 
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
 import org.gradle.performance.categories.SlowPerformanceRegressionTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 @Category(SlowPerformanceRegressionTest)
+@Requires(TestPrecondition.LINUX)
 class NativeCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
-        runner.targetVersions = ["6.7-20200809220033+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -22,12 +22,15 @@ import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListener
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
 import org.gradle.performance.measure.MeasuredOperation
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["6.7-20200806220106+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.minimumBaseVersion = "4.0"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
@@ -19,13 +19,16 @@ package org.gradle.performance.regression.nativeplatform
 import org.gradle.initialization.ParallelismBuildOptions
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
 import org.gradle.performance.mutator.AbstractFileChangeMutator
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+@Requires(TestPrecondition.LINUX)
 class SwiftBuildPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
     def setup() {
         runner.minimumBaseVersion = '4.6'
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -19,15 +19,18 @@ package org.gradle.performance.regression.nativeplatform
 import org.gradle.initialization.ParallelismBuildOptions
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
 import org.gradle.performance.categories.SlowPerformanceRegressionTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 @Category(SlowPerformanceRegressionTest)
+@Requires(TestPrecondition.LINUX)
 class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
     def setup() {
         runner.minimumBaseVersion = '4.6'
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200824220048+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }
 


### PR DESCRIPTION
(Supersedes #11157)

A step towards https://github.com/gradle/gradle-private/issues/1860.

Current problems with the performance tests:
- [x] For Android build, the AAPT2 Daemon startup fails, probably because of too long paths. See for example [this build](https://builds.gradle.org/buildConfiguration/Gradle_Check_IndividualPerformanceScenarioWorkersWindows/37375610?buildTab=overview).
  - Fixed by using `C:\gradle-perf` as checkout dir.
- [x] Make sure performance results from Windows and Linux performance tests are not mixed up in the performance database. That means that the history of a test running on Linux shouldn't show results from Windows and vice-versa.
  - Use `commits-windows`/`adhoc-windows`, etc. on Windows.
- [x] Kill other Gradle processes on Windows, see [here](https://github.com/gradle/gradle/blob/34537c967d5cc1ccbd6628b7a448ceeee998cdce/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt#L24-L35)
- [x] System property containing spaces is incorrectly escaped when passed to Gradle profiler. See for example [this build](https://builds.gradle.org/buildConfiguration/Gradle_Check_IndividualPerformanceScenarioWorkersWindows/37375786?buildTab=overview).
  - Spaces are removed.
- [x] Perf Android large doesn't work on Windows, since it expects `zip` to be available. See [here](https://github.com/gradle/perf-android-large/blob/android-36/build.gradle#L159-L163)
  - `7z` was used on Windows to perform the same action.
- [x] The Swift performance tests don't run on Windows and should be ignored there.
  - Done.
- [x] Some dependency management tests can't load dependencies from the embedded repository, check e.g. [this build](https://builds.gradle.org/buildConfiguration/Gradle_Check_IndividualPerformanceScenarioWorkersWindows/37375664?buildTab=overview).
  - Confirmed to be path length issue, fixed by shorter checkout dir.
- [x] Native tests fail with errors when linking, probably related to too long paths, see e.g. [this build](https://builds.gradle.org/buildConfiguration/Gradle_Check_IndividualPerformanceScenarioWorkersWindows/37375646?buildTab=overview).
  - Native tests are ignored.
- [x] Some other native sources don't compile on Windows, see [this build](https://builds.gradle.org/buildConfiguration/Gradle_Check_IndividualPerformanceScenarioWorkersWindows/37375800?buildTab=overview).
  - Native tests are ignored.
