### PR TITLE
Update some DSL syntax used in init templates 

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1454,7 +1454,7 @@ public class BuildScriptBuilder {
 
         @Override
         public String containerElement(String container, String element) {
-            return container + ".getByName(" + string(element) + ")";
+            return container + "[" + string(element) + "]";
         }
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1415,7 +1415,7 @@ public class BuildScriptBuilder {
 
         @Override
         public String taskSelector(TaskSelector selector) {
-            return "val " + selector.taskName + " by tasks.getting(" + selector.taskType + "::class)";
+            return "tasks." + selector.taskName;
         }
 
         @Override
@@ -1534,7 +1534,7 @@ public class BuildScriptBuilder {
 
         @Override
         public String taskSelector(TaskSelector selector) {
-            return selector.taskName;
+            return "tasks.named('" + selector.taskName + "')";
         }
 
         @Override

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
@@ -712,7 +712,7 @@ tasks.withType(Test) {
     encoding = 'UTF-8'
 }
 
-test {
+tasks.named('test') {
     maxParallelForks = 23
 
     // Use TestNG

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
@@ -616,12 +616,12 @@ foo {
  */
 
 // Call method
-things.getByName("element1").thing(12, things.nested.getByName("element2"))
+things["element1"].thing(12, things.nested["element2"])
 
 // Set property
-prop = things.nested.getByName("element2")
+prop = things.nested["element2"]
 
-other = extendsFrom(things.nested.getByName("element2").outputDir)
+other = extendsFrom(things.nested["element2"].outputDir)
 """)
     }
 
@@ -681,7 +681,7 @@ tasks.withType(Test) {
     encoding = "UTF-8"
 }
 
-val test by tasks.getting(Test::class) {
+tasks.test {
     maxParallelForks = 23
 
     // Use TestNG


### PR DESCRIPTION
- Use lazy and simple task configuration syntax
- Use [] for accessing elements in Kotlin DSL instead of clumsy 'getByName()'