### PR TITLE
Make scala incremental analysis configurations resolve early

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.scala
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+import spock.lang.Issue
+
+
+class ScalaConcurrencyIntegrationTest extends AbstractIntegrationSpec {
+    @Rule BlockingHttpServer httpServer = new BlockingHttpServer()
+
+    @Issue("https://github.com/gradle/gradle/issues/14434")
+    def "can run tests in parallel with project dependencies"() {
+        given:
+        httpServer.expectConcurrent(':a:test', ':b:test', ':c:test', ':d:test')
+        httpServer.start()
+
+        settingsFile << """
+            include 'a', 'b', 'c', 'd'
+        """
+        buildFile << """
+            allprojects {
+                tasks.withType(AbstractScalaCompile) {
+                    options.fork = true
+                }
+                repositories {
+                    ${jcenterRepository()}
+                }
+                plugins.withId("scala") {
+                    dependencies {
+                        implementation 'org.scala-lang:scala-library:2.13.3'
+
+                        testImplementation 'junit:junit:4.12'
+                        testImplementation 'org.scalatest:scalatest_2.13:3.2.0'
+                        testImplementation 'org.scalatestplus:junit-4-12_2.13:3.2.0.0'
+                    }
+                }
+                tasks.withType(Test) { task ->
+                    doLast {
+                        ${httpServer.callFromBuild('${task.path}')}
+                    }
+                }
+            }
+        """
+        ['a', 'b', 'c', 'd'].each { project ->
+            file("${project}/build.gradle") << """
+                plugins {
+                    id 'scala'
+                }
+            """
+            file("${project}/src/main/scala/${project}/${project.toUpperCase()}.scala") << """
+                package ${project}
+                trait ${project.toUpperCase()}
+            """
+            file("${project}/src/test/scala/${project}/${project.toUpperCase()}Test.scala") << """
+                package ${project}
+                import org.scalatest.funsuite.AnyFunSuite
+                import org.junit.runner.RunWith
+                import org.scalatestplus.junit.JUnitRunner
+
+                @RunWith(classOf[JUnitRunner])
+                class ${project.toUpperCase()}Test extends AnyFunSuite {
+                  test("always true") {
+                      assert(true)
+                  }
+                }
+            """
+        }
+        file("a/build.gradle") << """
+            dependencies {
+              implementation(project(":b"))
+              implementation(project(":c"))
+              implementation(project(":d"))
+            }
+        """
+
+        expect:
+        succeeds("build", "--parallel", "--max-workers", "4")
+        true
+    }
+}

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -237,6 +237,11 @@ public class ScalaBasePlugin implements Plugin<Project> {
                         });
                     }
                 }).getFiles());
+
+                // See https://github.com/gradle/gradle/issues/14434.  We do this so that the incrementalScalaAnalysisForXXX configuration
+                // is resolved during task graph calculation.  It is not an input, but if we leave it to be resolved during task execution,
+                // it can potentially block trying to resolve project dependencies.
+                scalaCompile.dependsOn(incrementalAnalysis);
             }
         });
         JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, scalaSourceSet.getScala(), project, scalaCompile, scalaCompile.map(new Transformer<CompileOptions, ScalaCompile>() {

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -241,7 +241,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 // See https://github.com/gradle/gradle/issues/14434.  We do this so that the incrementalScalaAnalysisForXXX configuration
                 // is resolved during task graph calculation.  It is not an input, but if we leave it to be resolved during task execution,
                 // it can potentially block trying to resolve project dependencies.
-                scalaCompile.dependsOn(incrementalAnalysis);
+                scalaCompile.dependsOn(scalaCompile.getAnalysisFiles());
             }
         });
         JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, scalaSourceSet.getScala(), project, scalaCompile, scalaCompile.map(new Transformer<CompileOptions, ScalaCompile>() {


### PR DESCRIPTION
Fixes #14434 

This resolves issues with the incremental analysis configuration being resolved during task execution and blocking on long-running upstream tasks.