### PR TITLE
Improve name matching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
@@ -82,26 +82,29 @@ public class NameMatcher {
         Set<String> kebabCasePrefixMatches = new TreeSet<>();
 
         for (String candidate : items) {
+            boolean found = false;
+
             if (candidate.equalsIgnoreCase(pattern)) {
                 caseInsensitiveMatches.add(candidate);
+                found = true;
             }
             if (camelCasePattern.matcher(candidate).matches()) {
                 caseSensitiveCamelCaseMatches.add(candidate);
-                continue;
+                found = true;
             }
             if (normalisedCamelCasePattern.matcher(candidate).lookingAt()) {
                 caseInsensitiveCamelCaseMatches.add(candidate);
-                continue;
+                found = true;
             }
             if (kebabCasePattern.matcher(candidate).matches()) {
                 kebabCaseMatches.add(candidate);
-                continue;
+                found = true;
             }
             if (kebabCasePrefixPattern.matcher(candidate).matches()) {
                 kebabCasePrefixMatches.add(candidate);
-                continue;
+                found = true;
             }
-            if (StringUtils.getLevenshteinDistance(normalisedPattern, candidate.toUpperCase()) <= Math.min(3, pattern.length() / 2)) {
+            if (!found && StringUtils.getLevenshteinDistance(normalisedPattern, candidate.toUpperCase()) <= Math.min(3, pattern.length() / 2)) {
                 candidates.add(candidate);
             }
         }
@@ -110,7 +113,7 @@ public class NameMatcher {
             matches.addAll(caseInsensitiveMatches);
         } else if (!caseSensitiveCamelCaseMatches.isEmpty()) {
             matches.addAll(caseSensitiveCamelCaseMatches);
-        } else {
+        } else if (kebabCaseMatches.isEmpty() && kebabCasePrefixMatches.isEmpty()) {
             matches.addAll(caseInsensitiveCamelCaseMatches);
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameMatcherTest.groovy
@@ -138,6 +138,13 @@ class NameMatcherTest extends Specification {
         matches("soNa", "sona", "someName")
     }
 
+    def "prefers kebab case match over case insensitive camel case match"() {
+        expect:
+        matches("sN", "some-name", "sand")
+        matches("sN", "some-name-with", "sand")
+        matches("sN", "some-name-with-extra", "sand")
+    }
+
     def "does not select items when no matches"() {
         expect:
         doesNotMatch("name")


### PR DESCRIPTION
The existing name matching treated case-insensitive and kebab case matches equally. This lead to a regression where the pattern 'dC' matched on both the 'distribution-core' and on the 'documentation' strings. This commit fixes the issue by prioritizing kebab case matches.

