### PR TITLE
Enforce using the compiler daemon for toolchains

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -123,9 +123,7 @@ public class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public JavaForkOptionsInternal newJavaForkOptions() {
-        final DefaultJavaForkOptions forkOptions = new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
-        forkOptions.setExecutable(Jvm.current().getJavaExecutable());
-        return forkOptions;
+        return new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal.worker;
 import org.gradle.api.Action;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.id.IdGenerator;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.remote.Address;
 import org.gradle.internal.remote.ConnectionAcceptor;
@@ -70,6 +71,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
 
     DefaultWorkerProcessBuilder(JavaExecHandleFactory execHandleFactory, MessagingServer server, IdGenerator<Long> idGenerator, ApplicationClassesInSystemClassLoaderWorkerImplementationFactory workerImplementationFactory, OutputEventListener outputEventListener, MemoryManager memoryManager) {
         this.javaCommand = execHandleFactory.newJavaExec();
+        this.javaCommand.setExecutable(Jvm.current().getJavaExecutable());
         this.server = server;
         this.idGenerator = idGenerator;
         this.workerImplementationFactory = workerImplementationFactory;

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -57,6 +57,7 @@ class JavaExecHandleBuilderTest extends Specification {
         builder.minHeapSize = "64m"
         builder.maxHeapSize = "1g"
         builder.defaultCharacterEncoding = inputEncoding
+        builder.setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath())
 
         when:
         List jvmArgs = builder.getAllJvmArgs()

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -18,16 +18,30 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.jvm.toolchain.JavaInstallationMetadata;
+
+import javax.annotation.Nullable;
 
 public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> implements Factory<T> {
     private final CompileOptions compileOptions;
 
-    public AbstractJavaCompileSpecFactory(CompileOptions compileOptions) {
+    private final JavaInstallationMetadata toolchain;
+
+    public AbstractJavaCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata toolchain) {
         this.compileOptions = compileOptions;
+        this.toolchain = toolchain;
+    }
+
+    public AbstractJavaCompileSpecFactory(CompileOptions compileOptions) {
+        this(compileOptions, null);
     }
 
     @Override
     public T create() {
+        if (toolchain != null) {
+            return chooseSpecForToolchain();
+        }
         if (compileOptions.isFork()) {
             if (compileOptions.getForkOptions().getExecutable() != null || compileOptions.getForkOptions().getJavaHome() != null) {
                 return getCommandLineSpec();
@@ -37,6 +51,24 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         } else {
             return getDefaultSpec();
         }
+    }
+
+    private T chooseSpecForToolchain() {
+        if (!toolchain.getLanguageVersion().canCompileOrRun(8)) {
+            return getCommandLineSpec();
+        }
+        if (compileOptions.isFork()) {
+            return getForkingSpec();
+        } else {
+            if (isCurrentVmOurToolchain()) {
+                return getDefaultSpec();
+            }
+            return getForkingSpec();
+        }
+    }
+
+    boolean isCurrentVmOurToolchain() {
+        return toolchain.getInstallationPath().getAsFile().equals(Jvm.current().getJavaHome());
     }
 
     abstract protected T getCommandLineSpec();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
@@ -58,6 +59,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(forkOptions);
         javaForkOptions.setWorkingDir(daemonWorkingDir);
+        javaForkOptions.setExecutable(findSuitableExecutable(spec));
 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("JAVA-COMPILER");
         FlatClassLoaderStructure classLoaderStructure = new FlatClassLoaderStructure(new VisitableURLClassLoader.Spec("compiler", compilerClasspath.getAsURLs()));
@@ -67,6 +69,16 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
             .withClassLoaderStructure(classLoaderStructure)
             .keepAliveMode(KeepAliveMode.SESSION)
             .build();
+    }
+
+    private File findSuitableExecutable(JavaCompileSpec spec) {
+        final ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        if (forkOptions.getExecutable() != null) {
+            return new File(forkOptions.getExecutable());
+        } else if (forkOptions.getJavaHome() != null) {
+            return new File(forkOptions.getJavaHome(), "bin/java");
+        }
+        return Jvm.current().getJavaExecutable();
     }
 
     public static class JavaCompilerParameters extends CompilerParameters {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -76,7 +76,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         if (forkOptions.getExecutable() != null) {
             return new File(forkOptions.getExecutable());
         } else if (forkOptions.getJavaHome() != null) {
-            return new File(forkOptions.getJavaHome(), "bin/java");
+            return Jvm.forHome(forkOptions.getJavaHome()).getJavaExecutable();
         }
         return Jvm.current().getJavaExecutable();
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
@@ -17,10 +17,11 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.CompileOptions;
+import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
 public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultJavaCompileSpec> {
-    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions) {
-        super(compileOptions);
+    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions, JavaInstallationMetadata toolchain) {
+        super(compileOptions, toolchain);
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -25,7 +25,6 @@ import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
-import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.reflect.DirectInstantiator;
 
@@ -65,16 +64,16 @@ public class JdkTools {
 
     private Class<JavaCompiler.CompilationTask> incrementalCompileTaskClass;
 
-    JdkTools(JavaInfo javaInfo, List<File> compilerPlugins) {
+    JdkTools(Jvm jvm, List<File> compilerPlugins) {
         DefaultClassLoaderFactory defaultClassLoaderFactory = new DefaultClassLoaderFactory();
-        JavaVersion javaVersion = Jvm.current().getJavaVersion();
+        JavaVersion javaVersion = jvm.getJavaVersion();
         boolean java9Compatible = javaVersion.isJava9Compatible();
         ClassLoader filteringClassLoader = getSystemFilteringClassLoader(defaultClassLoaderFactory);
         if (!java9Compatible) {
-            File toolsJar = javaInfo.getToolsJar();
+            File toolsJar = jvm.getToolsJar();
             if (toolsJar == null) {
                 throw new IllegalStateException("Could not find tools.jar. Please check that "
-                    + javaInfo.getJavaHome().getAbsolutePath()
+                    + jvm.getJavaHome().getAbsolutePath()
                     + " contains a valid JDK installation.");
             }
             ClassPath defaultClassPath = DefaultClassPath.of(toolsJar).plus(compilerPlugins);

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
@@ -16,16 +16,29 @@
 
 package org.gradle.api.internal.tasks.compile
 
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.compile.CompileOptions
+import org.gradle.internal.jvm.Jvm
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.internal.JavaToolchain
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class DefaultJavaCompileSpecFactoryTest extends Specification {
-    def "produces correct spec type" () {
+
+    @Unroll
+    def "produces correct spec with fork=#fork, executable=#executable, toolchain=#toolchainHome"() {
         CompileOptions options = new CompileOptions(Mock(ObjectFactory))
         options.fork = fork
         options.forkOptions.executable = executable
-        DefaultJavaCompileSpecFactory factory = new DefaultJavaCompileSpecFactory(options)
+        def toolchain = null
+        if (toolchainHome != null) {
+            toolchain = Mock(JavaToolchain)
+            toolchain.installationPath >> TestFiles.fileFactory().dir(toolchainHome)
+            toolchain.languageVersion >> JavaLanguageVersion.of(8)
+        }
+        DefaultJavaCompileSpecFactory factory = new DefaultJavaCompileSpecFactory(options, toolchain)
 
         when:
         def spec = factory.create()
@@ -36,9 +49,12 @@ class DefaultJavaCompileSpecFactoryTest extends Specification {
         CommandLineJavaCompileSpec.isAssignableFrom(spec.getClass()) == implementsCommandLine
 
         where:
-        fork  | executable | implementsForking | implementsCommandLine
-        false | null       | false             | false
-        true  | null       | true              | false
-        true  | "X"        | false             | true
+        fork  | executable | implementsForking | implementsCommandLine | toolchainHome
+        false | null       | false             | false                 | null
+        true  | null       | true              | false                 | null
+        true  | "X"        | false             | true                  | null
+        true | "X" | true | false | File.createTempDir()
+        false | null       | false             | false                 | Jvm.current().javaHome
     }
+
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile
 
-import org.gradle.internal.jvm.JavaInfo
+import org.gradle.api.JavaVersion
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -40,11 +40,11 @@ class JdkToolsTest extends Specification {
         compiler.class == current.systemJavaCompiler.class
     }
 
-    @Requires(TestPrecondition.JDK8_OR_EARLIER)
     def "throws when no tools"() {
         when:
-        new JdkTools(Mock(JavaInfo) {
+        new JdkTools(Mock(Jvm) {
             getToolsJar() >> null
+            getJavaVersion() >> JavaVersion.VERSION_1_8
             getJavaHome() >> new File('.')
         }, [])
 
@@ -58,7 +58,7 @@ class JdkToolsTest extends Specification {
         if (defaultCompilerClassAlreadyInjectedIntoExtensionClassLoader()) {
             throw new IllegalStateException()
         }
-        new JdkTools(Mock(JavaInfo) {
+        new JdkTools(Mock(Jvm) {
             getToolsJar() >> new File("/nothing")
         }, []).systemJavaCompiler
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.tasks.compile.CommandLineJavaCompileSpec
+import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaCompiler
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
@@ -128,7 +128,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         spec.compileOptions.forkOptions.javaHome == javaHome
     }
 
-    def "spec is configured using the toolchain compiler via command line"() {
+    def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
         javaCompile.setDestinationDir(new File("tmp"))
         def javaHome = Jvm.current().javaHome
@@ -144,7 +144,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def spec = javaCompile.createSpec()
 
         then:
-        spec instanceof CommandLineJavaCompileSpec
+        spec instanceof DefaultJavaCompileSpec
         spec.compileOptions.forkOptions.javaHome == javaHome
         spec.getSourceCompatibility() == "12"
         spec.getTargetCompatibility() == "12"

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -25,6 +25,7 @@ import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.play.internal.spec.PlayCompileSpec;
 import org.gradle.process.JavaForkOptions;
@@ -68,6 +69,7 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
         BaseForkOptions forkOptions = spec.getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(forkOptions);
         javaForkOptions.setWorkingDir(daemonWorkingDir);
+        javaForkOptions.setExecutable(Jvm.current().getJavaExecutable());
 
         ClassPath playCompilerClasspath = classPathRegistry.getClassPath("PLAY-COMPILER").plus(DefaultClassPath.of(compilerClasspath));
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -213,7 +213,7 @@ compileJava {
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
     @Unroll
-    def "compile with release flag"() {
+    def "compile with release flag using #notation notation"() {
         given:
         goodCode()
         buildFile << """

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -54,7 +54,6 @@ import org.gradle.jvm.toolchain.JavaInstallationRegistry;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
-import org.gradle.jvm.toolchain.internal.JavaToolchain;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -54,6 +54,7 @@ import org.gradle.jvm.toolchain.JavaInstallationRegistry;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
+import org.gradle.jvm.toolchain.internal.JavaToolchain;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
@@ -312,7 +313,7 @@ public class JavaBasePlugin implements Plugin<Project> {
         });
     }
 
-    private Callable<Object> determineCompatibility(AbstractCompile compile, Supplier<JavaVersion> javaVersionSupplier) {
+    private Callable<String> determineCompatibility(AbstractCompile compile, Supplier<JavaVersion> javaVersionSupplier) {
         return () -> {
             if (compile instanceof JavaCompile) {
                 JavaCompile javaCompile = (JavaCompile) compile;

--- a/subprojects/plugins/src/main/java/org/gradle/internal/deployment/RunApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/internal/deployment/RunApplication.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.deployment.internal.DeploymentRegistry;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.internal.JavaExecHandleBuilder;
 import org.gradle.process.internal.JavaExecHandleFactory;
 
@@ -68,6 +69,7 @@ public class RunApplication extends DefaultTask {
         JavaApplicationHandle handle = registry.get(getPath(), JavaApplicationHandle.class);
         if (handle == null) {
             JavaExecHandleBuilder builder = getExecActionFactory().newJavaExec();
+            builder.setExecutable(Jvm.current().getJavaExecutable());
             builder.setClasspath(classpath);
             builder.setMain(mainClassName);
             builder.setArgs(arguments);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -223,15 +223,15 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
     void "source and target compatibility are configured if toolchain is configured"() {
         given:
-        setupProjectWithToolchain(JavaVersion.VERSION_13)
+        setupProjectWithToolchain(JavaVersion.VERSION_14)
 
         when:
         project.sourceSets.create('custom')
 
         then:
         def compileTask = project.tasks.compileJava
-        compileTask.getSourceCompatibility() == "13"
-        compileTask.getTargetCompatibility() == "13"
+        compileTask.getSourceCompatibility() == "14"
+        compileTask.getTargetCompatibility() == "14"
     }
 
     void "wires toolchain for test if toolchain is configured"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -229,9 +229,10 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.sourceSets.create('custom')
 
         then:
-        def compileTask = project.tasks.compileJava
-        compileTask.getSourceCompatibility() == Jvm.current().javaVersion.majorVersion
-        compileTask.getTargetCompatibility() == Jvm.current().javaVersion.majorVersion
+        project.tasks.compileJava.getSourceCompatibility() == Jvm.current().javaVersion.majorVersion
+        project.tasks.compileJava.getTargetCompatibility() == Jvm.current().javaVersion.majorVersion
+        project.tasks.compileCustomJava.getSourceCompatibility() == Jvm.current().javaVersion.majorVersion
+        project.tasks.compileCustomJava.getTargetCompatibility() == Jvm.current().javaVersion.majorVersion
     }
 
     void "wires toolchain for test if toolchain is configured"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -223,15 +223,15 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
     void "source and target compatibility are configured if toolchain is configured"() {
         given:
-        setupProjectWithToolchain(JavaVersion.VERSION_14)
+        setupProjectWithToolchain(Jvm.current().javaVersion)
 
         when:
         project.sourceSets.create('custom')
 
         then:
         def compileTask = project.tasks.compileJava
-        compileTask.getSourceCompatibility() == "14"
-        compileTask.getTargetCompatibility() == "14"
+        compileTask.getSourceCompatibility() == Jvm.current().javaVersion.majorVersion
+        compileTask.getTargetCompatibility() == Jvm.current().javaVersion.majorVersion
     }
 
     void "wires toolchain for test if toolchain is configured"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -210,7 +210,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     void "wires toolchain for sourceset if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
-        setupProjectWithToolchain(someJdk)
+        setupProjectWithToolchain(someJdk.javaVersion)
 
         when:
         project.sourceSets.create('custom')
@@ -221,10 +221,23 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredToolchain.displayName.contains(someJdk.javaVersion.getMajorVersion())
     }
 
+    void "source and target compatibility are configured if toolchain is configured"() {
+        given:
+        setupProjectWithToolchain(JavaVersion.VERSION_13)
+
+        when:
+        project.sourceSets.create('custom')
+
+        then:
+        def compileTask = project.tasks.compileJava
+        compileTask.getSourceCompatibility() == "13"
+        compileTask.getTargetCompatibility() == "13"
+    }
+
     void "wires toolchain for test if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
-        setupProjectWithToolchain(someJdk)
+        setupProjectWithToolchain(someJdk.javaVersion)
 
         when:
         def testTask = project.tasks.named("test", Test).get()
@@ -237,7 +250,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     void "wires toolchain for javadoc if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
-        setupProjectWithToolchain(someJdk)
+        setupProjectWithToolchain(someJdk.javaVersion)
 
         when:
         def javadocTask = project.tasks.named("javadoc", Javadoc).get()
@@ -250,7 +263,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     void 'wires toolchain to java compile source compatibility if toolchain is configured'() {
         given:
         def someJdk = Jvm.current()
-        setupProjectWithToolchain(someJdk)
+        setupProjectWithToolchain(someJdk.javaVersion)
         project.java.sourceCompatibility = JavaVersion.VERSION_1_1
 
         when:
@@ -261,9 +274,9 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         javaCompileTask.sourceCompatibility == javaCompileTask.javaCompiler.get().metadata.languageVersion.toString()
     }
 
-    private void setupProjectWithToolchain(Jvm someJdk) {
+    private void setupProjectWithToolchain(JavaVersion version) {
         project.pluginManager.apply(JavaPlugin)
-        project.java.toolchain.languageVersion = JavaLanguageVersion.of(someJdk.javaVersion.majorVersion)
+        project.java.toolchain.languageVersion = JavaLanguageVersion.of(version.majorVersion)
         // workaround for https://github.com/gradle/gradle/issues/13122
         ((DefaultProject) project).getServices().get(GradlePropertiesController.class).loadGradlePropertiesFrom(project.projectDir)
     }


### PR DESCRIPTION
This adds general support for using the compile daemon
over dropping down to the cli compiler if possible.
Most of the changes are about removing the assumption
that the current JVM is the worker/compiler default.

Fixes #12513