### PR TITLE
Allow running performance tests without DB connection

### DIFF
--- a/.teamcity/Gradle_Check/configurations/TestPerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/TestPerformanceTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configurations
+
+import common.Os
+import common.applyPerformanceTestSettings
+import common.buildToolGradleParameters
+import common.builtInRemoteBuildCacheNode
+import common.checkCleanM2
+import common.gradleWrapper
+import common.individualPerformanceTestArtifactRules
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import model.CIBuildModel
+import model.Stage
+
+class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage, init = {
+    val os = Os.LINUX
+
+    fun BuildSteps.gradleStep(tasks: List<String>) {
+        gradleWrapper {
+            name = "GRADLE_RUNNER"
+            gradleParams = (
+                tasks +
+                    buildToolGradleParameters(isContinue = false) +
+                    builtInRemoteBuildCacheNode.gradleParameters(os)
+                ).joinToString(separator = " ")
+        }
+    }
+
+    fun BuildSteps.adHocPerformanceTest(scenario: String) {
+        gradleStep(listOf(
+            "performance:performanceAdHocTest",
+            "--baselines force-defaults",
+            """--scenarios "$scenario" --warmups 2 --runs 2 --checks none""",
+            """"-PtestJavaHome=${individualPerformanceTestJavaHome(os)}""""
+        ))
+    }
+
+    uuid = "${model.projectPrefix}TestPerformanceTest"
+    id = AbsoluteId(uuid)
+    name = "Test performance test tasks - Java8 Linux"
+    description = "Tries to run an adhoc performance test without a database connection to verify this is still working"
+
+    applyPerformanceTestSettings()
+    artifactRules = individualPerformanceTestArtifactRules
+
+    steps {
+        script {
+            name = "KILL_GRADLE_PROCESSES"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = os.killAllGradleProcesses
+        }
+        gradleStep(listOf("clean", "largeMonolithicJavaProject"))
+        adHocPerformanceTest("get IDE model on largeMonolithicJavaProject for IDEA")
+        adHocPerformanceTest("up-to-date assemble on largeMonolithicJavaProject (parallel false)")
+        adHocPerformanceTest("help on largeMonolithicJavaProject with lazy and eager tasks")
+
+        checkCleanM2(os)
+    }
+})

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -13,6 +13,7 @@ import configurations.FunctionalTest
 import configurations.Gradleception
 import configurations.SanityCheck
 import configurations.SmokeTests
+import configurations.TestPerformanceTest
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 
 enum class StageNames(override val stageName: String, override val description: String, override val uuid: String) : StageName {
@@ -73,6 +74,7 @@ data class CIBuildModel(
         ),
         Stage(StageNames.READY_FOR_RELEASE,
             trigger = Trigger.daily,
+            specificBuilds = listOf(SpecificBuild.TestPerformanceTest),
             functionalTests = listOf(
                 TestCoverage(7, TestType.parallel, Os.LINUX, JvmCategory.MAX_VERSION),
                 TestCoverage(8, TestType.soak, Os.LINUX, JvmCategory.MAX_VERSION),
@@ -315,6 +317,11 @@ enum class SpecificBuild {
     Gradleception {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
             return Gradleception(model, stage)
+        }
+    },
+    TestPerformanceTest {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return TestPerformanceTest(model, stage)
         }
     },
     SmokeTestsMinJavaVersion {

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -44,7 +44,6 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
 
 fun performanceTestCommandLine(task: String, baselines: String, extraParameters: String = "", os: Os = Os.LINUX) = listOf(
     "$task --baselines $baselines $extraParameters",
-    "-x prepareSamples",
     "\"-PtestJavaHome=" + individualPerformanceTestJavaHome(os) + "\""
 ) + listOf(
     "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -44,7 +44,7 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
 
 fun performanceTestCommandLine(task: String, baselines: String, extraParameters: String = "", os: Os = Os.LINUX) = listOf(
     "$task --baselines $baselines $extraParameters",
-    "\"-PtestJavaHome=" + individualPerformanceTestJavaHome(os) + "\""
+    """"-PtestJavaHome=${individualPerformanceTestJavaHome(os)}""""
 ) + listOf(
     "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
     "-Porg.gradle.performance.db.url" to "%performance.db.url%",

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -59,8 +59,6 @@ class PerformanceTestBuildTypeTest {
             "--baselines",
             "%performance.baselines%",
             "",
-            "-x",
-            "prepareSamples",
             "\"-PtestJavaHome=%linux.java8.oracle.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -18,8 +18,8 @@ package gradlebuild.performance.tasks
 
 import com.google.common.collect.Sets
 import gradlebuild.integrationtests.tasks.DistributionTest
-import gradlebuild.performance.reporter.PerformanceReporter
 import gradlebuild.performance.ScenarioBuildResultData
+import gradlebuild.performance.reporter.PerformanceReporter
 import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import org.apache.commons.io.FileUtils
@@ -176,6 +176,7 @@ abstract class PerformanceTest extends DistributionTest {
         this.flamegraphs = Boolean.parseBoolean(flamegraphs)
     }
 
+    @Optional
     @Input
     String getDatabaseUrl() {
         return databaseParameters.get("org.gradle.performance.db.url")

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -107,7 +107,6 @@ class PerformanceTestPlugin : Plugin<Project> {
         createCheckNoIdenticalBuildFilesTask()
         configureGeneratorTasks()
 
-        createPrepareSamplesTask()
         createCleanSamplesTask()
 
         createLocalPerformanceTestTasks(performanceTestSourceSet)
@@ -193,16 +192,6 @@ class PerformanceTestPlugin : Plugin<Project> {
             sharedTemplateDirectory = project(":internal-performance-testing").file("src/templates")
         }
     }
-
-    private
-    fun Project.createPrepareSamplesTask(): TaskProvider<Task> =
-        tasks.register("prepareSamples") {
-            group = "Project Setup"
-            description = "Generates all sample projects for automated performance tests"
-            configureSampleGenerators {
-                this@register.dependsOn(this)
-            }
-        }
 
     private
     fun Project.configureSampleGenerators(action: TaskCollection<*>.() -> Unit) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractAndroidStudioMockupCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractAndroidStudioMockupCrossVersionPerformanceTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.tooling.BuildActionExecuter
  *
  */
 @CompileStatic
-public abstract class AbstractAndroidStudioMockupCrossVersionPerformanceTest extends AbstractToolingApiCrossVersionPerformanceTest {
+abstract class AbstractAndroidStudioMockupCrossVersionPerformanceTest extends AbstractToolingApiCrossVersionPerformanceTest {
 
     @Override
     void experiment(String projectName, @DelegatesTo(AndroidStudioExperiment) Closure<?> spec) {
@@ -41,7 +41,7 @@ public abstract class AbstractAndroidStudioMockupCrossVersionPerformanceTest ext
         clone.call(experiment)
     }
 
-    public class AndroidStudioExperiment extends AbstractToolingApiCrossVersionPerformanceTest.ToolingApiExperiment {
+    class AndroidStudioExperiment extends AbstractToolingApiCrossVersionPerformanceTest.ToolingApiExperiment {
 
         AndroidStudioExperiment(String projectName) {
             super(projectName)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
@@ -30,9 +30,11 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
+import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
+
 @CleanupTestDirectory
 class AbstractCrossBuildPerformanceTest extends Specification {
-    private static final CrossBuildResultsStore RESULT_STORE = new CrossBuildResultsStore()
+    private static final RESULTS_STORE = createResultsStoreWhenDatabaseAvailable { new CrossBuildResultsStore() }
 
     protected final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 
@@ -46,8 +48,8 @@ class AbstractCrossBuildPerformanceTest extends Specification {
 
     def setup() {
         def gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
-        def compositeReporter = CompositeDataReporter.of(RESULT_STORE, gradleProfilerReporter)
-        runner = new CrossBuildGradleProfilerPerformanceTestRunner(new GradleProfilerBuildExperimentRunner(gradleProfilerReporter.getResultCollector()), RESULT_STORE, compositeReporter, buildContext) {
+        def compositeReporter = CompositeDataReporter.of(RESULTS_STORE, gradleProfilerReporter)
+        runner = new CrossBuildGradleProfilerPerformanceTestRunner(new GradleProfilerBuildExperimentRunner(gradleProfilerReporter.getResultCollector()), RESULTS_STORE, compositeReporter, buildContext) {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {
                 super.defaultSpec(builder)
@@ -75,7 +77,7 @@ class AbstractCrossBuildPerformanceTest extends Specification {
     static {
         // TODO - find a better way to cleanup
         System.addShutdownHook {
-            ((Closeable) RESULT_STORE).close()
+            ((Closeable) RESULTS_STORE).close()
         }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleInternalPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleInternalPerformanceTest.groovy
@@ -32,6 +32,8 @@ import org.junit.Rule
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
 
+import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
+
 /**
  * A base class for cross version performance tests.
  *
@@ -42,7 +44,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class AbstractCrossVersionGradleInternalPerformanceTest extends Specification {
 
-    private static def resultStore = new CrossVersionResultsStore()
+    private static final RESULTS_STORE = createResultsStoreWhenDatabaseAvailable { new CrossVersionResultsStore() }
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
@@ -57,8 +59,8 @@ class AbstractCrossVersionGradleInternalPerformanceTest extends Specification {
     def setup() {
         runner = new GradleInternalCrossVersionPerformanceTestRunner(
             new GradleInternalBuildExperimentRunner(new GradleSessionProvider(buildContext)),
-            resultStore,
-            resultStore,
+            RESULTS_STORE,
+            RESULTS_STORE,
             new ReleasedVersionDistributions(buildContext),
             buildContext
         )
@@ -74,7 +76,7 @@ class AbstractCrossVersionGradleInternalPerformanceTest extends Specification {
     static {
         // TODO - find a better way to cleanup
         System.addShutdownHook {
-            resultStore.close()
+            RESULTS_STORE.close()
         }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
@@ -33,6 +33,8 @@ import org.junit.Rule
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
 
+import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
+
 /**
  * A base class for cross version performance tests.
  *
@@ -43,7 +45,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class AbstractCrossVersionGradleProfilerPerformanceTest extends Specification {
 
-    private static def resultStore = new CrossVersionResultsStore()
+    private static final RESULTS_STORE = createResultsStoreWhenDatabaseAvailable { new CrossVersionResultsStore() }
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
@@ -59,8 +61,8 @@ class AbstractCrossVersionGradleProfilerPerformanceTest extends Specification {
         def gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
         runner = new GradleProfilerCrossVersionPerformanceTestRunner(
             new GradleProfilerBuildExperimentRunner(gradleProfilerReporter.getResultCollector()),
-            resultStore,
-            CompositeDataReporter.of(gradleProfilerReporter, resultStore),
+            RESULTS_STORE,
+            CompositeDataReporter.of(gradleProfilerReporter, RESULTS_STORE),
             new ReleasedVersionDistributions(buildContext),
             buildContext
         )
@@ -76,7 +78,7 @@ class AbstractCrossVersionGradleProfilerPerformanceTest extends Specification {
     static {
         // TODO - find a better way to cleanup
         System.addShutdownHook {
-            resultStore.close()
+            RESULTS_STORE.close()
         }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
@@ -25,18 +25,22 @@ import org.gradle.performance.fixture.GradleVsMavenBuildExperimentRunner
 import org.gradle.performance.fixture.GradleVsMavenPerformanceTestRunner
 import org.gradle.performance.fixture.PerformanceTestDirectoryProvider
 import org.gradle.performance.fixture.PerformanceTestIdProvider
+import org.gradle.performance.results.GradleVsMavenBuildPerformanceResults
 import org.gradle.performance.results.GradleVsMavenBuildResultsStore
+import org.gradle.performance.results.WritableResultsStore
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
 
+import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
+
 @Category(PerformanceExperiment)
 @CompileStatic
 @CleanupTestDirectory
 class AbstractGradleVsMavenPerformanceTest extends Specification {
-    private static final GradleVsMavenBuildResultsStore RESULT_STORE = new GradleVsMavenBuildResultsStore()
+    private static final WritableResultsStore<GradleVsMavenBuildPerformanceResults> RESULT_STORE = createResultsStoreWhenDatabaseAvailable { new GradleVsMavenBuildResultsStore() }
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
@@ -44,7 +48,12 @@ class AbstractGradleVsMavenPerformanceTest extends Specification {
     final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 
     GradleVsMavenPerformanceTestRunner runner = new GradleVsMavenPerformanceTestRunner(
-        temporaryFolder, new GradleVsMavenBuildExperimentRunner(new GradleSessionProvider(buildContext), TestFiles.execActionFactory()), RESULT_STORE, RESULT_STORE, buildContext) {
+        temporaryFolder,
+        new GradleVsMavenBuildExperimentRunner(new GradleSessionProvider(buildContext), TestFiles.execActionFactory()),
+        RESULT_STORE,
+        RESULT_STORE,
+        buildContext
+    ) {
         @Override
         protected void defaultSpec(BuildExperimentSpec.Builder builder) {
             super.defaultSpec(builder)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -68,6 +68,8 @@ import spock.lang.Specification
 
 import java.lang.reflect.Proxy
 
+import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
+
 /**
  * Base class for all Tooling API performance regression tests. Subclasses can profile arbitrary actions against a {@link ProjectConnection).
  *
@@ -79,7 +81,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     protected final static ReleasedVersionDistributions RELEASES = new ReleasedVersionDistributions()
     protected final static GradleDistribution CURRENT = new UnderDevelopmentGradleDistribution()
 
-    static def resultStore = new CrossVersionResultsStore()
+    private static final RESULTS_STORE = createResultsStoreWhenDatabaseAvailable { new CrossVersionResultsStore() }
     final TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     protected ToolingApiExperiment experiment
@@ -119,11 +121,11 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     static {
         // TODO - find a better way to cleanup
         System.addShutdownHook {
-            ((Closeable) resultStore).close()
+            ((Closeable) RESULTS_STORE).close()
         }
     }
 
-    public class ToolingApiExperiment {
+    class ToolingApiExperiment {
         final String projectName
         String displayName
         String testClassName
@@ -165,7 +167,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
 
         private CrossVersionPerformanceResults run() {
             def testId = experiment.displayName
-            Assume.assumeTrue(TestScenarioSelector.shouldRun(experiment.testClassName, testId, [experiment.projectName].toSet(), resultStore))
+            Assume.assumeTrue(TestScenarioSelector.shouldRun(experiment.testClassName, testId, [experiment.projectName].toSet(), RESULTS_STORE))
             profiler = Profiler.create()
             try {
                 doRun(testId)
@@ -229,7 +231,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
 
             results.endTime = clock.getCurrentTime()
 
-            resultStore.report(results)
+            RESULTS_STORE.report(results)
 
             results
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -38,7 +38,7 @@ import static org.gradle.performance.results.ResultsStoreHelper.split;
 import static org.gradle.performance.results.ResultsStoreHelper.toArray;
 import static org.gradle.performance.results.ResultsStoreHelper.toList;
 
-public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> implements ResultsStore, DataReporter<R>, Closeable {
+public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> implements WritableResultsStore<R>, Closeable {
 
     private final PerformanceDatabase db;
     private final String resultType;

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -51,7 +51,7 @@ import static org.gradle.performance.results.ResultsStoreHelper.toArray;
 /**
  * A {@link DataReporter} implementation that stores results in an H2 relational database.
  */
-public class CrossVersionResultsStore implements DataReporter<CrossVersionPerformanceResults>, ResultsStore {
+public class CrossVersionResultsStore implements WritableResultsStore<CrossVersionPerformanceResults> {
     private static final String FLAKINESS_RATE_SQL =
         "SELECT TESTID, AVG(\n" +
             "  CASE WHEN DIFFCONFIDENCE > 0.97 THEN 1.0\n" +

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/EmptyPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/EmptyPerformanceTestHistory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class EmptyPerformanceTestHistory implements PerformanceTestHistory {
+
+    private final String name;
+
+    public EmptyPerformanceTestHistory(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return name;
+    }
+
+    @Override
+    public List<? extends PerformanceTestExecution> getExecutions() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public int getScenarioCount() {
+        return 0;
+    }
+
+    @Override
+    public List<String> getScenarioLabels() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<? extends ScenarioDefinition> getScenarios() {
+        return ImmutableList.of();
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -16,30 +16,34 @@
 
 package org.gradle.performance.results
 
-class NoResultsStore<T extends PerformanceTestResult> implements DataReporter<T>, ResultsStore {
+class NoResultsStore<T extends PerformanceTestResult> implements WritableResultsStore<T> {
 
-    @Override
-    void close() {
+    private static final INSTANCE = new NoResultsStore()
 
+    static <T extends PerformanceTestResult> WritableResultsStore<T> getInstance() {
+        return INSTANCE
     }
 
     @Override
     void report(T results) {
-
     }
 
     @Override
     List<String> getTestNames() {
-        null
+        []
     }
 
     @Override
     PerformanceTestHistory getTestResults(String testName, String channel) {
-        null
+        new EmptyPerformanceTestHistory(testName)
     }
 
     @Override
     PerformanceTestHistory getTestResults(String testName, int mostRecentN, int maxDaysOld, String channel) {
-        null
+        new EmptyPerformanceTestHistory(testName)
+    }
+
+    @Override
+    void close() {
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
@@ -23,14 +23,20 @@ import java.util.Arrays;
 import java.util.List;
 
 public class PerformanceDatabase {
+    private static final String PERFORMANCE_DB_URL_PROPERTY_NAME = "org.gradle.performance.db.url";
     private static final int LOGIN_TIMEOUT_SECONDS = 60;
     private final String databaseName;
     private final List<ConnectionAction<Void>> databaseInitializers;
     private Connection connection;
 
+    @SafeVarargs
     public PerformanceDatabase(String databaseName, ConnectionAction<Void>... schemaInitializers) {
         this.databaseName = databaseName;
         this.databaseInitializers = Arrays.asList(schemaInitializers);
+    }
+
+    public static boolean isAvailable() {
+        return System.getProperty(PERFORMANCE_DB_URL_PROPERTY_NAME) != null;
     }
 
     public void close() {
@@ -67,8 +73,10 @@ public class PerformanceDatabase {
     }
 
     public String getUrl() {
-        String defaultUrl = "jdbc:h2:" + System.getProperty("user.home") + "/.gradle-performance-test-data";
-        String baseUrl = System.getProperty("org.gradle.performance.db.url", defaultUrl);
+        String baseUrl = System.getProperty(PERFORMANCE_DB_URL_PROPERTY_NAME);
+        if (baseUrl == null) {
+            throw new RuntimeException("You need to specify a URL for the performance database");
+        }
         StringBuilder url = new StringBuilder(baseUrl);
         if (!baseUrl.endsWith("/")) {
             url.append('/');

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -16,6 +16,7 @@
 package org.gradle.performance.results;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,12 @@ public class ResultsStoreHelper {
             return ImmutableList.copyOf(Splitter.on(",").split(string));
         }
         return Collections.emptyList();
+    }
+
+    public static <T extends PerformanceTestResult> WritableResultsStore<T> createResultsStoreWhenDatabaseAvailable(Supplier<WritableResultsStore<T>> supplier) {
+        return PerformanceDatabase.isAvailable()
+            ? supplier.get()
+            : NoResultsStore.getInstance();
     }
 
     /**

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/WritableResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/WritableResultsStore.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+public interface WritableResultsStore<T extends PerformanceTestResult> extends DataReporter<T>, ResultsStore {
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
@@ -18,6 +18,8 @@ package org.gradle.performance.results.report;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.performance.results.FileRenderer;
+import org.gradle.performance.results.NoResultsStore;
+import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ResultsStoreHelper;
@@ -89,6 +91,9 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
     }
 
     protected ResultsStore getResultsStore() throws ReflectiveOperationException {
+        if (!PerformanceDatabase.isAvailable()) {
+            return NoResultsStore.getInstance();
+        }
         Type superClass = getClass().getGenericSuperclass();
         Class<? extends ResultsStore> resultsStoreClass = (Class<R>) ((ParameterizedType) superClass).getActualTypeArguments()[0];
         return resultsStoreClass.getConstructor().newInstance();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -19,6 +19,7 @@ package org.gradle.performance.results.report;
 import org.gradle.api.GradleException;
 import org.gradle.performance.results.AllResultsStore;
 import org.gradle.performance.results.CrossVersionResultsStore;
+import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.ScenarioBuildResultData;
 
 import java.util.Set;
@@ -36,8 +37,12 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
 
     @Override
     protected PerformanceFlakinessDataProvider getFlakinessDataProvider() {
-        try (CrossVersionResultsStore resultsStore = new CrossVersionResultsStore()) {
-            return new DefaultPerformanceFlakinessDataProvider(resultsStore);
+        if (PerformanceDatabase.isAvailable()) {
+            try (CrossVersionResultsStore resultsStore = new CrossVersionResultsStore()) {
+                return new DefaultPerformanceFlakinessDataProvider(resultsStore);
+            }
+        } else {
+            return super.getFlakinessDataProvider();
         }
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
@@ -81,12 +81,12 @@ public interface PerformanceFlakinessDataProvider {
 
         @Override
         public BigDecimal getFlakinessRate(String scenario) {
-            return null;
+            return BigDecimal.ZERO;
         }
 
         @Override
         public BigDecimal getFailureThreshold(String scenario) {
-            return null;
+            return BigDecimal.ZERO;
         }
 
         @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -30,7 +30,6 @@ import org.gradle.performance.results.ScenarioDefinition;
 import org.gradle.performance.util.Git;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.io.Writer;
 import java.util.Collections;
 import java.util.Date;
@@ -50,7 +49,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
     }
 
     @Override
-    public void render(final PerformanceTestHistory testHistory, Writer writer) throws IOException {
+    public void render(final PerformanceTestHistory testHistory, Writer writer) {
         // TODO: Add test name to the report
         // @formatter:off
         new MetricsHtml(writer) {{
@@ -292,7 +291,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             cleanTasks.add("clean" + StringUtils.capitalize(scenario.getTestProject()));
         }
 
-        return String.format("To reproduce, run ./gradlew %s %s cleanPerformanceAdhocTest :%s:performanceAdhocTest --scenarios '%s'",
+        return String.format("To reproduce, run ./gradlew %s %s cleanPerformanceAdhocTest :%s:performanceAdhocTest --scenarios '%s' --baselines force-defaults",
             Joiner.on(' ').join(cleanTasks),
             Joiner.on(' ').join(templates),
             projectName,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -292,7 +292,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             cleanTasks.add("clean" + StringUtils.capitalize(scenario.getTestProject()));
         }
 
-        return String.format("To reproduce, run ./gradlew %s %s cleanPerformanceAdhocTest :%s:performanceAdhocTest --scenarios '%s' -x prepareSamples",
+        return String.format("To reproduce, run ./gradlew %s %s cleanPerformanceAdhocTest :%s:performanceAdhocTest --scenarios '%s'",
             Joiner.on(' ').join(cleanTasks),
             Joiner.on(' ').join(templates),
             projectName,

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/GradleInternalCrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/GradleInternalCrossVersionPerformanceTestRunnerTest.groovy
@@ -21,9 +21,8 @@ import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.performance.ResultSpecification
 import org.gradle.performance.measure.Duration
-import org.gradle.performance.results.DataReporter
 import org.gradle.performance.results.MeasuredOperationList
-import org.gradle.performance.results.ResultsStore
+import org.gradle.performance.results.WritableResultsStore
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
@@ -31,8 +30,6 @@ import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 class GradleInternalCrossVersionPerformanceTestRunnerTest extends ResultSpecification {
-    private static interface ReporterAndStore extends DataReporter, ResultsStore {}
-
     private static final String MOST_RECENT_RELEASE = "2.10"
 
     @Rule
@@ -45,7 +42,7 @@ class GradleInternalCrossVersionPerformanceTestRunnerTest extends ResultSpecific
 
     final buildContext = IntegrationTestBuildContext.INSTANCE
     final experimentRunner = Mock(BuildExperimentRunner)
-    final reporter = Mock(ReporterAndStore)
+    final reporter = Mock(WritableResultsStore)
     final currentGradle = Stub(GradleDistribution)
     final releases = Stub(ReleasedVersionDistributions)
 


### PR DESCRIPTION
After using Amazons RDS services it is not possible any more to use a local h2 database for the performance tests. In effect, you couldn't run performance tests locally.

This PR uses a no-op implementation of the `ResultsStore` to allow running performance tests locally. When the test uses Gradle profiler, then their will be a `benchmark.html` and a `benchmark.csv` file. The performance test report will be generated, though it won't have any data for the test.

Fixes gradle/gradle-private#3179.