### PR TITLE
Appply only required plugins to architecture-test subproject

### DIFF
--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/code-quality.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/code-quality.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild
+
+apply(from = "$rootDir/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-library.gradle.kts
@@ -17,6 +17,7 @@ package gradlebuild
 
 plugins {
     `java-library`
+    id("gradlebuild.code-quality")
     id("gradlebuild.dependency-modules")
     id("gradlebuild.repositories")
     id("gradlebuild.minify")
@@ -30,8 +31,6 @@ plugins {
     id("gradlebuild.integration-tests")
     id("gradlebuild.cross-version-tests")
 }
-
-apply(from = "$rootDir/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
 
 tasks.named("check").configure {
     dependsOn("codeQuality")

--- a/subprojects/architecture-test/architecture-test.gradle.kts
+++ b/subprojects/architecture-test/architecture-test.gradle.kts
@@ -1,7 +1,12 @@
 import gradlebuild.basics.PublicApi
 
 plugins {
-    id("gradlebuild.internal.java")
+    id("gradlebuild.code-quality")
+    id("gradlebuild.dependency-modules")
+    id("gradlebuild.repositories")
+    id("gradlebuild.strict-compile")
+    id("gradlebuild.classycle")
+    id("gradlebuild.unittest-and-compile")
     id("gradlebuild.binary-compatibility")
 }
 
@@ -14,6 +19,10 @@ dependencies {
     testImplementation(libs.guava)
 
     testRuntimeOnly(project(":distributions-full"))
+}
+
+tasks.named("check").configure {
+    dependsOn("codeQuality")
 }
 
 tasks.test {


### PR DESCRIPTION
The idea is to dissect what this subproject really is and then possibly extract that to a separate convention plugin. Currently, it states that it is a java library which it is not. The complication made by this statement is that in lifecycle plugin we have to filter out this project and conditionally apply additional logic to the projects that are in fact java libraries.

Several other projects (`soak`, `distributions-integ-tests`) have similar issues - I'll handle them in separate changes and then we can perhaps see the commonalities and extract those to their own conventions.
