### PR TITLE
Add verbose VFS logging

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 public class StartParameterInternal extends StartParameter {
     private boolean watchFileSystem;
+    private boolean watchFileSystemVerboseLogging;
     private boolean watchFileSystemUsingDeprecatedOption;
 
     private boolean configurationCache;
@@ -45,6 +46,7 @@ public class StartParameterInternal extends StartParameter {
     protected StartParameter prepareNewBuild(StartParameter startParameter) {
         StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
         p.watchFileSystem = watchFileSystem;
+        p.watchFileSystemVerboseLogging = watchFileSystemVerboseLogging;
         p.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
         p.configurationCache = configurationCache;
         p.configurationCacheProblems = configurationCacheProblems;
@@ -84,6 +86,14 @@ public class StartParameterInternal extends StartParameter {
 
     public void setWatchFileSystem(boolean watchFileSystem) {
         this.watchFileSystem = watchFileSystem;
+    }
+
+    public boolean isWatchFileSystemVerboseLogging() {
+        return watchFileSystemVerboseLogging;
+    }
+
+    public void setWatchFileSystemVerboseLogging(boolean watchFileSystemVerboseLogging) {
+        this.watchFileSystemVerboseLogging = watchFileSystemVerboseLogging;
     }
 
     public boolean isWatchFileSystemUsingDeprecatedOption() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -63,6 +63,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         options.add(new BuildCacheOption());
         options.add(new BuildCacheDebugLoggingOption());
         options.add(new WatchFileSystemOption());
+        options.add(new WatchFileSystemVerboseLoggingOption());
         options.add(new DeprecatedWatchFileSystemOption());
         options.add(new BuildScanOption());
         options.add(new DependencyLockingWriteOption());
@@ -308,6 +309,19 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
             startParameter.setWatchFileSystem(value);
+        }
+    }
+
+    public static class WatchFileSystemVerboseLoggingOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String GRADLE_PROPERTY = "org.gradle.vfs.verbose";
+
+        public WatchFileSystemVerboseLoggingOption() {
+            super(GRADLE_PROPERTY);
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
+            startParameter.setWatchFileSystemVerboseLogging(value);
         }
     }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.watch
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
@@ -43,7 +42,6 @@ class ChangesDuringTheBuildFileSystemWatchingIntegrationTest extends AbstractFil
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "Cannot use buildFinished listener")
     def "detects input file change just before the task is executed"() {
         def inputFile = file("input.txt")
         buildFile << """
@@ -85,7 +83,6 @@ class ChangesDuringTheBuildFileSystemWatchingIntegrationTest extends AbstractFil
         vfsLogs.retainedFilesInCurrentBuild >= 2
     }
 
-    @ToBeFixedForConfigurationCache(because = "Cannot use buildFinished listener")
     def "detects input file change after the task has been executed"() {
         def inputFile = file("input.txt")
         def outputFile = file("build/output.txt")

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -76,6 +76,35 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         "--no-watch-fs"   | DISABLED_MESSAGE
     }
 
+    def "verbose logging can be enabled"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        when:
+        run("assemble", "--watch-fs", "-D${StartParameterBuildOptions.WatchFileSystemVerboseLoggingOption.GRADLE_PROPERTY}=true")
+        then:
+        !(result.output =~ /Received \d+ file system events since last build/)
+        result.output =~ /Virtual file system retained information about 0 files, 0 directories and 0 missing files since last build/
+        result.output =~ /Virtual file system retains information about \d+ files, \d+ directories and \d+ missing files until next build/
+        result.output =~ /Received \d+ file system events during the current build/
+
+        when:
+        run("assemble", "--watch-fs", "-D${StartParameterBuildOptions.WatchFileSystemVerboseLoggingOption.GRADLE_PROPERTY}=true")
+        then:
+        result.output =~ /Received \d+ file system events since last build/
+        result.output =~ /Virtual file system retained information about \d+ files, \d+ directories and \d+ missing files since last build/
+        result.output =~ /Virtual file system retains information about \d+ files, \d+ directories and \d+ missing files until next build/
+        result.output =~ /Received \d+ file system events during the current build/
+
+        when:
+        run("assemble", "--watch-fs", "-D${StartParameterBuildOptions.WatchFileSystemVerboseLoggingOption.GRADLE_PROPERTY}=false")
+        then:
+        !(result.output =~ /Received \d+ file system events since last build/)
+        !(result.output =~ /Virtual file system retained information about \d+ files, \d+ directories and \d+ missing files since last build/)
+        !(result.output =~ /Virtual file system retains information about \d+ files, \d+ directories and \d+ missing files until next build/)
+        !(result.output =~ /Received \d+ file system events during the current build/)
+    }
+
     @Unroll
     @SuppressWarnings('GrDeprecatedAPIUsage')
     def "deprecation message is shown when using the old property to enable watching the file system (enabled: #enabled)"() {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -29,7 +29,7 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is started.
      */
-    void afterBuildStarted(boolean watchingEnabled, BuildOperationRunner buildOperationRunner);
+    void afterBuildStarted(boolean watchingEnabled, boolean verboseLogging, BuildOperationRunner buildOperationRunner);
 
     /**
      * Register a watchable hierarchy.
@@ -43,5 +43,5 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is finished.
      */
-    void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
+    void beforeBuildFinished(boolean watchingEnabled, boolean verboseLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -55,7 +55,7 @@ public class WatchingNotSupportedVirtualFileSystem implements BuildLifecycleAwar
     }
 
     @Override
-    public void afterBuildStarted(boolean watchingEnabled, BuildOperationRunner buildOperationRunner) {
+    public void afterBuildStarted(boolean watchingEnabled, boolean verboseLogging, BuildOperationRunner buildOperationRunner) {
         if (watchingEnabled) {
             LOGGER.warn("Watching the file system is not supported on this operating system.");
         }
@@ -79,7 +79,7 @@ public class WatchingNotSupportedVirtualFileSystem implements BuildLifecycleAwar
     }
 
     @Override
-    public void beforeBuildFinished(boolean watchingEnabled, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
+    public void beforeBuildFinished(boolean watchingEnabled, boolean verboseLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
         rootReference.update(vfsRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -34,13 +34,13 @@ class WatchingNotSupportedVirtualFileSystemTest extends Specification {
 
     def "invalidates the virtual file system before and after the build"() {
         when:
-        watchingNotSupportedHandler.afterBuildStarted(retentionEnabled, buildOperationRunner)
+        watchingNotSupportedHandler.afterBuildStarted(retentionEnabled, false, buildOperationRunner)
         then:
         rootReference.getRoot() == emptySnapshotHierarchy
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingNotSupportedHandler.beforeBuildFinished(retentionEnabled, buildOperationRunner, Integer.MAX_VALUE)
+        watchingNotSupportedHandler.beforeBuildFinished(retentionEnabled, false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         rootReference.getRoot() == emptySnapshotHierarchy
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -47,7 +47,7 @@ class WatchingVirtualFileSystemTest extends Specification {
     def "invalidates the virtual file system before and after the build when watching is disabled"() {
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(false, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(false, false, buildOperationRunner)
         then:
         0 * _
 
@@ -55,7 +55,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.beforeBuildFinished(false, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(false, false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         0 * _
 
@@ -64,13 +64,13 @@ class WatchingVirtualFileSystemTest extends Specification {
 
     def "stops the watchers before the build when watching is disabled"() {
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(true, false, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(true, false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
@@ -78,7 +78,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(false, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(false, false, buildOperationRunner)
         then:
         1 * watcherRegistry.close()
         0 * _
@@ -88,13 +88,13 @@ class WatchingVirtualFileSystemTest extends Specification {
 
     def "retains the virtual file system when watching is enabled"() {
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(true, false, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(true, false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
@@ -102,7 +102,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(true, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(true, false, buildOperationRunner)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         0 * _
@@ -121,7 +121,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         0 * _
 
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(true, false, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.registerWatchableHierarchy(watchableHierarchy, _)
@@ -133,7 +133,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         1 * watcherRegistry.registerWatchableHierarchy(anotherWatchableHierarchy, _)
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(true, false, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingFixture.groovy
@@ -30,21 +30,56 @@ trait FileSystemWatchingFixture {
 
     AbstractIntegrationSpec withWatchFs() {
         executer.withArgument(FileSystemWatchingHelper.enableFsWatchingArgument)
-        this
+        this as AbstractIntegrationSpec
     }
 
     AbstractIntegrationSpec withoutWatchFs() {
         executer.withArgument(FileSystemWatchingHelper.disableFsWatchingArgument)
-        this
+        this as AbstractIntegrationSpec
+    }
+
+    AbstractIntegrationSpec withVerboseVfsLog() {
+        executer.withArgument(FileSystemWatchingHelper.verboseLoggingArgument)
+        this as AbstractIntegrationSpec
     }
 
     void waitForChangesToBePickedUp() {
         FileSystemWatchingHelper.waitForChangesToBePickedUp()
     }
 
-    int getReceivedFileSystemEventsInCurrentBuild() {
-        def duringBuildStatusLine = result.getPostBuildOutputLineThatContains(" file system events for current build")
-        def numberMatcher = duringBuildStatusLine =~ /Received (\d+) file system events for current build/
-        return numberMatcher[0][1] as int
+    VerboseVfsLogAccessor getVfsLogs() {
+        return new VerboseVfsLogAccessor(this as AbstractIntegrationSpec)
+    }
+
+    protected static class VerboseVfsLogAccessor {
+        private final AbstractIntegrationSpec spec
+
+        VerboseVfsLogAccessor(AbstractIntegrationSpec spec) {
+            this.spec = spec
+        }
+
+        int getReceivedFileSystemEventsInCurrentBuild() {
+            def duringBuildStatusLine = spec.result.getPostBuildOutputLineThatContains(" file system events during the current build")
+            def numberMatcher = duringBuildStatusLine =~ /Received (\d+) file system events during the current build/
+            return numberMatcher[0][1] as int
+        }
+
+        int getRetainedFilesInCurrentBuild() {
+            def retainedInformation = spec.result.getPostBuildOutputLineThatContains("Virtual file system retains information about ")
+            def numberMatcher = retainedInformation =~ /Virtual file system retains information about (\d+) files, (\d+) directories and (\d+) missing files until next build/
+            return numberMatcher[0][1] as int
+        }
+
+        int getReceivedFileSystemEventsSinceLastBuild() {
+            String eventsSinceLastBuild = spec.result.getOutputLineThatContains("file system events since last build")
+            def numberMatcher = eventsSinceLastBuild =~ /Received (\d+) file system events since last build/
+            return numberMatcher[0][1] as int
+        }
+
+        int getRetainedFilesSinceLastBuild() {
+            String retainedInformation = spec.result.getOutputLineThatContains("Virtual file system retained information about ")
+            def numberMatcher = retainedInformation =~ /Virtual file system retained information about (\d+) files, (\d+) directories and (\d+) missing files since last build/
+            return numberMatcher[0][1] as int
+        }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
@@ -40,6 +40,10 @@ public class FileSystemWatchingHelper {
         return systemProperty(VFS_DROP_PROPERTY, true);
     }
 
+    public static String getVerboseLoggingArgument() {
+        return systemProperty(StartParameterBuildOptions.WatchFileSystemVerboseLoggingOption.GRADLE_PROPERTY, true);
+    }
+
     private static String systemProperty(String key, Object value) {
         return "-D" + key + "=" + value;
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -116,6 +116,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildCacheEnabled());
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystem());
+            encoder.writeBoolean(startParameter.isWatchFileSystemVerboseLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystemUsingDeprecatedOption());
             encoder.writeBoolean(startParameter.isConfigurationCache());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
@@ -194,6 +195,7 @@ public class BuildActionSerializer {
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
             startParameter.setWatchFileSystem(decoder.readBoolean());
+            startParameter.setWatchFileSystemVerboseLogging(decoder.readBoolean());
             startParameter.setWatchFileSystemUsingDeprecatedOption(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -47,6 +47,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         BuildOperationRunner buildOperationRunner = gradle.getServices().get(BuildOperationRunner.class);
 
         boolean watchFileSystem = startParameter.isWatchFileSystem();
+        boolean verboseLogging = startParameter.isWatchFileSystemVerboseLogging();
 
         logMessageForDeprecatedWatchFileSystemProperty(startParameter);
         logMessageForDeprecatedVfsRetentionProperty(startParameter);
@@ -54,12 +55,12 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         if (watchFileSystem) {
             dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
         }
-        virtualFileSystem.afterBuildStarted(watchFileSystem, buildOperationRunner);
+        virtualFileSystem.afterBuildStarted(watchFileSystem, verboseLogging, buildOperationRunner);
         try {
             return delegate.run(action, buildController);
         } finally {
             int maximumNumberOfWatchedHierarchies = VirtualFileSystemServices.getMaximumNumberOfWatchedHierarchies(startParameter);
-            virtualFileSystem.beforeBuildFinished(watchFileSystem, buildOperationRunner, maximumNumberOfWatchedHierarchies);
+            virtualFileSystem.beforeBuildFinished(watchFileSystem, verboseLogging, buildOperationRunner, maximumNumberOfWatchedHierarchies);
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -45,25 +45,28 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
     def delegate = Mock(BuildActionRunner)
     def buildAction = Mock(BuildAction)
 
-    def "watching virtual file system is informed about watching the file system being #watchFsEnabledString"() {
+    def "watching virtual file system is informed about watching the file system being #watchFsEnabledString (verbose logging: #verboseLogging)"() {
         _ * startParameter.getSystemPropertiesArgs() >> [:]
         _ * startParameter.isWatchFileSystem() >> watchFsEnabled
+        _ * startParameter.isWatchFileSystemVerboseLogging() >> verboseLogging
 
         def runner = new FileSystemWatchingBuildActionRunner(delegate)
 
         when:
         runner.run(buildAction, buildController)
         then:
-        1 * watchingHandler.afterBuildStarted(watchFsEnabled, buildOperationRunner)
+        1 * watchingHandler.afterBuildStarted(watchFsEnabled, verboseLogging, buildOperationRunner)
 
         then:
         1 * delegate.run(buildAction, buildController)
 
         then:
-        1 * watchingHandler.beforeBuildFinished(watchFsEnabled, buildOperationRunner, _)
+        1 * watchingHandler.beforeBuildFinished(watchFsEnabled, verboseLogging, buildOperationRunner, _)
 
         where:
-        watchFsEnabled << [true, false]
-        watchFsEnabledString = watchFsEnabled ? "enabled" : "disabled"
+        watchFsEnabled | watchFsEnabledString | verboseLogging
+        true           | "enabled"            | true
+        true           | "enabled"            | false
+        false          | "disabled"           | false
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #14185 

This adds `-Dorg.gradle.vfs.verbose=true` to enable some logging like:

```text
$ gradle assemble --watch-fs -Dorg.gradle.vfs.verbose=true
Virtual file system retained information about 36 files, 17 directories and 4 missing files since last build
Received 14 file system events since last build

BUILD SUCCESSFUL in 589ms
5 actionable tasks: 5 up-to-date
Virtual file system retains information about 36 files, 17 directories and 4 missing files until next build
Received 7 file system events during the current build
```