### PR TITLE
Do not drop the VFS on CI

### DIFF
--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -122,8 +122,6 @@ fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true
         // for each test task, such that we are independent of whatever default value is defined in the build itself.
         "-Dorg.gradle.workers.max=%maxParallelForks%",
         "-PmaxParallelForks=%maxParallelForks%",
-        // Drop the VFS on before the build CI for dogfooding, until we do that automatically
-        "-Dorg.gradle.unsafe.vfs.drop=true",
         "-s",
         if (daemon) "--daemon" else "--no-daemon",
         if (isContinue) "--continue" else "",

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -124,5 +124,5 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "") =
-        "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.unsafe.vfs.drop=true -s $daemon --continue -Dorg.gradle.internal.tasks.createops $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
+        "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -s $daemon --continue -Dorg.gradle.internal.tasks.createops $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
 }

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -69,7 +69,6 @@ class PerformanceTestBuildTypeTest {
             "\"-PteamCityToken=%teamcity.user.bot-gradle.token%\"",
             "-Dorg.gradle.workers.max=%maxParallelForks%",
             "-PmaxParallelForks=%maxParallelForks%",
-            "-Dorg.gradle.unsafe.vfs.drop=true",
             "-s",
             "--daemon",
             "",


### PR DESCRIPTION
this should not be necessary.

Fixes gradle/gradle-private#3192.