### PR TITLE
Refine Windows performance builds

### DIFF
--- a/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
@@ -1,5 +1,6 @@
 package configurations
 
+import common.Os.LINUX
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
@@ -10,7 +11,7 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
     name = "Build Distributions"
     description = "Creation and verification of the distribution and documentation"
 
-    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${buildJavaHome()}")
+    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${LINUX.buildJavaHome()}")
 
     features {
         publishBuildStatusToGithub(model)
@@ -22,6 +23,6 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
     """.trimIndent()
 
     params {
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 })

--- a/.teamcity/Gradle_Check/configurations/BuildJavaVersions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildJavaVersions.kt
@@ -1,9 +1,0 @@
-package configurations
-
-import common.JvmVendor
-import common.JvmVersion
-import common.Os
-
-fun buildJavaHome(os: Os = Os.LINUX) = "%${os.name.toLowerCase()}.${JvmVersion.java11}.${JvmVendor.openjdk}.64bit%"
-
-fun individualPerformanceTestJavaHome(os: Os) = "%${os.name.toLowerCase()}.${JvmVersion.java8}.${JvmVendor.oracle}.64bit%"

--- a/.teamcity/Gradle_Check/configurations/CompileAll.kt
+++ b/.teamcity/Gradle_Check/configurations/CompileAll.kt
@@ -1,5 +1,6 @@
 package configurations
 
+import common.Os.LINUX
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
@@ -11,7 +12,7 @@ class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model,
     description = "Compiles all the source code and warms up the build cache"
 
     params {
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     features {

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -45,7 +45,7 @@ class FunctionalTest(
 
     applyTestDefaults(model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
-            listOf(""""-PtestJavaHome=%${testCoverage.os.name.toLowerCase()}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""") +
+            listOf(""""-PtestJavaHome=${testCoverage.os.javaHome(testCoverage.testJvmVersion, testCoverage.vendor)}"""") +
                 buildScanTags.map { buildScanTag(it) } +
                 buildScanValues.map { buildScanCustomValue(it.key, it.value) } +
                 if (enableTestDistribution) "-DenableTestDistribution=true -Dscan.tag.test-distribution -Dgradle.enterprise.url=https://e.grdev.net" else "" +

--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -1,5 +1,6 @@
 package configurations
 
+import common.Os.LINUX
 import common.buildToolGradleParameters
 import common.customGradle
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
@@ -15,7 +16,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
     description = "Builds Gradle with the version of Gradle which is currently under development (twice)"
 
     params {
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     features {

--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -14,9 +14,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 
 class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINUX) : BaseGradleBuildType(model, init = {
-    uuid = model.projectPrefix + "IndividualPerformanceScenarioWorkers${os.name.toLowerCase().capitalize()}"
+    uuid = model.projectPrefix + "IndividualPerformanceScenarioWorkers$os"
     id = AbsoluteId(uuid)
-    name = "Individual Performance Scenario Workers - ${os.name.toLowerCase().capitalize()}"
+    name = "Individual Performance Scenario Workers - $os"
 
     applyPerformanceTestSettings(os = os, timeout = 420)
     artifactRules = individualPerformanceTestArtifactRules

--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -14,9 +14,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 
 class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINUX) : BaseGradleBuildType(model, init = {
-    uuid = model.projectPrefix + "IndividualPerformanceScenarioWorkers$os"
+    uuid = model.projectPrefix + "IndividualPerformanceScenarioWorkers${os.asName()}"
     id = AbsoluteId(uuid)
-    name = "Individual Performance Scenario Workers - $os"
+    name = "Individual Performance Scenario Workers - ${os.asName()}"
 
     applyPerformanceTestSettings(os = os, timeout = 420)
     artifactRules = individualPerformanceTestArtifactRules

--- a/.teamcity/Gradle_Check/configurations/SanityCheck.kt
+++ b/.teamcity/Gradle_Check/configurations/SanityCheck.kt
@@ -1,5 +1,6 @@
 package configurations
 
+import common.Os.LINUX
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
@@ -11,7 +12,7 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model
     description = "Static code analysis, checkstyle, release notes verification, etc."
 
     params {
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     features {

--- a/.teamcity/Gradle_Check/configurations/SmokeTests.kt
+++ b/.teamcity/Gradle_Check/configurations/SmokeTests.kt
@@ -1,7 +1,7 @@
 package configurations
 
 import common.JvmCategory
-import common.Os
+import common.Os.LINUX
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
@@ -13,8 +13,8 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
     params {
-        param("env.ANDROID_HOME", Os.LINUX.androidHome)
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.ANDROID_HOME", LINUX.androidHome)
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     features {

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -2,7 +2,7 @@ package configurations
 
 import Gradle_Check.configurations.masterReleaseBranchFilter
 import Gradle_Check.configurations.triggerExcludes
-import common.Os
+import common.Os.LINUX
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.gradleWrapper
@@ -63,7 +63,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
     }
 
     params {
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     val baseBuildType = this
@@ -71,7 +71,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
 
     val defaultGradleParameters = (
         buildToolGradleParameters() +
-            baseBuildType.buildCache.gradleParameters(Os.LINUX) +
+            baseBuildType.buildCache.gradleParameters(LINUX) +
             buildScanTags.map(::buildScanTag)
         ).joinToString(" ")
     steps {

--- a/.teamcity/Gradle_Check/configurations/TestPerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/TestPerformanceTest.kt
@@ -58,7 +58,7 @@ class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildTy
             "performance:performanceAdHocTest",
             "--baselines force-defaults",
             """--scenarios "$scenario" --warmups 2 --runs 2 --checks none""",
-            """"-PtestJavaHome=${individualPerformanceTestJavaHome(os)}""""
+            """"-PtestJavaHome=${os.individualPerformanceTestJavaHome()}""""
         ))
         movePerformanceResults("[^\\p{Alpha}]".toRegex().replace(scenario, ""))
     }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -252,7 +252,7 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     }
 
     fun asName(): String =
-        "Test Coverage - ${testType.name.capitalize()} ${testJvmVersion.name.capitalize()} ${vendor.name.capitalize()} $os${if (withoutDependencies) " without dependencies" else ""}"
+        "Test Coverage - ${testType.name.capitalize()} ${testJvmVersion.name.capitalize()} ${vendor.name.capitalize()} ${os.asName()}${if (withoutDependencies) " without dependencies" else ""}"
 
     val isQuick: Boolean = withoutDependencies || testType == TestType.quick
 }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -252,7 +252,7 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     }
 
     fun asName(): String =
-        "Test Coverage - ${testType.name.capitalize()} ${testJvmVersion.name.capitalize()} ${vendor.name.capitalize()} ${os.name.toLowerCase().capitalize()}${if (withoutDependencies) " without dependencies" else ""}"
+        "Test Coverage - ${testType.name.capitalize()} ${testJvmVersion.name.capitalize()} ${vendor.name.capitalize()} $os${if (withoutDependencies) " without dependencies" else ""}"
 
     val isQuick: Boolean = withoutDependencies || testType == TestType.quick
 }

--- a/.teamcity/Gradle_Util/buildTypes/WarmupEc2Agent.kt
+++ b/.teamcity/Gradle_Util/buildTypes/WarmupEc2Agent.kt
@@ -1,10 +1,9 @@
 package Gradle_Util.buildTypes
 
-import common.Os
+import common.Os.LINUX
 import common.buildToolGradleParameters
 import common.builtInRemoteBuildCacheNode
 import common.gradleWrapper
-import configurations.buildJavaHome
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
@@ -31,7 +30,7 @@ object WarmupEc2Agent : BuildType({
 
     params {
         param("defaultBranchName", "master")
-        param("env.JAVA_HOME", buildJavaHome())
+        param("env.JAVA_HOME", LINUX.buildJavaHome())
     }
 
     steps {
@@ -40,7 +39,7 @@ object WarmupEc2Agent : BuildType({
             tasks = "resolveAllDependencies"
             gradleParams = (
                     buildToolGradleParameters(isContinue = false) +
-                    builtInRemoteBuildCacheNode.gradleParameters(Os.LINUX)
+                    builtInRemoteBuildCacheNode.gradleParameters(LINUX)
             ).joinToString(separator = " ")
         }
     }

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -15,9 +15,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 
 abstract class AdHocPerformanceScenario(os: Os) : BuildType({
-    val id = "Gradle_Util_Performance_AdHocPerformanceScenario$os"
+    val id = "Gradle_Util_Performance_AdHocPerformanceScenario${os.asName()}"
     this.uuid = id
-    name = "AdHoc Performance Scenario - $os"
+    name = "AdHoc Performance Scenario - ${os.asName()}"
     id(id)
 
     applyPerformanceTestSettings(os = os, timeout = 420)

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -15,9 +15,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 
 abstract class AdHocPerformanceScenario(os: Os) : BuildType({
-    val id = "Gradle_Util_Performance_AdHocPerformanceScenario${os.name.toLowerCase().capitalize()}"
+    val id = "Gradle_Util_Performance_AdHocPerformanceScenario$os"
     this.uuid = id
-    name = "AdHoc Performance Scenario - ${os.name.toLowerCase().capitalize()}"
+    name = "AdHoc Performance Scenario - $os"
     id(id)
 
     applyPerformanceTestSettings(os = os, timeout = 420)
@@ -32,13 +32,16 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
         text("warmups", "3", display = ParameterDisplay.PROMPT, allowEmpty = false)
         text("scenario", "", display = ParameterDisplay.PROMPT, allowEmpty = false)
 
-        if (os != Os.WINDOWS) {
-            param("flamegraphs", "--flamegraphs true")
-            param("env.FG_HOME_DIR", "/opt/FlameGraph")
-            param("env.PATH", "%env.PATH%:/opt/swift/4.2.3/usr/bin")
-            param("env.HP_HOME_DIR", "/opt/honest-profiler")
-        } else {
-            param("flamegraphs", "--flamegraphs false")
+        when (os) {
+            Os.WINDOWS -> {
+                param("flamegraphs", "--flamegraphs false")
+            }
+            else -> {
+                param("flamegraphs", "--flamegraphs true")
+                param("env.FG_HOME_DIR", "/opt/FlameGraph")
+                param("env.PATH", "%env.PATH%:/opt/swift/4.2.3/usr/bin")
+                param("env.HP_HOME_DIR", "/opt/honest-profiler")
+            }
         }
 
         param("additional.gradle.parameters", "")

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceTestCoordinator.kt
@@ -28,10 +28,10 @@ import common.performanceTestCommandLine
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 
 open class AdHocPerformanceTestCoordinator(os: Os) : BuildType({
-    val id = "Gradle_Util_Performance_PerformanceTestCoordinator${os.name.toLowerCase().capitalize()}"
+    val id = "Gradle_Util_Performance_PerformanceTestCoordinator$os"
     this.uuid = id
     id(id)
-    name = "AdHoc Performance Test Coordinator - ${os.name.toLowerCase().capitalize()}"
+    name = "AdHoc Performance Test Coordinator - $os"
 
     applyPerformanceTestSettings(os = os, timeout = 420)
 
@@ -48,7 +48,7 @@ open class AdHocPerformanceTestCoordinator(os: Os) : BuildType({
             gradleParams = (
                 buildToolGradleParameters(isContinue = false) +
                     performanceTestCommandLine(task = "clean :performance:distributedPerformanceTest", baselines = "%performance.baselines%", os = os) +
-                    distributedPerformanceTestParameters("Gradle_Check_IndividualPerformanceScenarioWorkers${os.name.toLowerCase().capitalize()}") +
+                    distributedPerformanceTestParameters("Gradle_Check_IndividualPerformanceScenarioWorkers$os") +
                     builtInRemoteBuildCacheNode.gradleParameters(os)
                 ).joinToString(separator = " ")
         }

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceTestCoordinator.kt
@@ -28,10 +28,10 @@ import common.performanceTestCommandLine
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 
 open class AdHocPerformanceTestCoordinator(os: Os) : BuildType({
-    val id = "Gradle_Util_Performance_PerformanceTestCoordinator$os"
+    val id = "Gradle_Util_Performance_PerformanceTestCoordinator${os.asName()}"
     this.uuid = id
     id(id)
-    name = "AdHoc Performance Test Coordinator - $os"
+    name = "AdHoc Performance Test Coordinator - ${os.asName()}"
 
     applyPerformanceTestSettings(os = os, timeout = 420)
 
@@ -48,7 +48,7 @@ open class AdHocPerformanceTestCoordinator(os: Os) : BuildType({
             gradleParams = (
                 buildToolGradleParameters(isContinue = false) +
                     performanceTestCommandLine(task = "clean :performance:distributedPerformanceTest", baselines = "%performance.baselines%", os = os) +
-                    distributedPerformanceTestParameters("Gradle_Check_IndividualPerformanceScenarioWorkers$os") +
+                    distributedPerformanceTestParameters("Gradle_Check_IndividualPerformanceScenarioWorkers${os.asName()}") +
                     builtInRemoteBuildCacheNode.gradleParameters(os)
                 ).joinToString(separator = " ")
         }

--- a/.teamcity/common/Os.kt
+++ b/.teamcity/common/Os.kt
@@ -52,4 +52,12 @@ enum class Os(
     );
 
     fun escapeKeyValuePair(key: String, value: String) = if (this == WINDOWS) """$key="$value"""" else """"$key=$value""""
+
+    override fun toString() = name.toLowerCase().capitalize()
+
+    fun buildJavaHome() = javaHome(JvmVersion.java11, JvmVendor.openjdk)
+
+    fun individualPerformanceTestJavaHome() = javaHome(JvmVersion.java8, JvmVendor.oracle)
+
+    fun javaHome(jvmVersion: JvmVersion, vendor: JvmVendor) = "%${name.toLowerCase()}.$jvmVersion.$vendor.64bit%"
 }

--- a/.teamcity/common/Os.kt
+++ b/.teamcity/common/Os.kt
@@ -53,7 +53,7 @@ enum class Os(
 
     fun escapeKeyValuePair(key: String, value: String) = if (this == WINDOWS) """$key="$value"""" else """"$key=$value""""
 
-    override fun toString() = name.toLowerCase().capitalize()
+    fun asName() = name.toLowerCase().capitalize()
 
     fun buildJavaHome() = javaHome(JvmVersion.java11, JvmVendor.openjdk)
 

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -16,8 +16,6 @@
 
 package common
 
-import configurations.buildJavaHome
-import configurations.individualPerformanceTestJavaHome
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -36,7 +34,7 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
     }
     params {
         param("env.GRADLE_OPTS", "-Xmx1536m -XX:MaxPermSize=384m")
-        param("env.JAVA_HOME", buildJavaHome(os))
+        param("env.JAVA_HOME", os.buildJavaHome())
         param("env.BUILD_BRANCH", "%teamcity.build.branch%")
         param("performance.db.username", "tcagent")
     }
@@ -44,7 +42,7 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
 
 fun performanceTestCommandLine(task: String, baselines: String, extraParameters: String = "", os: Os = Os.LINUX) = listOf(
     "$task --baselines $baselines $extraParameters",
-    """"-PtestJavaHome=${individualPerformanceTestJavaHome(os)}""""
+    """"-PtestJavaHome=${os.individualPerformanceTestJavaHome()}""""
 ) + listOf(
     "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
     "-Porg.gradle.performance.db.url" to "%performance.db.url%",


### PR DESCRIPTION
1. Use `subst` to avoid long path issue.
2. Introduce Os.capitalized() and Os.lowerCase().
3. Refactoring.