### PR TITLE
Improve toolchain support with other compile options

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -375,9 +375,21 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
 
     private void configureCompatibilityOptions(DefaultJavaCompileSpec spec) {
         if (javaCompiler.isPresent()) {
-            final JavaInstallationMetadata toolchain = javaCompiler.get().getMetadata();
-            spec.setTargetCompatibility(toolchain.getLanguageVersion().asString());
-            spec.setSourceCompatibility(toolchain.getLanguageVersion().asString());
+            if (compileOptions.getRelease().isPresent()) {
+                spec.setRelease(compileOptions.getRelease().get());
+            } else {
+                final JavaInstallationMetadata toolchain = javaCompiler.get().getMetadata();
+                if (super.getSourceCompatibility() != null) {
+                    spec.setSourceCompatibility(getSourceCompatibility());
+                } else {
+                    spec.setSourceCompatibility(toolchain.getLanguageVersion().asString());
+                }
+                if (super.getTargetCompatibility() != null) {
+                    spec.setTargetCompatibility(getTargetCompatibility());
+                } else {
+                    spec.setTargetCompatibility(toolchain.getLanguageVersion().asString());
+                }
+            }
         } else if (compileOptions.getRelease().isPresent()) {
             spec.setRelease(compileOptions.getRelease().get());
         } else {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -382,12 +382,12 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
                 if (super.getSourceCompatibility() != null) {
                     spec.setSourceCompatibility(getSourceCompatibility());
                 } else {
-                    spec.setSourceCompatibility(toolchain.getLanguageVersion().asString());
+                    spec.setSourceCompatibility(toolchain.getLanguageVersion().toString());
                 }
                 if (super.getTargetCompatibility() != null) {
                     spec.setTargetCompatibility(getTargetCompatibility());
                 } else {
-                    spec.setTargetCompatibility(toolchain.getLanguageVersion().asString());
+                    spec.setTargetCompatibility(toolchain.getLanguageVersion().toString());
                 }
             }
         } else if (compileOptions.getRelease().isPresent()) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaLanguageVersion.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaLanguageVersion.java
@@ -37,17 +37,22 @@ public interface JavaLanguageVersion extends Comparable<JavaLanguageVersion> {
 
     /**
      * Return this version as a number, 14 for Java 14.
+     * <p>
+     * Given the type used, this method returns the simple version even for versions lower than 5.
      *
      * @return the version number
+     * @see #toString()
      */
     int asInt();
 
     /**
      * Return this version as a String, "14" for Java 14.
+     * <p>
+     * This method will return {@code 1.<version>} when the version is lower than 5.
      *
      * @return the version number
      */
-    String asString();
+    String toString();
 
     /**
      * Indicates if this version can compile or run code based on the passed in language version.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -61,7 +61,7 @@ public class AdoptOpenJdkRemoteBinary {
 
     private URI constructUri(JavaToolchainSpec spec) {
         return URI.create(getServerBaseUri() +
-            "v3/binary/latest/" + getLanguageVersion(spec).asString() +
+            "v3/binary/latest/" + getLanguageVersion(spec).toString() +
             "/" +
             determineReleaseState() +
             "/" +
@@ -72,7 +72,7 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     public String toFilename(JavaToolchainSpec spec) {
-        return String.format("adoptopenjdk-%s-%s-%s.%s", getLanguageVersion(spec).asString(), determineArch(), determineOs(), determineFileExtension());
+        return String.format("adoptopenjdk-%s-%s-%s.%s", getLanguageVersion(spec).toString(), determineArch(), determineOs(), determineFileExtension());
     }
 
     private String determineFileExtension() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersion.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersion.java
@@ -34,6 +34,9 @@ public class DefaultJavaLanguageVersion implements JavaLanguageVersion, Serializ
     }
 
     public static JavaLanguageVersion of(int version) {
+        if (version <= 0) {
+            throw new IllegalArgumentException("JavaLanguageVersion must be a positive integer, not " + version);
+        }
         if (version >= LOWER_CACHED_VERSION && version <= HIGHER_CACHED_VERSION) {
             return KNOWN_VERSIONS[version - LOWER_CACHED_VERSION];
         } else {
@@ -53,7 +56,10 @@ public class DefaultJavaLanguageVersion implements JavaLanguageVersion, Serializ
     }
 
     @Override
-    public String asString() {
+    public String toString() {
+        if (version < 5) {
+            return String.format("1.%d", version);
+        }
         return Integer.toString(version);
     }
 
@@ -87,10 +93,5 @@ public class DefaultJavaLanguageVersion implements JavaLanguageVersion, Serializ
     @Override
     public int hashCode() {
         return version;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(version);
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -43,7 +43,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
 
     @Override
     public String getDisplayName() {
-        return "{languageVersion=" + languageVersion.map(JavaLanguageVersion::asString).getOrElse("unspecified") + "}";
+        return "{languageVersion=" + languageVersion.map(JavaLanguageVersion::toString).getOrElse("unspecified") + "}";
     }
 
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersionTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersionTest.groovy
@@ -31,24 +31,32 @@ class DefaultJavaLanguageVersionTest extends Specification {
         }
     }
 
+    def 'special cases versions 1 to 4'() {
+        given:
+        def values = 1..4
+
+        expect:
+        values.forEach {
+            assert DefaultJavaLanguageVersion.of(it).toString() == "1.$it"
+        }
+    }
+
     def 'behaves as an integer wrapper'() {
         given:
-        def value = new Random().nextInt()
+        def value = getVersion()
 
         when:
         def version = DefaultJavaLanguageVersion.of(value)
 
         then:
         version.asInt() == value
-        version.asString() == String.valueOf(value)
         version.toString() == String.valueOf(value)
     }
 
     def 'compatibility relates to sort order'() {
         given:
-        def rand = new Random()
-        def firstValue = rand.nextInt()
-        def secondValue = rand.nextInt()
+        def firstValue = getVersion()
+        def secondValue = getVersion()
 
         when:
         def firstVersion = DefaultJavaLanguageVersion.of(firstValue)
@@ -57,5 +65,9 @@ class DefaultJavaLanguageVersionTest extends Specification {
         then:
         firstVersion.canCompileOrRun(secondVersion) == firstVersion >= secondVersion
         secondVersion.canCompileOrRun(firstVersion) == secondVersion >= firstVersion
+    }
+
+    private static int getVersion() {
+        Math.max(Math.abs(new Random().nextInt()), 5)
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -18,7 +18,9 @@
 package org.gradle.java.compile
 
 import org.gradle.api.Action
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.test.fixtures.file.ClassFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -142,6 +144,71 @@ public class FxApp extends Application {
 
         expect:
         succeeds("compileJava")
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) != null })
+    def 'ignores project level compatibility when using toolchain'() {
+        given:
+        goodCode()
+        buildFile << """
+java.sourceCompatibility = JavaVersion.VERSION_14
+java.targetCompatibility = JavaVersion.VERSION_15
+java.toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+}
+
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
+    }
+}
+"""
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) != null })
+    def 'honors task level compatibility when using toolchain'() {
+        given:
+        goodCode()
+        buildFile << """
+java.toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_9
+    targetCompatibility = JavaVersion.VERSION_9
+
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 9
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 9
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 9
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 9
+    }
+}
+"""
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_14) != null })
+    def 'computes target jvm version when using toolchain'() {
+        given:
+        goodCode()
+        buildFile << """
+java.toolchain {
+    languageVersion = JavaLanguageVersion.of(14)
+}
+
+compileJava {
+    doFirst {
+        assert configurations.apiElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 14
+        assert configurations.runtimeElements.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 14
+        assert configurations.compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 14
+        assert configurations.runtimeClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 14
+    }
+}
+"""
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -318,6 +318,8 @@ public class JavaBasePlugin implements Plugin<Project> {
                 JavaCompile javaCompile = (JavaCompile) compile;
                 if (javaCompile.getOptions().getRelease().isPresent()) {
                     return JavaVersion.toVersion(javaCompile.getOptions().getRelease().get()).toString();
+                } else if (javaCompile.getJavaCompiler().isPresent()) {
+                    return javaCompile.getJavaCompiler().get().getMetadata().getLanguageVersion().asString();
                 }
             }
             return javaVersionSupplier.get().toString();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -319,7 +319,7 @@ public class JavaBasePlugin implements Plugin<Project> {
                 if (javaCompile.getOptions().getRelease().isPresent()) {
                     return JavaVersion.toVersion(javaCompile.getOptions().getRelease().get()).toString();
                 } else if (javaCompile.getJavaCompiler().isPresent()) {
-                    return javaCompile.getJavaCompiler().get().getMetadata().getLanguageVersion().asString();
+                    return javaCompile.getJavaCompiler().get().getMetadata().getLanguageVersion().toString();
                 }
             }
             return javaVersionSupplier.get().toString();

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -258,7 +258,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         javaCompileTask.javaCompiler.isPresent()
-        javaCompileTask.sourceCompatibility == javaCompileTask.javaCompiler.get().metadata.languageVersion.asString()
+        javaCompileTask.sourceCompatibility == javaCompileTask.javaCompiler.get().metadata.languageVersion.toString()
     }
 
     private void setupProjectWithToolchain(Jvm someJdk) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -247,6 +247,20 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredJavadocTool.isPresent()
     }
 
+    void 'wires toolchain to java compile source compatibility if toolchain is configured'() {
+        given:
+        def someJdk = Jvm.current()
+        setupProjectWithToolchain(someJdk)
+        project.java.sourceCompatibility = JavaVersion.VERSION_1_1
+
+        when:
+        def javaCompileTask = project.tasks.named("compileJava", JavaCompile).get()
+
+        then:
+        javaCompileTask.javaCompiler.isPresent()
+        javaCompileTask.sourceCompatibility == javaCompileTask.javaCompiler.get().metadata.languageVersion.asString()
+    }
+
     private void setupProjectWithToolchain(Jvm someJdk) {
         project.pluginManager.apply(JavaPlugin)
         project.java.toolchain.languageVersion = JavaLanguageVersion.of(someJdk.javaVersion.majorVersion)


### PR DESCRIPTION
* Enable combining `*Compatibility` or `release` on the compile task with a toolchain selected
* Toolchain usage is reflected in `*Compatibility` for integration with tools relying on these values
* Improvement to the recently introduced `JavaLanguageVersion`