### PR TITLE
Improve configuration cache invalidation tests

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildSrcChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildSrcChangesIntegrationTest.groovy
@@ -55,6 +55,7 @@ class ConfigurationCacheBuildSrcChangesIntegrationTest extends AbstractConfigura
         }
 
         then:
+        outputContains changeFixture.expectedCacheInvalidationMessage
         outputContains changeFixture.expectedOutputAfterChange
         configurationCache.assertStateStored()
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptChangesIntegrationTest.groovy
@@ -36,12 +36,21 @@ class ConfigurationCacheScriptChangesIntegrationTest extends AbstractConfigurati
 
         then:
         outputContains fixture.expectedOutputBeforeChange
+        configurationCache.assertStateStored()
+
+        when:
+        build()
+
+        then: 'scripts are not executed when loading from cache'
+        outputDoesNotContain fixture.expectedOutputBeforeChange
+        configurationCache.assertStateLoaded()
 
         when:
         fixture.applyChange()
         build()
 
         then:
+        outputContains fixture.expectedCacheInvalidationMessage
         outputContains fixture.expectedOutputAfterChange
         configurationCache.assertStateStored()
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/BuildLogicChangeFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/BuildLogicChangeFixture.groovy
@@ -134,6 +134,20 @@ class BuildLogicChangeFixture {
         }
     }
 
+    String getExpectedCacheInvalidationMessage() {
+        "configuration cache cannot be reused because an input to task ':${projectDir.name}:$invalidatedTaskName' has changed."
+    }
+
+    String getInvalidatedTaskName() {
+        switch (kind) {
+            case Kind.CHANGE_RESOURCE:
+            case Kind.ADD_RESOURCE:
+                return 'processResources'
+            default:
+                return "compile$language"
+        }
+    }
+
     String getExpectedOutputBeforeChange() {
         ORIGINAL_GREETING
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
@@ -143,6 +143,8 @@ class CollectingVisitor : FileCollectionStructureVisitor {
                 false
             }
             is ProviderBackedFileCollection -> {
+                // Guard against file collection created from a task provider such as `layout.files(compileJava)`
+                // being referenced from a different task.
                 val provider = fileCollection.provider
                 if (provider !is TaskProvider<*>) {
                     elements.add(ProviderBackedFileCollectionSpec(provider))


### PR DESCRIPTION
- add a check prior to applying a change to verify that the cache entry is loaded
- assert that the user is informed of why the cache entry is not reused