### PR TITLE
Kill leaked processes from previous builds for non-test CI jobs

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -158,6 +158,7 @@ fun BaseGradleBuildType.killProcessStep(stepName: String, daemon: Boolean = true
 fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: Os = Os.linux, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
     buildType.applyDefaultSettings(os, timeout)
 
+    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS")
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
     buildType.steps {

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -63,6 +63,7 @@ class ApplyDefaultConfigurationTest {
         applyDefaults(buildModel, buildType, "myTask")
 
         assertEquals(listOf(
+            "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
             "GRADLE_RUNNER",
             "CHECK_CLEAN_M2"
         ), steps.items.map(BuildStep::name))


### PR DESCRIPTION
It happens that processes remain on build agents and prevent `clean` job from cleaning up the build directories for non-test CI jobs. Test CI jobs do kill any leaked processes prior to starting the build. Do the same for non-test jobs.

We used to do this killing from the `clean` task in the build, but now do it on CI only instead.