### PR TITLE
Lint multiproject docs links

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi_project_builds.adoc
@@ -73,6 +73,7 @@ Let's say the `app` subproject is a Java application by applying the <<applicati
 include::sample[dir="snippets/multiproject/basic-multiproject/groovy",files="app/build.gradle[]"]
 include::sample[dir="snippets/multiproject/basic-multiproject/kotlin",files="app/build.gradle.kts[]"]
 .app/src/main/java/com/example/Hello.java
+[source, java]
 ----
 include::{snippetsPath}/multiproject/basic-multiproject/groovy/app/src/main/java/com/example/Hello.java[]
 ----

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
@@ -369,8 +369,8 @@ NOTE: You can use this feature to apply the `<dependencyManagement>` information
 [[migmvn:multimodule_builds]]
 == Migrating multi-module builds (project aggregation)
 
-Maven's multi-module builds map nicely to Gradle's <<multi_project_builds#,multi-project builds>>.
-Try the corresponding link:{guidesUrl}/creating-multi-project-builds/[tutorial] to see how a basic multi-project Gradle build is set up.
+Maven's multi-module builds map nicely to Gradle's <<multi_project_builds#multi_project_builds,multi-project builds>>.
+Try the corresponding link:../samples/sample_jvm_multi_project_build.html[sample] to see how a basic multi-project Gradle build is set up.
 
 To migrate a multi-module Maven build, simply follow these steps:
 


### PR DESCRIPTION
* Fix maven migration docs link to point to concrete section in multi-project documentation
* Replace link to outdated multi-project guide with a link to current multi-project sample
* Highlight syntax of Java snippet in multi-project documentation