### PR TITLE
Fix 'DOM text reinterpreted as HTML' CodeQL scanning warnings

### DIFF
--- a/subprojects/diagnostics/src/main/resources/org/gradle/api/tasks/diagnostics/htmldependencyreport/script.js
+++ b/subprojects/diagnostics/src/main/resources/org/gradle/api/tasks/diagnostics/htmldependencyreport/script.js
@@ -102,7 +102,7 @@ function initializeProjectPage(report) {
             var $insightDiv = $('#insight');
             $insightDiv.html('');
             $insightDiv.append($('<i> </i>').attr('id', 'dismissInsight').attr('title', 'Close'));
-            $insightDiv.append($('<h3>Insight for module </h3>').append(module));
+            $insightDiv.append($('<h3>Insight for module </h3>').append(document.createTextNode(module)));
             var $tree = $('<div>').addClass('insightTree');
             var insight = findInsight(moduleInsights, module);
             var nodes = [];

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/report.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/report.js
@@ -15,14 +15,14 @@ $(document).ready(function () {
                 var startCol = currentCol;
                 currentCol += parseInt(e.attr('colspan'));
                 var endCol = currentCol;
-                if (title.length == 0) {
+                if (title.length === 0) {
                     return;
                 }
                 var id = title.replace(/[^\w]/g, '-').toLowerCase();
                 if (groups.indexOf(id) < 0) {
                     groups.push(id);
                     var div = controls.append("<div/>");
-                    div.append("<label for='" + id + "'>" + title + "</label>");
+                    div.append($("<label>", {for: id}).text(title));
                     var checkbox = $("<input>", {type: "checkbox", id: id, checked: true});
                     div.append(checkbox);
                     checkbox.change(function () {


### PR DESCRIPTION
Fixes
 - https://github.com/gradle/gradle/security/code-scanning/49
 - https://github.com/gradle/gradle/security/code-scanning/50
 - https://github.com/gradle/gradle/security/code-scanning/51
 - https://github.com/gradle/gradle/security/code-scanning/52

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
