### PR TITLE
Persist distributed performance test result

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -80,7 +80,7 @@ object Config {
 
     const val performanceTestReportsDir = "performance-tests/report"
 
-    const val performanceTestResultsJson = "perf-results.json"
+    const val performanceTestResultsJson = "performance-tests/perf-results.json"
 
     const val teamCityUrl = "https://builds.gradle.org/"
 }
@@ -338,7 +338,7 @@ class PerformanceTestPlugin : Plugin<Project> {
     ): TaskProvider<out DistributedPerformanceTest> {
         val performanceTest = tasks.register(name, clazz) {
             configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask)
-            scenarioList = layout.buildDirectory.file(Config.performanceTestScenarioListFileName).get().asFile
+            scenarioList = layout.buildDirectory.file("$name/${Config.performanceTestScenarioListFileName}").get().asFile
             buildTypeId = stringPropertyOrNull(PropertyNames.buildTypeId)
             workerTestTaskName = stringPropertyOrNull(PropertyNames.workerTestTaskName) ?: "fullPerformanceTest"
             teamCityUrl = Config.teamCityUrl
@@ -451,7 +451,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             group = "verification"
             buildId = System.getenv("BUILD_ID")
             reportDir = layout.buildDirectory.file("${task.name}/${Config.performanceTestReportsDir}").get().asFile
-            resultsJson = layout.buildDirectory.file(Config.performanceTestResultsJson).get().asFile
+            resultsJson = layout.buildDirectory.file("${task.name}/${Config.performanceTestResultsJson}").get().asFile
             addDatabaseParameters(propertiesForPerformanceDb())
             testClassesDirs = performanceSourceSet.output.classesDirs
             classpath = performanceSourceSet.runtimeClasspath


### PR DESCRIPTION
Previously, we generated scenario list file for scheduling the worker builds and
result json for generating report, then deleted them. Now we put these files
under html report dir so we can check these files in TeamCity artifact page
to help us understand the build.
