### PR TITLE
Java Toolchain convention mapping

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -35,13 +35,13 @@ class JavaExecToolchainIntegrationTest extends AbstractPluginIntegrationTest {
             }
 
             compileJava {
-                javaCompiler = javaToolchains.compilerFrom {
+                javaCompiler = javaToolchains.compilerFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }
 
             run {
-                javaLauncher = javaToolchains.launcherFrom {
+                javaLauncher = javaToolchains.launcherFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -33,7 +33,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
             apply plugin: "java"
 
             compileJava {
-                javaCompiler = javaToolchains.compilerFrom {
+                javaCompiler = javaToolchains.compilerFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -34,7 +34,7 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
             }
 
             javadoc {
-                javadocTool = javaToolchains.javadocToolFrom {
+                javadocTool = javaToolchains.javadocToolFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }
@@ -42,7 +42,7 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
             // need to do as separate task as -version stop javadoc generation
             task javadocVersionOutput(type: Javadoc) {
                 options.jFlags("-version")
-                javadocTool = javaToolchains.javadocToolFrom {
+                javadocTool = javaToolchains.javadocToolFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainService.java
@@ -31,7 +31,7 @@ import org.gradle.api.provider.Provider;
 public interface JavaToolchainService {
 
     /**
-     * Obtain a {@link JavaCompiler} matching the {@link JavaToolchainSpec}
+     * Obtain a {@link JavaCompiler} matching the {@link JavaToolchainSpec}, as configured by the provided action.
      *
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavaCompiler>}
@@ -39,7 +39,15 @@ public interface JavaToolchainService {
     Provider<JavaCompiler> compilerFor(Action<? super JavaToolchainSpec> config);
 
     /**
-     * Obtain a {@link JavaLauncher} matching the {@link JavaToolchainSpec}
+     * Obtain a {@link JavaCompiler} matching the {@link JavaToolchainSpec}.
+     *
+     * @param spec The {@code JavaToolchainSpec}
+     * @return A {@code Provider<JavaCompiler>}
+     */
+    Provider<JavaCompiler> compilerFor(JavaToolchainSpec spec);
+
+    /**
+     * Obtain a {@link JavaLauncher} matching the {@link JavaToolchainSpec}, as configured by the provided action.
      *
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavaLauncher>}
@@ -47,10 +55,26 @@ public interface JavaToolchainService {
     Provider<JavaLauncher> launcherFor(Action<? super JavaToolchainSpec> config);
 
     /**
-     * Obtain a {@link JavadocTool} matching the {@link JavaToolchainSpec}
+     * Obtain a {@link JavaLauncher} matching the {@link JavaToolchainSpec}.
+     *
+     * @param spec The {@code JavaToolchainSpec}
+     * @return A {@code Provider<JavaLauncher>}
+     */
+    Provider<JavaLauncher> launcherFor(JavaToolchainSpec spec);
+
+    /**
+     * Obtain a {@link JavadocTool} matching the {@link JavaToolchainSpec}, as configured by the provided action.
      *
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavadocTool>}
      */
     Provider<JavadocTool> javadocToolFor(Action<? super JavaToolchainSpec> config);
+
+    /**
+     * Obtain a {@link JavadocTool} matching the {@link JavaToolchainSpec}.
+     *
+     * @param spec The {@code JavaToolchainSpec}
+     * @return A {@code Provider<JavadocTool>}
+     */
+    Provider<JavadocTool> javadocToolFor(JavaToolchainSpec spec);
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainService.java
@@ -36,7 +36,7 @@ public interface JavaToolchainService {
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavaCompiler>}
      */
-    Provider<JavaCompiler> compilerFrom(Action<? super JavaToolchainSpec> config);
+    Provider<JavaCompiler> compilerFor(Action<? super JavaToolchainSpec> config);
 
     /**
      * Obtain a {@link JavaLauncher} matching the {@link JavaToolchainSpec}
@@ -44,7 +44,7 @@ public interface JavaToolchainService {
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavaLauncher>}
      */
-    Provider<JavaLauncher> launcherFrom(Action<? super JavaToolchainSpec> config);
+    Provider<JavaLauncher> launcherFor(Action<? super JavaToolchainSpec> config);
 
     /**
      * Obtain a {@link JavadocTool} matching the {@link JavaToolchainSpec}
@@ -52,5 +52,5 @@ public interface JavaToolchainService {
      * @param config The configuration of the {@code JavaToolchainSpec}
      * @return A {@code Provider<JavadocTool>}
      */
-    Provider<JavadocTool> javadocToolFrom(Action<? super JavaToolchainSpec> config);
+    Provider<JavadocTool> javadocToolFor(Action<? super JavaToolchainSpec> config);
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainService.java
@@ -17,6 +17,7 @@
 package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaLauncher;
@@ -29,24 +30,47 @@ import javax.inject.Inject;
 public class DefaultJavaToolchainService implements JavaToolchainService {
 
     private final JavaToolchainQueryService queryService;
+    private final ObjectFactory objectFactory;
 
     @Inject
-    public DefaultJavaToolchainService(JavaToolchainQueryService queryService) {
+    public DefaultJavaToolchainService(JavaToolchainQueryService queryService, ObjectFactory objectFactory) {
         this.queryService = queryService;
+        this.objectFactory = objectFactory;
     }
 
     @Override
     public Provider<JavaCompiler> compilerFor(Action<? super JavaToolchainSpec> config) {
-        return queryService.compilerFor(config);
+        return compilerFor(configureToolchainSpec(config));
+    }
+
+    @Override
+    public Provider<JavaCompiler> compilerFor(JavaToolchainSpec spec) {
+        return queryService.toolFor(spec, JavaToolchain::getJavaCompiler);
     }
 
     @Override
     public Provider<JavaLauncher> launcherFor(Action<? super JavaToolchainSpec> config) {
-        return queryService.launcherFor(config);
+        return launcherFor(configureToolchainSpec(config));
+    }
+
+    @Override
+    public Provider<JavaLauncher> launcherFor(JavaToolchainSpec spec) {
+        return queryService.toolFor(spec, JavaToolchain::getJavaLauncher);
     }
 
     @Override
     public Provider<JavadocTool> javadocToolFor(Action<? super JavaToolchainSpec> config) {
-        return queryService.javadocToolFor(config);
+        return javadocToolFor(configureToolchainSpec(config));
+    }
+
+    @Override
+    public Provider<JavadocTool> javadocToolFor(JavaToolchainSpec spec) {
+        return queryService.toolFor(spec, JavaToolchain::getJavadocTool);
+    }
+
+    private DefaultToolchainSpec configureToolchainSpec(Action<? super JavaToolchainSpec> config) {
+        DefaultToolchainSpec toolchainSpec = objectFactory.newInstance(DefaultToolchainSpec.class);
+        config.execute(toolchainSpec);
+        return toolchainSpec;
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainService.java
@@ -36,17 +36,17 @@ public class DefaultJavaToolchainService implements JavaToolchainService {
     }
 
     @Override
-    public Provider<JavaCompiler> compilerFrom(Action<? super JavaToolchainSpec> config) {
-        return queryService.compilerFrom(config);
+    public Provider<JavaCompiler> compilerFor(Action<? super JavaToolchainSpec> config) {
+        return queryService.compilerFor(config);
     }
 
     @Override
-    public Provider<JavaLauncher> launcherFrom(Action<? super JavaToolchainSpec> config) {
-        return queryService.launcherFrom(config);
+    public Provider<JavaLauncher> launcherFor(Action<? super JavaToolchainSpec> config) {
+        return queryService.launcherFor(config);
     }
 
     @Override
-    public Provider<JavadocTool> javadocToolFrom(Action<? super JavaToolchainSpec> config) {
-        return queryService.javadocToolFrom(config);
+    public Provider<JavadocTool> javadocToolFor(Action<? super JavaToolchainSpec> config) {
+        return queryService.javadocToolFor(config);
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -47,15 +47,15 @@ public class JavaToolchainQueryService {
         this.objectFactory = objectFactory;
     }
 
-    Provider<JavaCompiler> compilerFrom(Action<? super JavaToolchainSpec> config) {
+    Provider<JavaCompiler> compilerFor(Action<? super JavaToolchainSpec> config) {
         return findMatchingToolchain(configureToolchainSpec(config)).map(JavaToolchain::getJavaCompiler);
     }
 
-    Provider<JavaLauncher> launcherFrom(Action<? super JavaToolchainSpec> config) {
+    Provider<JavaLauncher> launcherFor(Action<? super JavaToolchainSpec> config) {
         return findMatchingToolchain(configureToolchainSpec(config)).map(JavaToolchain::getJavaLauncher);
     }
 
-    Provider<JavadocTool> javadocToolFrom(Action<? super JavaToolchainSpec> config) {
+    Provider<JavadocTool> javadocToolFor(Action<? super JavaToolchainSpec> config) {
         return findMatchingToolchain(configureToolchainSpec(config)).map(JavaToolchain::getJavadocTool);
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -34,7 +34,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         given:
         def registry = createInstallationRegistry()
         def toolchainFactory = newToolchainFactory()
-        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), TestUtil.objectFactory())
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService))
 
         when:
         def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
@@ -56,7 +56,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         given:
         def registry = createInstallationRegistry(["8.0", "8.0.242.hs-adpt", "7.9", "7.7", "14.0.2+12", "8.0.zzz.j9"])
         def toolchainFactory = newToolchainFactory()
-        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), TestUtil.objectFactory())
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService))
 
         when:
         def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
@@ -80,7 +80,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def toolchainFactory = newToolchainFactory()
         def provisioningService = Mock(JavaToolchainProvisioningService)
         provisioningService.tryInstall(_) >> Optional.empty()
-        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, provisioningService, TestUtil.objectFactory())
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, provisioningService)
 
         when:
         def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
@@ -97,7 +97,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         given:
         def registry = createInstallationRegistry(["8", "9", "10"])
         def toolchainFactory = newToolchainFactory()
-        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), TestUtil.objectFactory())
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService))
 
         when:
         def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
@@ -118,7 +118,7 @@ class JavaToolchainQueryServiceTest extends Specification {
                 Optional.of(new File("/path/12"))
             }
         }
-        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, provisionService, TestUtil.objectFactory())
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, provisionService)
 
         when:
         def filter = new DefaultToolchainSpec(TestUtil.objectFactory())

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
@@ -53,8 +52,8 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.jvm.toolchain.JavaInstallationRegistry;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
-import org.gradle.jvm.toolchain.internal.JavaToolchain;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
@@ -63,6 +62,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -188,7 +188,7 @@ public class JavaBasePlugin implements Plugin<Project> {
             compileTask.getOptions().getHeaderOutputDirectory().convention(target.getLayout().getBuildDirectory().dir(generatedHeadersDir));
             JavaPluginExtension javaPluginExtension = target.getExtensions().getByType(JavaPluginExtension.class);
             compileTask.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
-            compileTask.getJavaCompiler().convention(getToolchainTool(target, JavaToolchain::getJavaCompiler));
+            compileTask.getJavaCompiler().convention(getToolchainTool(target, JavaToolchainService::compilerFor));
         });
     }
 
@@ -328,7 +328,7 @@ public class JavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             javadoc.getConventionMapping().map("destinationDir", () -> new File(convention.getDocsDir(), "javadoc"));
             javadoc.getConventionMapping().map("title", () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
-            javadoc.getJavadocTool().convention(getToolchainTool(project, JavaToolchain::getJavadocTool));
+            javadoc.getJavadocTool().convention(getToolchainTool(project, JavaToolchainService::javadocToolFor));
         });
     }
 
@@ -367,12 +367,13 @@ public class JavaBasePlugin implements Plugin<Project> {
         htmlReport.getOutputLocation().convention(project.getLayout().getProjectDirectory().dir(project.provider(() -> new File(convention.getTestReportDir(), test.getName()).getAbsolutePath())));
         test.getBinaryResultsDirectory().convention(project.getLayout().getProjectDirectory().dir(project.provider(() -> new File(convention.getTestResultsDir(), test.getName() + "/binary").getAbsolutePath())));
         test.workingDir(project.getProjectDir());
-        test.getJavaLauncher().convention(getToolchainTool(project, JavaToolchain::getJavaLauncher));
+        test.getJavaLauncher().convention(getToolchainTool(project, JavaToolchainService::launcherFor));
     }
 
-    private <T> Provider<T> getToolchainTool(Project project, Transformer<T, JavaToolchain> toolMapper) {
+    private <T> Provider<T> getToolchainTool(Project project, BiFunction<JavaToolchainService, JavaToolchainSpec, Provider<T>> toolMapper) {
         final JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
-        return getJavaToolchainQueryService().findMatchingToolchain(extension.getToolchain()).map(toolMapper).orElse(Providers.notDefined());
+        final JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
+        return toolMapper.apply(service, extension.getToolchain()).orElse(Providers.notDefined());
     }
 
     @Inject

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -38,12 +38,12 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
             }
 
             tasks.withType(JavaCompile).configureEach {
-                javaCompiler = javaToolchains.compilerFrom {
+                javaCompiler = javaToolchains.compilerFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }
             test {
-                javaLauncher = javaToolchains.launcherFrom {
+                javaLauncher = javaToolchains.launcherFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }


### PR DESCRIPTION
This PR updates available public methods so that convention mapping for Java plugin tasks can be done without internal APIs.