### PR TITLE
Serialize `ProviderBackedFileCollection`'s provider to the config cache

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
@@ -58,6 +58,10 @@ class AbstractConfigurationCacheIntegrationTest extends AbstractIntegrationSpec 
         assert System.getProperty(ConfigurationCacheOption.PROPERTY_NAME) == null
     }
 
+    void buildFile(@Language("groovy") String script) {
+        buildFile << script
+    }
+
     void buildKotlinFile(@Language("kotlin") String script) {
         buildKotlinFile << script
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -29,11 +29,16 @@ class ConfigurableFileCollectionCodec(
     private val codec: Codec<FileCollectionInternal>,
     private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<ConfigurableFileCollection> {
-    override suspend fun WriteContext.encode(value: ConfigurableFileCollection) =
-        codec.run { encode(value as FileCollectionInternal) }
+    override suspend fun WriteContext.encode(value: ConfigurableFileCollection) = codec.run {
+        encode(value as FileCollectionInternal)
+    }
 
     override suspend fun ReadContext.decode(): ConfigurableFileCollection =
-        fileCollectionFactory.configurableFiles().also {
-            it.from(codec.run { decode() })
+        fileCollectionFactory.configurableFiles().apply {
+            from(
+                codec.run {
+                    decode()
+                }
+            )
         }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
@@ -112,18 +112,15 @@ class FileCollectionCodec(
 
 
 private
-class
-SubtractingFileCollectionSpec(val left: FileCollection, val right: FileCollection)
+class SubtractingFileCollectionSpec(val left: FileCollection, val right: FileCollection)
 
 
 private
-class
-FilteredFileCollectionSpec(val collection: FileCollection, val filter: Spec<in File>)
+class FilteredFileCollectionSpec(val collection: FileCollection, val filter: Spec<in File>)
 
 
 private
-class
-TransformedLocalFileSpec(val origin: File, val transformation: Transformation)
+class TransformedLocalFileSpec(val origin: File, val transformation: Transformation)
 
 
 private

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -535,7 +535,6 @@ The following types/formats are supported:
         file("out.txt").text == "1"
     }
 
-    @ToBeFixedForConfigurationCache(because = "queries mapped value of task output before it has completed")
     def "input file collection containing filtered tree of task output implies dependency on the task"() {
         taskTypeWithOutputDirectoryProperty()
         taskTypeWithInputFileCollection()
@@ -698,7 +697,6 @@ The following types/formats are supported:
         file("out.txt").text == "b"
     }
 
-    @ToBeFixedForConfigurationCache(because = "queries mapped value of task output before it has completed")
     def "input file collection containing mapped task output property implies dependency on a specific output of the task"() {
         taskTypeWithMultipleOutputFileProperties()
         taskTypeWithInputFileCollection()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -461,7 +461,6 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(because = "file collection containing a String provider is not serialized correctly")
     def "can use input path sensitivity #pathSensitivity for parameter object"() {
         settingsFile << """
                 include 'a', 'b', 'c'

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -58,4 +58,8 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
         UnpackingVisitor unpackingVisitor = new UnpackingVisitor(visitor, resolver, patternSetFactory);
         unpackingVisitor.add(provider.get());
     }
+
+    public ProviderInternal<?> getProvider() {
+        return provider;
+    }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -402,14 +402,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         ins.close()
     }
 
-    @ToBeFixedForConfigurationCache(because = """
-        `ProviderBackedFileCollection#visitChildren` evaluates the provider after `stopCollectingValueSources()` thus
-        the system property below is not captured in the fingerprint.
-        There are two possible solutions:
-            1. Move the `stopCollectionValueSources()` call to happen after the task graph state has been captured;
-               This would allow the system property to be captured in the fingerprint.
-            2. Store `ProviderBackedFileCollection` as a spec so the provider is re-evaluated at every execution;
-    """)
     @Issue("https://github.com/gradle/gradle/issues/9586")
     def "change in case of input file will sync properly"() {
         given:


### PR DESCRIPTION
Instead of resolving it so mapped task outputs as file collection sources are handled correctly.

Fixes #13965
Fixes #13966