### PR TITLE
Remove unneeded uses of allprojects from documentation snippets

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -41,7 +41,6 @@ abstract class CountLoc implements TransformAction<TransformParameters.None> {
 // end::artifact-transform-countloc[]
 
 def usage = Attribute.of('usage', String)
-// tag::artifact-transform-registration[]
 def artifactType = Attribute.of('artifactType', String)
 
 dependencies {
@@ -50,16 +49,12 @@ dependencies {
         to.attribute(artifactType, 'loc')
     }
 }
-// end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute usage, 'api'
-    }
+}
+configurations.create("compile") {
+    attributes.attribute usage, 'api'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
@@ -41,7 +41,6 @@ abstract class CountLoc : TransformAction<TransformParameters.None> {
 // end::artifact-transform-countloc[]
 
 val usage = Attribute.of("usage", String::class.java)
-// tag::artifact-transform-registration[]
 val artifactType = Attribute.of("artifactType", String::class.java)
 
 dependencies {
@@ -50,16 +49,12 @@ dependencies {
         to.attribute(artifactType, "loc")
     }
 }
-// end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute(usage, "api")
-    }
+}
+configurations.create("compile") {
+    attributes.attribute(usage, "api")
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/groovy/build.gradle
@@ -76,7 +76,6 @@ abstract class ClassRelocator implements TransformAction<Parameters> {
 configurations.create("externalClasspath")
 
 def usage = Attribute.of('usage', String)
-// tag::artifact-transform-registration[]
 def artifactType = Attribute.of('artifactType', String)
 
 dependencies {
@@ -89,16 +88,12 @@ dependencies {
         }
     }
 }
-// end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute usage, 'api'
-    }
+}
+configurations.create("compile") {
+    attributes.attribute usage, 'api'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-relocate/kotlin/build.gradle.kts
@@ -73,7 +73,6 @@ abstract class ClassRelocator : TransformAction<ClassRelocator.Parameters> {
 configurations.create("externalClasspath")
 
 val usage = Attribute.of("usage", String::class.java)
-// tag::artifact-transform-registration[]
 val artifactType = Attribute.of("artifactType", String::class.java)
 
 dependencies {
@@ -86,16 +85,12 @@ dependencies {
         }
     }
 }
-// end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute(usage, "api")
-    }
+}
+configurations.create("compile") {
+    attributes.attribute(usage, "api")
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/groovy/build.gradle
@@ -56,14 +56,11 @@ dependencies {
 }
 // end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute usage, 'api'
-    }
+}
+configurations.create("compile") {
+    attributes.attribute usage, 'api'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-unzip/kotlin/build.gradle.kts
@@ -57,14 +57,11 @@ dependencies {
 }
 // end::artifact-transform-registration[]
 
-
-allprojects {
-    dependencies {
-        attributesSchema {
-            attribute(usage)
-        }
+dependencies {
+    attributesSchema {
+        attribute(usage)
     }
-    configurations.create("compile") {
-        attributes.attribute(usage, "api")
-    }
+}
+configurations.create("compile") {
+    attributes.attribute(usage, "api")
 }

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/build.gradle
@@ -1,4 +1,0 @@
-allprojects {
-    group = 'org.gradle.demo'
-    version = '1.0'
-}

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
@@ -6,10 +6,10 @@ repositories {
     jcenter()
 }
 
-// tag::producer[]
 group = 'org.gradle.demo'
 version = '1.0'
 
+// tag::producer[]
 java {
     registerFeature('mysqlSupport') {
         usingSourceSet(sourceSets.main)

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
@@ -7,6 +7,9 @@ repositories {
 }
 
 // tag::producer[]
+group = 'org.gradle.demo'
+version = '1.0'
+
 java {
     registerFeature('mysqlSupport') {
         usingSourceSet(sourceSets.main)

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/build.gradle.kts
@@ -1,4 +1,0 @@
-allprojects {
-    group = "org.gradle.demo"
-    version = "1.0"
-}

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
@@ -6,10 +6,10 @@ repositories {
     jcenter()
 }
 
-// tag::producer[]
 group = "org.gradle.demo"
 version = "1.0"
 
+// tag::producer[]
 java {
     registerFeature("mysqlSupport") {
         usingSourceSet(sourceSets["main"])

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
@@ -7,6 +7,9 @@ repositories {
 }
 
 // tag::producer[]
+group = "org.gradle.demo"
+version = "1.0"
+
 java {
     registerFeature("mysqlSupport") {
         usingSourceSet(sourceSets["main"])

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/build.gradle
@@ -1,4 +1,0 @@
-allprojects {
-    group = 'org.gradle.demo'
-    version = '1.0'
-}

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
@@ -7,6 +7,8 @@ repositories {
 }
 
 // tag::producer[]
+group = 'org.gradle.demo'
+
 java {
     registerFeature('mysqlSupport') {
         usingSourceSet(sourceSets.main)

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/build.gradle.kts
@@ -1,4 +1,0 @@
-allprojects {
-    group = "org.gradle.demo"
-    version = "1.0"
-}

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 // tag::producer[]
+group = "org.gradle.demo"
+
 java {
     registerFeature("mysqlSupport") {
         usingSourceSet(sourceSets["main"])


### PR DESCRIPTION
Remove `allprojects {}` construct from single-project snippets.
Remove `allprojects {}` snippet from feature variant snippets where the configuration is only needed by one of the subprojects.