### PR TITLE
Allow injecting ProcessEnvironment for BuildServices

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ConfigurationCacheRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.internal.nativeintegration.ProcessEnvironment
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
 import org.junit.runner.RunWith
@@ -557,7 +558,8 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
             FileSystemOperations,
             ObjectFactory,
             ProviderFactory,
-            LoggingOutput
+            LoggingOutput,
+            ProcessEnvironment
         ].collect { it.name }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -25,6 +25,7 @@ import org.gradle.internal.Try;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.isolated.IsolationScheme;
 import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.state.Managed;
@@ -97,7 +98,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
                 ServiceLookup instantiationServices = isolationScheme.servicesForImplementation(
                     isolatedParameters,
                     internalServices,
-                    ImmutableList.of(LoggingOutput.class),
+                    ImmutableList.of(LoggingOutput.class, ProcessEnvironment.class),
                     serviceType -> false
                 );
                 try {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
@@ -16,6 +16,8 @@
 package org.gradle.internal.nativeintegration;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 import java.util.Map;
@@ -26,6 +28,7 @@ import java.util.Map;
  * <p>Implementations are not thread-safe.</p>
  */
 @UsedByScanPlugin("test-distribution")
+@ServiceScope(Scope.Global.class)
 public interface ProcessEnvironment {
     /**
      * Sets the environment of this process, if possible.


### PR DESCRIPTION
so Gradle profiler could be using it for determining the Daemon PID.