### PR TITLE
Fix embedded test running for projects applying the 'kotlin-dsl' plugin

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
@@ -30,7 +29,6 @@ import org.gradle.test.fixtures.server.http.PomHttpArtifact
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TextUtil
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
@@ -58,7 +56,6 @@ class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @ToBeFixedForConfigurationCache(because = ":projects")
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Kotlin DSL pre-compiled script compilation fails in embedded mode
     def "multiModule"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
         def warSubprojectBuildFile = targetDir.file("webinar-war/" + dsl.buildFileName)
@@ -114,7 +111,6 @@ Root project 'webinar-parent'
     }
 
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin") // Kotlin compilation is used for the pre-compiled script plugin
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Kotlin DSL pre-compiled script compilation fails in embedded mode
     def "multiModuleWithNestedParent"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
 
@@ -140,7 +136,6 @@ Root project 'webinar-parent'
     }
 
     @ToBeFixedForConfigurationCache(because = ":projects")
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Kotlin DSL pre-compiled script compilation fails in embedded mode
     def "flatmultimodule"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
         executer.beforeExecute {
@@ -482,7 +477,6 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
 
     @Issue("GRADLE-2819")
     @ToBeFixedForConfigurationCache(because = ":projects")
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Kotlin DSL pre-compiled script compilation fails in embedded mode
     def "multiModuleWithRemoteParent"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
 

--- a/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
+++ b/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
@@ -18,9 +18,11 @@ package org.gradle.testfixtures
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
@@ -40,6 +42,7 @@ class ProjectBuilderCrossVersionIntegrationTest extends MultiVersionIntegrationS
         executers.each { it.cleanup() }
     }
 
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     def "can apply plugin using ProjectBuilder in a test running with Gradle version under development"() {
         writeSourceFiles(false)
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -82,6 +82,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-3068")
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     def "can use gradleApi in test"() {
         given:
         file("src/test/groovy/org/acme/ProjectBuilderTest.groovy") << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
@@ -64,6 +64,9 @@ public class DependencyClassPathProvider implements ClassPathProvider {
     }
 
     private ClassPath initGradleApi() {
+        // This gradleApi() method creates a Gradle API classpath based on real jars for embedded test running.
+        // Currently this leaks additional dependencies that may cause unexpected issues.
+        // This method is NOT involved in generating the gradleApi() Jar which is used in a real Gradle run.
         ClassPath classpath = ClassPath.EMPTY;
         for (String moduleName : Arrays.asList("gradle-worker-processes", "gradle-launcher", "gradle-workers", "gradle-dependency-management", "gradle-plugin-use", "gradle-tooling-api", "gradle-configuration-cache")) {
             classpath = classpath.plus(moduleRegistry.getModule(moduleName).getAllRequiredModulesClasspath());
@@ -71,7 +74,11 @@ public class DependencyClassPathProvider implements ClassPathProvider {
         for (Module pluginModule : pluginModuleRegistry.getApiModules()) {
             classpath = classpath.plus(pluginModule.getClasspath());
         }
-        return classpath;
+        return classpath.removeIf(f ->
+            // Remove dependencies that are not part of the API and cause trouble when they leak.
+            // 'kotlin-sam-with-receiver-compiler-plugin' clashes with 'kotlin-sam-with-receiver' causing a 'SamWithReceiverComponentRegistrar is not compatible with this version of compiler' exception
+            f.getName().startsWith("kotlin-sam-with-receiver-compiler-plugin")
+        );
     }
 
     private ClassPath gradleTestKit() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
@@ -17,6 +17,8 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 
 class CustomPluginIntegrationTest extends AbstractIntegrationSpec {
     void "can reference plugin in buildSrc by id"() {
@@ -125,6 +127,7 @@ task test
         succeeds('test')
     }
 
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     def "can integration test plugin"() {
         given:
         file('src/main/groovy/CustomPlugin.groovy') << """
@@ -170,6 +173,7 @@ dependencies {
         succeeds('test')
     }
 
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     def "can use java plugin from custom plugin and its integration tests"() {
         given:
         file('src/main/groovy/CustomPlugin.groovy') << """

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -138,8 +138,6 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can use Gradle API generated extensions in buildSrc`() {
 
-        assumeNonEmbeddedGradleExecuter() // Classloader issue with pre-compiled script plugins lets ':compileKotlin' fail
-
         withKotlinBuildSrc()
 
         withFile("buildSrc/src/main/kotlin/foo/FooTask.kt", """

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -179,6 +179,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache
     fun `can compile against a different (but compatible) version of the Kotlin compiler`() {
+
         assumeNonEmbeddedGradleExecuter() // Class path isolation, tested here, is not correct in embedded mode
 
         val differentKotlinVersion = "1.3.30"

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
@@ -17,7 +17,6 @@ class JacocoIntegrationTest : AbstractPluginIntegrationTest() {
     fun `jacoco ignore codegen`() {
 
         assumeTrue(TestPrecondition.JDK14_OR_EARLIER.isFulfilled) // reevaluate when upgrading JaCoco from current 0.8.5
-        assumeNonEmbeddedGradleExecuter() // Classloader issue with pre-compiled script plugins lets ':compileKotlin' fail
 
         withBuildScript("""
             plugins {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -50,8 +50,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache
     fun `precompiled script plugins tasks are cached and relocatable`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         val firstLocation = "first-location"
         val secondLocation = "second-location"
         val cacheDir = newDir("cache-dir")
@@ -133,8 +131,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can apply precompiled script plugin from groovy script`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withKotlinBuildSrc()
         withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
             tasks.register("myTask") {}
@@ -153,8 +149,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache
     fun `accessors are available after script body change`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         withKotlinBuildSrc()
         val myPluginScript = withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
@@ -191,8 +185,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors are available after re-running tasks`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withKotlinBuildSrc()
         withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
             plugins { base }
@@ -215,8 +207,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors are available after renaming precompiled script plugin from project dependency`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         withSettings("""
             $defaultSettingsScript

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -42,8 +42,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can access sub-project specific task`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withDefaultSettings().appendText("""
             include(":sub")
         """)
@@ -98,8 +96,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache
     fun `can access extension of internal type made public`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         lateinit var extensionSourceFile: File
 
@@ -159,8 +155,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can access extension of default package type`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withBuildSrc {
 
             "src/main/kotlin" {
@@ -200,8 +194,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can access task of default package type`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withBuildSrc {
             "src/main/kotlin" {
 
@@ -237,8 +229,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `can access extension of nested type`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         withBuildSrc {
             "src/main/kotlin/my" {
@@ -296,8 +286,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache
     fun `multiple generic extension targets`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withBuildSrc {
 
             "src/main/kotlin" {
@@ -351,9 +339,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache
     fun `conflicting extensions across build scripts with same body`() {
 
-
-        assumeNonEmbeddedGradleExecuter()
-
         withFolders {
 
             "buildSrc" {
@@ -400,8 +385,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache
     fun `conflicting extensions across build runs`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         withFolders {
 
@@ -1077,7 +1060,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors to extensions of the dependency handler`() {
-        assumeNonEmbeddedGradleExecuter()
 
         withKotlinBuildSrc()
         withFile("buildSrc/src/main/kotlin/Mine.kt", """
@@ -1167,7 +1149,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors to kotlin internal task types are typed with the first kotlin public parent type`() {
-        assumeNonEmbeddedGradleExecuter()
 
         withDefaultSettings()
         withKotlinBuildSrc()

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaLambdaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaLambdaAccessorsIntegrationTest.kt
@@ -66,8 +66,6 @@ class ProjectSchemaLambdaAccessorsIntegrationTest : AbstractPluginIntegrationTes
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors to __untyped__ kotlin lambda extensions are typed Any`() {
 
-        assumeNonEmbeddedGradleExecuter()
-
         withDefaultSettings()
         withKotlinBuildSrc()
         withFile("buildSrc/src/main/kotlin/my.gradle.kts", """
@@ -187,8 +185,6 @@ class ProjectSchemaLambdaAccessorsIntegrationTest : AbstractPluginIntegrationTes
     @Issue("https://github.com/gradle/gradle/issues/10772")
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors to __typed__ kotlin lambda extensions are typed`() {
-
-        assumeNonEmbeddedGradleExecuter()
 
         withDefaultSettings()
         withKotlinBuildSrc()

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -58,7 +58,7 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
     )
     fun `kotlin-dsl plugin in buildSrc and production code using kotlin-gradle-plugin `() {
 
-        assumeNonEmbeddedGradleExecuter()
+        assumeNonEmbeddedGradleExecuter() // newer Kotlin version always leaks on the classpath when running embedded
 
         executer.noDeprecationChecks()
         // Ignore stacktraces when the Kotlin daemon fails

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -63,6 +63,8 @@ class KotlinDslPluginTest : AbstractPluginTest() {
     @ToBeFixedForConfigurationCache
     fun `gradle kotlin dsl api is available for test implementation`() {
 
+        assumeNonEmbeddedGradleExecuter() // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
+
         withBuildScript("""
 
             plugins {

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
@@ -26,7 +26,6 @@ open class AbstractPrecompiledScriptPluginTest : AbstractPluginTest() {
 
     @Before
     fun setupPluginTest() {
-        assumeNonEmbeddedGradleExecuter()
         executer.beforeExecute {
             // Ignore stacktraces when the Kotlin daemon fails
             // See https://github.com/gradle/gradle-private/issues/2936

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -236,6 +236,8 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
     @ToBeFixedForConfigurationCache
     fun `can use type-safe accessors for the Kotlin Gradle plugin extensions`() {
 
+        assumeNonEmbeddedGradleExecuter() // Unknown issue with accessing the plugin portal from pre-compiled script plugin in embedded test mode
+
         withKotlinDslPlugin().appendText("""
             dependencies {
                 implementation(kotlin("gradle-plugin"))

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.IgnoreIf
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -695,6 +697,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @ToBeFixedForConfigurationCache(because = "groovy precompiled scripts")
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     def "can write tests for precompiled script plugins"() {
         given:
         pluginWithSampleTask("src/main/groovy/test-plugin.gradle")

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomExternalTaskIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomExternalTaskIntegrationTest.groovy
@@ -19,8 +19,10 @@ import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 class SamplesCustomExternalTaskIntegrationTest extends AbstractSampleIntegrationTest {
@@ -28,6 +30,7 @@ class SamplesCustomExternalTaskIntegrationTest extends AbstractSampleIntegration
     public final Sample sample = new Sample(temporaryFolder)
 
     @Unroll
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     @UsesSample("base/customExternalTask")
     def "can test task implementation with #dsl dsl"() {
         when:

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
@@ -20,14 +20,17 @@ import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 class SamplesCustomPluginIntegrationTest extends AbstractSampleIntegrationTest {
     @Rule public final Sample sample = new Sample(temporaryFolder)
 
     @Unroll
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
     @UsesSample("plugins/customPlugin")
     def "can test plugin and task implementation with #dsl dsl"() {
         when:


### PR DESCRIPTION
`kotlin-sam-with-receiver-compiler-plugin` is leaking on the _Kotlin compile plugin classpath_ and causing the Kotlin compiler to crash on the attemp to load this Kotlin compiler plugin.

```
e: java.lang.IllegalStateException: The provided plugin org.jetbrains.kotlin.samWithReceiver.SamWithReceiverComponentRegistrar is not compatible with this version of compiler
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.registerExtensionsFromPlugins$cli(KotlinCoreEnvironment.kt:577)
...
Caused by: java.lang.AbstractMethodError: org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar.registerProjectComponents(Lorg/jetbrains/kotlin/com/intellij/mock/MockProject;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.registerExtensionsFromPlugins$cli(KotlinCoreEnvironment.kt:569)

```

This PR patches the issue by removing the `kotlin-sam-with-receiver-compiler-plugin` from the simulated _gradleApi()_ .

Notes:
* ~This changes production code of the plugin. However, the new code path is purely for internal use during Gradle development. Therefore, there is no need to release a new version of the plugin.~
* ~I attempted to filter the _simulated gradleApi()_ earlier to not touch the plugin. That is not possible with our current setup: The leak of all dependencies on the gradleApi is "exploited" by the embedded test running to find the dependencies (which are usually packaged in the distribution) on the classpath. So the embedded running in total is relying on gradleApi() leaking everything that belongs to the distribution (and `kotlin-sam-with-receiver-compiler-plugin` is part of the distribution).~