### PR TITLE
Some improvements for service serialization to the configuration cache

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -27,6 +27,7 @@ import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.AbstractResourceLockRegistry;
 import org.gradle.internal.resources.AbstractTrackedResourceLock;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
@@ -35,8 +36,6 @@ import org.gradle.internal.resources.ProjectLockStatistics;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockState;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.util.CollectionUtils;
@@ -55,8 +54,7 @@ import static org.gradle.internal.resources.DefaultResourceLockCoordinationServi
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
 import static org.gradle.internal.resources.ResourceLockState.Disposition.FINISHED;
 
-@ServiceScope(Scopes.BuildSession.class)
-public class DefaultWorkerLeaseService implements WorkerLeaseService {
+public class DefaultWorkerLeaseService implements WorkerLeaseService, Stoppable {
     public static final String PROJECT_LOCK_STATS_PROPERTY = "org.gradle.internal.project.lock.stats";
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWorkerLeaseService.class);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
@@ -17,12 +17,13 @@
 package org.gradle.internal.work;
 
 import org.gradle.internal.Factory;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
 
 import java.util.Collection;
 
-public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
+public class StopShieldingWorkerLeaseService implements WorkerLeaseService, Stoppable {
 
     private final WorkerLeaseService delegate;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
@@ -17,11 +17,13 @@
 package org.gradle.internal.work;
 
 import org.gradle.internal.Factory;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
-public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseRegistry, Stoppable {
+@ServiceScope(Scopes.BuildSession.class)
+public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseRegistry {
     /**
      * Returns the maximum number of worker leases that this service will grant at any given time. Note that the actual limit may vary over time but will never _exceed_ the value returned by this method.
      */

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -346,9 +346,8 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCache.assertStateLoaded()
         postBuildOutputContains("Configuration cache entry reused with 2 problems.")
         problems.assertResultHasProblems(result) {
-            // TODO - retain the location information
-            withProblem("task `:anotherBroken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
-            withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("build file 'build.gradle': invocation of 'Task.project' at execution time is unsupported.")
+            withTotalProblemsCount(2)
         }
 
         when:
@@ -359,8 +358,8 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCache.assertStateLoaded()
         outputContains("Configuration cache entry reused with 2 problems.")
         problems.assertFailureHasProblems(failure) {
-            withProblem("task `:anotherBroken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
-            withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("build file 'build.gradle': invocation of 'Task.project' at execution time is unsupported.")
+            withTotalProblemsCount(2)
         }
     }
 
@@ -414,7 +413,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCache.assertStateLoaded()
         outputContains("Configuration cache entry reused with 1 problem.")
         problems.assertFailureHasProblems(failure) {
-            withProblem("task `:broken` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("build file 'build.gradle': invocation of 'Task.project' at execution time is unsupported.")
         }
         failure.assertHasDescription("Execution failed for task ':broken'.")
         failure.assertHasCause("BOOM")
@@ -703,11 +702,10 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCache.assertStateLoaded()
         postBuildOutputContains("Configuration cache entry reused with 5 problems.")
         problems.assertResultHasProblems(result) {
+            withProblem("build file 'build.gradle': invocation of '$invocation' at execution time is unsupported.")
             withProblem("task `:a` of type `MyTask`: invocation of '$invocation' at execution time is unsupported.")
             withProblem("task `:b` of type `MyTask`: invocation of '$invocation' at execution time is unsupported.")
             withProblem("task `:c` of type `org.gradle.api.DefaultTask`: invocation of '$invocation' at execution time is unsupported.")
-            // TODO - should retain the location information
-            withProblem("task `:d` of type `org.gradle.api.DefaultTask`: invocation of '$invocation' at execution time is unsupported.")
             withTotalProblemsCount(5)
         }
 
@@ -719,7 +717,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
     }
 
     @Unroll
-    def "report build listener registration on #registrationPoint"() {
+    def "reports build listener registration on #registrationPoint"() {
 
         given:
         buildFile << code

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -333,7 +333,6 @@ class DefaultConfigurationCache internal constructor(
             fileResolver = service(),
             instantiator = service(),
             listenerManager = service(),
-            projectStateRegistry = service(),
             taskNodeFactory = service(),
             fingerprinterRegistry = service(),
             buildOperationExecutor = service(),

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -32,7 +32,6 @@ import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
-import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.model.ObjectFactory
@@ -217,7 +216,7 @@ class Codecs(
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
         fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
 
-        bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
+        bind(TaskNodeCodec(userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
         bind(ChainedTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
         bind(IsolateTransformerParametersNodeCodec(userTypesCodec))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -99,7 +99,6 @@ class Codecs(
     fileResolver: FileResolver,
     instantiator: Instantiator,
     listenerManager: ListenerManager,
-    projectStateRegistry: ProjectStateRegistry,
     taskNodeFactory: TaskNodeFactory,
     fingerprinterRegistry: FileCollectionFingerprinterRegistry,
     buildOperationExecutor: BuildOperationExecutor,

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -155,7 +155,6 @@ abstract class AbstractUserTypeCodecTest {
         fileResolver = mock(),
         instantiator = mock(),
         listenerManager = mock(),
-        projectStateRegistry = mock(),
         taskNodeFactory = mock(),
         fingerprinterRegistry = mock(),
         buildOperationExecutor = mock(),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -51,7 +51,7 @@ public interface DomainObjectContext {
     /**
      * The container that holds the model for this context, to allow synchronized access to the model.
      */
-    ModelContainer getModel();
+    ModelContainer<?> getModel();
 
     /**
      * The path to the build that is associated with this object.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -18,16 +18,16 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.Factory;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class RootScriptDomainObjectContext implements DomainObjectContext, ModelContainer {
-
+public class RootScriptDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
+    private static final Object MODEL = new Object();
     public static final DomainObjectContext INSTANCE = new RootScriptDomainObjectContext();
 
     private RootScriptDomainObjectContext() {
@@ -55,7 +55,7 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     }
 
     @Override
-    public ModelContainer getModel() {
+    public ModelContainer<Object> getModel() {
         return this;
     }
 
@@ -65,13 +65,13 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     }
 
     @Override
-    public <T> T withMutableState(Factory<? extends T> factory) {
-        return factory.create();
+    public <S> S fromMutableState(Function<? super Object, ? extends S> factory) {
+        return factory.apply(MODEL);
     }
 
     @Override
-    public void withMutableState(Runnable runnable) {
-        runnable.run();
+    public void applyToMutableState(Consumer<? super Object> action) {
+        action.accept(MODEL);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
@@ -70,17 +70,12 @@ public class BuildOperationCrossProjectConfigurator implements CrossProjectConfi
     }
 
     private void runProjectConfigureAction(final Project project, final Action<? super Project> configureAction) {
-        ((ProjectInternal)project).getMutationState().withMutableState(new Runnable() {
+        ((ProjectInternal) project).getMutationState().applyToMutableState(p -> buildOperationExecutor.run(new CrossConfigureProjectBuildOperation(project) {
             @Override
-            public void run() {
-                buildOperationExecutor.run(new CrossConfigureProjectBuildOperation(project) {
-                    @Override
-                    public void run(BuildOperationContext context) {
-                        Actions.with(project, mutationGuard.withMutationEnabled(configureAction));
-                    }
-                });
+            public void run(BuildOperationContext context) {
+                Actions.with(project, mutationGuard.withMutationEnabled(configureAction));
             }
-        });
+        }));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -615,7 +615,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     }
 
     @Override
-    public ModelContainer getModel() {
+    public ModelContainer<ProjectInternal> getModel() {
         return getMutationState();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.project;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.resources.ResourceLock;
@@ -26,12 +25,14 @@ import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Encapsulates the identity and state of a particular project in a build tree.
  */
 @ThreadSafe
-public interface ProjectState extends ModelContainer {
+public interface ProjectState extends ModelContainer<ProjectInternal> {
     /**
      * Returns the containing build of this project.
      */
@@ -74,7 +75,7 @@ public interface ProjectState extends ModelContainer {
     ProjectInternal getMutableModel();
 
     /**
-     * Returns the lock that will be acquired when accessing the mutable state of this project via {@link #withMutableState(Runnable)} and {@link #withMutableState(Factory)}.
+     * Returns the lock that will be acquired when accessing the mutable state of this project via {@link #withMutableState(Consumer)} and {@link #withMutableState(Function)}.
      * A caller can optionally acquire this lock before calling one of these accessor methods, in order to avoid those methods blocking.
      *
      * <p>Note that the lock may be shared between projects.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
@@ -45,26 +45,23 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
     private static final ModelType<Task> TASK_MODEL_TYPE = ModelType.of(Task.class);
     private static final ModelReference<Task> TASK_MODEL_REFERENCE = ModelReference.of(TASK_MODEL_TYPE);
     private static final SimpleModelRuleDescriptor COPY_TO_TASK_CONTAINER_DESCRIPTOR = new SimpleModelRuleDescriptor("copyToTaskContainer");
-    private final ModelRegistry modelRegistry;
     private final Instantiator instantiator;
     private final ITaskFactory taskFactory;
     private final CollectionCallbackActionDecorator callbackDecorator;
-    private final Project project;
+    private final ProjectInternal project;
     private final ProjectAccessListener projectAccessListener;
     private final TaskStatistics statistics;
     private final BuildOperationExecutor buildOperationExecutor;
     private final CrossProjectConfigurator crossProjectConfigurator;
 
-    public DefaultTaskContainerFactory(ModelRegistry modelRegistry,
-                                       Instantiator instantiator,
+    public DefaultTaskContainerFactory(Instantiator instantiator,
                                        ITaskFactory taskFactory,
-                                       Project project,
+                                       ProjectInternal project,
                                        ProjectAccessListener projectAccessListener,
                                        TaskStatistics statistics,
                                        BuildOperationExecutor buildOperationExecutor,
                                        CrossProjectConfigurator crossProjectConfigurator,
                                        CollectionCallbackActionDecorator callbackDecorator) {
-        this.modelRegistry = modelRegistry;
         this.instantiator = instantiator;
         this.taskFactory = taskFactory;
         this.project = project;
@@ -83,7 +80,7 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
     }
 
     private void bridgeIntoSoftwareModelWhenNeeded(final DefaultTaskContainer tasks) {
-        ((ProjectInternal) project).addRuleBasedPluginListener(new RuleBasedPluginListener() {
+        project.addRuleBasedPluginListener(new RuleBasedPluginListener() {
             @Override
             public void prepareForRuleBasedPlugins(Project project) {
                 ModelReference<DefaultTaskContainer> containerReference = ModelReference.of(TaskContainerInternal.MODEL_PATH, DEFAULT_TASK_CONTAINER_MODEL_TYPE);
@@ -102,6 +99,7 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
                     new Namer()
                 );
 
+                ModelRegistry modelRegistry = ((ProjectInternal) project).getServices().get(ModelRegistry.class);
                 modelRegistry.register(
                     registrationBuilder
                         .withProjection(ModelMapModelProjection.unmanaged(TASK_MODEL_TYPE, ChildNodeInitializerStrategyAccessors.of(NodeBackedModelMap.createUsingParentNode(new Transformer<NamedEntityInstantiator<Task>, MutableModelNode>() {

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/BuildScriptProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/BuildScriptProcessor.java
@@ -39,12 +39,7 @@ public class BuildScriptProcessor implements ProjectConfigureAction {
         final Timer clock = Time.startTimer();
         try {
             final ScriptPlugin configurer = configurerFactory.create(project.getBuildScriptSource(), project.getBuildscript(), project.getClassLoaderScope(), project.getBaseClassLoaderScope(), true);
-            project.getMutationState().withMutableState(new Runnable() {
-                @Override
-                public void run() {
-                    configurer.apply(project);
-                }
-            });
+            project.getMutationState().applyToMutableState(configurer::apply);
         } finally {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Timing: Running the build script took {}", clock.getElapsed());

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -88,34 +88,31 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
 
         @Override
         public void run(final BuildOperationContext context) {
-            project.getMutationState().withMutableState(new Runnable() {
-                @Override
-                public void run() {
-                    // Note: beforeEvaluate and afterEvaluate ops do not throw, instead mark state as failed
-                    try {
-                        state.toBeforeEvaluate();
-                        buildOperationExecutor.run(new NotifyBeforeEvaluate(project, state));
+            project.getMutationState().applyToMutableState(p -> {
+                // Note: beforeEvaluate and afterEvaluate ops do not throw, instead mark state as failed
+                try {
+                    state.toBeforeEvaluate();
+                    buildOperationExecutor.run(new NotifyBeforeEvaluate(project, state));
 
-                        if (!state.hasFailure()) {
-                            state.toEvaluate();
-                            try {
-                                delegate.evaluate(project, state);
-                            } catch (Exception e) {
-                                addConfigurationFailure(project, state, e, context);
-                            } finally {
-                                state.toAfterEvaluate();
-                                buildOperationExecutor.run(new NotifyAfterEvaluate(project, state));
-                            }
+                    if (!state.hasFailure()) {
+                        state.toEvaluate();
+                        try {
+                            delegate.evaluate(project, state);
+                        } catch (Exception e) {
+                            addConfigurationFailure(project, state, e, context);
+                        } finally {
+                            state.toAfterEvaluate();
+                            buildOperationExecutor.run(new NotifyAfterEvaluate(project, state));
                         }
-
-                        if (state.hasFailure()) {
-                            state.rethrowFailure();
-                        } else {
-                            context.setResult(ConfigureProjectBuildOperationType.RESULT);
-                        }
-                    } finally {
-                        state.configured();
                     }
+
+                    if (state.hasFailure()) {
+                        state.rethrowFailure();
+                    } else {
+                        context.setResult(ConfigureProjectBuildOperationType.RESULT);
+                    }
+                } finally {
+                    state.configured();
                 }
             });
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
@@ -26,10 +26,8 @@ import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.internal.Actions;
-import org.gradle.internal.Factory;
 import org.gradle.internal.InternalBuildAdapter;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 
@@ -64,7 +62,7 @@ public class BuildSrcBuildListenerFactory {
 
         @Override
         public void projectsLoaded(Gradle gradle) {
-            rootProjectConfiguration.execute((ProjectInternal)gradle.getRootProject());
+            rootProjectConfiguration.execute((ProjectInternal) gradle.getRootProject());
         }
 
         @Override
@@ -76,13 +74,7 @@ public class BuildSrcBuildListenerFactory {
         }
 
         public Collection<File> getRuntimeClasspath() {
-            return rootProjectState.withMutableState(new Factory<Collection<File>>() {
-                @Nullable
-                @Override
-                public Collection<File> create() {
-                    return classpath.getFiles();
-                }
-            });
+            return rootProjectState.fromMutableState(p -> classpath.getFiles());
         }
 
         private BuildableJavaComponent mainComponentOf(GradleInternal gradle) {

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
@@ -29,25 +29,23 @@ public interface CalculatedModelValue<T> {
     /**
      * Returns the current value, failing if not present.
      *
-     * <p>May be called by any thread, except any thread currently inside {@link #update(Function)}.
-     * This method does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
+     * <p>May be called by any thread. This method returns immediately and does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
      */
     T get() throws IllegalStateException;
 
     /**
-     * Returns the current value, failing if not present.
+     * Returns the current value, returning {@code null} if not present.
      *
-     * <p>May be called by any thread, except any thread currently inside {@link #update(Function)}.
-     * This method does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
+     * <p>May be called by any thread. This method returns immediately and does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
      */
     @Nullable
     T getOrNull();
 
     /**
-     * Updates the current value. The function is passed the current value or null if there is no value and the return value is
+     * Updates the current value. The function is passed the current value or {@code null} if there is no value, and the function's return value is
      * used as the new value.
      *
-     * <p>The current thread must hold the lock for the mutable state from which the value is calculated. At most a single thread
+     * <p>The calling thread must own the mutable state from which the value is calculated (via {@link ModelContainer#withMutableState(Runnable)}). At most a single thread
      * will run the update function at a given time. This additional guarantee is because the mutable state lock may be released
      * while the function is running or while waiting to access the value.
      */
@@ -55,6 +53,8 @@ public interface CalculatedModelValue<T> {
 
     /**
      * Sets the current value.
+     *
+     * <p>The calling thread< must own the mutable state from which the value is calculated.</p>
      */
     void set(T newValue);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
@@ -45,7 +45,7 @@ public interface CalculatedModelValue<T> {
      * Updates the current value. The function is passed the current value or {@code null} if there is no value, and the function's return value is
      * used as the new value.
      *
-     * <p>The calling thread must own the mutable state from which the value is calculated (via {@link ModelContainer#withMutableState(Runnable)}). At most a single thread
+     * <p>The calling thread must own the mutable state from which the value is calculated (via {@link ModelContainer#withMutableState(Function)}). At most a single thread
      * will run the update function at a given time. This additional guarantee is because the mutable state lock may be released
      * while the function is running or while waiting to access the value.
      */

--- a/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/ModelContainer.java
@@ -16,32 +16,28 @@
 
 package org.gradle.internal.model;
 
-import org.gradle.internal.Factory;
-
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Encapsulates some mutable model, and provides synchronized access to the model.
  */
-public interface ModelContainer {
+public interface ModelContainer<T> {
 
     /**
-     * Runs the given action against the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
+     * Runs the given function to calculate a value from the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
      * However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
      *
      * <p>It is usually a better option to use {@link #newCalculatedValue(Object)} instead of this method.</p>
-     *
-     * <p>Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
      */
-    <T> T withMutableState(Factory<? extends T> factory);
+    <S> S fromMutableState(Function<? super T, ? extends S> factory);
 
     /**
      * Runs the given action against the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
      * However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
-     *
-     * <p>Note also that the mutable state should be passed to the action, but is not yet. This is to help with migration.
      */
-    void withMutableState(Runnable runnable);
+    void applyToMutableState(Consumer<? super T> action);
 
     /**
      * Returns whether or not the current thread has access to the mutable model.
@@ -51,5 +47,5 @@ public interface ModelContainer {
     /**
      * Creates a new container for a value that is calculated from the mutable state of this container, and then reused by multiple threads.
      */
-    <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue);
+    <S> CalculatedModelValue<S> newCalculatedValue(@Nullable S initialValue);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -195,7 +195,6 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected TaskContainerInternal createTaskContainerInternal(TaskStatistics taskStatistics, BuildOperationExecutor buildOperationExecutor, CrossProjectConfigurator crossProjectConfigurator, CollectionCallbackActionDecorator decorator) {
         return new DefaultTaskContainerFactory(
-            get(ModelRegistry.class),
             get(Instantiator.class),
             get(ITaskFactory.class),
             project,
@@ -217,9 +216,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     }
 
     protected ModelRegistry createModelRegistry(ModelRuleExtractor ruleExtractor) {
-        return new DefaultModelRegistry(ruleExtractor, project.getPath(), run -> {
-            project.getMutationState().withMutableState(run);
-        });
+        return new DefaultModelRegistry(ruleExtractor, project.getPath(), run -> project.getMutationState().applyToMutableState(p -> run.run()));
     }
 
     protected ScriptHandlerInternal createScriptHandler(DependencyManagementServices dependencyManagementServices, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, DependencyMetaDataProvider dependencyMetaDataProvider, ScriptClassPathResolver scriptClassPathResolver, NamedObjectInstantiator instantiator) {
@@ -266,7 +263,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         }
 
         @Override
-        public ModelContainer getModel() {
+        public ModelContainer<?> getModel() {
             return delegate.getModel();
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -98,6 +98,7 @@ import spock.lang.Specification
 import java.awt.Point
 import java.lang.reflect.Type
 import java.text.FieldPosition
+import java.util.function.Consumer
 
 class DefaultProjectTest extends Specification {
 
@@ -254,8 +255,9 @@ class DefaultProjectTest extends Specification {
         def container = Stub(ProjectState)
         _ * container.identityPath >> (parent == null ? Path.ROOT : parent.identityPath.child(name))
         _ * container.projectPath >> (parent == null ? Path.ROOT : parent.projectPath.child(name))
-        _ * container.withMutableState(_) >> { Runnable runnable -> runnable.run() }
-        TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultProject, name, parent, rootDir, new File(rootDir, 'build.gradle'), script, build, container, projectServiceRegistryFactoryMock, scope, baseClassLoaderScope)
+        def project = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultProject, name, parent, rootDir, new File(rootDir, 'build.gradle'), script, build, container, projectServiceRegistryFactoryMock, scope, baseClassLoaderScope)
+        _ * container.applyToMutableState(_) >> { Consumer action -> action.accept(project) }
+        return project
     }
 
     Type getProjectRegistryType() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -39,7 +39,6 @@ import org.gradle.api.tasks.TaskDependency
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.model.internal.registry.ModelRegistry
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
 
@@ -48,7 +47,6 @@ import static java.util.Collections.singletonMap
 class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerSpec<Task> {
 
     private taskFactory = Mock(ITaskFactory)
-    def modelRegistry = Mock(ModelRegistry)
     private project = Mock(ProjectInternal, name: "<project>") {
         identityPath(_) >> { String name ->
             Path.path(":project").child(name)
@@ -65,7 +63,6 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
     private taskCount = 1
     private accessListener = Mock(ProjectAccessListener)
     private container = new DefaultTaskContainerFactory(
-        modelRegistry,
         DirectInstantiator.INSTANCE,
         taskFactory,
         project,

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/BuildScriptProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/BuildScriptProcessorTest.groovy
@@ -25,6 +25,8 @@ import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.groovy.scripts.ScriptSource
 import spock.lang.Specification
 
+import java.util.function.Consumer
+
 class BuildScriptProcessorTest extends Specification {
     def project = Mock(ProjectInternal)
     def scriptSource = Mock(ScriptSource)
@@ -42,7 +44,7 @@ class BuildScriptProcessorTest extends Specification {
         project.getClassLoaderScope() >> targetScope
         project.getBaseClassLoaderScope() >> baseScope
         project.getMutationState() >> projectState
-        projectState.withMutableState(_) >> { args -> args[0].run() }
+        projectState.applyToMutableState(_) >> { Consumer consumer -> consumer.accept(project) }
     }
 
     def configuresProjectUsingBuildScript() {

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -27,6 +27,8 @@ import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.util.Path
 import spock.lang.Specification
 
+import java.util.function.Consumer
+
 class LifecycleProjectEvaluatorTest extends Specification {
 
     private project = Mock(ProjectInternal)
@@ -55,7 +57,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
             null
         }
         project.getMutationState() >> mutationState
-        mutationState.withMutableState(_) >> { args -> args[0].run() }
+        mutationState.applyToMutableState(_) >> { Consumer consumer -> consumer.accept(project) }
     }
 
     void "nothing happens if project was already configured"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.initialization.buildsrc
 
-
 import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.GradleInternal
@@ -28,13 +27,13 @@ import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.service.ServiceRegistry
 import spock.lang.Specification
 
+import java.util.function.Function
+
 class BuildSrcBuildListenerFactoryTest extends Specification {
 
     def startParameter = Mock(StartParameterInternal)
     def projectState = Mock(ProjectState) {
-        withMutableState(_) >> { args ->
-            args[0].create()
-        }
+        fromMutableState(_) >> { Function function -> function.apply(project) }
     }
     def component = Stub(BuildableJavaComponent) {
         getRuntimeClasspath() >> Stub(FileCollection)

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -55,6 +55,8 @@ import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import java.util.function.Consumer
+
 class DefaultGradleSpec extends Specification {
     ServiceRegistryFactory serviceRegistryFactory = Stub(ServiceRegistryFactory)
     ListenerManager listenerManager = Spy(TestListenerManager)
@@ -432,7 +434,7 @@ class DefaultGradleSpec extends Specification {
         projectRegistry.addProject(project)
         _ * project.getProjectRegistry() >> projectRegistry
         _ * project.getMutationState() >> projectState
-        _ * projectState.withMutableState(_) >> { Runnable runnable -> runnable.run() }
+        _ * projectState.applyToMutableState(_) >> { Consumer consumer -> consumer.accept(project) }
         return project
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -562,7 +562,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 // Error if we are executing in a user-managed thread.
                 throw new IllegalStateException("The configuration " + identityPath.toString() + " was resolved from a thread not managed by Gradle.");
             } else {
-                // We don't currently have mutable access to the project, so report a deprecation warning and then continue by attempting to lock
+                // We don't currently have mutable access to the project, so report a deprecation warning and then continue by attempting to acquire mutable access
                 DeprecationLogger.deprecateBehaviour("The configuration " + identityPath.toString() + " was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a different project.")
                     .willBeRemovedInGradle7()
                     .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -567,7 +567,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                     .willBeRemovedInGradle7()
                     .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")
                     .nagUser();
-                return owner.getModel().withMutableState(() -> resolveExclusively(requestedState));
+                return owner.getModel().fromMutableState(p -> resolveExclusively(requestedState));
             }
         }
         return resolveExclusively(requestedState);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -450,8 +450,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         }
     }
 
-    private static void resolveAllConfigurationsAndForceDownload(Project p) {
-        ((ProjectInternal) p).getMutationState().withMutableState(() ->
+    private static void resolveAllConfigurationsAndForceDownload(Project project) {
+        ((ProjectInternal) project).getMutationState().applyToMutableState(p ->
             p.getConfigurations().all(cnf -> {
                 if (((DeprecatableConfiguration) cnf).canSafelyBeResolved()) {
                     try {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -27,10 +27,8 @@ import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvid
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.component.local.model.BuildableLocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.local.model.RootLocalComponentMetadata;
@@ -81,13 +79,9 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
             if (!projectState.hasMutableState()) {
                 throw new IllegalStateException("Thread should hold project lock for " + projectId);
             }
-            return projectState.withMutableState(new Factory<DefaultLocalComponentMetadata>() {
-                @Override
-                public DefaultLocalComponentMetadata create() {
-                    ProjectInternal project = projectState.getMutableModel();
-                    final AttributesSchemaInternal schema = (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-                    return getRootComponentMetadata(module, componentIdentifier, moduleVersionIdentifier, schema, dependencyLockingProvider);
-                }
+            return projectState.fromMutableState(project -> {
+                AttributesSchemaInternal schema = (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
+                return getRootComponentMetadata(module, componentIdentifier, moduleVersionIdentifier, schema, dependencyLockingProvider);
             });
         } else {
             return getRootComponentMetadata(module, componentIdentifier, moduleVersionIdentifier, null, dependencyLockingProvider);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -84,10 +84,10 @@ public class DefaultProjectLocalComponentProvider implements LocalComponentProvi
 
     private LocalComponentMetadata getLocalComponentMetadata(final ProjectComponentIdentifier projectIdentifier) {
         ProjectState projectState = projectStateRegistry.stateFor(projectIdentifier);
-        return projectState.withMutableState(() -> {
+        return projectState.fromMutableState(p -> {
             LocalComponentMetadata metadata = projects.getIfPresent(projectIdentifier);
             if (metadata == null) {
-                metadata = getLocalComponentMetadata(projectState, projectState.getMutableModel());
+                metadata = getLocalComponentMetadata(projectState, p);
                 projects.put(projectIdentifier, metadata);
             }
             return metadata;
@@ -104,5 +104,4 @@ public class DefaultProjectLocalComponentProvider implements LocalComponentProvi
         }
         return metaData;
     }
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
@@ -46,9 +46,9 @@ public class ProjectArtifactResolver implements ArtifactResolver {
 
     @Override
     public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
-        final LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
+        LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
         ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) artifact.getComponentId();
-        File localArtifactFile = projectStateRegistry.stateFor(projectId).withMutableState(() -> projectArtifact.getFile());
+        File localArtifactFile = projectStateRegistry.stateFor(projectId).fromMutableState(p -> projectArtifact.getFile());
         if (localArtifactFile != null) {
             result.resolved(localArtifactFile);
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -122,7 +122,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction<?>> 
         FileLookup fileLookup,
         PropertyWalker parameterPropertyWalker,
         InstantiationScheme actionInstantiationScheme,
-        ModelContainer owner,
+        ModelContainer<?> owner,
         ServiceLookup internalServices
     ) {
         super(implementationClass, fromAttributes);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.component.local.model.LocalComponentMetadata
@@ -29,6 +30,8 @@ import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult
 import spock.lang.Specification
+
+import java.util.function.Consumer
 
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 
@@ -43,7 +46,7 @@ class ProjectDependencyResolverTest extends Specification {
     def setup() {
         def projectState = Stub(ProjectState)
         _ * projectRegistry.stateFor(_) >> projectState
-        _ * projectState.withMutableState(_) >> { Runnable action -> action.run() }
+        _ * projectState.applyToMutableState(_) >> { Consumer consumer -> consumer.accept(Stub(ProjectInternal)) }
     }
 
     def "resolves project dependency"() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
@@ -22,12 +22,11 @@ import com.google.common.collect.Sets;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.tasks.options.Option;
 import org.gradle.api.reporting.dependents.internal.TextDependentComponentsReportRenderer;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -138,8 +137,7 @@ public class DependentComponentsReport extends DefaultTask {
             // Output reports per execution, not mixed.
             // Cross-project ModelRegistry operations do not happen concurrently.
             synchronized (DependentComponentsReport.class) {
-                ((ProjectInternal) getProject()).getMutationState().withMutableState(() -> {
-                    Project project = getProject();
+                ((ProjectInternal) getProject()).getMutationState().applyToMutableState(project -> {
                     ModelRegistry modelRegistry = getModelRegistry();
 
                     DependentBinariesResolver dependentBinariesResolver = modelRegistry.find("dependentBinariesResolver", DependentBinariesResolver.class);

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -126,7 +126,7 @@ public class TaskReportTask extends AbstractReportTask {
 
     private SingleProjectTaskReportModel buildTaskReportModelFor(final TaskDetailsFactory taskDetailsFactory, final Project subproject) {
         ProjectState projectState = getProjectStateRegistry().stateFor(subproject);
-        return projectState.withMutableState(() -> {
+        return projectState.fromMutableState(p -> {
             SingleProjectTaskReportModel subprojectTaskModel = new SingleProjectTaskReportModel(taskDetailsFactory);
             subprojectTaskModel.build(getProjectTaskLister().listProjectTasks(subproject));
             return subprojectTaskModel;

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/load.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/load.out
@@ -2,7 +2,7 @@ Reusing configuration cache.
 > Task :someTask
 
 1 problem was found reusing the configuration cache.
-- task `:someTask` of type `org.gradle.api.DefaultTask`: invocation of 'Task.project' at execution time is unsupported.
+- build file 'build.gradle': invocation of 'Task.project' at execution time is unsupported.
   See https://docs.gradle.org/0.0.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
 
 See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
@@ -35,7 +35,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.internal.Cast;
-import org.gradle.internal.Factory;
 import org.gradle.language.scala.internal.DefaultScalaPlatform;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.plugins.ide.idea.model.Dependency;
@@ -46,7 +45,6 @@ import org.gradle.plugins.ide.idea.model.ModuleLibrary;
 import org.gradle.plugins.ide.idea.model.ProjectLibrary;
 import org.gradle.util.VersionNumber;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
@@ -113,14 +111,7 @@ public class IdeaScalaConfigurer {
         for (final Project scalaProject : scalaProjects) {
             final IdeaModule ideaModule = scalaProject.getExtensions().getByType(IdeaModel.class).getModule();
             final Iterable<File> files = getIdeaModuleLibraryDependenciesAsFiles(ideaModule);
-            ProjectLibrary library = ((ProjectInternal)scalaProject).getMutationState().withMutableState(new Factory<ProjectLibrary>() {
-                @Nullable
-                @Override
-                public ProjectLibrary create() {
-                    return createScalaSdkLibrary(scalaProject, files, useScalaSdk, ideaModule);
-                }
-            });
-
+            ProjectLibrary library = ((ProjectInternal) scalaProject).getMutationState().fromMutableState(p -> createScalaSdkLibrary(scalaProject, files, useScalaSdk, ideaModule));
             if (library != null) {
                 ProjectLibrary duplicate = Iterables.find(scalaCompilerLibraries.values(), Predicates.equalTo(library), null);
                 scalaCompilerLibraries.put(scalaProject.getPath(), duplicate == null ? library : duplicate);
@@ -133,7 +124,7 @@ public class IdeaScalaConfigurer {
         // could make resolveDependencies() cache its result for later use by GenerateIdeaModule
         Set<Dependency> dependencies = ideaModule.resolveDependencies();
         List<File> files = Lists.newArrayList();
-        for(ModuleLibrary moduleLibrary : Iterables.filter(dependencies, ModuleLibrary.class)) {
+        for (ModuleLibrary moduleLibrary : Iterables.filter(dependencies, ModuleLibrary.class)) {
             for (FilePath filePath : Iterables.filter(moduleLibrary.getClasses(), FilePath.class)) {
                 files.add(filePath.getFile());
             }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -30,7 +30,6 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
@@ -110,14 +109,10 @@ public class IdeaDependenciesProvider {
         final JavaModuleDetector javaModuleDetector = projectInternal.getServices().get(JavaModuleDetector.class);
 
         final IdeaDependenciesVisitor visitor = new IdeaDependenciesVisitor(ideaModule, scope.name());
-        return projectInternal.getMutationState().withMutableState(new Factory<IdeaDependenciesVisitor>() {
-            @Override
-            public IdeaDependenciesVisitor create() {
-                new IdeDependencySet(handler, javaModuleDetector, plusConfigurations, minusConfigurations, false, gradleApiSourcesResolver).visit(visitor);
-                return visitor;
-            }
+        return projectInternal.getMutationState().fromMutableState(p -> {
+            new IdeDependencySet(handler, javaModuleDetector, plusConfigurations, minusConfigurations, false, gradleApiSourcesResolver).visit(visitor);
+            return visitor;
         });
-
     }
 
     private Collection<Configuration> getPlusConfigurations(IdeaModule ideaModule, GeneratedIdeaScope scope) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -40,10 +40,6 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    void stop() {
-    }
-
-    @Override
     int getMaxWorkerCount() {
         return 0
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultPomDependenciesConverter.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultPomDependenciesConverter.java
@@ -23,13 +23,25 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Exclusion;
 import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.maven.Conf2ScopeMapping;
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.publication.maven.internal.VersionRangeMapper;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Strings.emptyToNull;
 
@@ -132,21 +144,18 @@ class DefaultPomDependenciesConverter implements PomDependenciesConverter {
         if (dependency instanceof ProjectDependency) {
             // TODO: Combine with ProjectDependencyPublicationResolver
             final ProjectDependency projectDependency = (ProjectDependency) dependency;
-            ((ProjectInternal)projectDependency.getDependencyProject()).getMutationState().withMutableState(new Runnable() {
-                @Override
-                public void run() {
-                    String artifactId = determineProjectDependencyArtifactId(projectDependency);
+            ((ProjectInternal) projectDependency.getDependencyProject()).getMutationState().applyToMutableState(p -> {
+                String artifactId = determineProjectDependencyArtifactId(projectDependency);
 
-                    Configuration dependencyConfig = getTargetConfiguration(projectDependency);
+                Configuration dependencyConfig = getTargetConfiguration(projectDependency);
 
-                    for (PublishArtifact artifactToPublish : dependencyConfig.getAllArtifacts()) {
-                        Dependency mavenDependency = new Dependency();
-                        mavenDependency.setArtifactId(artifactId);
-                        if (artifactToPublish.getClassifier() != null && !artifactToPublish.getClassifier().equals("")) {
-                            mavenDependency.setClassifier(artifactToPublish.getClassifier());
-                        }
-                        mavenDependencies.add(mavenDependency);
+                for (PublishArtifact artifactToPublish : dependencyConfig.getAllArtifacts()) {
+                    Dependency mavenDependency = new Dependency();
+                    mavenDependency.setArtifactId(artifactId);
+                    if (artifactToPublish.getClassifier() != null && !artifactToPublish.getClassifier().equals("")) {
+                        mavenDependency.setClassifier(artifactToPublish.getClassifier());
                     }
+                    mavenDependencies.add(mavenDependency);
                 }
             });
         } else {

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/DefaultModelRegistry.java
@@ -301,7 +301,7 @@ public class DefaultModelRegistry implements ModelRegistryInternal {
             }
         }
         if (!Iterables.isEmpty(node.getDependents())) {
-            throw new IllegalStateException(String.format("Tried to remove model '%s' but it is depended on by: '%s'",  node.getPath(), Joiner.on(", ").join(node.getDependents())));
+            throw new IllegalStateException(String.format("Tried to remove model '%s' but it is depended on by: '%s'", node.getPath(), Joiner.on(", ").join(node.getDependents())));
         }
         nodesToRemove.add(node);
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Fix serializing services where `@ServiceScope` is attached to the contract type rather than the implementation type (which is the expected pattern).

Also some other minor tidy-ups.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
