### PR TITLE
Prevent buildSrc build from hanging when included build is substituted as a dependency

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
-import spock.lang.Ignore
 
 class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
     def "buildSrc cannot (yet) define any included builds"() {
@@ -139,7 +138,6 @@ class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
         outputContains("test-plugin applied to :included")
     }
 
-    @Ignore("this does not work yet and hangs indefinitely")
     @ToBeFixedForConfigurationCache(because="composite build")
     def "buildSrc can depend on dependencies contributed by other included builds"() {
         file("buildSrc/build.gradle") << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization.buildsrc
 
-import groovy.transform.NotYetImplemented
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
@@ -111,31 +111,6 @@ class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
         then:
         outputContains("test-plugin applied to :buildSrc")
-    }
-
-    @NotYetImplemented
-    def "plugins from buildSrc can be used by other included builds"() {
-        file("included/build.gradle") << """
-            plugins {
-                id "test-plugin"
-            }
-        """
-
-        writePluginTo(file("buildSrc"))
-
-
-        buildFile << """
-            task executeIncluded {
-                dependsOn gradle.includedBuild("included").task(":help")
-            }
-        """
-        settingsFile << """
-            includeBuild("included")
-        """
-        when:
-        succeeds("executeIncluded")
-        then:
-        outputContains("test-plugin applied to :included")
     }
 
     @ToBeFixedForConfigurationCache(because="composite build")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
@@ -147,7 +147,6 @@ class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
         outputContains("test-plugin applied to :")
     }
 
-    @ToBeFixedForConfigurationCache(because="composite build")
     def "user gets reasonable error when included build fails to compile when buildSrc needs it"() {
         file("buildSrc/build.gradle") << """
             plugins {

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
@@ -71,4 +71,42 @@ public interface IncludedBuildControllers {
     void finishBuild(Collection<? super Throwable> failures);
 
     IncludedBuildController getBuildController(BuildIdentifier buildIdentifier);
+
+    class BuildSrcIncludedBuildControllers implements IncludedBuildControllers {
+        private final IncludedBuildControllers delegate;
+
+        public BuildSrcIncludedBuildControllers(IncludedBuildControllers delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void rootBuildOperationStarted() {
+            delegate.rootBuildOperationStarted();
+        }
+
+        @Override
+        public void populateTaskGraphs() {
+            delegate.populateTaskGraphs();
+        }
+
+        @Override
+        public void startTaskExecution() {
+            delegate.startTaskExecution();
+        }
+
+        @Override
+        public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
+            delegate.awaitTaskCompletion(taskFailures);
+        }
+
+        @Override
+        public void finishBuild(Collection<? super Throwable> failures) {
+            // Do nothing
+        }
+
+        @Override
+        public IncludedBuildController getBuildController(BuildIdentifier buildIdentifier) {
+            return delegate.getBuildController(buildIdentifier);
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -156,6 +157,12 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         if (gradle.isRootBuild()) {
             return sharedControllers;
         } else {
+            // TODO: buildSrc shouldn't be special here, but since buildSrc is built separately from other included builds and the root build
+            // We need to treat buildSrc as if it's a root build so that it can depend on included builds that may substitute dependencies
+            // into buildSrc
+            if (gradle.getOwner().getBuildIdentifier().getName().equals(SettingsInternal.BUILD_SRC)) {
+                return new IncludedBuildControllers.BuildSrcIncludedBuildControllers(sharedControllers);
+            }
             return IncludedBuildControllers.EMPTY;
         }
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
