### PR TITLE
Pull authoring multi project builds topic to its own section in docs nav menu

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -170,7 +170,7 @@
                     <li><a href="../userguide/potential_traps.html">Avoiding Traps</a></li>
                 </ul>
             </li>
-            <li><a href="../userguide/multi_project_builds.html">Multi-Project Builds</a></li>
+            <li><a href="../userguide/multi_project_builds.html">Author Multi-Project Builds</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#authoring-sustainable-builds" aria-expanded="false" aria-controls="authoring-sustainable-builds">Authoring Sustainable Builds</a>
                 <ul id="authoring-sustainable-builds">
                     <li><a href="../userguide/organizing_gradle_projects.html">Organizing Build Logic</a></li>

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -167,10 +167,10 @@
                     <li><a href="../userguide/plugins.html">Using Gradle Plugins</a></li>
                     <li><a href="../userguide/build_lifecycle.html">Understanding the Build Lifecycle</a></li>
                     <li><a href="../userguide/logging.html">Working with Logging</a></li>
-                    <li><a href="../userguide/multi_project_builds.html">Configuring Multi-Project Builds</a></li>
                     <li><a href="../userguide/potential_traps.html">Avoiding Traps</a></li>
                 </ul>
             </li>
+            <li><a href="../userguide/multi_project_builds.html">Multi-Project Builds</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#authoring-sustainable-builds" aria-expanded="false" aria-controls="authoring-sustainable-builds">Authoring Sustainable Builds</a>
                 <ul id="authoring-sustainable-builds">
                     <li><a href="../userguide/organizing_gradle_projects.html">Organizing Build Logic</a></li>


### PR DESCRIPTION
So that it is visible directly below "Learning the basics" menu.
Currently it this important topic is buried within "Learning the basics" close to the bottom.
Next steps after pulling it up could be to create a new hamburger menu for the multi-project build authoring and split the lengthy page into multiple sub-menus.
