### PR TITLE
Introduce snapshotting service for TD to use

### DIFF
--- a/subprojects/enterprise/enterprise.gradle.kts
+++ b/subprojects/enterprise/enterprise.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation(project(":core-api"))
     implementation(project(":core"))
     implementation(project(":launcher"))
+    implementation(project(":file-collections"))
+    implementation(project(":snapshots"))
 
     integTestImplementation(project(":internal-testing"))
     integTestImplementation(project(":internal-integ-testing"))

--- a/subprojects/enterprise/enterprise.gradle.kts
+++ b/subprojects/enterprise/enterprise.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     implementation(project(":core-api"))
     implementation(project(":core"))
     implementation(project(":launcher"))
-    implementation(project(":file-collections"))
     implementation(project(":snapshots"))
 
     integTestImplementation(project(":internal-testing"))

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
@@ -17,17 +17,19 @@
 package org.gradle.internal.snapshot
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer
 import org.gradle.test.fixtures.plugin.PluginBuilder
 
 class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
 
     def "can inject service into plugin"() {
         def pluginBuilder = new PluginBuilder(file("buildSrc"))
-        file("buildSrc/build.gradle") << """
-            plugins {
-                id ''
-            }
+        pluginBuilder.addPlugin("""
+            $SnapshottingService.name service = project.getServices(${SnapshottingService.name}.class);
+            $Snapshot.name hash = service.snapshotFor(project.file("input.txt").toPath(), ${IgnoredPathInputNormalizer.name}.class);
+            System.out.println("Hash: " + hash.getHashValue());
         """
+        )
         buildFile << """
         """
     }

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.plugin.PluginBuilder
+
+class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can inject service into plugin"() {
+        def pluginBuilder = new PluginBuilder(file("buildSrc"))
+        file("buildSrc/build.gradle") << """
+            plugins {
+                id ''
+            }
+        """
+        buildFile << """
+        """
+    }
+}

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
@@ -32,10 +32,7 @@ class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
         def pluginBuilder = new PluginBuilder(file("buildSrc"))
         pluginBuilder.addPlugin("""
             def input = ($Paths.name).get("$inputFile")
-            def projectInternal = (org.gradle.api.internal.project.ProjectInternal)project
-            def serviceRegistry = projectInternal.getServices()
-
-            def snapshottingService = serviceRegistry.get($SnapshottingService.name)
+            def snapshottingService = project.services.get(${SnapshottingService.name})
             def snapshot = snapshottingService.snapshotFor(input)
 
             println("Snapshot for input file $inputFile.name is \$snapshot")

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
@@ -16,31 +16,29 @@
 
 package org.gradle.internal.snapshot
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer
-import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.test.fixtures.plugin.PluginBuilder
 
 import java.nio.file.Paths
 
 class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
 
-    def "can inject service into plugin"() {
+    def "can inject snapshotting service into plugin"() {
         given:
+        def inputFile = file("input.txt") << """
+            Some text
+        """
+
         def pluginBuilder = new PluginBuilder(file("buildSrc"))
         pluginBuilder.addPlugin("""
-            def input = ($Paths.name).get("input.txt")
+            def input = ($Paths.name).get("$inputFile")
             def projectInternal = (org.gradle.api.internal.project.ProjectInternal)project
             def serviceRegistry = projectInternal.getServices()
 
-            def serviceFsa = serviceRegistry.get($FileSystemAccess.name)
-            def hash = serviceFsa.read(input.toAbsolutePath().toString(), { snapshot -> snapshot.getHash().toString() })
-            println("Hash from FileSystemAccess service: \$hash")
-
             def snapshottingService = serviceRegistry.get($SnapshottingService.name)
-            def snapshot = snapshottingService.snapshotFor(input, $IgnoredPathInputNormalizer.name)
-            println("Hash from snapshotting service: \${snapshot.hashValue}")
+            def snapshot = snapshottingService.snapshotFor(input)
+
+            println("Snapshot for input file $inputFile.name is \$snapshot")
         """
         )
         pluginBuilder.generateForBuildSrc()
@@ -51,14 +49,10 @@ class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        file("input.txt") << """
-            Some input
-        """
-
         when:
         succeeds "help"
 
         then:
-        outputContains"Hash from snapshotting service: "
+        outputContains"Snapshot for input file"
     }
 }

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/snapshot/SnapshottingServiceIntegrationTest.groovy
@@ -53,6 +53,6 @@ class SnapshottingServiceIntegrationTest extends AbstractIntegrationSpec {
         succeeds "help"
 
         then:
-        outputContains"Snapshot for input file"
+        outputContains "Snapshot for input file"
     }
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+public interface Snapshot {
+
+    String getHashValue();
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
@@ -16,8 +16,14 @@
 
 package org.gradle.internal.snapshot;
 
+/**
+ * Snapshot directory or regular file.
+ */
 public interface Snapshot {
 
+    /**
+     * Returns the hash of the snapshot.
+     */
     String getHashValue();
 
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/Snapshot.java
@@ -19,4 +19,5 @@ package org.gradle.internal.snapshot;
 public interface Snapshot {
 
     String getHashValue();
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+import org.gradle.api.tasks.FileNormalizer;
+
+import java.nio.file.Path;
+
+public interface SnapshottingService {
+
+    Snapshot snapshotFor(Path filePath, Class<? extends FileNormalizer> normalizationType);
+
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
@@ -16,12 +16,10 @@
 
 package org.gradle.internal.snapshot;
 
-import org.gradle.api.tasks.FileNormalizer;
-
 import java.nio.file.Path;
 
 public interface SnapshottingService {
 
-    Snapshot snapshotFor(Path filePath, Class<? extends FileNormalizer> normalizationType);
+    Snapshot snapshotFor(Path filePath);
 
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/SnapshottingService.java
@@ -16,10 +16,22 @@
 
 package org.gradle.internal.snapshot;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.nio.file.Path;
 
+/**
+ * Snapshotting service which is used by test distribution.
+ */
+@UsedByScanPlugin("test-distribution")
 public interface SnapshottingService {
 
+    /**
+     * Returns a snapshot for the specified file.
+     *
+     * @param filePath path to file for which we want a snapshot
+     * @return snapshot for specified file
+     */
     Snapshot snapshotFor(Path filePath);
 
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.snapshot.impl;
 
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
@@ -28,17 +30,25 @@ import java.nio.file.Path;
 public class DefaultSnapshottingService implements SnapshottingService {
 
     private final FileCollectionFingerprinterRegistry fingerprinterRegistry;
-    private final FileColl
+    private final FileCollectionFactory fileCollectionFactory;
 
     @Inject
-    public DefaultSnapshottingService(FileCollectionFingerprinterRegistry fingerprinterRegistry) {
+    public DefaultSnapshottingService(FileCollectionFingerprinterRegistry fingerprinterRegistry, FileCollectionFactory fileCollectionFactory) {
         this.fingerprinterRegistry = fingerprinterRegistry;
+        this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
     public Snapshot snapshotFor(Path filePath, Class<? extends FileNormalizer> normalizationType) {
+        FileCollectionInternal fileCollection = fileCollectionFactory.fixed(filePath.toFile());
+
         FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(normalizationType);
-        fingerprinter.fingerprint();
+        org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(fileCollection);
+
         return null;
+    }
+
+    private static class DefaultSnapshot extends Snapshot {
+
     }
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+import org.gradle.api.tasks.FileNormalizer;
+import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
+import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
+import org.gradle.internal.snapshot.Snapshot;
+import org.gradle.internal.snapshot.SnapshottingService;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+
+public class DefaultSnapshottingService implements SnapshottingService {
+
+    private final FileCollectionFingerprinterRegistry fingerprinterRegistry;
+    private final FileColl
+
+    @Inject
+    public DefaultSnapshottingService(FileCollectionFingerprinterRegistry fingerprinterRegistry) {
+        this.fingerprinterRegistry = fingerprinterRegistry;
+    }
+
+    @Override
+    public Snapshot snapshotFor(Path filePath, Class<? extends FileNormalizer> normalizationType) {
+        FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(normalizationType);
+        fingerprinter.fingerprint();
+        return null;
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -19,8 +19,10 @@ package org.gradle.internal.snapshot.impl;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.tasks.FileNormalizer;
+import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.Snapshot;
 import org.gradle.internal.snapshot.SnapshottingService;
 
@@ -40,15 +42,23 @@ public class DefaultSnapshottingService implements SnapshottingService {
 
     @Override
     public Snapshot snapshotFor(Path filePath, Class<? extends FileNormalizer> normalizationType) {
-        FileCollectionInternal fileCollection = fileCollectionFactory.fixed(filePath.toFile());
-
         FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(normalizationType);
-        org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(fileCollection);
-
-        return null;
+        FileCollectionInternal fileCollection = fileCollectionFactory.fixed(filePath.toFile());
+        CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(fileCollection);
+        return new DefaultSnapshot(fingerprint.getHash());
     }
 
-    private static class DefaultSnapshot extends Snapshot {
+    private static class DefaultSnapshot implements Snapshot {
 
+        private final HashCode hashCode;
+
+        public DefaultSnapshot(HashCode hashCode) {
+            this.hashCode = hashCode;
+        }
+
+        @Override
+        public String getHashValue() {
+            return hashCode.toString();
+        }
     }
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -58,7 +58,7 @@ public class DefaultSnapshottingService implements SnapshottingService {
 
         @Override
         public String toString() {
-            return format("DefaultSnapshottingService { hashValue='%s' }", getHashValue());
+            return format("DefaultSnapshot { hashValue='%s' }", getHashValue());
         }
     }
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -30,6 +30,7 @@ import static java.lang.String.format;
 public class DefaultSnapshottingService implements SnapshottingService {
 
     private final FileSystemAccess fileSystemAccess;
+
     @Inject
     public DefaultSnapshottingService(FileSystemAccess fileSystemAccess) {
         this.fileSystemAccess = fileSystemAccess;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/SnapshottingServices.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/SnapshottingServices.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
+
+public class SnapshottingServices extends AbstractPluginServiceRegistry {
+
+    @Override
+    public void registerProjectServices(ServiceRegistration registration) {
+        registration.add(DefaultSnapshottingService.class);
+    }
+
+}

--- a/subprojects/enterprise/src/main/resources/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
+++ b/subprojects/enterprise/src/main/resources/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
@@ -1,1 +1,2 @@
 org.gradle.internal.enterprise.impl.GradleEnterprisePluginServices
+org.gradle.internal.snapshot.impl.SnapshottingServices

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/FileSystemAccess.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/FileSystemAccess.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.vfs;
 
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshottingFilter;
 
@@ -32,7 +31,6 @@ import java.util.function.Function;
  *
  * The file system access needs to be informed when some state on disk changes, so it does not become out of sync with the actual file system.
  */
-@UsedByScanPlugin("test-distribution")
 public interface FileSystemAccess {
 
     /**
@@ -45,7 +43,6 @@ public interface FileSystemAccess {
     /**
      * Visits the hierarchy of files at the given location.
      */
-    @UsedByScanPlugin("test-distribution")
     <T> T read(String location, Function<CompleteFileSystemLocationSnapshot, T> visitor);
 
     /**


### PR DESCRIPTION
This PR contains a new snapshotting service, which test distribution can use in order to get a snapshot for a specific input file or directory.

The initial goal was to come up with a solution that
* supports the current use case (simple hash for single files and directories)
* offer support for different normalization strategies

After a discussion with @lptr , we decided (?) to reduce the goal and just implement what we currently need. While the TD team thinks that we want class path normalization for individual JARs, @lptr is not convinced this is the best solution.

An point which is still open is how we can use this interface when we want to add Maven support to test distribution. The problem is that the `:enterprise` project is not a published artifact and the Test Distribution Gradle plugin has this project as a runtime dependency on its class path.

We will discuss with @ldaley how to deal with this. (that's why this PR is a draft so far).

UPDATE: Discussed this with Luke and he says it's OK to go with this solution.