### PR TITLE
Remove `:kotlin-dsl` dependency from `:configuration-cache`

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(project(":dependency-management"))
     implementation(project(":execution"))
     implementation(project(":file-collections"))
-    implementation(project(":kotlin-dsl"))
     implementation(project(":logging"))
     implementation(project(":messaging"))
     implementation(project(":model-core"))

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptTaskDefinitionIntegrationTest.groovy
@@ -213,7 +213,7 @@ class ConfigurationCacheScriptTaskDefinitionIntegrationTest extends AbstractConf
         then:
         problems.assertFailureHasProblems(failure) {
             withUniqueProblems(
-                "Task `:some` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with the configuration cache."
+                "Task `:some` of type `org.gradle.api.DefaultTask`: cannot serialize Gradle script object references as these are not supported with the configuration cache."
             )
             withProblemsWithStackTraceCount(0)
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -20,6 +20,7 @@ import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.ConfigurationCacheRepository.CheckedFingerprint
+import org.gradle.configurationcache.extensions.useToRun
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.fingerprint.InvalidationReason
 import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
@@ -44,7 +45,6 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
-import org.gradle.kotlin.dsl.support.useToRun
 import org.gradle.util.IncubationLogger
 import java.io.File
 import java.io.OutputStream

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/AutoCloseableExtensions.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/AutoCloseableExtensions.kt
@@ -16,20 +16,8 @@
 
 package org.gradle.configurationcache.extensions
 
-import org.gradle.api.Project
-import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.internal.service.ServiceRegistry
+
+inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =
+    use { run(action) }
 
 
-internal
-inline fun <reified T : Any> TaskInternal.serviceOf(): T =
-    project.serviceOf()
-
-
-inline fun <reified T : Any> Project.serviceOf(): T =
-    (this as ProjectInternal).services.get()
-
-
-inline fun <reified T : Any> ServiceRegistry.get(): T =
-    this[T::class.java]!!

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
@@ -46,6 +46,9 @@ enum class DocumentationSection(val anchor: String) {
 }
 
 
+typealias StructuredMessageBuilder = StructuredMessage.Builder.() -> Unit
+
+
 data class StructuredMessage(val fragments: List<Fragment>) {
 
     override fun toString(): String = fragments.joinToString(separator = "") { fragment ->
@@ -64,7 +67,7 @@ data class StructuredMessage(val fragments: List<Fragment>) {
 
     companion object {
 
-        fun build(builder: Builder.() -> Unit) = StructuredMessage(
+        fun build(builder: StructuredMessageBuilder) = StructuredMessage(
             Builder().apply(builder).fragments
         )
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Combinators.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Combinators.kt
@@ -18,6 +18,7 @@ package org.gradle.configurationcache.serialization
 
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.problems.DocumentationSection
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.serialize.BaseSerializerFactory
@@ -40,12 +41,38 @@ fun <T> singleton(value: T): Codec<T> =
 
 
 internal
-inline fun <reified T : Any> unsupported(documentationSection: DocumentationSection = DocumentationSection.RequirementsDisallowedTypes): Codec<T> = codec(
+inline fun <reified T : Any> unsupported(
+    documentationSection: DocumentationSection = DocumentationSection.RequirementsDisallowedTypes
+): Codec<T> = codec(
     encode = { value ->
         logUnsupported("serialize", T::class, value.javaClass, documentationSection)
     },
     decode = {
         logUnsupported("deserialize", T::class, documentationSection)
+        null
+    }
+)
+
+
+internal
+inline fun <reified T : Any> unsupported(
+    description: String,
+    documentationSection: DocumentationSection = DocumentationSection.RequirementsDisallowedTypes
+) = unsupported<T>(documentationSection) {
+    text(description)
+}
+
+
+internal
+inline fun <reified T : Any> unsupported(
+    documentationSection: DocumentationSection = DocumentationSection.RequirementsDisallowedTypes,
+    noinline unsupportedMessage: StructuredMessageBuilder
+): Codec<T> = codec(
+    encode = { _ ->
+        logUnsupported("serialize", documentationSection, unsupportedMessage)
+    },
+    decode = {
+        logUnsupported("deserialize", documentationSection, unsupportedMessage)
         null
     }
 )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Logging.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Logging.kt
@@ -22,14 +22,11 @@ import org.gradle.configurationcache.problems.DocumentationSection.NotYetImpleme
 import org.gradle.configurationcache.problems.DocumentationSection.RequirementsDisallowedTypes
 
 import org.gradle.configurationcache.problems.PropertyProblem
-import org.gradle.configurationcache.problems.StructuredMessage
 import org.gradle.configurationcache.problems.StructuredMessage.Companion.build
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.problems.propertyDescriptionFor
 
 import kotlin.reflect.KClass
-
-
-typealias StructuredMessageBuilder = StructuredMessage.Builder.() -> Unit
 
 
 fun IsolateContext.logPropertyProblem(
@@ -49,22 +46,13 @@ fun IsolateContext.logUnsupported(
     actualType: Class<*>,
     documentationSection: DocumentationSection = RequirementsDisallowedTypes
 ) {
-    logPropertyProblem(
-        action,
-        PropertyProblem(
-            trace,
-            build {
-                text("cannot ")
-                text(action)
-                text(" object of type ")
-                reference(GeneratedSubclasses.unpack(actualType))
-                text(", a subtype of ")
-                reference(baseType)
-                text(", as these are not supported with the configuration cache.")
-            },
-            null, documentationSection
-        )
-    )
+    logUnsupported(action, documentationSection) {
+        text(" object of type ")
+        reference(GeneratedSubclasses.unpack(actualType))
+        text(", a subtype of ")
+        reference(baseType)
+        text(",")
+    }
 }
 
 
@@ -74,6 +62,19 @@ fun IsolateContext.logUnsupported(
     baseType: KClass<*>,
     documentationSection: DocumentationSection = RequirementsDisallowedTypes
 ) {
+    logUnsupported(action, documentationSection) {
+        text(" object of type ")
+        reference(baseType)
+    }
+}
+
+
+internal
+fun IsolateContext.logUnsupported(
+    action: String,
+    documentationSection: DocumentationSection = RequirementsDisallowedTypes,
+    unsupportedThings: StructuredMessageBuilder
+) {
     logPropertyProblem(
         action,
         PropertyProblem(
@@ -81,11 +82,11 @@ fun IsolateContext.logUnsupported(
             build {
                 text("cannot ")
                 text(action)
-                text(" object of type ")
-                reference(baseType)
+                unsupportedThings()
                 text(" as these are not supported with the configuration cache.")
             },
-            null, documentationSection
+            null,
+            documentationSection
         )
     )
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.serialization.codecs
 
 import org.gradle.api.Project
-import org.gradle.api.Script
 import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
@@ -55,7 +54,7 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.configurationcache.serialization.unsupported
-import org.gradle.kotlin.dsl.*
+import org.gradle.internal.scripts.GradleScript
 import java.io.FileDescriptor
 import java.io.InputStream
 import java.io.OutputStream
@@ -82,8 +81,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<ServerSocket>())
 
     // Gradle Scripts
-    bind(unsupported<Script>())
-    bind(unsupported<KotlinScript>())
+    bind(unsupported<GradleScript>(" Gradle script object references"))
 
     // Gradle Build Model
     bind(unsupported<Gradle>())

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache.serialization.codecs
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.configurationcache.extensions.useToRun
 import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.serialization.Codec
@@ -34,7 +35,6 @@ import org.gradle.internal.io.NullOutputStream
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
-import org.gradle.kotlin.dsl.support.useToRun
 import org.gradle.util.TestUtil
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
@@ -19,10 +19,10 @@ package org.gradle.configurationcache.serialization.codecs
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.api.Project
 import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.configurationcache.extensions.useToRun
 import org.gradle.configurationcache.problems.DocumentationSection.NotYetImplementedJavaSerialization
 import org.gradle.configurationcache.problems.PropertyKind
 import org.gradle.configurationcache.problems.PropertyTrace
-import org.gradle.kotlin.dsl.support.useToRun
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.CoreMatchers.sameInstance

--- a/subprojects/core-api/src/main/java/org/gradle/api/Script.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Script.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
- * <p>This interface is implemented by all Gradle scripts to add in some Gradle-specific methods. As your compiled
+ * <p>This interface is implemented by all Gradle Groovy DSL scripts to add in some Gradle-specific methods. As your compiled
  * script class will implement this interface, you can use the methods and properties declared by this interface
  * directly in your script.</p>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/GradleScript.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/GradleScript.java
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.scripts;
 
-import org.gradle.api.Project
-import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.internal.service.ServiceRegistry
-
-
-internal
-inline fun <reified T : Any> TaskInternal.serviceOf(): T =
-    project.serviceOf()
-
-
-inline fun <reified T : Any> Project.serviceOf(): T =
-    (this as ProjectInternal).services.get()
-
-
-inline fun <reified T : Any> ServiceRegistry.get(): T =
-    this[T::class.java]!!
+/**
+ * Gradle script marker interface.
+ */
+public interface GradleScript {
+}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -26,12 +26,13 @@ import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.metaobject.DynamicObjectUtil;
+import org.gradle.internal.scripts.GradleScript;
 import org.gradle.internal.service.ServiceRegistry;
 
 import java.io.PrintStream;
 import java.util.Map;
 
-public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware {
+public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware, GradleScript {
     private StandardOutputCapture standardOutputCapture;
     private Object target;
     private ScriptDynamicObject dynamicObject = new ScriptDynamicObject(this);

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.support
 
 import org.gradle.api.Action
+import org.gradle.internal.scripts.GradleScript
 import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
@@ -46,7 +47,7 @@ import java.net.URI
  */
 open class DefaultKotlinScript internal constructor(
     host: Host
-) : KotlinScript {
+) : KotlinScript, GradleScript {
 
     internal
     interface Host {


### PR DESCRIPTION
It's only used for two extensions and the `KotlinScript` interfaces and contributes a long time to the build when iterating on unit tests.

- Inline `useToRun` and `serviceOf` extensions
- Introduce `GradleScript` marker interface to subsume the `Script` and `KotlinScript` interfaces