### PR TITLE
Fix outgoing edge reference counting

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.constraints
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import spock.lang.Issue
+
+class DependencyConstraintsBugsIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    // Ideally this should be a reproducer using generated dependencies but I wasn't able
+    // to figure out a reproducer
+    @Issue("https://github.com/gradle/gradle/issues/13960")
+    def "should resolve dependency which version is provided by an upgraded transitive platform"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${jcenterRepository()}
+
+            dependencies {
+                implementation(platform("io.micronaut:micronaut-bom:2.0.1"))
+                implementation("io.micronaut.kafka:micronaut-kafka")
+                testImplementation("io.micronaut.test:micronaut-test-spock")
+            }
+
+            task resolve {
+                inputs.files(configurations.testRuntimeClasspath)
+                doLast {
+                    configurations.testRuntimeClasspath.files.name.each {
+                        println(it)
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'resolve'
+
+        then:
+        noExceptionThrown()
+        outputContains "micronaut-messaging-2.0.1.jar"
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -1092,21 +1092,24 @@ public class NodeState implements DependencyGraphNode {
             if (from != backToPendingSource) {
                 // Only remove edges that come from a different node than the source of the dependency going back to pending
                 // The edges from the "From" will be removed first
-                incomingEdge.getSelector().release();
-                from.removeOutgoingEdge(incomingEdge);
+                if (from.removeOutgoingEdge(incomingEdge)) {
+                    incomingEdge.getSelector().release();
+                }
             }
             pendingDependencies.registerConstraintProvider(from);
         }
     }
 
-    private void removeOutgoingEdge(EdgeState edge) {
+    private boolean removeOutgoingEdge(EdgeState edge) {
         if (!removingOutgoingEdges) {
             // don't try to remove an outgoing edge if we're already doing it
             // because removeOutgoingEdges() will clear all of them so it's not required to do it twice
             // and it can cause a concurrent modification exception
             outgoingEdges.remove(edge);
             edge.markUnused();
+            return true;
         }
+        return false;
     }
 
     void forEachCapability(CapabilitiesConflictHandler capabilitiesConflictHandler, Action<? super Capability> action) {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -129,11 +129,20 @@ class ModuleVersionSpec {
     }
 
     void variant(String name, @DelegatesTo(value = VariantMetadataSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
-        def variant = new VariantMetadataSpec(name)
+        def variant = variants.find { it.name == name }
+        if (variant == null) {
+            variant = new VariantMetadataSpec(name)
+            variants << variant
+        }
         spec.delegate = variant
         spec.resolveStrategy = Closure.DELEGATE_FIRST
         spec()
-        variants << variant
+    }
+
+    void variants(List<String> names, @DelegatesTo(value = VariantMetadataSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        names.each { name ->
+            variant(name, spec)
+        }
     }
 
     void asPlatform() {


### PR DESCRIPTION
We were systematically decreasing the number of outgoing
edges even if we didn't actually remove an outgoing edge
in some cases. This commit makes sure that the reference
count is correct in this case.

Fixes #13960

