### PR TITLE
Fix documentation navigation menu highlighting

### DIFF
--- a/subprojects/docs/src/main/resources/footer.html
+++ b/subprojects/docs/src/main/resources/footer.html
@@ -104,7 +104,7 @@
         currentChapterFileName = window.location.pathname.substr(0, window.location.pathname.lastIndexOf("/"));
         currentChapterFileName = currentChapterFileName.substr(currentChapterFileName.lastIndexOf("/") + 1) + "/index.html";
     }
-    [].forEach.call(document.querySelectorAll(".docs-navigation a[href$='" + currentChapterFileName + "']"), function (link) {
+    [].forEach.call(document.querySelectorAll(".docs-navigation a[href$='/" + currentChapterFileName + "']"), function (link) {
         // Add "active" to all links same as current URL
         link.classList.add("active");
 


### PR DESCRIPTION
Currently it would highlight items in the menu that have the ending mathing current html page opened and in case of `multi_project_builds.html` it also highlights `intro_multi_project_builds.html`.
With this change it will match the ending starting with a slash - `/multi_project_builds.html` will not match `/intro_multi_project_builds.html`.

When on `multi_project_builds.html` page,
before change:
![image](https://user-images.githubusercontent.com/5560673/91555837-6a5bd680-e93a-11ea-8e02-2c97a16eb26d.png)

after change:
![image](https://user-images.githubusercontent.com/5560673/91555969-a131ec80-e93a-11ea-963f-db37c6980759.png)
