### PR TITLE
Use isolated daemons for play tests

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
@@ -43,6 +43,7 @@ abstract class AbstractPlaySampleIntegrationTest extends AbstractSampleIntegrati
     }
 
     def setup() {
+        executer.requireIsolatedDaemons()
         executer.noDeprecationChecks()
         executer.withPluginRepositoryMirror()
         initScript = file("initFile") << """


### PR DESCRIPTION
We found some play test failures which still write to build directory
after the build. This might be caused by non-isolated daemons.

Examples: https://builds.gradle.org/viewLog.html?buildId=37461795&buildTypeId=Gradle_Check_ConfigCache_20_platformPlay&tab=buildResultsDiv

https://builds.gradle.org/viewLog.html?buildId=37528200&buildTypeId=Gradle_Check_ConfigCache_20_platformPlay&tab=buildResultsDiv