### PR TITLE
Use subst to avoid long path issue for windows performance test

### DIFF
--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -6,10 +6,11 @@ import common.buildToolGradleParameters
 import common.checkCleanM2
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
+import common.killGradleProcessesStep
 import common.performanceTestCommandLine
+import common.removeSubstDirOnWindows
+import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
 
 class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINUX) : BaseGradleBuildType(model, init = {
@@ -20,12 +21,6 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINU
     applyPerformanceTestSettings(os = os, timeout = 420)
     artifactRules = individualPerformanceTestArtifactRules
 
-    if (os == Os.WINDOWS) {
-        // to avoid pathname too long error
-        vcs {
-            checkoutDir = "C:\\gradle-perf"
-        }
-    }
     params {
         param("baselines", "defaults")
         param("templates", "")
@@ -43,14 +38,12 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINU
     }
 
     steps {
-        script {
-            name = "KILL_GRADLE_PROCESSES"
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = os.killAllGradleProcesses
-        }
+        killGradleProcessesStep(os)
+        substDirOnWindows(os)
         gradleWrapper {
             name = "GRADLE_RUNNER"
             tasks = ""
+            workingDir = os.perfTestWorkingDir
             gradleParams = (
                 performanceTestCommandLine(
                     "clean %templates% :performance:fullPerformanceTest",
@@ -63,6 +56,7 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel, os: Os = Os.LINU
                     model.parentBuildCache.gradleParameters(os)
                 ).joinToString(separator = " ")
         }
+        removeSubstDirOnWindows(os)
         checkCleanM2(os)
     }
 

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -52,6 +52,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
         }
         gradleWrapper {
             name = "GRADLE_RUNNER"
+            workingDir = os.perfTestWorkingDir
             gradleParams = (
                 performanceTestCommandLine(
                     "clean %templates% performance:performanceAdHocTest",

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -7,11 +7,12 @@ import common.builtInRemoteBuildCacheNode
 import common.checkCleanM2
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
+import common.killGradleProcessesStep
 import common.performanceTestCommandLine
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import common.removeSubstDirOnWindows
+import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 abstract class AdHocPerformanceScenario(os: Os) : BuildType({
     val id = "Gradle_Util_Performance_AdHocPerformanceScenario${os.name.toLowerCase().capitalize()}"
@@ -45,11 +46,8 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
     }
 
     steps {
-        script {
-            name = "KILL_GRADLE_PROCESSES"
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = os.killAllGradleProcesses
-        }
+        killGradleProcessesStep(os)
+        substDirOnWindows(os)
         gradleWrapper {
             name = "GRADLE_RUNNER"
             workingDir = os.perfTestWorkingDir
@@ -64,6 +62,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
                     builtInRemoteBuildCacheNode.gradleParameters(os)
                 ).joinToString(separator = " ")
         }
+        removeSubstDirOnWindows(os)
         checkCleanM2(os)
     }
 })

--- a/.teamcity/common/Os.kt
+++ b/.teamcity/common/Os.kt
@@ -16,26 +16,35 @@
 
 package common
 
-val killAllGradleProcessesUnixLike = """
-    free -m
-    ps aux | egrep 'Gradle(Daemon|Worker)'
-    ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill -9
-    free -m
-    ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}'
-""".trimIndent()
+private const val killAllGradleProcessesUnixLike = """
+free -m
+ps aux | egrep 'Gradle(Daemon|Worker)'
+ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill -9
+free -m
+ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}'
+"""
 
-val killAllGradleProcessesWindows = """
-    wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
-    wmic Path win32_process Where "name='java.exe'"
-    wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleDaemon%%%%'" Call Terminate
-    wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleWorker%%%%'" Call Terminate
-    wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
-    wmic Path win32_process Where "name='java.exe'"
-""".trimIndent()
+private const val killAllGradleProcessesWindows = """
+wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
+wmic Path win32_process Where "name='java.exe'"
+wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleDaemon%%%%'" Call Terminate
+wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleWorker%%%%'" Call Terminate
+wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
+wmic Path win32_process Where "name='java.exe'"
+"""
 
-enum class Os(val agentRequirement: String, val ignoredSubprojects: List<String> = emptyList(), val androidHome: String, val killAllGradleProcesses: String) {
+enum class Os(
+    val agentRequirement: String,
+    val ignoredSubprojects: List<String> = emptyList(),
+    val androidHome: String,
+    val killAllGradleProcesses: String,
+    val perfTestWorkingDir: String = "%teamcity.build.checkoutDir%"
+) {
     LINUX("Linux", androidHome = "/opt/android/sdk", killAllGradleProcesses = killAllGradleProcessesUnixLike),
-    WINDOWS("Windows", androidHome = """C:\Program Files\android\sdk""", killAllGradleProcesses = killAllGradleProcessesWindows),
+    WINDOWS("Windows",
+        androidHome = """C:\Program Files\android\sdk""",
+        killAllGradleProcesses = killAllGradleProcessesWindows,
+        perfTestWorkingDir = "P:/"),
     MACOS("Mac",
         listOf("integ-test", "native", "plugins", "resources", "scala", "workers", "wrapper", "platform-play", "tooling-native"),
         androidHome = "/opt/android/sdk",

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -18,7 +18,10 @@ package common
 
 import configurations.buildJavaHome
 import configurations.individualPerformanceTestJavaHome
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30) {
     applyDefaultSettings(os = os, timeout = timeout)
@@ -55,8 +58,37 @@ fun distributedPerformanceTestParameters(workerId: String = "Gradle_Check_Indivi
     "-Porg.gradle.performance.buildTypeId=$workerId -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%"
 )
 
-val individualPerformanceTestArtifactRules = """
-        subprojects/*/build/test-results-*.zip => results
-        subprojects/*/build/tmp/**/log.txt => failure-logs
-        subprojects/*/build/tmp/**/profile.log => failure-logs
-    """.trimIndent()
+const val individualPerformanceTestArtifactRules = """
+subprojects/*/build/test-results-*.zip => results
+subprojects/*/build/tmp/**/log.txt => failure-logs
+subprojects/*/build/tmp/**/profile.log => failure-logs
+"""
+
+fun BuildSteps.killGradleProcessesStep(os: Os) {
+    script {
+        name = "KILL_GRADLE_PROCESSES"
+        executionMode = BuildStep.ExecutionMode.ALWAYS
+        scriptContent = os.killAllGradleProcesses
+    }
+}
+
+// to avoid pathname too long error
+fun BuildSteps.substDirOnWindows(os: Os) {
+    if (os == Os.WINDOWS) {
+        script {
+            name = "SETUP_VIRTUAL_DISK_FOR_PERF_TEST"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = """subst p: "%teamcity.build.checkoutDir%" """
+        }
+    }
+}
+
+fun BuildSteps.removeSubstDirOnWindows(os: Os) {
+    if (os == Os.WINDOWS) {
+        script {
+            name = "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = """subst p: /d"""
+        }
+    }
+}


### PR DESCRIPTION
This PR sets up a virtual `P:/` disk which maps default checkout directory for windows performance test to avoid long path issue.