### PR TITLE
Reimplement `available-at`

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
@@ -19,8 +19,11 @@ package org.gradle.integtests.resolve.validation
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
+import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.Issue
 
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
@@ -110,4 +113,116 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
         fails ":checkDeps"
         failure.assertHasCause("Gradle Module Metadata for module org.test:projectA:1.1 is invalid because it doesn't declare any variant")
     }
+
+    @UnsupportedWithConfigurationCache(because = "tries to revisit a file collection which failed to resolve")
+    def "fails if an available-at module isn't published"() {
+        buildFile << """
+            dependencies {
+                conf 'org.test:module:1.0'
+            }
+        """
+
+        when:
+        repository {
+            'org.test:module:1.0' {
+                variants(['api', 'runtime']) {
+                    availableAt("../../module2/1.0/module2-1.0.module", "org.test", "module2", "1.0")
+                }
+            }
+        }
+
+        then:
+        repositoryInteractions {
+            'org.test:module:1.0' {
+                expectGetMetadata()
+            }
+            'org.test:module2:1.0' {
+                withModule {
+                    moduleMetadata.expectGetMissing()
+                }
+            }
+        }
+        fails ":checkDeps"
+        failure.assertHasCause("Module org.test:module:1.0 is invalid because it references a variant from a module which isn't published in the same repository.")
+    }
+
+    @UnsupportedWithConfigurationCache(because = "tries to revisit a file collection which failed to resolve")
+    def "fails if an available-at module is published in a different repository"() {
+        def otherRepo = new MavenFileRepository(temporaryFolder.createDir("other-repo"))
+        otherRepo.module('org.test', 'module2', '1.0').publish()
+
+        buildFile << """
+            repositories {
+                maven {
+                    name = 'other'
+                    url = '${otherRepo.uri}'
+                }
+            }
+            dependencies {
+                conf 'org.test:module:1.0'
+            }
+        """
+
+        when:
+        repository {
+            'org.test:module:1.0' {
+                variants(['api', 'runtime']) {
+                    availableAt("../../module2/1.0/module2-1.0.module", "org.test", "module2", "1.0")
+                }
+            }
+        }
+
+        then:
+        repositoryInteractions {
+            'org.test:module:1.0' {
+                expectGetMetadata()
+            }
+            'org.test:module2:1.0' {
+                withModule {
+                    moduleMetadata.expectGetMissing()
+                }
+            }
+        }
+        fails ":checkDeps"
+        failure.assertHasCause("Module org.test:module:1.0 is invalid because it references a variant from a module which isn't published in the same repository.")
+    }
+
+    @UnsupportedWithConfigurationCache(because = "tries to revisit a file collection which failed to resolve")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    def "fails if an available-at module is a snapshot"() {
+        buildFile << """
+            dependencies {
+                conf 'org.test:module:1.0'
+            }
+        """
+
+        when:
+        repository {
+            'org.test:module2:1.0-SNAPSHOT' {
+                withModule(MavenModule) {
+                    withNonUniqueSnapshots() // this is just a trick because `available-at` would need to reference the timestamp otherwise
+                }
+            }
+            'org.test:module:1.0' {
+                variants(['api', 'runtime']) {
+                    availableAt("../../module2/1.0-SNAPSHOT/module2-1.0-SNAPSHOT.module", "org.test", "module2", "1.0-SNAPSHOT")
+                }
+            }
+        }
+
+        then:
+        repositoryInteractions {
+            'org.test:module:1.0' {
+                expectGetMetadata()
+            }
+            'org.test:module2:1.0-SNAPSHOT' {
+                withModule {
+                    moduleMetadata.expectGet()
+                }
+            }
+        }
+        fails ":checkDeps"
+        failure.assertHasCause("Module org.test:module:1.0 is invalid because it references a variant from a changing module: org.test:module2:1.0-SNAPSHOT.")
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -58,6 +58,7 @@ public enum CacheLayout {
         .changedTo(82, "6.0-rc-2")
         .changedTo(95, "6.1-rc-1")
         .changedTo(96, "6.4-rc-1")
+        .changedTo(97_000_000, "6.7-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -409,9 +409,6 @@ public class GradleModuleMetadataParser {
             if (targetComponent instanceof MutableMavenModuleResolveMetadata) {
                 MavenResolver.processMetaData((MutableMavenModuleResolveMetadata) targetComponent);
             }
-            if (targetComponent.isChanging()) {
-                throw invalidReferenceToExternalModule(id, "it references a variant from a changing module: " + targetComponent.getModuleVersionId() + ".");
-            }
             return ExternalVariant.of(url, targetComponent, fallbackDependencies);
         } else {
             throw invalidReferenceToExternalModule(id, "it references a variant from a module which isn't published in the same repository.");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -45,6 +45,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.component.external.model.AvailableAtUrlBackedArtifactMetadata;
 import org.gradle.internal.component.external.model.ComponentVariant;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultShadowedCapability;
@@ -67,11 +68,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.gson.stream.JsonToken.BOOLEAN;
-import static com.google.gson.stream.JsonToken.END_ARRAY;
-import static com.google.gson.stream.JsonToken.END_OBJECT;
-import static com.google.gson.stream.JsonToken.NULL;
-import static com.google.gson.stream.JsonToken.NUMBER;
+import static com.google.gson.stream.JsonToken.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang.StringUtils.capitalize;
 
@@ -395,12 +392,13 @@ public class GradleModuleMetadataParser {
         ModuleComponentIdentifier targetId = DefaultModuleComponentIdentifier.newId(
             DefaultModuleIdentifier.newId(group, module), version
         );
+        UrlBackedArtifactMetadata artifact = new AvailableAtUrlBackedArtifactMetadata(
+            targetId,
+            module + "-" + version + ".module",
+            url
+        );
         LocallyAvailableExternalResource resource = externalArtifactResolver.resolveArtifact(
-            new UrlBackedArtifactMetadata(
-                targetId,
-                module + "-" + version + ".module",
-                url
-            ), result
+            artifact, result
         );
         ImmutableList<ModuleDependency> fallbackDependencies = ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), ImmutableList.of(), null, ImmutableAttributes.EMPTY, Collections.emptyList(), false, null));
         if (resource != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
@@ -70,7 +70,7 @@ public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<Mu
         LocallyAvailableExternalResource gradleMetadataArtifact = artifactResolver.resolveArtifact(artifactId, result);
         if (gradleMetadataArtifact != null) {
             MutableModuleComponentResolveMetadata metaDataFromResource = mutableModuleMetadataFactory.createForGradleModuleMetadata(moduleComponentIdentifier);
-            metadataParser.parse(gradleMetadataArtifact, metaDataFromResource);
+            metadataParser.parse(gradleMetadataArtifact, metaDataFromResource, artifactResolver, mutableModuleMetadataFactory);
             validateGradleMetadata(metaDataFromResource);
             createModuleSources(artifactId, gradleMetadataArtifact, metaDataFromResource);
             metadataCompatibilityConverter.process(metaDataFromResource);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -67,7 +67,15 @@ public class GradleModuleMetadataCompatibilityConverter {
                 if (invalidFiles != null) {
                     for (ComponentVariant.File invalidFile : invalidFiles) {
                         mutableVariant.removeFile(invalidFile);
-                        mutableVariant.addFile(invalidFile.getName(), invalidFile.getUri().replace("SNAPSHOT", uniqueIdentifier.getTimestamp()));
+                        String uri = invalidFile.getUri();
+                        int idx = uri.lastIndexOf("/");
+                        if (idx > 0) {
+                            String prefix = uri.substring(0, idx);
+                            uri = prefix + uri.substring(idx).replace("SNAPSHOT", uniqueIdentifier.getTimestamp());
+                        } else {
+                            uri = uri.replace("SNAPSHOT", uniqueIdentifier.getTimestamp());
+                        }
+                        mutableVariant.addFile(invalidFile.getName(), uri);
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AvailableAtUrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AvailableAtUrlBackedArtifactMetadata.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+
+/**
+ * Represents an an artifact metadata available at some relative url
+ * in a repository. The URL may contain `-SNAPSHOT` in the file part
+ * which would be resolved properly.
+ */
+public class AvailableAtUrlBackedArtifactMetadata extends UrlBackedArtifactMetadata {
+    public AvailableAtUrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
+        super(componentIdentifier, fileName, relativeUrl);
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 96
+        expectedVersion = 97000000
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -36,6 +36,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DesugaredAttributeContainerSerializer
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.metadata.MutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
@@ -148,7 +150,7 @@ class ModuleMetadataSerializerTest extends Specification {
 
     MutableModuleComponentResolveMetadata parseGradle(File gradleFile) {
         def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('test', 'test-module'), '1.0'), [])
-        gradleMetadataParser.parse(resource(gradleFile), metadata)
+        gradleMetadataParser.parse(resource(gradleFile), metadata, Mock(ExternalResourceArtifactResolver), Mock(MutableModuleMetadataFactory))
         metadata
     }
 

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -124,6 +124,14 @@ This value, nested in `variants`, must contain an object with the following valu
 - `module`: The name of the module. A string
 - `version`: The version of the module. A string
 
+There are a number of constraints when using the `available-at` feature:
+
+- the module referenced by the `available-at` must be published in the same repository as the including module
+- the module referenced by the `available-at` must exist before the including module is first resolved. This means that if different builds produce the including module and the included modules, then before a consumer starts using the including module all other modules must be published.
+- the module referenced by the `available-at` must not be changing (typically mustn't be a `SNAPSHOT`)
+
+The attributes of the variant which has an `available-at` must match exactly the attributes of one variant in the included module.
+
 ### `dependencies` value
 
 This value, nested in `variants`, must contain an array with zero or more elements. Each element must be an object with the following values:

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -446,6 +446,12 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
         assertMainModuleIsPublished('some.group', 'test', '1.2', targetMachines)
         assertVariantsArePublished('some.group', 'test', '1.2', ['debug', 'release'], targetMachines)
 
+        // The following part of the test is commented because this used to work
+        // but because of #14017 we can't support this anymore: when a consumer
+        // consumes a module which uses `available-at`, then _all_ variants must
+        // be published beforehand
+        /*
+
         when:
         consumer.file("build.gradle") << """
             configurations {
@@ -463,6 +469,8 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
         then:
         def installation = installation("consumer/install")
         installation.exec().out == app.expectedOutput
+
+         */
     }
 
     // macOS can only build 64-bit under 10.14+

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -797,6 +797,11 @@ dependencies { implementation 'some.group:greeter:1.2' }
         assertMainModuleIsPublished('some.group', 'shuffle', '1.2', targetMachines)
         assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines)
 
+        // The following part of the test is commented because this used to work
+        // but because of #14017 we can't support this anymore: when a consumer
+        // consumes a module which uses `available-at`, then _all_ variants must
+        // be published beforehand
+        /*
         when:
         def consumer = file("consumer").createDir()
         consumer.file('settings.gradle') << ''
@@ -816,6 +821,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
         sharedLibrary(consumer.file("build/install/main/debug/lib/card")).file.assertExists()
         sharedLibrary(consumer.file("build/install/main/debug/lib/shuffle")).file.assertExists()
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
+         */
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -79,6 +79,11 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
         assertMainModuleIsPublished('some.group', 'shuffle', '1.2', targetMachines)
         assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines)
 
+        // The following part of the test is commented because this used to work
+        // but because of #14017 we can't support this anymore: when a consumer
+        // consumes a module which uses `available-at`, then _all_ variants must
+        // be published beforehand
+        /*
         when:
         def consumer = file("consumer").createDir()
         consumer.file('settings.gradle') << ''
@@ -95,6 +100,8 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
         then:
         noExceptionThrown()
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
+        
+         */
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)


### PR DESCRIPTION
This commit reworks how `available-at` is implemented in Gradle
Module Metadata. Previously, if a module was referencing a variant
using `available-at`, then the variant of the module would add
the "referenced" module as a dependency. That module _could_ have
a variant with the same attributes but it wasn't enforced.

Because it was added as a _dependency_, it also means that the
behavior of resolution depended on whether resolution was transitive
or not. It also means that the _actual_ variant couldn't be mutated
independenly of the referenced module.

This caused a number of issues, in particular the one referenced
in #14017.

The new implementation works by actually parsing the referenced
module metadata and _inlining_ variants. For backwards compatibility,
we fallback to the old behavior if we can't find the target module
or a matching variant.

Fixes #14017 
