### PR TITLE
Inline buildSrc for convention plugins sample

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -548,12 +548,6 @@ samples {
             common {
                 from(templates.precompiledScriptPluginUtilsInBuildSrc)
             }
-            groovy {
-                from(templates.precompiledScriptPluginGroovyInBuildSrc)
-            }
-            kotlin {
-                from(templates.precompiledScriptPluginKotlinInBuildSrc)
-            }
         }
 
         jvmMultiProjectBuild {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -1,0 +1,22 @@
+// tag::apply[]
+plugins {
+    id 'groovy-gradle-plugin'
+// end::apply[]
+    id 'maven-publish'
+// tag::apply[]
+}
+// end::apply[]
+
+group = 'com.example.conventions'
+version = '1.0'
+
+// tag::repositories-and-dependencies[]
+repositories {
+    gradlePluginPortal() // so that external plugins can be resolved in dependencies section
+}
+
+dependencies {
+    implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.5'
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+}
+// end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -1,14 +1,8 @@
 // tag::apply[]
 plugins {
     id 'groovy-gradle-plugin'
-// end::apply[]
-    id 'maven-publish'
-// tag::apply[]
 }
 // end::apply[]
-
-group = 'com.example.conventions'
-version = '1.0'
 
 // tag::repositories-and-dependencies[]
 repositories {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/settings.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name='my-org-conventions'

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -1,0 +1,30 @@
+// Define Java conventions for this organization.
+// Projects need to use the Java, Checkstyle and Spotbugs plugins.
+
+// tag::apply-external-plugin[]
+plugins {
+    id 'java'
+    id 'checkstyle'
+
+    // NOTE: external plugin version is specified in implementation dependency artifact of the project's build file
+    id 'com.github.spotbugs'
+}
+// end::apply-external-plugin[]
+
+// Projects should use JCenter for external dependencies
+// This could be the organization's private repository
+repositories {
+    jcenter() 
+}
+
+// Use the Checkstyle rules provided by the convention plugin
+// Do not allow any warnings
+checkstyle {
+    config = resources.text.fromString(com.example.CheckstyleUtil.getCheckstyleConfig("/checkstyle.xml"))
+    maxWarnings = 0
+}
+
+// Enable deprecation messages when compiling Java code
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << "-Xlint:deprecation"
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.library-conventions.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.library-conventions.gradle
@@ -1,0 +1,39 @@
+// Define Java Library conventions for this organization.
+// Projects need to use the organization's Java conventions and publish using Maven Publish
+
+// tag::plugins[]
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'myproject.java-conventions'
+}
+// end::plugins[]
+
+// Projects have the 'com.example' group by convention
+group = 'com.example'
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            name "myOrgPrivateRepo"
+            url 'build/my-repo'
+        }
+    }
+}
+
+// The project requires libraries to have a README containing sections configured below
+// tag::use-java-class[]
+def readmeCheck = tasks.register('readmeCheck', com.example.ReadmeVerificationTask) {
+    // Expect the README in the project directory
+    readme = layout.projectDirectory.file("README.md")
+    // README must contain a Service API header
+    readmePatterns = ['^## API$', '^## Changelog$']
+}
+// end::use-java-class[]
+
+tasks.named('check') { dependsOn(readmeCheck) }

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/JavaConventionPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/JavaConventionPluginTest.groovy
@@ -1,0 +1,111 @@
+package com.example
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class JavaConventionPluginTest extends PluginTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'myproject.java-conventions'
+            }
+        """
+    }
+
+    def "fails on checkstyle error"() {
+        given:
+        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
+        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+            package com.example;
+
+            import java.util.*;
+
+            class Foo {
+                void bar() {
+                }
+            }
+        """
+
+        when:
+        def result = runTaskWithFailure('build')
+
+        then:
+        result.task(":checkstyleMain").outcome == TaskOutcome.FAILED
+        result.output.contains('Checkstyle rule violations were found.')
+        result.output.contains('Checkstyle violations by severity: [error:1]')
+    }
+
+    def "fails on checkstyle warning"() {
+        given:
+        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
+        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+            package com.example;
+
+            class Foo {
+                final static public String FOO = "BAR";
+
+                void bar() {
+                }
+            }
+        """
+
+        when:
+        def result = runTaskWithFailure('build')
+
+        then:
+        result.task(":checkstyleMain").outcome == TaskOutcome.FAILED
+        result.output.contains('Checkstyle rule violations were found.')
+        result.output.contains('Checkstyle violations by severity: [warning:1]')
+    }
+
+    def "fails on spotbugs error"() {
+        given:
+        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
+        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+            package com.example;
+
+            class Foo {
+                void bar() {
+                    String s = null;
+                    s.hashCode();
+                }
+            }
+        """
+
+        when:
+        def result = runTaskWithFailure('build')
+
+        then:
+        result.task(":spotbugsMain").outcome == TaskOutcome.FAILED
+    }
+
+    def "warns on deprecated API usage"() {
+        given:
+        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
+        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+            package com.example;
+
+            public class Foo {
+                @Deprecated
+                public void deprecatedMethod() {}
+            }
+        """
+
+        testProjectDir.newFile('src/main/java/com/example/Bar.java') << """
+            package com.example;
+
+            public class Bar {
+                public void bar() {
+                    new Foo().deprecatedMethod();
+                }
+            }
+        """
+
+        when:
+        def result = runTask('build')
+
+        then:
+        result.task(":build").outcome == TaskOutcome.SUCCESS
+        result.output.contains('warning: [deprecation] deprecatedMethod() in Foo has been deprecated')
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/LibraryPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/LibraryPluginTest.groovy
@@ -1,0 +1,116 @@
+package com.example
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class LibraryPluginTest extends PluginTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'myproject.library-conventions'
+            }
+        """
+    }
+
+    def "can declare api dependencies"() {
+        given:
+        readmeContainingMandatorySectionsExists()
+        buildFile << """
+            dependencies {
+                api 'org.apache.commons:commons-lang3:3.4'
+            }
+        """
+
+        when:
+        def result = runTask('build')
+
+        then:
+        result.task(":build").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "publishes library with versionin"() {
+        given:
+        readmeContainingMandatorySectionsExists()
+        settingsFile.setText("rootProject.name = 'my-library'")
+        buildFile << """
+            version = '0.1.0'
+
+            publishing {
+                repositories {
+                    maven {
+                        name 'testRepo'
+                        url 'build/test-repo'
+                    }
+                }
+            }
+        """
+
+        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
+        testProjectDir.newFile('src/main/java/com/example/Util.java') << """
+            package com.example;
+
+            public class Util {
+                public static void someUtil() {
+                }
+            }
+        """
+
+        when:
+        def result = runTask('publishLibraryPublicationToTestRepoRepository')
+
+        then:
+        result.task(":jar").outcome == TaskOutcome.SUCCESS
+        result.task(":publishLibraryPublicationToTestRepoRepository").outcome == TaskOutcome.SUCCESS
+        new File(testProjectDir.getRoot(), 'build/test-repo/com/example/my-library/0.1.0/my-library-0.1.0.jar').exists()
+    }
+
+    def "fails when no README exists"() {
+        when:
+        def result = runTaskWithFailure('check')
+
+        then:
+        result.task(":readmeCheck").outcome == TaskOutcome.FAILED
+    }
+
+    def "fails when README does not have API section"() {
+        given:
+        testProjectDir.newFile('README.md') << """
+## Changelog
+- change 1
+- change 2
+        """
+
+        when:
+        def result = runTaskWithFailure('check')
+
+        then:
+        result.task(":readmeCheck").outcome == TaskOutcome.FAILED
+        result.output.contains('README should contain section: ^## API$')
+    }
+
+    def "fails when README does not have Changelog section"() {
+        given:
+        testProjectDir.newFile('README.md') << """
+## API
+public API description
+        """
+
+        when:
+        def result = runTaskWithFailure('check')
+
+        then:
+        result.task(":readmeCheck").outcome == TaskOutcome.FAILED
+        result.output.contains('README should contain section: ^## Changelog')
+    }
+
+    private def readmeContainingMandatorySectionsExists() {
+        testProjectDir.newFile('README.md') << """
+## API
+public API description
+
+## Changelog
+- change 1
+- change 2
+        """
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/PluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/PluginTest.groovy
@@ -1,0 +1,34 @@
+package com.example
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+abstract class PluginTest extends Specification {
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle') << "rootProject.name = 'test'"
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def runTask(String task) {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(task, '--stacktrace')
+                .withPluginClasspath()
+                .build()
+    }
+
+    def runTaskWithFailure(String task) {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(task, '--stacktrace')
+                .withPluginClasspath()
+                .buildAndFail()
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
@@ -1,0 +1,22 @@
+// tag::apply[]
+plugins {
+    `kotlin-dsl`
+// end::apply[]
+    `maven-publish`
+// tag::apply[]
+}
+// end::apply[]
+
+group = "com.example.conventions"
+version = "1.0"
+
+// tag::repositories-and-dependencies[]
+repositories {
+    gradlePluginPortal() // so that external plugins can be resolved in dependencies section
+}
+
+dependencies {
+    implementation("gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.5")
+    testImplementation("junit:junit:4.13")
+}
+// end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
@@ -1,14 +1,8 @@
 // tag::apply[]
 plugins {
     `kotlin-dsl`
-// end::apply[]
-    `maven-publish`
-// tag::apply[]
 }
 // end::apply[]
-
-group = "com.example.conventions"
-version = "1.0"
 
 // tag::repositories-and-dependencies[]
 repositories {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/settings.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name="my-org-conventions"

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -1,0 +1,30 @@
+// Define Java conventions for this organization.
+// Projects need to use the Java, Checkstyle and Spotbugs plugins.
+
+// tag::apply-external-plugin[]
+plugins {
+    java
+    checkstyle
+
+    // NOTE: external plugin version is specified in implementation dependency artifact of the project's build file
+    id("com.github.spotbugs")
+}
+// end::apply-external-plugin[]
+
+// Projects should use JCenter for external dependencies
+// This could be the organization's private repository
+repositories {
+    jcenter() 
+}
+
+// Use the Checkstyle rules provided by the convention plugin
+// Do not allow any warnings
+checkstyle {
+    config = resources.text.fromString(com.example.CheckstyleUtil.getCheckstyleConfig("/checkstyle.xml"))
+    maxWarnings = 0
+}
+
+// Enable deprecation messages when compiling Java code
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:deprecation")
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.library-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.library-conventions.gradle.kts
@@ -1,0 +1,37 @@
+// Define Java Library conventions for this organization.
+// Projects need to use the organization's Java conventions and publish using Maven Publish
+
+// tag::plugins[]
+plugins {
+    `java-library`
+    `maven-publish`
+    id("myproject.java-conventions")
+}
+// end::plugins[]
+
+// Projects have the 'com.example' group by convention
+group = "com.example"
+
+publishing {
+    publications {
+        create<MavenPublication>("library") {
+            from(components["java"])
+        }
+    }
+    repositories {
+        maven {
+            name = "myOrgPrivateRepo"
+            url = uri("build/my-repo")
+        }
+    }
+}
+
+// The project requires libraries to have a README containing sections configured below
+// tag::use-java-class[]
+val readmeCheck by tasks.registering(com.example.ReadmeVerificationTask::class) {
+    readme.set(layout.projectDirectory.file("README.md"))
+    readmePatterns.set(listOf("^## API$", "^## Changelog$"))
+}
+// end::use-java-class[]
+
+tasks.named("check") { dependsOn(readmeCheck) }

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/JavaConventionPluginTest.kt
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/JavaConventionPluginTest.kt
@@ -1,0 +1,108 @@
+package com.example
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class JavaConventionPluginTest : PluginTest() {
+
+    @Before
+    fun init() {
+        buildFile.appendText("""
+            plugins {
+                id("myproject.java-conventions")
+            }
+        """)
+    }
+
+    @Test
+    fun `fails on checkstyle error`() {
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        testProjectDir.newFile("src/main/java/com/example/Foo.java").appendText("""
+            package com.example;
+
+            import java.util.*;
+
+            class Foo {
+                void bar() {
+                }
+            }
+        """)
+
+        val result = runTaskWithFailure("build")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":checkstyleMain")?.outcome)
+        assertTrue(result.output.contains("Checkstyle rule violations were found."))
+        assertTrue(result.output.contains("Checkstyle violations by severity: [error:1]"))
+    }
+
+    @Test
+    fun `fails on checkstyle warning`() {
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        testProjectDir.newFile("src/main/java/com/example/Foo.java").writeText("""
+            package com.example;
+
+            class Foo {
+                final static public String FOO = "BAR";
+
+                void bar() {
+                }
+            }
+        """)
+
+        val result = runTaskWithFailure("build")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":checkstyleMain")?.outcome)
+        assertTrue(result.output.contains("Checkstyle rule violations were found."))
+        assertTrue(result.output.contains("Checkstyle violations by severity: [warning:1]"))
+    }
+
+    @Test
+    fun `fails on spotbugs error`() {
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        testProjectDir.newFile("src/main/java/com/example/Foo.java").writeText("""
+            package com.example;
+
+            class Foo {
+                void bar() {
+                    String s = null;
+                    s.hashCode();
+                }
+            }
+        """)
+
+        val result = runTaskWithFailure("build")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":spotbugsMain")?.outcome)
+    }
+
+    @Test
+    fun `warns on deprecated API usage`() {
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        testProjectDir.newFile("src/main/java/com/example/Foo.java").writeText("""
+            package com.example;
+
+            public class Foo {
+                @Deprecated
+                public void deprecatedMethod() {}
+            }
+        """)
+
+        testProjectDir.newFile("src/main/java/com/example/Bar.java").writeText("""
+            package com.example;
+
+            public class Bar {
+                public void bar() {
+                    new Foo().deprecatedMethod();
+                }
+            }
+        """)
+
+        val result = runTask("build")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":build")?.outcome)
+        assertTrue(result.output.contains("warning: [deprecation] deprecatedMethod() in Foo has been deprecated"))
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/LibraryPluginTest.kt
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/LibraryPluginTest.kt
@@ -1,0 +1,115 @@
+package com.example
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class LibraryPluginTest : PluginTest() {
+
+    @Before
+    fun init() {
+        buildFile.appendText("""
+            plugins {
+                id("myproject.library-conventions")
+            }
+        """)
+    }
+
+    @Test
+    fun `can declare api dependencies`() {
+        readmeContainingMandatorySectionsExists()
+        buildFile.appendText("""
+            dependencies {
+                api("org.apache.commons:commons-lang3:3.4")
+            }
+        """)
+
+        val result = runTask("build")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":build")?.outcome)
+    }
+
+    @Test
+    fun `publishes library with versionin`() {
+        readmeContainingMandatorySectionsExists()
+        settingsFile.writeText("""
+            rootProject.name = "my-library"
+        """.trimIndent())
+        buildFile.appendText("""
+            version = "0.1.0"
+
+            publishing {
+                repositories {
+                    maven {
+                        name = "testRepo"
+                        url = uri("build/test-repo")
+                    }
+                }
+            }
+        """)
+
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        testProjectDir.newFile("src/main/java/com/example/Util.java").writeText("""
+            package com.example;
+
+            public class Util {
+                public static void someUtil() {
+                }
+            }
+        """)
+
+        val result = runTask("publishLibraryPublicationToTestRepoRepository")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":jar")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishLibraryPublicationToTestRepoRepository")?.outcome)
+        assertTrue(File(testProjectDir.getRoot(), "build/test-repo/com/example/my-library/0.1.0/my-library-0.1.0.jar").exists())
+    }
+
+    @Test
+    fun `fails when no README exists`() {
+        val result = runTaskWithFailure ("check")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":readmeCheck")?.outcome)
+    }
+
+    @Test
+    fun `fails when README does not have API section`() {
+        testProjectDir.newFile("README.md").writeText("""
+            ## Changelog
+            - change 1
+            - change 2
+        """.trimIndent())
+
+        val result = runTaskWithFailure ("check")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":readmeCheck")?.outcome)
+        assertTrue(result.output.contains("README should contain section: ^## API$"))
+    }
+
+    @Test
+    fun `fails when README does not have Changelog section`() {
+        testProjectDir.newFile("README.md").writeText("""
+            ## API
+            public API description
+        """.trimIndent())
+
+        val result = runTaskWithFailure ("check")
+
+        assertEquals(TaskOutcome.FAILED, result.task(":readmeCheck")?.outcome)
+        assertTrue(result.output.contains("README should contain section: ^## Changelog$"))
+    }
+
+    private fun readmeContainingMandatorySectionsExists() {
+        testProjectDir.newFile("README.md").writeText("""
+            ## API
+            public API description
+
+            ## Changelog
+            - change 1
+            - change 2
+        """.trimIndent())
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/PluginTest.kt
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/test/kotlin/com/example/PluginTest.kt
@@ -1,0 +1,42 @@
+package com.example
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+abstract class PluginTest {
+
+    @Rule
+    @JvmField
+    val testProjectDir: TemporaryFolder = TemporaryFolder()
+    protected lateinit var settingsFile: File
+    protected lateinit var buildFile: File
+
+    @Before
+    fun setup() {
+        settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        settingsFile.appendText("""
+            rootProject.name = "test"
+        """)
+        buildFile = testProjectDir.newFile("build.gradle.kts")
+    }
+
+    fun runTask(task: String): BuildResult {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(task, "--stacktrace")
+                .withPluginClasspath()
+                .build()
+    }
+
+    fun runTaskWithFailure(task: String): BuildResult {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(task, "--stacktrace")
+                .withPluginClasspath()
+                .buildAndFail()
+    }
+}


### PR DESCRIPTION
Only include what the sample uses so that it does not include source leftovers that are not used by the sample code to not distract the users with noise that's relevant for another sample.

I'll inline the original to the other precompiled plugins sample as a next step and I'll redo that sample to focus on publishing the convention plugins.
