### PR TITLE
Remove limitation on SUBST drives

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -235,7 +235,7 @@ Limitations::
 File system watching currently has the following limitations:
 - If you have symlinks in your build, you won’t get the performance benefits for those locations.
 - When multiple daemons are running, the idle ones can pick up the changes produced by the others and create large log files with lots of debug info about the changes.
-- On Windows, we don’t support SUBST and network drives (they might work, but we don’t test them yet).
+- On Windows, we don’t support network drives (they might work, but we don’t test them yet).
 
 Enable verbose logging::
 You can instruct Gradle to some more information about the state of the virtual file system, and the events received from the file system using the `org.gradle.vfs.verbose` flag.


### PR DESCRIPTION
We are running our Windows performance tests using SUBST, and they work fine.
