### PR TITLE
Move initialization of available included builds to before buildSrc is executed

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -80,17 +80,20 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[2].details.buildPath == ":buildB:buildSrc"
         loadOps[2].parentId == buildSrcOps[0].id
 
+        def buildTreeOp = operations.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
+
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 3
-        configureOps[0].displayName == "Configure build"
-        configureOps[0].details.buildPath == ":"
-        configureOps[0].parentId == root.id
-        configureOps[1].displayName == "Configure build (:buildB:buildSrc)"
-        configureOps[1].details.buildPath == ":buildB:buildSrc"
-        configureOps[1].parentId == buildSrcOps[0].id
-        configureOps[2].displayName == "Configure build (:buildB)"
-        configureOps[2].details.buildPath == ":buildB"
-        configureOps[2].parentId == configureOps[0].id
+        configureOps[0].displayName == "Configure build (:buildB:buildSrc)"
+        configureOps[0].details.buildPath == ":buildB:buildSrc"
+        configureOps[0].parentId == buildSrcOps[0].id
+        configureOps[1].displayName == "Configure build (:buildB)"
+        configureOps[1].details.buildPath == ":buildB"
+        configureOps[1].parentId == buildTreeOp.id
+        configureOps[2].displayName == "Configure build"
+        configureOps[2].details.buildPath == ":"
+        configureOps[2].parentId == buildTreeOp.id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 3
@@ -154,9 +157,9 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         def buildSrcOps = operations.all(BuildBuildSrcBuildOperationType)
         buildSrcOps.size() == 2
         buildSrcOps[0].displayName == "Build buildSrc"
-        // TODO should have a buildPath associated
+        buildSrcOps[0].details.buildPath == ":buildB"
         buildSrcOps[1].displayName == "Build buildSrc"
-        // TODO should have a buildPath associated
+        buildSrcOps[1].details.buildPath == ":"
 
         def loadOps = operations.all(LoadBuildBuildOperationType)
         loadOps.size() == 4
@@ -168,49 +171,58 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[1].details.buildPath == ":buildB"
         loadOps[1].parentId == loadOps[0].id
 
-        loadOps[2].displayName == "Load build (:buildSrc)"
-        loadOps[2].details.buildPath == ":buildSrc"
+        loadOps[2].displayName == "Load build (:buildB:buildSrc)"
+        loadOps[2].details.buildPath == ":buildB:buildSrc"
         loadOps[2].parentId == buildSrcOps[0].id
 
-        loadOps[3].displayName == "Load build (:buildB:buildSrc)"
-        loadOps[3].details.buildPath == ":buildB:buildSrc"
+        loadOps[3].displayName == "Load build (:buildSrc)"
+        loadOps[3].details.buildPath == ":buildSrc"
         loadOps[3].parentId == buildSrcOps[1].id
+
+        def buildTreeOp = operations.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 4
-        configureOps[0].displayName == "Configure build (:buildSrc)"
-        configureOps[0].details.buildPath == ":buildSrc"
+        configureOps[0].displayName == "Configure build (:buildB:buildSrc)"
+        configureOps[0].details.buildPath == ":buildB:buildSrc"
         configureOps[0].parentId == buildSrcOps[0].id
-        configureOps[1].displayName == "Configure build"
-        configureOps[1].details.buildPath == ":"
-        configureOps[1].parentId == root.id
-        configureOps[2].displayName == "Configure build (:buildB:buildSrc)"
-        configureOps[2].details.buildPath == ":buildB:buildSrc"
+
+        configureOps[1].displayName == "Configure build (:buildB)"
+        configureOps[1].details.buildPath == ":buildB"
+        configureOps[1].parentId == buildTreeOp.id
+
+        configureOps[2].displayName == "Configure build (:buildSrc)"
+        configureOps[2].details.buildPath == ":buildSrc"
         configureOps[2].parentId == buildSrcOps[1].id
-        configureOps[3].displayName == "Configure build (:buildB)"
-        configureOps[3].details.buildPath == ":buildB"
-        configureOps[3].parentId == configureOps[1].id
+
+        configureOps[3].displayName == "Configure build"
+        configureOps[3].details.buildPath == ":"
+        configureOps[3].parentId == buildTreeOp.id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 4
-        taskGraphOps[0].displayName == "Calculate task graph (:buildSrc)"
-        taskGraphOps[0].details.buildPath == ":buildSrc"
+        taskGraphOps[0].displayName == "Calculate task graph (:buildB:buildSrc)"
+        taskGraphOps[0].details.buildPath == ":buildB:buildSrc"
         taskGraphOps[0].parentId == buildSrcOps[0].id
-        taskGraphOps[1].displayName == "Calculate task graph (:buildB:buildSrc)"
-        taskGraphOps[1].details.buildPath == ":buildB:buildSrc"
+
+        taskGraphOps[1].displayName == "Calculate task graph (:buildSrc)"
+        taskGraphOps[1].details.buildPath == ":buildSrc"
         taskGraphOps[1].parentId == buildSrcOps[1].id
+
         taskGraphOps[2].displayName == "Calculate task graph"
         taskGraphOps[2].details.buildPath == ":"
         taskGraphOps[2].parentId == root.id
+
         taskGraphOps[3].displayName == "Calculate task graph (:buildB)"
         taskGraphOps[3].details.buildPath == ":buildB"
         taskGraphOps[3].parentId == taskGraphOps[2].id
 
         def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
         runTasksOps.size() == 4
-        runTasksOps[0].displayName == "Run tasks (:buildSrc)"
+        runTasksOps[0].displayName == "Run tasks (:buildB:buildSrc)"
         runTasksOps[0].parentId == buildSrcOps[0].id
-        runTasksOps[1].displayName == "Run tasks (:buildB:buildSrc)"
+        runTasksOps[1].displayName == "Run tasks (:buildSrc)"
         runTasksOps[1].parentId == buildSrcOps[1].id
         runTasksOps[2].displayName == "Run tasks"
         runTasksOps[2].parentId == root.id
@@ -219,15 +231,18 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
 
         def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
         graphNotifyOps.size() == 4
-        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
-        graphNotifyOps[0].details.buildPath == ':buildSrc'
+        graphNotifyOps[0].displayName == "Notify task graph whenReady listeners (:buildB:buildSrc)"
+        graphNotifyOps[0].details.buildPath == ":buildB:buildSrc"
         graphNotifyOps[0].parentId == taskGraphOps[0].id
-        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:buildB:buildSrc)"
-        graphNotifyOps[1].details.buildPath == ":buildB:buildSrc"
+
+        graphNotifyOps[1].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
+        graphNotifyOps[1].details.buildPath == ':buildSrc'
         graphNotifyOps[1].parentId == taskGraphOps[1].id
+
         graphNotifyOps[2].displayName == "Notify task graph whenReady listeners"
         graphNotifyOps[2].details.buildPath == ":"
         graphNotifyOps[2].parentId == taskGraphOps[2].id
+
         graphNotifyOps[3].displayName == "Notify task graph whenReady listeners (:buildB)"
         graphNotifyOps[3].details.buildPath == ":buildB"
         graphNotifyOps[3].parentId == taskGraphOps[3].id

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -91,14 +91,17 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         loadOps[1].details.buildPath == ":${buildName}"
         loadOps[1].parentId == loadOps[0].id
 
+        def buildTreeOp = operations.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
+
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
-        configureOps[0].displayName == "Configure build"
-        configureOps[0].details.buildPath == ":"
-        configureOps[0].parentId == root.id
-        configureOps[1].displayName == "Configure build (:${buildName})"
-        configureOps[1].details.buildPath == ":${buildName}"
-        configureOps[1].parentId == configureOps[0].id
+        configureOps[0].displayName == "Configure build (:${buildName})"
+        configureOps[0].details.buildPath == ":${buildName}"
+        configureOps[0].parentId == buildTreeOp.id
+        configureOps[1].displayName == "Configure build"
+        configureOps[1].details.buildPath == ":"
+        configureOps[1].parentId == buildTreeOp.id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 2
@@ -161,14 +164,18 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         loadOps[1].details.buildPath == ":buildB"
         loadOps[1].parentId == loadOps[0].id
 
+        def buildTreeOp = operations.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
+
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
-        configureOps[0].displayName == "Configure build"
-        configureOps[0].details.buildPath == ":"
-        configureOps[0].parentId == root.id
-        configureOps[1].displayName == "Configure build (:buildB)"
-        configureOps[1].details.buildPath == ":buildB"
-        configureOps[1].parentId == configureOps[0].id
+        configureOps[0].displayName == "Configure build (:buildB)"
+        configureOps[0].details.buildPath == ":buildB"
+        configureOps[0].parentId == buildTreeOp.id
+        configureOps[1].displayName == "Configure build"
+        configureOps[1].details.buildPath == ":"
+        configureOps[1].parentId == buildTreeOp.id
+
 
         // The task graph for buildB is calculated multiple times, once for buildscript dependency and again for production dependency
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -151,8 +151,6 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-cli",
             ":nested-nested",
             ":nested-cli-nested",
-            ":buildSrc",
-            ":buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
@@ -161,16 +159,15 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-nested:buildSrc:buildSrc",
             ":nested-cli-nested:buildSrc",
             ":nested-cli-nested:buildSrc:buildSrc",
+            ":buildSrc",
+            ":buildSrc:buildSrc",
         ]
-
         loadBuildBuildOperations*.details.includedBy == [
             null,
             ":",
             ":",
             ":nested",
             ":nested-cli",
-            ":",
-            ":buildSrc",
             ":nested",
             ":nested:buildSrc",
             ":nested-cli",
@@ -179,6 +176,8 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-nested:buildSrc",
             ":nested-cli-nested",
             ":nested-cli-nested:buildSrc",
+            ":",
+            ":buildSrc",
         ]
 
         def evaluateSettingsBuildOperations = buildOperations.all(EvaluateSettingsBuildOperationType)
@@ -188,8 +187,6 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-cli",
             ":nested-nested",
             ":nested-cli-nested",
-            ":buildSrc",
-            ":buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
@@ -198,24 +195,26 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-nested:buildSrc:buildSrc",
             ":nested-cli-nested:buildSrc",
             ":nested-cli-nested:buildSrc:buildSrc",
+            ":buildSrc",
+            ":buildSrc:buildSrc",
         ]
 
         def configureOrder = [
-            ":buildSrc:buildSrc",
-            ":buildSrc",
-            ":",
-            ":nested:buildSrc:buildSrc",
-            ":nested:buildSrc",
-            ":nested",
-            ":nested-cli:buildSrc:buildSrc",
-            ":nested-cli:buildSrc",
-            ":nested-cli",
-            ":nested-nested:buildSrc:buildSrc",
-            ":nested-nested:buildSrc",
-            ":nested-nested",
-            ":nested-cli-nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested",
+                ":nested:buildSrc:buildSrc",
+                ":nested:buildSrc",
+                ":nested",
+                ":nested-cli:buildSrc:buildSrc",
+                ":nested-cli:buildSrc",
+                ":nested-cli",
+                ":nested-nested:buildSrc:buildSrc",
+                ":nested-nested:buildSrc",
+                ":nested-nested",
+                ":nested-cli-nested:buildSrc:buildSrc",
+                ":nested-cli-nested:buildSrc",
+                ":nested-cli-nested",
+                ":buildSrc:buildSrc",
+                ":buildSrc",
+                ":",
         ]
 
         def configureBuildBuildOperations = buildOperations.all(ConfigureBuildBuildOperationType)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -136,17 +136,21 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
 
 
         then:
-        def rootBuildOperation = operations()[0]
+        def buildOperations = operations()
+        buildOperations.size() == 2
+
+        def nestedBuildOperation = operations()[0]
+        nestedBuildOperation.result.buildPath == ":nested"
+        nestedBuildOperation.result.rootProject.path == ":"
+        verifyProject(nestedBuildOperation.result.rootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))
+        verifyProject(project(":b", nestedBuildOperation), 'b', ':nested:b', [], testDirectory.file('nested/b'))
+
+        def rootBuildOperation = operations()[1]
         rootBuildOperation.result.buildPath == ":"
         rootBuildOperation.result.rootProject.path == ":"
         verifyProject(rootBuildOperation.result.rootProject, 'root', ':', [':a'], testDirectory, 'root.gradle')
         verifyProject(project(":a", rootBuildOperation), 'a')
 
-        def nestedBuildOperation = operations()[1]
-        nestedBuildOperation.result.buildPath == ":nested"
-        nestedBuildOperation.result.rootProject.path == ":"
-        verifyProject(nestedBuildOperation.result.rootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))
-        verifyProject(project(":b", nestedBuildOperation), 'b', ':nested:b', [], testDirectory.file('nested/b'))
     }
 
     private void verifyProject(def project, String name, String identityPath = null, List<String> children = [], File projectDir = testDirectory.file(name), String buildFileName = 'build.gradle') {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -59,6 +59,9 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         loadOps[1].details.buildPath == ':buildSrc'
         loadOps[1].parentId == buildSrcOps[0].id
 
+        def buildTreeOp = ops.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
+
         def configureOps = ops.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
         configureOps[0].displayName == "Configure build (:buildSrc)"
@@ -66,7 +69,7 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         configureOps[0].parentId == buildSrcOps[0].id
         configureOps[1].displayName == "Configure build"
         configureOps[1].details.buildPath == ":"
-        configureOps[1].parentId == root.id
+        configureOps[1].parentId == buildTreeOp.id
 
         def taskGraphOps = ops.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 2

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -183,7 +183,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
 
         notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
-        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
         notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
         notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.initialization.buildsrc.BuildSourceBuilder;
+import org.gradle.internal.build.BuildStateRegistry;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
+    private final ProjectsPreparer delegate;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final BuildStateRegistry buildStateRegistry;
+    private final BuildSourceBuilder buildSourceBuilder;
+
+    public BuildTreePreparingProjectsPreparer(ProjectsPreparer delegate, BuildOperationExecutor buildOperationExecutor, BuildStateRegistry buildStateRegistry, BuildSourceBuilder buildSourceBuilder) {
+        this.delegate = delegate;
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.buildStateRegistry = buildStateRegistry;
+        this.buildSourceBuilder = buildSourceBuilder;
+    }
+
+    @Override
+    public void prepareProjects(GradleInternal gradle) {
+        if (gradle.isRootBuild()) {
+            buildOperationExecutor.run(new PrepareBuildTree(gradle));
+        } else {
+            buildBuildSrcAndPrepareProjects(gradle);
+        }
+    }
+
+    private void buildBuildSrcAndPrepareProjects(GradleInternal gradle) {
+        ClassLoaderScope baseProjectClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle);
+        gradle.setBaseProjectClassLoaderScope(baseProjectClassLoaderScope);
+        delegate.prepareProjects(gradle);
+    }
+
+    private class PrepareBuildTree implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+
+        public PrepareBuildTree(GradleInternal gradle) {
+            this.gradle = gradle;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            buildStateRegistry.beforeConfigureRootBuild();
+            buildBuildSrcAndPrepareProjects(gradle);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            BuildOperationDescriptor.Builder builder = BuildOperationDescriptor.displayName(gradle.contextualize("Prepare build tree"));
+            return builder;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
@@ -21,7 +21,6 @@ import org.gradle.execution.ProjectConfigurer;
 import org.gradle.initialization.BuildLoader;
 import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.initialization.ProjectsEvaluatedNotifier;
-import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.util.IncubationLogger;
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
@@ -29,18 +29,15 @@ public class DefaultProjectsPreparer implements ProjectsPreparer {
     private final BuildLoader buildLoader;
     private final BuildOperationExecutor buildOperationExecutor;
     private final ProjectConfigurer projectConfigurer;
-    private final BuildStateRegistry buildRegistry;
     private final ModelConfigurationListener modelConfigurationListener;
 
     public DefaultProjectsPreparer(
-        ProjectConfigurer projectConfigurer,
-        BuildStateRegistry buildRegistry,
-        BuildLoader buildLoader,
-        ModelConfigurationListener modelConfigurationListener,
-        BuildOperationExecutor buildOperationExecutor
+            ProjectConfigurer projectConfigurer,
+            BuildLoader buildLoader,
+            ModelConfigurationListener modelConfigurationListener,
+            BuildOperationExecutor buildOperationExecutor
     ) {
         this.projectConfigurer = projectConfigurer;
-        this.buildRegistry = buildRegistry;
         this.buildLoader = buildLoader;
         this.modelConfigurationListener = modelConfigurationListener;
         this.buildOperationExecutor = buildOperationExecutor;
@@ -52,9 +49,6 @@ public class DefaultProjectsPreparer implements ProjectsPreparer {
 
         buildLoader.load(gradle.getSettings(), gradle);
 
-        if (gradle.isRootBuild()) {
-            buildRegistry.beforeConfigureRootBuild();
-        }
         if (gradle.getStartParameter().isConfigureOnDemand()) {
             projectConfigurer.configure(gradle.getRootProject());
         } else {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -22,15 +22,12 @@ import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.MultipleBuildFailures;
-import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
@@ -67,7 +64,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
     private final ConfigurationCache configurationCache;
     private final SettingsPreparer settingsPreparer;
     private final TaskExecutionPreparer taskExecutionPreparer;
-    private final BuildSourceBuilder buildSourceBuilder;
     private final BuildOptionBuildOperationProgressEventsEmitter buildOptionBuildOperationProgressEventsEmitter;
 
     private Stage stage;
@@ -85,7 +81,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
                                  SettingsPreparer settingsPreparer,
                                  TaskExecutionPreparer taskExecutionPreparer,
                                  ConfigurationCache configurationCache,
-                                 BuildSourceBuilder buildSourceBuilder,
                                  BuildOptionBuildOperationProgressEventsEmitter buildOptionBuildOperationProgressEventsEmitter
     ) {
         this.gradle = gradle;
@@ -101,7 +96,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
         this.configurationCache = configurationCache;
         this.settingsPreparer = settingsPreparer;
         this.taskExecutionPreparer = taskExecutionPreparer;
-        this.buildSourceBuilder = buildSourceBuilder;
         this.buildOptionBuildOperationProgressEventsEmitter = buildOptionBuildOperationProgressEventsEmitter;
     }
 
@@ -231,12 +225,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
     private void prepareProjects() {
         if (stage == Stage.LoadSettings) {
-            if (gradle.isRootBuild()) {
-                gradle.getServices().get(BuildStateRegistry.class).beforeConfigureRootBuild();
-            }
-
-            ClassLoaderScope baseProjectClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle);
-            gradle.setBaseProjectClassLoaderScope(baseProjectClassLoaderScope);
             projectsPreparer.prepareProjects(gradle);
             stage = Stage.Configure;
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -30,6 +30,7 @@ import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.layout.BuildLayout;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
@@ -230,6 +231,10 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
     private void prepareProjects() {
         if (stage == Stage.LoadSettings) {
+            if (gradle.isRootBuild()) {
+                gradle.getServices().get(BuildStateRegistry.class).beforeConfigureRootBuild();
+            }
+
             ClassLoaderScope baseProjectClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle);
             gradle.setBaseProjectClassLoaderScope(baseProjectClassLoaderScope);
             projectsPreparer.prepareProjects(gradle);

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -28,7 +28,6 @@ import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.execution.BuildWorkExecutor;
-import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.build.BuildState;
@@ -151,7 +150,6 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             settingsPreparer,
             taskExecutionPreparer,
             gradle.getServices().get(ConfigurationCache.class),
-            gradle.getServices().get(BuildSourceBuilder.class),
             new BuildOptionBuildOperationProgressEventsEmitter(
                 gradle.getServices().get(BuildOperationProgressEventEmitter.class)
             )

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
@@ -146,7 +146,7 @@ public final class BuildOperationRecord {
 
     @Override
     public String toString() {
-        return "BuildOperationRecord{" + displayName + '}';
+        return "BuildOperationRecord{" + id + "->" + displayName + '}';
     }
 
     public static class Progress {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.caching.internal.BuildCacheServices;
 import org.gradle.configuration.BuildOperationFiringProjectsPreparer;
+import org.gradle.configuration.BuildTreePreparingProjectsPreparer;
 import org.gradle.configuration.CompileOperationFactory;
 import org.gradle.configuration.DefaultInitScriptProcessor;
 import org.gradle.configuration.DefaultProjectsPreparer;
@@ -515,15 +516,19 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new TaskPathProjectEvaluator(cancellationToken);
     }
 
-    protected ProjectsPreparer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildLoader buildLoader, ListenerManager listenerManager, BuildOperationExecutor buildOperationExecutor) {
+    protected ProjectsPreparer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildSourceBuilder buildSourceBuilder, BuildStateRegistry buildStateRegistry, BuildLoader buildLoader, ListenerManager listenerManager, BuildOperationExecutor buildOperationExecutor) {
         ModelConfigurationListener modelConfigurationListener = listenerManager.getBroadcaster(ModelConfigurationListener.class);
-        return new BuildOperationFiringProjectsPreparer(
-            new DefaultProjectsPreparer(
-                projectConfigurer,
-                    buildLoader,
-                modelConfigurationListener,
-                buildOperationExecutor),
-            buildOperationExecutor);
+        return new BuildTreePreparingProjectsPreparer(
+                new BuildOperationFiringProjectsPreparer(
+                        new DefaultProjectsPreparer(
+                                projectConfigurer,
+                                buildLoader,
+                                modelConfigurationListener,
+                                buildOperationExecutor),
+                        buildOperationExecutor),
+                buildOperationExecutor,
+                buildStateRegistry,
+                buildSourceBuilder);
     }
 
     protected ProjectAccessHandler createProjectAccessHandler() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -515,13 +515,12 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new TaskPathProjectEvaluator(cancellationToken);
     }
 
-    protected ProjectsPreparer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildStateRegistry buildStateRegistry, BuildLoader buildLoader, ListenerManager listenerManager, BuildOperationExecutor buildOperationExecutor) {
+    protected ProjectsPreparer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildLoader buildLoader, ListenerManager listenerManager, BuildOperationExecutor buildOperationExecutor) {
         ModelConfigurationListener modelConfigurationListener = listenerManager.getBroadcaster(ModelConfigurationListener.class);
         return new BuildOperationFiringProjectsPreparer(
             new DefaultProjectsPreparer(
                 projectConfigurer,
-                buildStateRegistry,
-                buildLoader,
+                    buildLoader,
                 modelConfigurationListener,
                 buildOperationExecutor),
             buildOperationExecutor);

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
@@ -35,7 +35,7 @@ class DefaultProjectsPreparerTest extends Specification {
     def buildLoader = Mock(BuildLoader)
     def modelListener = Mock(ModelConfigurationListener)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
-    private configurer = new DefaultProjectsPreparer(projectConfigurer, buildRegistry, buildLoader, modelListener, buildOperationExecutor)
+    private configurer = new DefaultProjectsPreparer(projectConfigurer, buildLoader, modelListener, buildOperationExecutor)
 
     def setup() {
         gradle.startParameter >> startParameter

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -19,13 +19,11 @@ package org.gradle.initialization
 import org.gradle.BuildListener
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
-import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.composite.internal.IncludedBuildControllers
 import org.gradle.configuration.ProjectsPreparer
 import org.gradle.execution.BuildWorkExecutor
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
-import org.gradle.initialization.buildsrc.BuildSourceBuilder
 import org.gradle.initialization.exception.ExceptionAnalyser
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.service.scopes.BuildScopeServices
@@ -41,7 +39,6 @@ class DefaultGradleLauncherSpec extends Specification {
     def buildConfigurerMock = Mock(ProjectsPreparer)
     def buildBroadcaster = Mock(BuildListener)
     def buildExecuter = Mock(BuildWorkExecutor)
-    def buildSourceBuilder = Mock(BuildSourceBuilder)
 
     def settingsMock = Mock(SettingsInternal.class)
     def gradleMock = Mock(GradleInternal.class)
@@ -69,7 +66,7 @@ class DefaultGradleLauncherSpec extends Specification {
     DefaultGradleLauncher launcher() {
         return new DefaultGradleLauncher(gradleMock, buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
             buildCompletionListener, buildFinishedListener, buildExecuter, buildServices, [otherService], includedBuildControllers,
-            settingsPreparerMock, taskExecutionPreparerMock, configurationCache, buildSourceBuilder, Mock(BuildOptionBuildOperationProgressEventsEmitter))
+            settingsPreparerMock, taskExecutionPreparerMock, configurationCache, Mock(BuildOptionBuildOperationProgressEventsEmitter))
     }
 
     void testRunTasks() {
@@ -108,8 +105,6 @@ class DefaultGradleLauncherSpec extends Specification {
         expectBuildListenerCallbacks()
 
         and:
-        def buildSrcClassLoaderScope = Mock(ClassLoaderScope)
-        1 * buildSourceBuilder.buildAndCreateClassLoader(_) >> buildSrcClassLoaderScope
         1 * buildConfigurerMock.prepareProjects(gradleMock)
 
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -126,8 +121,6 @@ class DefaultGradleLauncherSpec extends Specification {
         expectBuildListenerCallbacks()
 
         and:
-        def buildSrcClassLoaderScope = Mock(ClassLoaderScope)
-        1 * buildSourceBuilder.buildAndCreateClassLoader(_) >> buildSrcClassLoaderScope
         1 * buildConfigurerMock.prepareProjects(gradleMock)
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -174,12 +174,12 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
 
         and:
         childBuildScript.waitForAllPendingCalls()
-        assertHasBuildPhase("0% CONFIGURING")
+        assertHasBuildPhase("0% INITIALIZING")
         childBuildScript.releaseAll()
 
         and:
         rootBuildScript.waitForAllPendingCalls()
-        assertHasBuildPhase("75% CONFIGURING")
+        assertHasBuildPhase("0% CONFIGURING")
         rootBuildScript.releaseAll()
 
         and:

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
@@ -51,7 +51,7 @@ public class BuildStatusRenderer implements OutputEventListener {
     private final ConsoleMetaData consoleMetaData;
     private OperationIdentifier buildProgressOperationId;
     private Phase currentPhase;
-    private Set<OperationIdentifier> currentPhaseChildren = new HashSet<OperationIdentifier>();
+    private final Set<OperationIdentifier> currentPhaseChildren = new HashSet<OperationIdentifier>();
     private long currentTimePeriod;
 
     // What actually shows up on the console

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
@@ -29,11 +29,11 @@ public class ProgressBar {
 
     private final ConsoleMetaData consoleMetaData;
     private final String progressBarPrefix;
-    private int progressBarWidth;
+    private final int progressBarWidth;
     private final String progressBarSuffix;
-    private char fillerChar;
+    private final char fillerChar;
     private final char incompleteChar;
-    private String suffix;
+    private final String suffix;
 
     private int current;
     private int total;

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -85,11 +85,14 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
         loadOps[1].details.buildPath == ":buildB"
         loadOps[1].parentId == resolve.id
 
+        def buildTreeOp = operations.only(/Prepare build tree/)
+        buildTreeOp.parentId == root.id
+
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
         configureOps[0].displayName == "Configure build"
         configureOps[0].details.buildPath == ":"
-        configureOps[0].parentId == root.id
+        configureOps[0].parentId == buildTreeOp.id
         configureOps[1].displayName == "Configure build (:${buildName})"
         configureOps[1].details.buildPath == ":${buildName}"
         configureOps[1].parentId == resolve.id


### PR DESCRIPTION
<!--- The issue this PR addresses -->
refs #14045 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
