### PR TITLE
Introduce experimental feature to exercise Gradle 7 removals

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
 import org.gradle.api.model.ObjectFactory;
@@ -40,10 +41,12 @@ import java.util.concurrent.Callable;
 public class AntlrPlugin implements Plugin<Project> {
     public static final String ANTLR_CONFIGURATION_NAME = "antlr";
     private final ObjectFactory objectFactory;
+    private final FeaturePreviews featurePreviews;
 
     @Inject
-    public AntlrPlugin(ObjectFactory objectFactory) {
+    public AntlrPlugin(ObjectFactory objectFactory, FeaturePreviews featurePreviews) {
         this.objectFactory = objectFactory;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -63,9 +66,11 @@ public class AntlrPlugin implements Plugin<Project> {
             }
         });
 
-        @SuppressWarnings("deprecation")
-        Configuration compileConfiguration = project.getConfigurations().getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME);
-        compileConfiguration.extendsFrom(antlrConfiguration);
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            @SuppressWarnings("deprecation")
+            Configuration compileConfiguration = project.getConfigurations().getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME);
+            compileConfiguration.extendsFrom(antlrConfiguration);
+        }
 
         // Wire the antlr configuration into all antlr tasks
         project.getTasks().withType(AntlrTask.class).configureEach(new Action<AntlrTask>() {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -271,6 +271,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * @return The name of the associated upload task
      * @see org.gradle.api.tasks.Upload
      */
+    @Deprecated
     String getUploadTaskName();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -29,7 +29,8 @@ public class FeaturePreviews {
         GRADLE_METADATA(false),
         GROOVY_COMPILATION_AVOIDANCE(true),
         ONE_LOCKFILE_PER_PROJECT(true),
-        VERSION_ORDERING_V2(true);
+        VERSION_ORDERING_V2(true),
+        GRADLE7_REMOVALS(true);
 
         public static Feature withName(String name) {
             try {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -907,6 +907,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return this;
     }
 
+    @Deprecated
     @Override
     public String getUploadTaskName() {
         return Configurations.uploadTaskName(getName());

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.model.ObjectFactory;
@@ -53,6 +54,7 @@ public class EarPlugin implements Plugin<Project> {
     static final String DEFAULT_LIB_DIR_NAME = "lib";
 
     private final ObjectFactory objectFactory;
+    private final FeaturePreviews featurePreviews;
 
     /**
      * Injects an {@link ObjectFactory}
@@ -60,8 +62,9 @@ public class EarPlugin implements Plugin<Project> {
      * @since 4.2
      */
     @Inject
-    public EarPlugin(ObjectFactory objectFactory) {
+    public EarPlugin(ObjectFactory objectFactory, FeaturePreviews featurePreviews) {
         this.objectFactory = objectFactory;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -195,7 +198,9 @@ public class EarPlugin implements Plugin<Project> {
         Configuration earlibConfiguration = configurations.create(EARLIB_CONFIGURATION_NAME).setVisible(false)
             .setDescription("Classpath for module dependencies.");
 
-        configurations.getByName(Dependency.DEFAULT_CONFIGURATION)
-            .extendsFrom(moduleConfiguration, earlibConfiguration);
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            configurations.getByName(Dependency.DEFAULT_CONFIGURATION)
+                .extendsFrom(moduleConfiguration, earlibConfiguration);
+        }
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -278,6 +278,7 @@ val <T : Configuration> NamedDomainObjectProvider<T>.resolvedConfiguration
 /**
  * See [Configuration.getUploadTaskName].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().uploadTaskName"))
 val <T : Configuration> NamedDomainObjectProvider<T>.uploadTaskName
     get() = get().uploadTaskName

--- a/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.artifacts.maven.MavenPom;
 import org.gradle.api.artifacts.maven.MavenResolver;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
@@ -73,14 +74,19 @@ public class MavenPlugin implements Plugin<ProjectInternal> {
     private final MavenSettingsProvider mavenSettingsProvider;
     private final LocalMavenRepositoryLocator mavenRepositoryLocator;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final FeaturePreviews featurePreviews;
 
     private Project project;
 
     @Inject
-    public MavenPlugin(Factory<LoggingManagerInternal> loggingManagerFactory, FileResolver fileResolver,
-                       ProjectPublicationRegistry publicationRegistry, ProjectConfigurationActionContainer configurationActionContainer,
-                       MavenSettingsProvider mavenSettingsProvider, LocalMavenRepositoryLocator mavenRepositoryLocator,
-                       ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+    public MavenPlugin(Factory<LoggingManagerInternal> loggingManagerFactory,
+                       FileResolver fileResolver,
+                       ProjectPublicationRegistry publicationRegistry,
+                       ProjectConfigurationActionContainer configurationActionContainer,
+                       MavenSettingsProvider mavenSettingsProvider,
+                       LocalMavenRepositoryLocator mavenRepositoryLocator,
+                       ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                       FeaturePreviews featurePreviews) {
         this.loggingManagerFactory = loggingManagerFactory;
         this.fileResolver = fileResolver;
         this.publicationRegistry = publicationRegistry;
@@ -88,10 +94,15 @@ public class MavenPlugin implements Plugin<ProjectInternal> {
         this.mavenSettingsProvider = mavenSettingsProvider;
         this.mavenRepositoryLocator = mavenRepositoryLocator;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
     public void apply(final ProjectInternal project) {
+        if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            // make this plugin a no-op if Gradle 7 removals is active
+            return;
+        }
         this.project = project;
         DeprecationLogger.deprecatePlugin("maven").replaceWith("maven-publish")
             .willBeRemovedInGradle7()

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.internal.DefaultDistributionContainer;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
@@ -60,12 +61,14 @@ public class DistributionPlugin implements Plugin<Project> {
     private final Instantiator instantiator;
     private final FileOperations fileOperations;
     private final CollectionCallbackActionDecorator callbackActionDecorator;
+    private final FeaturePreviews featurePreviews;
 
     @Inject
-    public DistributionPlugin(Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackActionDecorator) {
+    public DistributionPlugin(Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackActionDecorator, FeaturePreviews featurePreviews) {
         this.instantiator = instantiator;
         this.fileOperations = fileOperations;
         this.callbackActionDecorator = callbackActionDecorator;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -124,8 +127,10 @@ public class DistributionPlugin implements Plugin<Project> {
             task.with(childSpec);
         });
 
-        PublishArtifact archiveArtifact = new LazyPublishArtifact(archiveTask);
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(archiveArtifact);
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            PublishArtifact archiveArtifact = new LazyPublishArtifact(archiveTask);
+            project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(archiveArtifact);
+        }
     }
 
     private void addInstallTask(final Project project, final String taskName, final Distribution distribution) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.java.WebApplication;
@@ -49,11 +50,13 @@ public class WarPlugin implements Plugin<Project> {
 
     private final ObjectFactory objectFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private final FeaturePreviews featurePreviews;
 
     @Inject
-    public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
+    public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory, FeaturePreviews featurePreviews) {
         this.objectFactory = objectFactory;
         this.attributesFactory = attributesFactory;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -94,8 +97,10 @@ public class WarPlugin implements Plugin<Project> {
         Configuration provideRuntimeConfiguration = configurationContainer.create(PROVIDED_RUNTIME_CONFIGURATION_NAME).setVisible(false).
             extendsFrom(provideCompileConfiguration).
             setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
-        configurationContainer.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME).extendsFrom(provideCompileConfiguration);
-        configurationContainer.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            configurationContainer.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME).extendsFrom(provideCompileConfiguration);
+            configurationContainer.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
+        }
     }
 
     private void configureComponent(Project project, PublishArtifact warArtifact) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -33,6 +33,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
@@ -78,7 +79,7 @@ public class JvmPluginsHelper {
      * @param sourceSet the source set to add an API for
      * @return the created API configuration
      */
-    public static Configuration addApiToSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
+    public static Configuration addApiToSourceSet(SourceSet sourceSet, ConfigurationContainer configurations, FeaturePreviews featurePreviews) {
         Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
         apiConfiguration.setVisible(false);
         apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
@@ -91,9 +92,11 @@ public class JvmPluginsHelper {
         Configuration implementationConfiguration = configurations.getByName(sourceSet.getImplementationConfigurationName());
         implementationConfiguration.extendsFrom(apiConfiguration);
 
-        @SuppressWarnings("deprecation")
-        Configuration compileConfiguration = configurations.getByName(sourceSet.getCompileConfigurationName());
-        apiConfiguration.extendsFrom(compileConfiguration);
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.GRADLE7_REMOVALS)) {
+            @SuppressWarnings("deprecation")
+            Configuration compileConfiguration = configurations.getByName(sourceSet.getCompileConfigurationName());
+            apiConfiguration.extendsFrom(compileConfiguration);
+        }
 
         return apiConfiguration;
     }


### PR DESCRIPTION
This commit introduces a new experimental "feature" which can
be used to preview what's going to happen in Gradle 7 with some
removals. In this case, this commit removes a number of configurations
like `compile` and `runtime` which have been deprecated for
quite some time already, and makes the `maven` plugin a no-op.

