### PR TITLE
Fix volatile test name

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
@@ -375,6 +375,16 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
 
     @CompileStatic
     static Closure<String> latestNotation() {
-        { -> GradleMetadataResolveRunner.useIvy() ? "latest.integration" : "latest.release" }
+        return new Closure(this) {
+            @Override
+            Object call() {
+                return GradleMetadataResolveRunner.useIvy() ? "latest.integration" : "latest.release"
+            }
+
+            @Override
+            String toString() {
+                return GradleMetadataResolveRunner.useIvy() ? "latest.integration" : "latest.release"
+            }
+        }
     }
 }


### PR DESCRIPTION
So they can be retried by retry-plugin

Previously the name was something like `fails with combination of selectors (org.gradle.integtests.resolve.reproducibility.FailOnDynamicVersionsResolveIntegrationTest$_latestNotation_closure1@5511fae2 and latest.release ) [with Gradle metadata, Maven repository]`