### PR TITLE
Match toolchains deterministically

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocToolAdapter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocToolAdapter.java
@@ -32,7 +32,7 @@ public class JavadocToolAdapter implements JavadocTool {
     }
 
     public WorkResult execute(JavadocSpec spec) {
-        spec.setExecutable(toolchain.findExecutable("javadoc"));
+        spec.setExecutable(toolchain.findExecutable("javadoc").getAbsolutePath());
         return generator.execute(spec);
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -17,13 +17,12 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.file.Directory
 import org.gradle.api.internal.tasks.compile.CommandLineJavaCompileSpec
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaCompiler
-import org.gradle.jvm.toolchain.JavaInstallation
 import org.gradle.jvm.toolchain.JavaToolChain
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory
+import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 import org.gradle.jvm.toolchain.internal.JavaToolchain
 import org.gradle.jvm.toolchain.internal.ToolchainToolFactory
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -84,12 +83,10 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
     def "spec is configured using the toolchain compiler via command line"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
         def javaHome = Jvm.current().javaHome
-        def installation = Mock(JavaInstallation)
-        def installDir = Mock(Directory)
-        installDir.asFile >> javaHome
-        installation.installationDirectory >> installDir
-        installation.getJavaVersion() >> JavaVersion.VERSION_12
-        def toolchain = new JavaToolchain(installation, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory))
+        def probe = Mock(JavaInstallationProbe.ProbeResult)
+        probe.getJavaVersion() >> JavaVersion.VERSION_12
+        probe.getJavaHome() >> javaHome
+        def toolchain = new JavaToolchain(probe, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory))
         javaCompile.setDestinationDir(new File("tmp"))
 
         when:

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -24,6 +24,7 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavadocTool;
+import org.gradle.util.VersionNumber;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -62,8 +63,18 @@ public class JavaToolchain implements Describable {
     }
 
     @Internal
+    public VersionNumber getToolVersion() {
+        return VersionNumber.parse(probe.getImplementationJavaVersion());
+    }
+
+    @Internal
     public File getJavaHome() {
         return probe.getJavaHome();
+    }
+
+    @Internal
+    public boolean isJdk() {
+        return probe.getInstallType() == JavaInstallationProbe.InstallType.IS_JDK;
     }
 
     @Internal

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -20,8 +20,8 @@ import org.gradle.api.Describable;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaCompiler;
-import org.gradle.jvm.toolchain.JavaInstallation;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavadocTool;
 
@@ -30,13 +30,13 @@ import java.io.File;
 
 public class JavaToolchain implements Describable {
 
-    private final JavaInstallation installation;
-    private JavaCompilerFactory compilerFactory;
+    private final JavaInstallationProbe.ProbeResult probe;
+    private final JavaCompilerFactory compilerFactory;
     private final ToolchainToolFactory toolFactory;
 
     @Inject
-    public JavaToolchain(JavaInstallation installation, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
-        this.installation = installation;
+    public JavaToolchain(JavaInstallationProbe.ProbeResult probe, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
+        this.probe = probe;
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
     }
@@ -48,7 +48,7 @@ public class JavaToolchain implements Describable {
 
     @Internal
     public JavaLauncher getJavaLauncher() {
-        return new DefaultToolchainJavaLauncher(installation.getJavaExecutable().getAsFile());
+        return new DefaultToolchainJavaLauncher(findExecutable("java"));
     }
 
     @Internal
@@ -58,12 +58,12 @@ public class JavaToolchain implements Describable {
 
     @Input
     public JavaVersion getJavaMajorVersion() {
-        return installation.getJavaVersion();
+        return probe.getJavaVersion();
     }
 
     @Internal
     public File getJavaHome() {
-        return installation.getInstallationDirectory().getAsFile();
+        return probe.getJavaHome();
     }
 
     @Internal
@@ -72,7 +72,7 @@ public class JavaToolchain implements Describable {
         return getJavaHome().getAbsolutePath();
     }
 
-    public String findExecutable(String toolname) {
-        return new File(getJavaHome(), "bin/javadoc").getAbsolutePath();
+    public File findExecutable(String toolname) {
+        return new File(getJavaHome(), "bin/" + OperatingSystem.current().getExecutableName(toolname));
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import java.util.Comparator;
+
+public class JavaToolchainComparator implements Comparator<JavaToolchain> {
+
+    @Override
+    public int compare(JavaToolchain o1, JavaToolchain o2) {
+        return Comparator
+            .comparing(JavaToolchain::getToolVersion)
+            .thenComparing(JavaToolchain::isJdk)
+            .reversed()
+            .compare(o1, o2);
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
@@ -16,31 +16,25 @@
 
 package org.gradle.jvm.toolchain.internal;
 
-import org.gradle.api.internal.file.FileFactory;
-import org.gradle.jvm.toolchain.JavaInstallation;
-import org.gradle.jvm.toolchain.JavaInstallationRegistry;
-
 import javax.inject.Inject;
 import java.io.File;
 
 public class JavaToolchainFactory {
 
-    private final FileFactory fileFactory;
-    private final JavaInstallationRegistry installationRegistry;
+    private final JavaInstallationProbe probeService;
     private final JavaCompilerFactory compilerFactory;
     private final ToolchainToolFactory toolFactory;
 
     @Inject
-    public JavaToolchainFactory(FileFactory fileFactory, JavaInstallationRegistry installationRegistry, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
-        this.fileFactory = fileFactory;
-        this.installationRegistry = installationRegistry;
+    public JavaToolchainFactory(JavaInstallationProbe probeService, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory) {
+        this.probeService = probeService;
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
     }
 
     public JavaToolchain newInstance(File javaHome) {
-        final JavaInstallation installation = installationRegistry.installationForDirectory(fileFactory.dir(javaHome)).get();
-        return new JavaToolchain(installation, compilerFactory, toolFactory);
+        final JavaInstallationProbe.ProbeResult probeResult = probeService.checkJdk(javaHome);
+        return new JavaToolchain(probeResult, compilerFactory, toolFactory);
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -24,7 +24,6 @@ import org.gradle.jvm.toolchain.install.internal.JavaToolchainProvisioningServic
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -52,16 +51,9 @@ public class JavaToolchainQueryService {
         return registry.listInstallations().stream()
             .map(this::asToolchain)
             .filter(matchingToolchain(filter))
-            .sorted(bestMatch())
+            .sorted(new JavaToolchainComparator())
             .findFirst()
             .orElseGet(() -> downloadToolchain(filter));
-    }
-
-    // TOOD: [bm] temporary order until #13892 is implemented
-    private Comparator<JavaToolchain> bestMatch() {
-        return Comparator.<JavaToolchain, String>
-            comparing(t -> t.getJavaHome().getName())
-            .reversed();
     }
 
     private JavaToolchain downloadToolchain(JavaToolchainSpec spec) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainComparatorTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainComparatorTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.util.VersionNumber
+import spock.lang.Specification
+
+class JavaToolchainComparatorTest extends Specification {
+
+    def "prefers higher major versions"() {
+        given:
+        def toolchains = [
+            mockToolchain("6.0"),
+            mockToolchain("8.0"),
+            mockToolchain("11.0"),
+            mockToolchain("5.1")
+        ]
+
+        when:
+        println toolchains
+        toolchains.sort(new JavaToolchainComparator())
+
+        then:
+        assertOrder(toolchains, "11.0.0", "8.0.0", "6.0.0", "5.1.0")
+    }
+
+    def "prefers higher minor versions"() {
+        given:
+        def toolchains = [
+            mockToolchain("8.0.1"),
+            mockToolchain("8.0.123"),
+            mockToolchain("8.0.1234"),
+        ]
+
+        when:
+        toolchains.sort(new JavaToolchainComparator())
+
+        then:
+        assertOrder(toolchains, "8.0.1234", "8.0.123", "8.0.1")
+    }
+
+    def "prefers jdk over jre"() {
+        def jdk = Mock(JavaToolchain) {
+            getToolVersion() >> VersionNumber.parse("8.0.1")
+            isJdk() >> true
+        }
+        def jre = Mock(JavaToolchain) {
+            getToolVersion() >> VersionNumber.parse("8.0.1")
+            isJdk() >> false
+        }
+        given:
+        def toolchains = [jre, jdk]
+
+        when:
+        toolchains.sort(new JavaToolchainComparator())
+
+        then:
+        toolchains == [jdk, jre]
+    }
+
+    void assertOrder(List<JavaToolchain> list, String[] expectedOrder) {
+        assert list*.toolVersion.toString() == expectedOrder.toString()
+    }
+
+    JavaToolchain mockToolchain(String implementationVersion, boolean isJdk = false) {
+        Mock(JavaToolchain) {
+            getToolVersion() >> VersionNumber.parse(implementationVersion)
+            isJdk() >> isJdk
+        }
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -52,7 +52,7 @@ class JavaToolchainQueryServiceTest extends Specification {
     @Unroll
     def "uses most recent version of multiple matches for version #versionToFind"() {
         given:
-        def registry = createInstallationRegistry(["8.0", "8.0.242.hs-adpt", "7.9", "7.7", "14.0.2+12"])
+        def registry = createInstallationRegistry(["8.0", "8.0.242.hs-adpt", "7.9", "7.7", "14.0.2+12", "8.0.zzz.j9"])
         def toolchainFactory = newToolchainFactory()
         def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService))
 
@@ -68,7 +68,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         where:
         versionToFind           | expectedPath
         JavaVersion.VERSION_1_7 | "/path/7.9"
-        JavaVersion.VERSION_1_8 | "/path/8.0.242.hs-adpt"
+        JavaVersion.VERSION_1_8 | "/path/8.0.zzz.j9" // zzz resolves to a real toolversion 999
         JavaVersion.VERSION_14  | "/path/14.0.2+12"
     }
 
@@ -140,9 +140,10 @@ class JavaToolchainQueryServiceTest extends Specification {
     }
 
     def newProbe(File javaHome) {
-        def probe = Mock(JavaInstallationProbe.ProbeResult) {
+        Mock(JavaInstallationProbe.ProbeResult) {
             getJavaVersion() >> JavaVersion.toVersion(javaHome.name)
             getJavaHome() >> javaHome
+            getImplementationJavaVersion() >> javaHome.name.replace("zzz", "999")
         }
     }
 


### PR DESCRIPTION
Prefer higher toolchain versions (tool, not only supported language) and prefer JDK over JRE.

Fixes #13892
