### PR TITLE
Fix missing gradle profiler report

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
@@ -58,7 +58,7 @@ class AbstractCrossVersionGradleProfilerPerformanceTest extends Specification {
         runner = new GradleProfilerCrossVersionPerformanceTestRunner(
             new GradleProfilerBuildExperimentRunner(gradleProfilerReporter.getResultCollector()),
             resultStore,
-            resultStore,
+            gradleProfilerReporter,
             new ReleasedVersionDistributions(buildContext),
             buildContext
         )

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GradleProfilerReporter.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GradleProfilerReporter.java
@@ -38,7 +38,6 @@ public class GradleProfilerReporter implements DataReporter<PerformanceTestResul
             new CsvGenerator(new File(debugArtifactsDirectory, "benchmark.csv"), CsvGenerator.Format.LONG),
             new HtmlGenerator(new File(debugArtifactsDirectory, "benchmark.html"))
         );
-
     }
 
     @Override


### PR DESCRIPTION
We seemed to accidentally remove gradle profiler reporter when removing slack reporter.
