### PR TITLE
Rebaseline `JavaConfigurationCachePerformanceTest` after renamings

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/KtsProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/KtsProjectGeneratorTask.groovy
@@ -24,7 +24,7 @@ class KtsProjectGeneratorTask extends JvmProjectGeneratorTask {
 
     @Override
     List<String> getDefaultProjectFiles() {
-        Object.defaultProjectFiles + ['build.gradle.kts']
+        super.defaultProjectFiles + ['build.gradle.kts']
     }
 
     @Override

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -45,7 +45,7 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionGradleIn
     def "assemble on #testProject #action configuration cache state with #daemon daemon"() {
 
         given:
-        runner.targetVersions = ["6.7-20200723220251+0000"]
+        runner.targetVersions = ["6.7-20200819190020+0000"]
         runner.minimumBaseVersion = "6.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]


### PR DESCRIPTION
The new names are slightly longer and some of them are captured in `BrokenValue` stack traces which could explain the small regression.