### PR TITLE
Hide gradle-api from runtime classpath for plugins

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -41,7 +41,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
 
     @Unroll
     @ToBeFixedForConfigurationCache
-    def "can co-develop plugin and consumer with plugin as included build"() {
+    def "can co-develop plugin and consumer with plugin as included build #pluginsBlock, #withVersion"() {
         given:
         applyPlugin(buildA, pluginsBlock, withVersion)
         addLifecycleTasks(buildA)
@@ -68,11 +68,9 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         false        | false
     }
 
-    @Unroll
-    @ToBeFixedForConfigurationCache
     def "does not expose Gradle runtime dependencies without shading"() {
         given:
-        applyPlugin(buildA, pluginsBlock, withVersion)
+        applyPlugin(buildA, true, false)
         addLifecycleTasks(buildA)
 
         includeBuild pluginBuild
@@ -86,13 +84,6 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
 
         then:
         failure.assertHasDescription("Could not compile build file '$buildA.buildFile.canonicalPath'.")
-
-        where:
-        pluginsBlock | withVersion
-        true         | true
-        true         | false
-        false        | true
-        false        | false
     }
 
     @ToBeFixedForConfigurationCache

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import spock.lang.Issue
@@ -59,6 +60,34 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
 
         then:
         executed ":pluginBuild:jar", ":pluginBuild:assemble", ":assemble"
+
+        where:
+        pluginsBlock | withVersion
+        true         | true
+        true         | false
+        false        | true
+        false        | false
+    }
+
+    @Unroll
+    @ToBeFixedForConfigurationCache
+    @NotYetImplemented
+    def "does not expose Gradle runtime dependencies without shading"() {
+        given:
+        applyPlugin(buildA, pluginsBlock, withVersion)
+        addLifecycleTasks(buildA)
+
+        includeBuild pluginBuild
+
+        buildA.buildFile << """
+            import ${com.google.common.collect.ImmutableList.name}
+        """
+
+        when:
+        fails(buildA, "taskFromPluginBuild")
+
+        then:
+        failure.assertHasDescription("Could not compile build file '$buildA.buildFile.canonicalPath'.")
 
         where:
         pluginsBlock | withVersion

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.integtests.composite
 
-import groovy.transform.NotYetImplemented
+
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import spock.lang.Issue
 import spock.lang.Unroll
-
 /**
  * Tests for plugin development scenarios within a composite build.
  */
@@ -71,7 +70,6 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
 
     @Unroll
     @ToBeFixedForConfigurationCache
-    @NotYetImplemented
     def "does not expose Gradle runtime dependencies without shading"() {
         given:
         applyPlugin(buildA, pluginsBlock, withVersion)

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal
 
+import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 
@@ -59,6 +60,67 @@ task runBrokenWorker {
         workerDaemonProcess.run(new Param())
     }
 }
+'''
+        when:
+        fails('runBrokenWorker')
+
+        then:
+        failureCauseContains('No response was received from Gradle Worker but the worker process has finished')
+        executer.getGradleUserHomeDir().file('workers').listFiles().find { it.name.startsWith('worker-error') }.text.contains(MESSAGE)
+    }
+
+    @NotYetImplemented
+    def "worker won't hang when error occurs in socket connection in included build"() {
+        given:
+        requireOwnGradleUserHomeDir()
+        executer.getGradleUserHomeDir().file()
+
+        file('included/src/main/java/Param.java') << """
+import java.io.*;
+public class Param implements Serializable {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        throw new IllegalStateException("$MESSAGE");
+    }
+}
+"""
+
+        file('included/src/main/java/TestWorkerProcessImpl.java') << '''
+import org.gradle.process.internal.worker.RequestHandler;
+
+public class TestWorkerProcessImpl implements RequestHandler<Object, Object> {
+    public Object run(Object param) { return null; }
+}
+'''
+        file('included/src/main/groovy/buildlogic.foo.gradle') << '''
+import org.gradle.process.internal.worker.WorkerProcessFactory
+
+task runBrokenWorker {
+    def rootDir = project.rootDir
+    doLast {
+        WorkerProcessFactory workerProcessFactory = services.get(WorkerProcessFactory)
+        def builder = workerProcessFactory.multiRequestWorker(TestWorkerProcessImpl)
+        builder.getJavaCommand().setWorkingDir(rootDir)
+
+        def workerDaemonProcess = builder.build()
+        workerDaemonProcess.start()
+        workerDaemonProcess.run(new Param())
+    }
+}
+'''
+        file('included/build.gradle') << """
+plugins {
+    id("groovy-gradle-plugin")
+}
+group = "buildlogic"
+
+"""
+        buildFile << '''
+plugins {
+    id('buildlogic.foo')
+}
+'''
+        settingsFile << '''
+includeBuild('included')
 '''
         when:
         fails('runBrokenWorker')

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.process.internal
 
-import groovy.transform.NotYetImplemented
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 
@@ -69,7 +69,6 @@ task runBrokenWorker {
         executer.getGradleUserHomeDir().file('workers').listFiles().find { it.name.startsWith('worker-error') }.text.contains(MESSAGE)
     }
 
-    @NotYetImplemented
     def "worker won't hang when error occurs in socket connection in included build"() {
         given:
         requireOwnGradleUserHomeDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.process.internal
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
@@ -28,7 +27,6 @@ class ErrorInWorkerSocketIntegrationTest extends AbstractIntegrationSpec {
     def "worker won't hang when error occurs in socket connection"() {
         given:
         requireOwnGradleUserHomeDir()
-        executer.getGradleUserHomeDir().file()
 
         file('buildSrc/src/main/java/Param.java') << """
 import java.io.*;
@@ -74,7 +72,6 @@ task runBrokenWorker {
     def "worker won't hang when error occurs in socket connection in included build"() {
         given:
         requireOwnGradleUserHomeDir()
-        executer.getGradleUserHomeDir().file()
 
         file('included/src/main/java/Param.java') << """
 import java.io.*;

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.process.internal
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 
 @IntegrationTestTimeout(180)
@@ -69,6 +70,7 @@ task runBrokenWorker {
         executer.getGradleUserHomeDir().file('workers').listFiles().find { it.name.startsWith('worker-error') }.text.contains(MESSAGE)
     }
 
+    @ToBeFixedForConfigurationCache(because="composite build")
     def "worker won't hang when error occurs in socket connection in included build"() {
         given:
         requireOwnGradleUserHomeDir()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -203,13 +203,13 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withFullDeprecationStackTraceDisabled();
 
     /**
-     * Downloads and sets up the JVM arguments for running with the file leak detector: https://file-leak-detector.kohsuke.org/
+     * Downloads and sets up the JVM arguments for running the Gradle daemon with the file leak detector: https://file-leak-detector.kohsuke.org/
      *
      * NOTE: This requires running the test with JDK8 and the forking executer.
      *
      * This should not be checked-in on. This is only for local debugging.
      *
-     * By default, this starts a HTTP server on port 19999 so you can observe which files are open. Passing any arguments disables this behavior.
+     * By default, this starts a HTTP server on port 19999, so you can observe which files are open. Passing any arguments disables this behavior.
      *
      * @param args the arguments to pass the file leak detector java agent
      */

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -203,6 +203,19 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withFullDeprecationStackTraceDisabled();
 
     /**
+     * Downloads and sets up the JVM arguments for running with the file leak detector: https://file-leak-detector.kohsuke.org/
+     *
+     * NOTE: This requires running the test with JDK8 and the forking executer.
+     *
+     * This should not be checked-in on. This is only for local debugging.
+     *
+     * By default, this starts a HTTP server on port 19999 so you can observe which files are open. Passing any arguments disables this behavior.
+     *
+     * @param args the arguments to pass the file leak detector java agent
+     */
+    GradleExecuter withFileLeakDetection(String... args);
+
+    /**
      * Specifies that the executer should only those JVM args explicitly requested using {@link #withBuildJvmOpts(String...)} and {@link #withCommandLineGradleOpts(String...)} (where appropriate) for
      * the build JVM and not attempt to provide any others.
      */

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -124,7 +124,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
 
         private String cleanupErrorMessage() {
             return "Couldn't delete test dir for `" + displayName() + "` (test is holding files open). "
-                + "In order to find out which files are held open you may find http://file-leak-detector.kohsuke.org/ useful.";
+                + "In order to find out which files are held open, you may find `org.gradle.integtests.fixtures.executer.GradleExecuter.withFileLeakDetection` useful.";
         }
 
         private String displayName() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/CompileGroovyScriptPluginsTask.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/CompileGroovyScriptPluginsTask.java
@@ -40,6 +40,7 @@ import org.gradle.groovy.scripts.internal.BuildScriptData;
 import org.gradle.groovy.scripts.internal.CompileOperation;
 import org.gradle.groovy.scripts.internal.ScriptCompilationHandler;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
+import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.model.dsl.internal.transform.ClosureCreationInterceptingVerifier;
 
@@ -104,6 +105,7 @@ abstract class CompileGroovyScriptPluginsTask extends DefaultTask {
             copySpec.from(intermediatePluginClassesDirectory.get().getAsFileTree().getFiles());
             copySpec.into(getPrecompiledGroovyScriptsOutputDirectory());
         });
+        ClassLoaderUtils.tryClose(compileClassLoader);
     }
 
     private void compileBuildScript(PrecompiledGroovyScript scriptPlugin, ClassLoader compileClassLoader) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
@@ -41,6 +41,7 @@ public abstract class PrecompiledGroovyPluginsPlugin implements Plugin<Project> 
         project.getPluginManager().apply(GroovyBasePlugin.class);
         project.getPluginManager().apply(JavaGradlePluginPlugin.class);
 
+        project.getDependencies().add("compileOnlyApi", project.getDependencies().localGroovy());
         project.afterEvaluate(this::exposeScriptsAsPlugins);
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -166,6 +166,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
         DependencyHandler dependencies = project.getDependencies();
         dependencies.add(compileOnlyApiName, dependencies.gradleApi());
+        dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, dependencies.gradleApi());
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -140,6 +140,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
+
         applyDependencies(project);
         GradlePluginDevelopmentExtension extension = createExtension(project);
         configureJarTask(project, extension);
@@ -158,8 +159,13 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
     }
 
     private void applyDependencies(Project project) {
+        String compileOnlyApiName = "compileOnlyApi";
+        Configuration compileOnlyApi = project.getConfigurations().maybeCreate(compileOnlyApiName);
+        project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(compileOnlyApi);
+        project.getConfigurations().getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME).extendsFrom(compileOnlyApi);
+
         DependencyHandler dependencies = project.getDependencies();
-        dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
+        dependencies.add(compileOnlyApiName, dependencies.gradleApi());
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
@@ -179,7 +179,7 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         project.configurations
-            .getByName(JavaGradlePluginPlugin.API_CONFIGURATION)
+            .getByName("compileOnlyApi")
             .dependencies.find {
             it.files == project.dependencies.gradleApi().files
         }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Refs #14045 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
