### PR TITLE
De-incubate file system watching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 public class StartParameterInternal extends StartParameter {
     private boolean watchFileSystem;
+    private boolean watchFileSystemUsingDeprecatedOption;
 
     private boolean configurationCache;
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
@@ -44,6 +45,7 @@ public class StartParameterInternal extends StartParameter {
     protected StartParameter prepareNewBuild(StartParameter startParameter) {
         StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
         p.watchFileSystem = watchFileSystem;
+        p.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
         p.configurationCache = configurationCache;
         p.configurationCacheProblems = configurationCacheProblems;
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
@@ -82,6 +84,14 @@ public class StartParameterInternal extends StartParameter {
 
     public void setWatchFileSystem(boolean watchFileSystem) {
         this.watchFileSystem = watchFileSystem;
+    }
+
+    public boolean isWatchFileSystemUsingDeprecatedOption() {
+        return watchFileSystemUsingDeprecatedOption;
+    }
+
+    public void setWatchFileSystemUsingDeprecatedOption(boolean watchFileSystemUsingDeprecatedOption) {
+        this.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
     }
 
     public boolean isConfigurationCache() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -21,8 +21,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.BasicFileResolver;
-import org.gradle.cli.CommandLineOption;
-import org.gradle.cli.CommandLineParser;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BooleanCommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
@@ -349,11 +347,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         DependencyVerificationWriteOption() {
             super(null, CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION,
                 "Generates checksums for dependencies used in the project (comma-separated list)").incubating());
-        }
-
-        @Override
-        protected CommandLineOption configureCommandLineOption(CommandLineParser parser, String[] options, String description, boolean deprecated, boolean incubating) {
-            return super.configureCommandLineOption(parser, options, description, deprecated, incubating);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -63,6 +63,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         options.add(new BuildCacheOption());
         options.add(new BuildCacheDebugLoggingOption());
         options.add(new WatchFileSystemOption());
+        options.add(new DeprecatedWatchFileSystemOption());
         options.add(new BuildScanOption());
         options.add(new DependencyLockingWriteOption());
         options.add(new DependencyVerificationWriteOption());
@@ -294,7 +295,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class WatchFileSystemOption extends BooleanBuildOption<StartParameterInternal> {
         public static final String LONG_OPTION = "watch-fs";
-        public static final String GRADLE_PROPERTY = "org.gradle.unsafe.watch-fs";
+        public static final String GRADLE_PROPERTY = "org.gradle.vfs.watch";
 
         public WatchFileSystemOption() {
             super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create(
@@ -307,6 +308,21 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
             startParameter.setWatchFileSystem(value);
+        }
+    }
+
+    @Deprecated
+    public static class DeprecatedWatchFileSystemOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String GRADLE_PROPERTY = "org.gradle.unsafe.watch-fs";
+
+        public DeprecatedWatchFileSystemOption() {
+            super(GRADLE_PROPERTY);
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
+            startParameter.setWatchFileSystem(value);
+            startParameter.setWatchFileSystemUsingDeprecatedOption(true);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -49,6 +49,7 @@ import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.classloader.ClasspathHasher;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.file.Stat;
@@ -118,16 +119,33 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
     public static final String DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY = "org.gradle.unsafe.vfs.retention";
 
     /**
-     * When retention is enabled, this system property can be used to invalidate the entire VFS.
+     * When file system watching is enabled, this system property can be used to invalidate the entire VFS.
      *
      * @see org.gradle.initialization.StartParameterBuildOptions.WatchFileSystemOption
      */
-    public static final String VFS_DROP_PROPERTY = "org.gradle.unsafe.vfs.drop";
+    public static final String VFS_DROP_PROPERTY = "org.gradle.vfs.drop";
+
+    /**
+     * Previous name for {@link #VFS_DROP_PROPERTY}.
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
+    @VisibleForTesting
+    public static final String DEPRECATED_VFS_DROP_PROPERTY = "org.gradle.unsafe.vfs.drop";
 
     private static final int DEFAULT_MAX_HIERARCHIES_TO_WATCH = 50;
     public static final String MAX_HIERARCHIES_TO_WATCH_PROPERTY = "org.gradle.vfs.watch.hierarchies.max";
 
     public static boolean isDropVfs(StartParameter startParameter) {
+        if (getSystemProperty(DEPRECATED_VFS_DROP_PROPERTY, startParameter.getSystemPropertiesArgs()) != null) {
+            DeprecationLogger
+                .deprecateSystemProperty(DEPRECATED_VFS_DROP_PROPERTY)
+                .replaceWith(VFS_DROP_PROPERTY)
+                .willBeRemovedInGradle7()
+                .undocumented()
+                .nagUser();
+            return isSystemPropertyEnabled(DEPRECATED_VFS_DROP_PROPERTY, startParameter.getSystemPropertiesArgs());
+        }
         return isSystemPropertyEnabled(VFS_DROP_PROPERTY, startParameter.getSystemPropertiesArgs());
     }
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -79,7 +79,7 @@ When configured, Gradle will fork up to `org.gradle.workers.max` JVMs to execute
 `org.gradle.priority=(low,normal)`::
 Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Default is `normal`. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.
 
-`org.gradle.unsafe.watch-fs=(true,false)`::
+`org.gradle.vfs.watch=(true,false)`::
 Toggles <<gradle_daemon.adoc#sec:daemon_watch_fs,watching the file system>>.
 Allows Gradle to re-use information about the file system in the next build.
 _Default is off_.

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -204,11 +204,6 @@ This can save a significant amount of time for incremental builds, where the num
 [[sec:daemon_watch_fs]]
 == Watching the file system
 
-[NOTE]
-====
-Watching the file system is an experimental feature.
-====
-
 To detect changes on the file system, and to calculate what needs to be rebuilt, Gradle collects information about the file system in-memory during every build (aka _Virtual File System_).
 By watching the file system, Gradle can keep the Virtual File System in sync with the file system even between builds.
 Doing so allows the Daemon to save the time to rebuild the Virtual File System from disk for the next build.

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -230,7 +230,7 @@ You can enable the feature in a couple of ways:
 
 Run with `--watch-fs` on the command line::
 This enables watching the file system for this build only.
-Put `org.gradle.unsafe.watch-fs=true` in your `gradle.properties`::
+Put `org.gradle.vfs.watch=true` in your `gradle.properties`::
 This enables watching the file system for all builds, unless explicitly disabled with `--no-watch-fs`.
 
 [[sec:daemon_watch_fs_troubleshooting]]

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -65,14 +65,34 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         commandLineOption << ["-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true", "--watch-fs"]
     }
 
-    def "deprecation message is shown when using the old property to enable watching the file system"() {
+    @Unroll
+    @SuppressWarnings('GrDeprecatedAPIUsage')
+    def "deprecation message is shown when using the old property to enable watching the file system (enabled: #enabled)"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        executer.expectDocumentedDeprecationWarning(
+                "The org.gradle.unsafe.watch-fs system property has been deprecated. " +
+                        "This is scheduled to be removed in Gradle 7.0. " +
+                        "Please use the org.gradle.vfs.watch system property instead. " +
+                        "See https://docs.gradle.org/current/userguide/gradle_daemon.html for more details."
+        )
+
+        expect:
+        succeeds("assemble", "-D${StartParameterBuildOptions.DeprecatedWatchFileSystemOption.GRADLE_PROPERTY}=${enabled}")
+
+        where:
+        enabled << [true, false]
+    }
+
+    def "deprecation message is shown when using old VFS retention property to enable watching the file system"() {
         buildFile << """
             apply plugin: "java"
         """
         executer.expectDocumentedDeprecationWarning(
                 "Using the system property org.gradle.unsafe.vfs.retention to enable watching the file system has been deprecated. " +
                         "This is scheduled to be removed in Gradle 7.0. " +
-                        "Use the gradle property org.gradle.unsafe.watch-fs instead. " +
+                        "Use the gradle property org.gradle.vfs.watch instead. " +
                         "See https://docs.gradle.org/current/userguide/gradle_daemon.html for more details."
         )
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.watch
 
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.service.scopes.VirtualFileSystemServices
+import spock.lang.Unroll
 
 class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatchingIntegrationTest {
     private static final String INCUBATING_MESSAGE = "Watching the file system is an incubating feature"
@@ -77,5 +78,20 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
 
         expect:
         succeeds("assemble", "-D${VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY}=true")
+    }
+
+    @Unroll
+    def "deprecation message is shown when using the old property to drop the VFS (drop: #drop)"() {
+        executer.expectDeprecationWarning(
+                "The org.gradle.unsafe.vfs.drop system property has been deprecated. " +
+                        "This is scheduled to be removed in Gradle 7.0. " +
+                        "Please use the org.gradle.vfs.drop system property instead."
+        )
+
+        expect:
+        succeeds("help", "--watch-fs", "-D${VirtualFileSystemServices.DEPRECATED_VFS_DROP_PROPERTY}=${drop}")
+
+        where:
+        drop << [true, false]
     }
 }

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -85,7 +85,9 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         enabled << [true, false]
     }
 
-    def "deprecation message is shown when using old VFS retention property to enable watching the file system"() {
+    @Unroll
+    @SuppressWarnings('GrDeprecatedAPIUsage')
+    def "deprecation message is shown when using old VFS retention property to enable watching the file system (enabled: #enabled)"() {
         buildFile << """
             apply plugin: "java"
         """
@@ -97,10 +99,14 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         )
 
         expect:
-        succeeds("assemble", "-D${VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY}=true")
+        succeeds("assemble", "-D${VirtualFileSystemServices.DEPRECATED_VFS_RETENTION_ENABLED_PROPERTY}=${enabled}")
+
+        where:
+        enabled << [true, false]
     }
 
     @Unroll
+    @SuppressWarnings('GrDeprecatedAPIUsage')
     def "deprecation message is shown when using the old property to drop the VFS (drop: #drop)"() {
         executer.expectDeprecationWarning(
                 "The org.gradle.unsafe.vfs.drop system property has been deprecated. " +

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -300,9 +300,13 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void multiProjectBuildCanHaveSettingsFileAndRootBuildFileInSubDir() {
+        // Stop traversing to parent directory; otherwise embedded test execution will
+        // find and load the `gradle.properties` file in the root of the source repository
+        getTestDirectory().file("settings.gradle").createFile();
+
         TestFile buildFilesDir = getTestDirectory().file("root");
-        TestFile settingsFile = buildFilesDir.file("settings.gradle");
-        settingsFile.writelns(
+        TestFile relocatedSettingsFile = buildFilesDir.file("settings.gradle");
+        relocatedSettingsFile.writelns(
             "includeFlat 'child'",
             "rootProject.projectDir = new File(settingsDir, '..')",
             "rootProject.buildFileName = 'root/build.gradle'"
@@ -314,9 +318,9 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         TestFile childBuildFile = testFile("child/build.gradle");
         childBuildFile.writelns("task('do-stuff')", "task('task')");
 
-        usingProjectDir(getTestDirectory()).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff").assertTaskOrder(":child:task", ":do-stuff");
+        usingProjectDir(getTestDirectory()).usingSettingsFile(relocatedSettingsFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff").assertTaskOrder(":child:task", ":do-stuff");
         usingBuildFile(rootBuildFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff").assertTaskOrder(":child:task", ":do-stuff");
-        usingBuildFile(childBuildFile).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecutedInOrder(":child:do-stuff");
+        usingBuildFile(childBuildFile).usingSettingsFile(relocatedSettingsFile).withTasks("do-stuff").run().assertTasksExecutedInOrder(":child:do-stuff");
     }
 
     @Test

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -57,9 +57,9 @@ public class BuildActionSerializer {
         private final Serializer<ConsoleOutput> consoleOutputSerializer;
         private final Serializer<WarningMode> warningModeSerializer;
         private final Serializer<File> nullableFileSerializer = new NullableFileSerializer();
-        private final Serializer<List<String>> stringListSerializer = new ListSerializer<String>(BaseSerializerFactory.STRING_SERIALIZER);
-        private final Serializer<List<File>> fileListSerializer = new ListSerializer<File>(BaseSerializerFactory.FILE_SERIALIZER);
-        private final Serializer<Set<String>> stringSetSerializer = new SetSerializer<String>(BaseSerializerFactory.STRING_SERIALIZER);
+        private final Serializer<List<String>> stringListSerializer = new ListSerializer<>(BaseSerializerFactory.STRING_SERIALIZER);
+        private final Serializer<List<File>> fileListSerializer = new ListSerializer<>(BaseSerializerFactory.FILE_SERIALIZER);
+        private final Serializer<Set<String>> stringSetSerializer = new SetSerializer<>(BaseSerializerFactory.STRING_SERIALIZER);
 
         ExecuteBuildActionSerializer() {
             BaseSerializerFactory serializerFactory = new BaseSerializerFactory();
@@ -216,7 +216,7 @@ public class BuildActionSerializer {
 
         private List<TaskExecutionRequest> readTaskRequests(Decoder decoder) throws Exception {
             int requestCount = decoder.readSmallInt();
-            List<TaskExecutionRequest> taskExecutionRequests = new ArrayList<TaskExecutionRequest>(requestCount);
+            List<TaskExecutionRequest> taskExecutionRequests = new ArrayList<>(requestCount);
             for (int i = 0; i < requestCount; i++) {
                 taskExecutionRequests.add(new DefaultTaskExecutionRequest(stringListSerializer.read(decoder)));
             }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -116,6 +116,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildCacheEnabled());
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystem());
+            encoder.writeBoolean(startParameter.isWatchFileSystemUsingDeprecatedOption());
             encoder.writeBoolean(startParameter.isConfigurationCache());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeSmallInt(startParameter.getConfigurationCacheMaxProblems());
@@ -193,6 +194,7 @@ public class BuildActionSerializer {
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
             startParameter.setWatchFileSystem(decoder.readBoolean());
+            startParameter.setWatchFileSystemUsingDeprecatedOption(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheMaxProblems(decoder.readSmallInt());

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -27,9 +27,12 @@ import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.scopes.VirtualFileSystemServices;
 import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
-import org.gradle.util.IncubationLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemWatchingBuildActionRunner.class);
+
     private final BuildActionRunner delegate;
 
     public FileSystemWatchingBuildActionRunner(BuildActionRunner delegate) {
@@ -47,8 +50,8 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
 
         logMessageForDeprecatedWatchFileSystemProperty(startParameter);
         logMessageForDeprecatedVfsRetentionProperty(startParameter);
+        LOGGER.info("Watching the file system is {}", watchFileSystem ? "enabled" : "disabled");
         if (watchFileSystem) {
-            IncubationLogger.incubatingFeatureUsed("Watching the file system");
             dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
         }
         virtualFileSystem.afterBuildStarted(watchFileSystem, buildOperationRunner);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -45,6 +45,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
 
         boolean watchFileSystem = startParameter.isWatchFileSystem();
 
+        logMessageForDeprecatedWatchFileSystemProperty(startParameter);
         logMessageForDeprecatedVfsRetentionProperty(startParameter);
         if (watchFileSystem) {
             IncubationLogger.incubatingFeatureUsed("Watching the file system");
@@ -62,6 +63,18 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
     private static void dropVirtualFileSystemIfRequested(StartParameterInternal startParameter, BuildLifecycleAwareVirtualFileSystem virtualFileSystem) {
         if (VirtualFileSystemServices.isDropVfs(startParameter)) {
             virtualFileSystem.update(VirtualFileSystem.INVALIDATE_ALL);
+        }
+    }
+
+    private static void logMessageForDeprecatedWatchFileSystemProperty(StartParameterInternal startParameter) {
+        if (startParameter.isWatchFileSystemUsingDeprecatedOption()) {
+            @SuppressWarnings("deprecation")
+            String deprecatedWatchFsProperty = StartParameterBuildOptions.DeprecatedWatchFileSystemOption.GRADLE_PROPERTY;
+            DeprecationLogger.deprecateSystemProperty(deprecatedWatchFsProperty)
+                .replaceWith(StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY)
+                .willBeRemovedInGradle7()
+                .withUserManual("gradle_daemon")
+                .nagUser();
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -29,6 +29,8 @@ import org.gradle.tooling.internal.provider.TestExecutionRequestAction
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload
 import spock.lang.Unroll
 
+import java.beans.Introspector
+
 @Unroll
 class BuildActionSerializerTest extends SerializerSpec {
     def "serializes ExecuteBuildAction with all defaults"() {
@@ -62,27 +64,11 @@ class BuildActionSerializerTest extends SerializerSpec {
         result.startParameter."${buildOptionName}" == expectedValue
 
         where:
-        buildOptionName << [
-            "parallelProjectExecutionEnabled",
-            "searchUpwardsWithoutDeprecationWarning",
-            "buildProjectDependencies",
-            "dryRun",
-            "rerunTasks",
-            "profile",
-            "continueOnFailure",
-            "offline",
-            "refreshDependencies",
-            "buildCacheEnabled",
-            "buildCacheDebugLogging",
-            "watchFileSystem",
-            "configureOnDemand",
-            "continuous",
-            "buildScan",
-            "noBuildScan",
-            "writeDependencyLocks",
-            "refreshKeys",
-            "exportKeys"
-        ]
+        // Check all boolean properties (must manually check for setters as many of them return StartParameter)
+        buildOptionName << Introspector.getBeanInfo(StartParameterInternal).propertyDescriptors
+            .findAll { it.propertyType == boolean }
+            .findAll { StartParameterInternal.methods*.name.contains("set" + it.name.capitalize()) }
+            .collect { it.name }
     }
 
     def "serializes other actions #action.class"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -64,7 +64,7 @@ class BuildActionSerializerTest extends SerializerSpec {
         result.startParameter."${buildOptionName}" == expectedValue
 
         where:
-        // Check all boolean properties (must manually check for setters as many of them return StartParameter)
+        // Check all mutable boolean properties (must manually check for setters as many of them return StartParameter)
         buildOptionName << Introspector.getBeanInfo(StartParameterInternal).propertyDescriptors
             .findAll { it.propertyType == boolean }
             .findAll { StartParameterInternal.methods*.name.contains("set" + it.name.capitalize()) }

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -159,6 +159,14 @@ public class DeprecationLogger {
     }
 
     /**
+     * Output: The ${property} system property has been deprecated.
+     */
+    @CheckReturnValue
+    public static DeprecationMessageBuilder.DeprecateSystemProperty deprecateSystemProperty(String systemProperty) {
+        return new DeprecationMessageBuilder.DeprecateSystemProperty(systemProperty);
+    }
+
+    /**
      * Output: The ${parameter} named parameter has been deprecated.
      */
     @CheckReturnValue

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -285,6 +285,39 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         }
     }
 
+    public static class DeprecateSystemProperty extends WithReplacement<String, DeprecateSystemProperty> {
+        private final String systemProperty;
+
+        DeprecateSystemProperty(String systemProperty) {
+            super(systemProperty);
+            this.systemProperty = systemProperty;
+        }
+
+        /**
+         * Output: This is scheduled to be removed in Gradle 7.
+         */
+        @Override
+        public WithDeprecationTimeline willBeRemovedInGradle7() {
+            setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE7));
+            return new WithDeprecationTimeline(this);
+        }
+
+        @Override
+        String formatSubject() {
+            return systemProperty;
+        }
+
+        @Override
+        String formatSummary(String property) {
+            return String.format("The %s system property has been deprecated.", property);
+        }
+
+        @Override
+        String formatAdvice(String replacement) {
+            return String.format("Please use the %s system property instead.", replacement);
+        }
+    }
+
     @CheckReturnValue
     public static class ConfigurationDeprecationTypeSelector {
         private final String configuration;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
@@ -153,6 +153,22 @@ class DeprecationMessagesTest extends Specification {
         expectMessage "The DeprecationLogger.propertyName property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacement property instead."
     }
 
+    def "logs deprecated system property message"() {
+        when:
+        DeprecationLogger.deprecateSystemProperty("org.gradle.test").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+
+        then:
+        expectMessage "The org.gradle.test system property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
+    }
+
+    def "logs deprecated and replaced system property message"() {
+        when:
+        DeprecationLogger.deprecateSystemProperty("org.gradle.deprecated.test").replaceWith("org.gradle.test").willBeRemovedInGradle7().undocumented().nagUser()
+
+        then:
+        expectMessage "The org.gradle.deprecated.test system property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the org.gradle.test system property instead."
+    }
+
     def "logs discontinued method message"() {
         when:
         DeprecationLogger.deprecateMethod(DeprecationLogger, "method()").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #14195
Fixes #14128

Remove the incubation message when file system watching is enabled, and drop "unsafe" from file system watching-related property names.