### PR TITLE
Fix kebab-case name matching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
@@ -73,11 +73,13 @@ public class NameMatcher {
         Pattern normalisedCamelCasePattern = Pattern.compile(camelCasePattern.pattern(), Pattern.CASE_INSENSITIVE);
         String normalisedPattern = pattern.toUpperCase();
         Pattern kebabCasePattern = getKebabCasePatternForName(pattern);
+        Pattern kebabCasePrefixPattern = Pattern.compile(kebabCasePattern.pattern() + "[\\p{javaLowerCase}\\p{Digit}-]*");
 
         Set<String> caseInsensitiveMatches = new TreeSet<>();
         Set<String> caseSensitiveCamelCaseMatches = new TreeSet<>();
         Set<String> caseInsensitiveCamelCaseMatches = new TreeSet<>();
         Set<String> kebabCaseMatches = new TreeSet<>();
+        Set<String> kebabCasePrefixMatches = new TreeSet<>();
 
         for (String candidate : items) {
             if (candidate.equalsIgnoreCase(pattern)) {
@@ -95,6 +97,10 @@ public class NameMatcher {
                 kebabCaseMatches.add(candidate);
                 continue;
             }
+            if (kebabCasePrefixPattern.matcher(candidate).matches()) {
+                kebabCasePrefixMatches.add(candidate);
+                continue;
+            }
             if (StringUtils.getLevenshteinDistance(normalisedPattern, candidate.toUpperCase()) <= Math.min(3, pattern.length() / 2)) {
                 candidates.add(candidate);
             }
@@ -110,6 +116,8 @@ public class NameMatcher {
 
         if (!kebabCaseMatches.isEmpty()) {
             matches.addAll(kebabCaseMatches);
+        } else if (!kebabCasePrefixMatches.isEmpty()) {
+            matches.addAll(kebabCasePrefixMatches);
         }
 
         if (matches.size() == 1) {
@@ -155,7 +163,6 @@ public class NameMatcher {
             pos = matcher.end();
         }
         builder.append(Pattern.quote(name.substring(pos)));
-        builder.append("[\\p{javaLowerCase}\\p{Digit}-]*");
         return Pattern.compile(builder.toString());
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.groovy
@@ -119,6 +119,12 @@ class NameMatcherTest extends Specification {
         matches("s_n", "some_name", "some_name_with_extra")
     }
 
+    def "prefers full kebab case match over kebab case prefix"() {
+        expect:
+        matches("sN", "some-name", "some-name-with-extra")
+        matches("name", "names", "name-with-extra")
+    }
+
     def "prefers case sensitive camel case match over case insensitive camel case match"() {
         expect:
         matches("soNa", "someName", "somename")
@@ -150,8 +156,8 @@ class NameMatcherTest extends Specification {
 
     def "does not select items when multiple kebab case matches"() {
         expect:
-        matcher.find("sN", ["some-name", "some-name-with-extra", "other"]) == null
-        matcher.matches == ["some-name", "some-name-with-extra"] as Set
+        matcher.find("sN", ["some-name", "some-number", "other"]) == null
+        matcher.matches == ["some-name", "some-number"] as Set
     }
 
     def "does not select items when multiple mixed camel and kebab case matches"() {


### PR DESCRIPTION
In previous Gradle versions, the pattern 'iE' selected 'instantExecution' from the following set: ['instantExecution', 'instantExecutionReport]. The new kebab case support in the pattern matching broke this behavior. 'iE' matched both on 'instant-execution' and on 'instant-execution-report. This change fixes this by prioritizing exact kebab case matches over kebab case prefix matches.