### PR TITLE
Do not depend on baseline version in jar names for binary compatibility check

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -128,7 +128,6 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", Japicm
         to.attribute(ARTIFACT_TYPE, 'gradle-baseline-jars')
         parameters {
             currentJars.from(currentDistributionJars)
-            baselineVersion.set(compatibilityBaselineVersion)
             currentVersion.set(baseVersion)
         }
     }

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleJars.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleJars.groovy
@@ -40,9 +40,6 @@ abstract class FindGradleJars implements TransformAction<Parameters> {
         ConfigurableFileCollection getCurrentJars()
 
         @Input
-        Property<String> getBaselineVersion()
-
-        @Input
         Property<String> getCurrentVersion()
     }
 
@@ -52,13 +49,15 @@ abstract class FindGradleJars implements TransformAction<Parameters> {
 
     @Override
     void transform(TransformOutputs outputs) {
-        File artifactFile = artifact.get().asFile
-        if (artifactFile.name == 'gradle-jars') {
-            def jarNames = parameters.currentJars.collect { it.name.replace(parameters.currentVersion.get(), parameters.baselineVersion.get()) }
-            artifactFile.listFiles().findAll {
-                jarNames.contains(it.name)
-            }.each {
-                outputs.file(it)
+        File baselineJarsDirectory = artifact.get().asFile
+        if (baselineJarsDirectory.name == 'gradle-jars') {
+            def jarPrefixes = parameters.currentJars.collect { it.name.replace("${parameters.currentVersion.get()}.jar", '') }
+            baselineJarsDirectory.listFiles().each {
+                for (def jarPrefix : jarPrefixes) {
+                    if (it.name.startsWith(jarPrefix)) {
+                        outputs.file(it)
+                    }
+                }
             }
         }
     }

--- a/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild/lifecycle.gradle.kts
+++ b/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild/lifecycle.gradle.kts
@@ -142,7 +142,7 @@ fun TaskContainer.registerEarlyFeedbackLifecycleTasks() {
         group = "verification"
         dependsOn(
             "compileAll", ":docs:checkstyleApi", "codeQuality", ":internal-build-reports:allIncubationReportsZip",
-            ":docs:javadocAll",
+            ":architecture-test:checkBinaryCompatibility", ":docs:javadocAll",
             ":architecture-test:test", ":tooling-api:toolingApiShadedJar")
     }
 }


### PR DESCRIPTION
The baseline jar https://services.gradle.org/distributions-snapshots/gradle-6.6.1-20200824231953+0000-bin.zip used to compare against current, contains Gradle jars internally with version `6.6.1` in the name and not `6.6.1-20200824231953+0000` (the baseline version used).
This caused the current logic that looked for version `6.6.1-20200824231953+0000` to miss those jars and not take them into account, effectively comparing current jars against nothing.

This change makes the binary compatibility check not depend on the exact version in the jar name. In fact, this is how this worked before refactoring the transform-per-jar logic into a single transform: https://github.com/gradle/gradle/blob/v6.6.0/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/transforms/FindGradleJar.groovy#L50