### PR TITLE
Create JfrProfiler correctly

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleProfilerBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleProfilerBuildExperimentRunner.java
@@ -26,6 +26,7 @@ import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.InvocationSettings;
 import org.gradle.profiler.ProfilerFactory;
 import org.gradle.profiler.ScenarioDefinition;
+import org.gradle.profiler.jfr.JfrProfilerFactory;
 import org.gradle.profiler.result.BuildInvocationResult;
 
 import java.io.File;
@@ -53,10 +54,20 @@ public abstract class AbstractGradleProfilerBuildExperimentRunner implements Bui
         this.flameGraphGenerator = jfrProfileTargetDir == null
             ? ProfilerFlameGraphGenerator.NOOP
             : new JfrFlameGraphGenerator(new File(jfrProfileTargetDir));
-        this.profiler = jfrProfileTargetDir == null
-            ? org.gradle.profiler.Profiler.NONE
-            : ProfilerFactory.of(Arrays.asList("jfr")).createFromOptions(new OptionParser().parse());
+        this.profiler = createProfiler(jfrProfileTargetDir);
         this.resultCollector = resultCollector;
+    }
+
+    private org.gradle.profiler.Profiler createProfiler(String jfrProfileTargetDir) {
+        if (jfrProfileTargetDir == null) {
+            return org.gradle.profiler.Profiler.NONE;
+        } else {
+            OptionParser optionParser = new OptionParser();
+            optionParser.accepts("profiler");
+            JfrProfilerFactory jfrProfilerFactory = new JfrProfilerFactory();
+            jfrProfilerFactory.addOptions(optionParser);
+            return jfrProfilerFactory.createFromOptions(optionParser.parse());
+        }
     }
 
     protected ProfilerFlameGraphGenerator getFlameGraphGenerator() {


### PR DESCRIPTION
Previously the jfr profiler can't be created because of incorrectly
configured OptionParser. Now we fix it.
