### PR TITLE
Do not use dedicated gradle home for samples

### DIFF
--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/tests/check.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/tests/check.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: check
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/tests/sanityCheck.conf
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/tests/sanityCheck.conf
@@ -1,5 +1,0 @@
-commands: [{
-    executable: gradle
-    args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
-}]

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/tests/publish.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/tests/publish.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: publish
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/tests/sanityCheck.sample.conf
@@ -1,5 +1,0 @@
-commands: [{
-    executable: gradle
-    args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
-}]

--- a/subprojects/docs/src/samples/credentials-handling/pass-credentials-to-external-tool-via-stdin/tests/commandLineCredentials.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/pass-credentials-to-external-tool-via-stdin/tests/commandLineCredentials.sample.conf
@@ -2,5 +2,4 @@ commands: [{
     executable: gradle
     args: "-q doAuthenticated -PloginUsername=secret-user -PloginPassword=secret-password"
     expected-output-file: commandLineCredentials.out
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/credentials-handling/pass-credentials-to-external-tool-via-stdin/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/pass-credentials-to-external-tool-via-stdin/tests/sanityCheck.sample.conf
@@ -1,5 +1,0 @@
-commands: [{
-    executable: gradle
-    args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
-}]

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/publishCommandLineCredentials.sample.conf
@@ -1,5 +1,4 @@
 commands: [{
     executable: gradle
     args: "publish -PmySecureRepositoryUsername=secret-user -PmySecureRepositoryPassword=secret-password"
-    flags: "--gradle-user-home=local-gradle-user-home"
 }]

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/tests/sanityCheck.sample.conf
@@ -1,5 +1,0 @@
-commands: [{
-    executable: gradle
-    args: help -q
-    flags: "--gradle-user-home=local-gradle-user-home"
-}]


### PR DESCRIPTION
With dedicated home directory, a single sample test run can generate over 1.5gb of data on disk.
Below is the difference in data size on disk for a single sample test execution with and without this flag:
```
1.6G    junit14836569920836269568
4.3M    junit1742054479419689705
```
