### PR TITLE
Move project layout documentation into dedicated multi-project section

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
@@ -59,85 +59,30 @@ include::{snippetsPath}/buildlifecycle/basic/tests-kotlin/buildlifecycle.kotlin.
 
 For a build script, the property access and method calls are delegated to a project object. Similarly property access and method calls within the settings file is delegated to a settings object. Look at the link:{groovyDslPath}/org.gradle.api.initialization.Settings.html[Settings] class in the API documentation for more information.
 
-[[sec:lifecycle_multi_project_builds]]
-== Multi-project builds
-
-A multi-project build is a build where you build more than one project during a single execution of Gradle. You have to declare the projects taking part in the multi-project build in the settings file. There is much more to say about multi-project builds in the chapter dedicated to this topic (see <<creating_multi_project_builds.adoc#multi_project_builds,Authoring Multi-Project Builds>>).
-
-
-[[sub:project_locations]]
-=== Project locations
-
-Multi-project builds are always represented by a tree with a single root. Each element in the tree represents a project. A project has a path which denotes the position of the project in the multi-project build tree. In most cases the project path is consistent with the physical location of the project in the file system. However, this behavior is configurable. The project tree is created in the `settings.gradle` file. By default it is assumed that the location of the settings file is also the location of the root project. But you can redefine the location of the root project in the settings file.
-
-[[sub:building_the_tree]]
-=== Building the tree
-
-In the settings file you can use a set of methods to build the project tree. Hierarchical and flat physical layouts get special support.
-
-
-[[sec:hierarchical_layouts]]
-==== Hierarchical layouts
-
-
-.Hierarchical layout
-====
-include::sample[dir="snippets/multiproject/standardLayouts/groovy",files="settings.gradle[tags=hierarchical-layout]"]
-include::sample[dir="snippets/multiproject/standardLayouts/kotlin",files="settings.gradle.kts[tags=hierarchical-layout]"]
-====
-
-The `include` method takes project paths as arguments. The project path is assumed to be equal to the relative physical file system path. For example, a path 'services:api' is mapped by default to a folder 'services/api' (relative from the project root). You only need to specify the leaves of the tree. This means that the inclusion of the path 'services:hotels:api' will result in creating 3 projects: 'services', 'services:hotels' and 'services:hotels:api'.
-More examples of how to work with the project path can be found in the DSL documentation of link:{groovyDslPath}++/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[])++[Settings.include(java.lang.String[\])].
-
-[[sec:flat_layouts]]
-==== Flat layouts
-
-
-.Flat layout
-====
-include::sample[dir="snippets/multiproject/standardLayouts/groovy",files="settings.gradle[tags=flat-layout]"]
-include::sample[dir="snippets/multiproject/standardLayouts/kotlin",files="settings.gradle.kts[tags=flat-layout]"]
-====
-
-The `includeFlat` method takes directory names as an argument. These directories need to exist as siblings of the root project directory. The location of these directories are considered as child projects of the root project in the multi-project tree.
-
-[[sub:modifying_element_of_the_project_tree]]
-=== Modifying elements of the project tree
-
-The multi-project tree created in the settings file is made up of so called _project descriptors_. You can modify these descriptors in the settings file at any time. To access a descriptor you can do:
-
-.Lookup of elements of the project tree
-====
-include::sample[dir="snippets/multiproject/customLayout/groovy",files="settings.gradle[tags=lookup-project]"]
-include::sample[dir="snippets/multiproject/customLayout/kotlin",files="settings.gradle.kts[tags=lookup-project]"]
-====
-
-Using this descriptor you can change the name, project directory and build file of a project.
-
-.Modification of elements of the project tree
-====
-include::sample[dir="snippets/multiproject/customLayout/groovy",files="settings.gradle[tags=change-project]"]
-include::sample[dir="snippets/multiproject/customLayout/kotlin",files="settings.gradle.kts[tags=change-project]"]
-====
-
-Look at the link:{javadocPath}/org/gradle/api/initialization/ProjectDescriptor.html[ProjectDescriptor] class in the API documentation for more information.
 
 [[sec:initialization]]
 == Initialization
 
-How does Gradle know whether to do a single or multi-project build? If you trigger a multi-project build from a directory with a settings file, things are easy. But Gradle also allows you to execute the build from within any subproject taking part in the build.footnote:[Gradle supports partial multi-project builds (see <<intro_multi_project_builds.adoc#,Executing Multi-Project Builds>>).] If you execute Gradle from within a project with no `settings.gradle` file, Gradle looks for a `settings.gradle` file in the following way:
+How does Gradle know whether to do a single or multi-project build?
+If you trigger a multi-project build from a directory with a `settings.gradle` file, Gradle uses it to configure the build.
+Gradle also allows you to execute the build from within any subproject taking part in the build.footnote:[Gradle supports partial multi-project builds (see <<intro_multi_project_builds.adoc#,Executing Multi-Project Builds>>).]
+If you execute Gradle from within a project with no `settings.gradle` file, Gradle looks for a `settings.gradle` file in the following way:
 
-* It looks in a directory called `master` which has the same nesting level as the current dir.
-* If not found yet, it searches parent directories.
-* If not found yet, the build is executed as a single project build.
-* If a `settings.gradle` file is found, Gradle checks if the current project is part of the multi-project hierarchy defined in the found `settings.gradle` file. If not, the build is executed as a single project build. Otherwise a multi-project build is executed.
+* It looks for `settings.gradle` in parent directories.
+* If not found, the build is executed as a single project build.
+* If a `settings.gradle` file is found, Gradle checks if the current project is part of the multi-project hierarchy defined in the found `settings.gradle` file.
+If not, the build is executed as a single project build. Otherwise a multi-project build is executed.
 
-What is the purpose of this behavior? Gradle needs to determine whether the project you are in is a subproject of a multi-project build or not. Of course, if it is a subproject, only the subproject and its dependent projects are built, but Gradle needs to create the build configuration for the whole multi-project build (see <<multi_project_configuration_and_execution.adoc#configuration_and_execution,Configuration and Execution>>). If the current project contains a `settings.gradle` file, the build is always executed as:
+What is the purpose of this behavior? Gradle needs to determine whether the project you are in is a subproject of a multi-project build or not.
+Of course, if it is a subproject, only the subproject and its dependent projects are built, but Gradle needs to create the build configuration for the whole multi-project build (see <<multi_project_configuration_and_execution.adoc#configuration_and_execution,Configuration and Execution>>).
+If the current project contains a `settings.gradle` file, the build is always executed as:
 
 * a single project build, if the `settings.gradle` file does not define a multi-project hierarchy
 * a multi-project build, if the `settings.gradle` file does define a multi-project hierarchy.
 
-The automatic search for a `settings.gradle` file only works for multi-project builds with a physical hierarchical or flat layout. For a flat layout you must additionally follow the naming convention described above (“`master`”). Gradle supports arbitrary physical layouts for a multi-project build, but for such arbitrary layouts you need to execute the build from the directory where the settings file is located. For information on how to run partial builds from the root, see <<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,Executing tasks by their fully qualified name>>.
+The automatic search for a `settings.gradle` file only works for multi-project builds with a default project layout where project paths match the physical subproject layout on disk.
+Gradle supports arbitrary physical layouts for a multi-project build, but for such arbitrary layouts you need to execute the build from the directory where the settings file is located.
+For information on how to run partial builds from the root, see <<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,Executing tasks by their fully qualified name>>.
 
 Gradle creates a Project object for every project taking part in the build. For a multi-project build these are the projects specified in the Settings object (plus the root project). Each project object has by default a name equal to the name of its top level directory, and every project except the root project has a parent project. Any project may have child projects.
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/fine_tuning_project_layout.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/fine_tuning_project_layout.adoc
@@ -1,0 +1,71 @@
+// Copyright 2020 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+[[fine_tuning_project_layout]]
+= Fine Tuning the Project Layout
+
+A multi-project build is a build where you build more than one project during a single execution of Gradle.
+You have to declare the projects taking part in the multi-project build in the settings file.
+
+
+[[sub:project_locations]]
+== Project locations
+
+Multi-project builds are always represented by a tree with a single root.
+Each element in the tree represents a project.
+A project has a path which denotes the position of the project in the multi-project build tree.
+In most cases the project path is consistent with the physical location of the project in the file system.
+However, this behavior is configurable. The project tree is created in the `settings.gradle` file.
+The location of the settings file is also the location of the root project.
+
+[[sub:building_the_tree]]
+== Building the tree
+
+In the settings file you can use the `include` method to build the project tree.
+
+.Project layout
+====
+include::sample[dir="snippets/multiproject/standardLayouts/groovy",files="settings.gradle[tags=hierarchical-layout]"]
+include::sample[dir="snippets/multiproject/standardLayouts/kotlin",files="settings.gradle.kts[tags=hierarchical-layout]"]
+====
+
+The `include` method takes project paths as arguments.
+The project path is assumed to be equal to the relative physical file system path.
+For example, a path 'services:api' is mapped by default to a folder 'services/api' (relative from the project root).
+You only need to specify the leaves of the tree.
+This means that the inclusion of the path 'services:hotels:api' will result in creating 3 projects: 'services', 'services:hotels' and 'services:hotels:api'.
+More examples of how to work with the project path can be found in the DSL documentation of link:{groovyDslPath}++/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[])++[Settings.include(java.lang.String[\])].
+
+
+[[sub:modifying_element_of_the_project_tree]]
+== Modifying elements of the project tree
+
+The multi-project tree created in the settings file is made up of so called _project descriptors_.
+You can modify these descriptors in the settings file at any time.
+To access a descriptor you can do:
+
+.Lookup of elements of the project tree
+====
+include::sample[dir="snippets/multiproject/customLayout/groovy",files="settings.gradle[tags=lookup-project]"]
+include::sample[dir="snippets/multiproject/customLayout/kotlin",files="settings.gradle.kts[tags=lookup-project]"]
+====
+
+Using this descriptor you can change the name, project directory and build file of a project.
+
+.Modification of elements of the project tree
+====
+include::sample[dir="snippets/multiproject/customLayout/groovy",files="settings.gradle[tags=change-project]"]
+include::sample[dir="snippets/multiproject/customLayout/kotlin",files="settings.gradle.kts[tags=change-project]"]
+====
+
+Look at the link:{javadocPath}/org/gradle/api/initialization/ProjectDescriptor.html[ProjectDescriptor] class in the API documentation for more information.

--- a/subprojects/docs/src/docs/userguide/userguide_single.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide_single.adoc
@@ -88,6 +88,8 @@ include::creating_multi_project_builds.adoc[leveloffset=+2]
 
 include::sharing_build_logic_between_subprojects.adoc[leveloffset=+2]
 
+include::fine_tuning_project_layout.adoc[leveloffset=+2]
+
 include::declaring_dependencies_between_subprojects.adoc[leveloffset=+2]
 
 include::multi_project_configuration_and_execution.adoc[leveloffset=+2]

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -174,6 +174,7 @@
                 <ul id="authoring-multi-project-builds">
                     <li><a href="../userguide/creating_multi_project_builds.html">Creating a Basic Multi-Project Build</a></li>
                     <li><a href="../userguide/sharing_build_logic_between_subprojects.html">Sharing Build Logic between Subprojects</a></li>
+                    <li><a href="../userguide/fine_tuning_project_layout.html">Fine Tuning the Project Layout</a></li>
                     <li><a href="../userguide/declaring_dependencies_between_subprojects.html">Declaring Dependencies between Subprojects</a></li>
                     <li><a href="../userguide/multi_project_configuration_and_execution.html">Understanding Configuration and Execution</a></li>
                 </ul>

--- a/subprojects/docs/src/snippets/multiproject/customLayout/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/customLayout/groovy/settings.gradle
@@ -7,6 +7,6 @@ println project(':project-a').name
 
 // tag::change-project[]
 rootProject.name = 'main'
-project(':project-a').projectDir = new File(settingsDir, '../my-project-a')
+project(':project-a').projectDir = file('../my-project-a')
 project(':project-a').buildFileName = 'project-a.gradle'
 // end::change-project[]

--- a/subprojects/docs/src/snippets/multiproject/customLayout/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/customLayout/kotlin/settings.gradle.kts
@@ -7,6 +7,6 @@ println(project(":project-a").name)
 
 // tag::change-project[]
 rootProject.name = "main"
-project(":project-a").projectDir = File(settingsDir, "../my-project-a")
+project(":project-a").projectDir = file("../my-project-a")
 project(":project-a").buildFileName = "project-a.gradle"
 // end::change-project[]

--- a/subprojects/docs/src/snippets/multiproject/standardLayouts/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/multiproject/standardLayouts/groovy/settings.gradle
@@ -2,7 +2,3 @@ rootProject.name = 'standard-layouts'
 // tag::hierarchical-layout[]
 include 'project1', 'project2:child', 'project3:child1'
 // end::hierarchical-layout[]
-
-// tag::flat-layout[]
-includeFlat 'project3', 'project4'
-// end::flat-layout[]

--- a/subprojects/docs/src/snippets/multiproject/standardLayouts/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/multiproject/standardLayouts/kotlin/settings.gradle.kts
@@ -2,7 +2,3 @@ rootProject.name = "standard-layouts"
 // tag::hierarchical-layout[]
 include("project1", "project2:child", "project3:child1")
 // end::hierarchical-layout[]
-
-// tag::flat-layout[]
-includeFlat("project3", "project4")
-// end::flat-layout[]


### PR DESCRIPTION
Remove mentions of "flat layout" and special `master` directory for multi-project roots.
