### PR TITLE
Capture only the names used in manifests as inputs

### DIFF
--- a/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
+++ b/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
@@ -40,13 +40,13 @@ abstract class ClasspathManifest : DefaultTask() {
     abstract val runtimeClasspath: ConfigurableFileCollection
 
     @Input
-    fun getRuntime() = externalDependencies.elements.map { it.map { it.asFile.name }.sorted() }
+    val runtime = externalDependencies.elements.map { it.map { it.asFile.name }.sorted() }
 
     @get:Internal
     abstract val externalDependencies: ConfigurableFileCollection
 
     @Input
-    fun getProjects() = runtimeClasspath.elements.map { it.filter { it.isGradleModule() }.map { it.toGradleModuleName() }.sorted() }
+    val projects = runtimeClasspath.elements.map { it.filter { it.isGradleModule() }.map { it.toGradleModuleName() }.sorted() }
 
     @get:OutputFile
     abstract val manifestFile: RegularFileProperty
@@ -58,15 +58,15 @@ abstract class ClasspathManifest : DefaultTask() {
 
     private
     fun createProperties() = Properties().also { properties ->
-        properties["runtime"] = getRuntime().get().joinToString(",")
-        properties["projects"] = getProjects().get().joinToString(",")
+        properties["runtime"] = runtime.get().joinToString(",")
+        properties["projects"] = projects.get().joinToString(",")
         optionalProjects.get().takeIf { it.isNotEmpty() }?.let { optional ->
             properties["optional"] = optional.joinForProperties()
         }
     }
 
     private
-    fun FileSystemLocation.isGradleModule() = asFile.name.startsWith("gradle-") || name.contains("-patched-for-gradle-")
+    fun FileSystemLocation.isGradleModule() = asFile.name.startsWith("gradle-") || asFile.name.contains("-patched-for-gradle-")
 
     private
     fun FileSystemLocation.toGradleModuleName() = asFile.name.substring(0, asFile.name.lastIndexOf('-'))

--- a/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
+++ b/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
@@ -18,14 +18,14 @@ package gradlebuild.basics.tasks
 import gradlebuild.basics.util.ReproduciblePropertiesWriter
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.Classpath
-import java.io.File
 
 import java.util.Properties
 
@@ -36,11 +36,17 @@ abstract class ClasspathManifest : DefaultTask() {
     @get:Input
     abstract val optionalProjects: ListProperty<String>
 
-    @get:Classpath
+    @get:Internal
     abstract val runtimeClasspath: ConfigurableFileCollection
 
-    @get:Classpath
+    @Input
+    fun getRuntime() = externalDependencies.elements.map { it.map { it.asFile.name }.sorted() }
+
+    @get:Internal
     abstract val externalDependencies: ConfigurableFileCollection
+
+    @Input
+    fun getProjects() = runtimeClasspath.elements.map { it.filter { it.isGradleModule() }.map { it.toGradleModuleName() }.sorted() }
 
     @get:OutputFile
     abstract val manifestFile: RegularFileProperty
@@ -52,18 +58,18 @@ abstract class ClasspathManifest : DefaultTask() {
 
     private
     fun createProperties() = Properties().also { properties ->
-        properties["runtime"] = externalDependencies.map { it.name }.joinForProperties()
-        properties["projects"] = runtimeClasspath.filter { it.isGradleModule() }.map { it.toGradleModuleName() }.joinForProperties()
+        properties["runtime"] = getRuntime().get().joinToString(",")
+        properties["projects"] = getProjects().get().joinToString(",")
         optionalProjects.get().takeIf { it.isNotEmpty() }?.let { optional ->
             properties["optional"] = optional.joinForProperties()
         }
     }
 
     private
-    fun File.isGradleModule() = name.startsWith("gradle-") || name.contains("-patched-for-gradle-")
+    fun FileSystemLocation.isGradleModule() = asFile.name.startsWith("gradle-") || name.contains("-patched-for-gradle-")
 
     private
-    fun File.toGradleModuleName() = name.substring(0, name.lastIndexOf('-'))
+    fun FileSystemLocation.toGradleModuleName() = asFile.name.substring(0, asFile.name.lastIndexOf('-'))
 
     private
     fun Iterable<String>.joinForProperties() = sorted().joinToString(",")

--- a/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/packaging/tasks/PluginsManifest.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/packaging/tasks/PluginsManifest.kt
@@ -17,14 +17,16 @@ package gradlebuild.packaging.tasks
 
 import gradlebuild.basics.util.ReproduciblePropertiesWriter
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.Classpath
-import java.io.File
 
 import java.util.Properties
 
@@ -33,11 +35,17 @@ import java.util.Properties
 @Suppress("unused")
 abstract class PluginsManifest : DefaultTask() {
 
-    @get:Classpath
+    @get:Internal
     abstract val coreClasspath: ConfigurableFileCollection
 
-    @get:Classpath
+    @Input
+    fun getCore() = coreClasspath.toGradleModuleNameProvider()
+
+    @get:Internal
     abstract val pluginsClasspath: ConfigurableFileCollection
+
+    @Input
+    fun getPlugins() = pluginsClasspath.toGradleModuleNameProvider()
 
     @get:OutputFile
     abstract val manifestFile: RegularFileProperty
@@ -49,14 +57,17 @@ abstract class PluginsManifest : DefaultTask() {
 
     private
     fun createProperties() = Properties().also { properties ->
-        properties["plugins"] = (pluginsClasspath - coreClasspath).filter { it.isGradleModule() }.map { it.toGradleModuleName() }.joinForProperties()
+        properties["plugins"] = (getPlugins().get() - getCore().get()).joinForProperties()
     }
 
     private
-    fun File.isGradleModule() = name.startsWith("gradle-")
+    fun FileCollection.toGradleModuleNameProvider() = elements.map { it.filter { it.isGradleModule() }.map { it.toGradleModuleName() }.sorted() }
 
     private
-    fun File.toGradleModuleName() = name.substring(0, name.lastIndexOf('-'))
+    fun FileSystemLocation.isGradleModule() = asFile.name.startsWith("gradle-")
+
+    private
+    fun FileSystemLocation.toGradleModuleName() = asFile.name.substring(0, asFile.name.lastIndexOf('-'))
 
     private
     fun Iterable<String>.joinForProperties() = sorted().joinToString(",")

--- a/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/packaging/tasks/PluginsManifest.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/packaging/tasks/PluginsManifest.kt
@@ -39,13 +39,13 @@ abstract class PluginsManifest : DefaultTask() {
     abstract val coreClasspath: ConfigurableFileCollection
 
     @Input
-    fun getCore() = coreClasspath.toGradleModuleNameProvider()
+    val core = coreClasspath.toGradleModuleNameProvider()
 
     @get:Internal
     abstract val pluginsClasspath: ConfigurableFileCollection
 
     @Input
-    fun getPlugins() = pluginsClasspath.toGradleModuleNameProvider()
+    val plugins = pluginsClasspath.toGradleModuleNameProvider()
 
     @get:OutputFile
     abstract val manifestFile: RegularFileProperty
@@ -57,7 +57,7 @@ abstract class PluginsManifest : DefaultTask() {
 
     private
     fun createProperties() = Properties().also { properties ->
-        properties["plugins"] = (getPlugins().get() - getCore().get()).joinForProperties()
+        properties["plugins"] = (plugins.get() - core.get()).joinForProperties()
     }
 
     private


### PR DESCRIPTION
We unnecessarily rebuild many `ClasspathManifest` and `PluginManifest` tasks after code changes that don't actually change the output of these tasks. This is because the tasks consume their input file collections as `@Classpath`, meaning that even non-ABI changes to any of the inputs will mark the tasks out-of-date.

Re-executing these tasks wastes a non-trivial amount of time (a few seconds): https://ge.gradle.org/s/toxmkpynqgqfw/timeline?hideTimeline&typeFilter=gradlebuild.basics.tasks.ClasspathManifest. With configuration cache and file system watching enabled this overhead now starts to show.

This PR ensures that we capture only the actual things that influence the outputs of the tasks. Afterwards these tasks are up-to-date after a non-ABI change: https://ge.gradle.org/s/43xd2igaog3zu/timeline?hideTimeline&typeFilter=gradlebuild.basics.tasks.ClasspathManifest.