### PR TITLE
Promote property to configure AdoptOpenJdk server

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -111,7 +111,7 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     private String getServerBaseUri() {
-        String baseUri = System.getProperty("org.gradle.jvm.toolchain.install.internal.adoptopenjdk.baseUri", "https://api.adoptopenjdk.net/");
+        String baseUri = System.getProperty("org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri", "https://api.adoptopenjdk.net/");
         if (!baseUri.endsWith("/")) {
             baseUri += "/";
         }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -17,6 +17,7 @@
 package org.gradle.jvm.toolchain.install.internal;
 
 import net.rubygrapefruit.platform.SystemInfo;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -31,12 +32,14 @@ public class AdoptOpenJdkRemoteBinary {
     private final SystemInfo systemInfo;
     private final OperatingSystem operatingSystem;
     private final AdoptOpenJdkDownloader downloader;
+    private final ProviderFactory providerFactory;
 
     @Inject
-    public AdoptOpenJdkRemoteBinary(SystemInfo systemInfo, OperatingSystem operatingSystem, AdoptOpenJdkDownloader downloader) {
+    public AdoptOpenJdkRemoteBinary(SystemInfo systemInfo, OperatingSystem operatingSystem, AdoptOpenJdkDownloader downloader, ProviderFactory providerFactory) {
         this.systemInfo = systemInfo;
         this.operatingSystem = operatingSystem;
         this.downloader = downloader;
+        this.providerFactory = providerFactory;
     }
 
     public Optional<File> download(JavaToolchainSpec spec, File destinationFile) {
@@ -111,7 +114,7 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     private String getServerBaseUri() {
-        String baseUri = System.getProperty("org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri", "https://api.adoptopenjdk.net/");
+        String baseUri = providerFactory.gradleProperty("org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri").getOrElse("https://api.adoptopenjdk.net/");
         if (!baseUri.endsWith("/")) {
             baseUri += "/";
         }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -101,7 +101,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
 
         when:
         def uri
-        def properties = ["org.gradle.jvm.toolchain.install.internal.adoptopenjdk.baseUri": customBaseUrl]
+        def properties = ["org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri": customBaseUrl]
         SystemProperties.getInstance().withSystemProperties(properties, {
             uri = binary.toDownloadUri(spec)
         })

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -17,7 +17,8 @@
 package org.gradle.jvm.toolchain.install.internal
 
 import net.rubygrapefruit.platform.SystemInfo
-import org.gradle.internal.SystemProperties
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
@@ -39,7 +40,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def systemInfo = Mock(SystemInfo)
         systemInfo.architecture >> architecture
         def operatingSystem = OperatingSystem.forName(operatingSystemName)
-        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader))
+        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader), providerFactory())
 
         when:
         def uri = binary.toDownloadUri(spec)
@@ -68,7 +69,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def systemInfo = Mock(SystemInfo)
         systemInfo.architecture >> architecture
         def operatingSystem = OperatingSystem.forName(operatingSystemName)
-        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader))
+        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader), providerFactory())
 
         when:
         def filename = binary.toFilename(spec)
@@ -97,14 +98,11 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def systemInfo = Mock(SystemInfo)
         systemInfo.architecture >> SystemInfo.Architecture.amd64
         def operatingSystem = OperatingSystem.MAC_OS
-        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader))
+        def providerFactory = providerFactory(Providers.of(customBaseUrl))
+        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader), providerFactory)
 
         when:
-        def uri
-        def properties = ["org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri": customBaseUrl]
-        SystemProperties.getInstance().withSystemProperties(properties, {
-            uri = binary.toDownloadUri(spec)
-        })
+        def uri = binary.toDownloadUri(spec)
 
         then:
         uri.toString() == "http://foobar/v3/binary/latest/11/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
@@ -120,11 +118,11 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         systemInfo.architecture >> SystemInfo.Architecture.amd64
         def operatingSystem = OperatingSystem.MAC_OS
         def downloader = Mock(AdoptOpenJdkDownloader)
-        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader)
+        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader, providerFactory())
 
         when:
         def targetFile = temporaryFolder.newFile("jdk")
-        def downloadFile = binary.download(spec, targetFile)
+        binary.download(spec, targetFile)
 
         then:
         1 * downloader.download(URI.create("https://api.adoptopenjdk.net/v3/binary/latest/12/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"), _)
@@ -137,7 +135,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def systemInfo = Mock(SystemInfo)
         systemInfo.architecture >> SystemInfo.Architecture.amd64
         def operatingSystem = OperatingSystem.MAC_OS
-        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader))
+        def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, Mock(AdoptOpenJdkDownloader), providerFactory())
 
         when:
         def file = binary.download(spec, Mock(File))
@@ -149,10 +147,15 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         javaVersion << [5, 6, 7]
     }
 
-
     def newSpec(int jdkVersion = 11) {
         def spec = new DefaultToolchainSpec(TestUtil.objectFactory())
         spec.languageVersion.set(JavaLanguageVersion.of(jdkVersion))
         spec
+    }
+
+    ProviderFactory providerFactory(hostnameProvider = Providers.notDefined()) {
+        Mock(ProviderFactory) {
+            gradleProperty("org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri") >> hostnameProvider
+        }
     }
 }


### PR DESCRIPTION
In cases when users want to point to their own instance
or to an alternative instance (e.g. once moved to Eclipse
Adoptium)
