### PR TITLE
Enable FilePropertyFactory to be used with configuration cache

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -34,11 +34,14 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.state.Managed;
 
 import javax.annotation.Nullable;
 import java.io.File;
 
+@ServiceScope(Scope.Global.class)
 public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFactory {
     private final PropertyHost host;
     private final FileResolver fileResolver;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/PropertyHost.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/PropertyHost.java
@@ -21,12 +21,7 @@ import org.gradle.internal.state.ModelObject;
 import javax.annotation.Nullable;
 
 public interface PropertyHost {
-    PropertyHost NO_OP = new PropertyHost() {
-        @Override
-        public String beforeRead(@org.jetbrains.annotations.Nullable ModelObject producer) {
-            return null;
-        }
-    };
+    PropertyHost NO_OP = producer -> null;
 
     /**
      * Returns null if the host allows reads of its state, or a string that explains why reads are not allowed.


### PR DESCRIPTION
This also allows reverting a workaround in `PropertyHost` as it used to be
serialized when running `JavaToolchainUpToDateIntegrationTest`
