### PR TITLE
Fix configuration caching when an artifact transform output is required to build build logic

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildSrcIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildSrcIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 class ConfigurationCacheBuildSrcIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-    def "can use tasks defined in buildSrc"() {
+    def "can use task types defined in buildSrc"() {
         given:
         file("buildSrc/settings.gradle") << """
             include 'ignored' // include some content

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -349,7 +349,6 @@ class DefaultConfigurationCache internal constructor(
             valueSourceProviderFactory = service(),
             patternSetFactory = factory(),
             fileOperations = service(),
-            fileSystem = service(),
             fileFactory = service()
         )
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -18,7 +18,9 @@ package org.gradle.configurationcache.fingerprint
 
 import org.gradle.api.execution.internal.TaskInputsListeners
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.configurationcache.BuildTreeListenerManager
@@ -54,7 +56,9 @@ class ConfigurationCacheFingerprintController internal constructor(
     private val fileCollectionFingerprinter: AbsolutePathFileCollectionFingerprinter,
     private val buildCommencedTimeProvider: BuildCommencedTimeProvider,
     private val listenerManager: ListenerManager,
-    private val buildTreeListenerManager: BuildTreeListenerManager
+    private val buildTreeListenerManager: BuildTreeListenerManager,
+    private val fileCollectionFactory: FileCollectionFactory,
+    private val directoryFileTreeFactory: DirectoryFileTreeFactory
 ) : Stoppable {
 
     private
@@ -83,7 +87,9 @@ class ConfigurationCacheFingerprintController internal constructor(
             val outputStream = ByteArrayOutputStream()
             val fingerprintWriter = ConfigurationCacheFingerprintWriter(
                 CacheFingerprintComponentHost(),
-                writeContextForOutputStream(outputStream)
+                writeContextForOutputStream(outputStream),
+                fileCollectionFactory,
+                directoryFileTreeFactory
             )
             addListener(fingerprintWriter)
             return Writing(fingerprintWriter, outputStream)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -23,10 +23,16 @@ import org.gradle.api.execution.internal.TaskInputsListener
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.Expiry
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
+import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.internal.provider.sources.FileContentValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.util.PatternSet
 import org.gradle.configurationcache.UndeclaredBuildInputListener
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint.InputFile
@@ -43,7 +49,9 @@ import java.io.File
 internal
 class ConfigurationCacheFingerprintWriter(
     private val host: Host,
-    private val writeContext: DefaultWriteContext
+    private val writeContext: DefaultWriteContext,
+    private val fileCollectionFactory: FileCollectionFactory,
+    private val directoryFileTreeFactory: DirectoryFileTreeFactory
 ) : ValueSourceProviderFactory.Listener, TaskInputsListener, ScriptExecutionListener, UndeclaredBuildInputListener, ChangingValueDependencyResolutionListener, FileResourceListener {
 
     interface Host {
@@ -198,7 +206,7 @@ class ConfigurationCacheFingerprintWriter(
         write(
             ConfigurationCacheFingerprint.TaskInputs(
                 task.identityPath.path,
-                fileSystemInputs,
+                simplify(fileSystemInputs),
                 host.fingerprintOf(fileSystemInputs, task)
             )
         )
@@ -216,6 +224,30 @@ class ConfigurationCacheFingerprintWriter(
         writeContext.runWriteOperation {
             write(value)
         }
+    }
+
+    private
+    fun simplify(source: FileCollectionInternal): FileCollectionInternal {
+        // Transform the collection into a sequence of files or directory trees and remove dynamic behaviour
+        val elements = mutableListOf<Any>()
+        source.visitStructure(object : FileCollectionStructureVisitor {
+            override fun visitCollection(source: FileCollectionInternal.Source, contents: Iterable<File>) {
+                elements.addAll(contents)
+            }
+
+            override fun visitGenericFileTree(fileTree: FileTreeInternal, sourceTree: FileSystemMirroringFileTree) {
+                elements.addAll(fileTree)
+            }
+
+            override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
+                elements.add(directoryFileTreeFactory.create(root, patterns))
+            }
+
+            override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal, sourceTree: FileSystemMirroringFileTree) {
+                elements.add(file)
+            }
+        })
+        return fileCollectionFactory.resolving(elements)
     }
 }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -39,8 +39,6 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
-import org.gradle.execution.plan.TaskNodeFactory
-import org.gradle.initialization.BuildRequestMetaData
 import org.gradle.configurationcache.problems.DocumentationSection.NotYetImplementedJavaSerialization
 import org.gradle.configurationcache.serialization.codecs.jos.JavaObjectSerializationCodec
 import org.gradle.configurationcache.serialization.codecs.transform.ChainedTransformationNodeCodec
@@ -56,13 +54,14 @@ import org.gradle.configurationcache.serialization.codecs.transform.TransformedE
 import org.gradle.configurationcache.serialization.ownerServiceCodec
 import org.gradle.configurationcache.serialization.reentrant
 import org.gradle.configurationcache.serialization.unsupported
+import org.gradle.execution.plan.TaskNodeFactory
+import org.gradle.initialization.BuildRequestMetaData
 import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.isolation.IsolatableFactory
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationListenerManager
 import org.gradle.internal.reflect.Instantiator
@@ -115,7 +114,6 @@ class Codecs(
     valueSourceProviderFactory: ValueSourceProviderFactory,
     patternSetFactory: Factory<PatternSet>,
     fileOperations: FileOperations,
-    fileSystem: FileSystem,
     fileFactory: FileFactory
 ) {
 
@@ -133,7 +131,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileFactory, patternSetFactory)
 
         bind(ApiTextResourceAdapterCodec)
 
@@ -213,7 +211,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileSystem, fileFactory, patternSetFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileFactory, patternSetFactory)
 
         bind(TaskNodeCodec(userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(userTypesCodec, buildOperationExecutor, transformListener))
@@ -241,11 +239,11 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileSystem: FileSystem, fileFactory: FileFactory, patternSetFactory: Factory<PatternSet>) {
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileFactory: FileFactory, patternSetFactory: Factory<PatternSet>) {
         bind(DirectoryCodec(fileFactory))
         bind(RegularFileCodec(fileFactory))
         bind(ConfigurableFileTreeCodec(fileCollectionFactory))
-        bind(FileTreeCodec(fileCollectionFactory, directoryFileTreeFactory, fileOperations, fileSystem))
+        bind(FileTreeCodec(fileCollectionFactory, directoryFileTreeFactory, fileOperations))
         val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory)
         bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
         bind(fileCollectionCodec)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileTreeCodec.kt
@@ -40,7 +40,6 @@ import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.decodePreservingIdentity
 import org.gradle.configurationcache.serialization.encodePreservingIdentityOf
 import org.gradle.configurationcache.serialization.readNonNull
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import java.io.File
 
 
@@ -72,8 +71,7 @@ internal
 class FileTreeCodec(
     private val fileCollectionFactory: FileCollectionFactory,
     private val directoryFileTreeFactory: DirectoryFileTreeFactory,
-    private val fileOperations: FileOperations,
-    private val fileSystem: FileSystem
+    private val fileOperations: FileOperations
 ) : Codec<FileTreeInternal> {
 
     override suspend fun WriteContext.encode(value: FileTreeInternal) {

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -171,7 +171,6 @@ abstract class AbstractUserTypeCodecTest {
         valueSourceProviderFactory = mock(),
         patternSetFactory = mock(),
         fileOperations = mock(),
-        fileSystem = mock(),
         fileFactory = mock()
     )
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -26,7 +26,7 @@ trait TasksWithInputsAndOutputs {
 
     abstract TestFile getBuildKotlinFile()
 
-    def taskTypeWithOutputFileProperty() {
+    def taskTypeWithOutputFileProperty(TestFile buildFile = getBuildFile()) {
         buildFile << """
             class FileProducer extends DefaultTask {
                 @OutputFile
@@ -69,7 +69,7 @@ trait TasksWithInputsAndOutputs {
         """
     }
 
-    def taskTypeWithOutputDirectoryProperty() {
+    def taskTypeWithOutputDirectoryProperty(TestFile buildFile = getBuildFile()) {
         buildFile << """
             import javax.inject.Inject
 
@@ -227,7 +227,7 @@ trait TasksWithInputsAndOutputs {
         """
     }
 
-    def taskTypeLogsArtifactCollectionDetails() {
+    def taskTypeLogsArtifactCollectionDetails(TestFile buildFile = getBuildFile()) {
         buildFile << """
             class ShowArtifactCollection extends DefaultTask {
                 @Internal

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -51,7 +51,7 @@ class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDepen
     }
 
     void setupBuildWithNoSteps(@DelegatesTo(Builder) Closure cl = {}) {
-        setupBuildWithColorAttributes(cl)
+        setupBuildWithColorAttributes(buildFile, cl)
         buildFile << """
 
 allprojects {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -43,15 +43,15 @@ trait ArtifactTransformTestFixture extends TasksWithInputsAndOutputs {
      * By default each variant will contain a single file, this can be configured using the supplied {@link Builder}.
      * Caller will need to register transforms that produce 'green' from 'blue'
      */
-    void setupBuildWithColorAttributes(@DelegatesTo(Builder) Closure cl = {}) {
+    void setupBuildWithColorAttributes(TestFile buildFile = getBuildFile(), @DelegatesTo(Builder) Closure cl = {}) {
         def builder = new Builder()
         builder.produceFiles()
         cl.delegate = builder
         cl.call()
-        setupBuildWithColorAttributes(builder)
+        setupBuildWithColorAttributes(buildFile, builder)
     }
 
-    void setupBuildWithColorAttributes(Builder builder) {
+    void setupBuildWithColorAttributes(TestFile buildFile = getBuildFile(), Builder builder) {
 
         buildFile << """
 import ${javax.inject.Inject.name}
@@ -62,6 +62,7 @@ def color = Attribute.of('color', String)
 allprojects {
     configurations {
         implementation {
+            canBeResolved = true
             attributes.attribute(color, 'blue')
         }
     }
@@ -121,9 +122,9 @@ class JarProducer extends DefaultTask {
     }
 }
 """
-        taskTypeWithOutputFileProperty()
-        taskTypeWithOutputDirectoryProperty()
-        taskTypeLogsArtifactCollectionDetails()
+        taskTypeWithOutputFileProperty(buildFile)
+        taskTypeWithOutputDirectoryProperty(buildFile)
+        taskTypeLogsArtifactCollectionDetails(buildFile)
     }
 
     /**
@@ -235,8 +236,8 @@ class JarProducer extends DefaultTask {
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'green'.
      * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
      */
-    void setupBuildWithSimpleColorTransform() {
-        setupBuildWithColorTransformAction()
+    void setupBuildWithSimpleColorTransform(TestFile buildFile = getBuildFile()) {
+        setupBuildWithColorTransformAction(buildFile)
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
@@ -335,8 +336,8 @@ class JarProducer extends DefaultTask {
      * By default the variant will contain a single file, this can be configured using the supplied {@link Builder}.
      * Caller will need to provide an implementation of 'MakeGreen' transform action
      */
-    void setupBuildWithColorTransformAction(@DelegatesTo(Builder) Closure cl = {}) {
-        setupBuildWithColorAttributes(cl)
+    void setupBuildWithColorTransformAction(TestFile buildFile = getBuildFile(), @DelegatesTo(Builder) Closure cl = {}) {
+        setupBuildWithColorAttributes(buildFile, cl)
         buildFile << """
 allprojects {
     dependencies {
@@ -347,6 +348,10 @@ allprojects {
     }
 }
 """
+    }
+
+    void setupBuildWithColorTransformAction(@DelegatesTo(Builder) Closure cl) {
+        setupBuildWithColorTransformAction(buildFile, cl)
     }
 
     /**


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
