### PR TITLE
Fail when using both toolchain and compatibility

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -28,6 +28,7 @@ import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 import org.gradle.internal.Actions;
 import org.gradle.testing.base.plugins.TestingBasePlugin;
 
@@ -51,10 +52,12 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     private JavaVersion targetCompat;
 
     private boolean autoTargetJvm = true;
+    private final DefaultToolchainSpec toolchainSpec;
 
-    public DefaultJavaPluginConvention(ProjectInternal project, SourceSetContainer sourceSets) {
+    public DefaultJavaPluginConvention(ProjectInternal project, SourceSetContainer sourceSets, DefaultToolchainSpec toolchainSpec) {
         this.project = project;
         this.sourceSets = sourceSets;
+        this.toolchainSpec = toolchainSpec;
         docsDirName = "docs";
         testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
         testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;
@@ -91,7 +94,17 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
 
     @Override
     public JavaVersion getSourceCompatibility() {
-        return srcCompat != null ? srcCompat : JavaVersion.current();
+        if (srcCompat != null) {
+            return srcCompat;
+        } else if (toolchainSpec != null && toolchainSpec.isConfigured()) {
+            return JavaVersion.toVersion(toolchainSpec.getLanguageVersion().get().toString());
+        } else {
+            return JavaVersion.current();
+        }
+    }
+
+    public JavaVersion getRawSourceCompatibility() {
+        return srcCompat;
     }
 
     @Override
@@ -107,6 +120,10 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     @Override
     public JavaVersion getTargetCompatibility() {
         return targetCompat != null ? targetCompat : getSourceCompatibility();
+    }
+
+    public JavaVersion getRawTargetCompatibility() {
+        return targetCompat;
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 
 import java.util.regex.Pattern;
 
@@ -55,18 +54,19 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final Project project;
     private final ModularitySpec modularity;
     private final JvmPluginServices jvmPluginServices;
-    private JavaToolchainSpec toolchain;
+    private final JavaToolchainSpec toolchain;
 
     public DefaultJavaPluginExtension(JavaPluginConvention convention,
                                       Project project,
-                                      JvmPluginServices jvmPluginServices) {
+                                      JvmPluginServices jvmPluginServices,
+                                      JavaToolchainSpec toolchainSpec) {
         this.convention = convention;
         this.objectFactory = project.getObjects();
         this.components = project.getComponents();
         this.project = project;
         this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         this.jvmPluginServices = jvmPluginServices;
-        this.toolchain = objectFactory.newInstance(DefaultToolchainSpec.class);
+        this.toolchain = toolchainSpec;
     }
 
     @Override

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.java.archives.Manifest
 import org.gradle.api.java.archives.internal.DefaultManifest
 import org.gradle.api.plugins.internal.DefaultJavaPluginConvention
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -37,11 +39,12 @@ class DefaultJavaPluginConventionTest extends Specification {
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.create(tmpDir).rootProject()
     def sourceSets = Stub(SourceSetContainer)
+    def toolchainSpec = TestUtil.objectFactory().newInstance(DefaultToolchainSpec)
     private JavaPluginConvention convention
 
     def setup() {
         project.pluginManager.apply(ReportingBasePlugin)
-        convention = new DefaultJavaPluginConvention(project, sourceSets)
+        convention = new DefaultJavaPluginConvention(project, sourceSets, toolchainSpec)
     }
 
     def defaultValues() {
@@ -58,6 +61,16 @@ class DefaultJavaPluginConventionTest extends Specification {
         expect:
         convention.sourceCompatibility == currentJvmVersion
         convention.targetCompatibility == currentJvmVersion
+    }
+
+    def 'source ansd target compatibility default to toolchain spec when it is configured'() {
+        given:
+        toolchainSpec.languageVersion.set(JavaLanguageVersion.of(14))
+
+        expect:
+        convention.sourceCompatibility == JavaVersion.VERSION_14
+        convention.targetCompatibility == JavaVersion.VERSION_14
+
     }
 
     @Test

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.MultipleCandidatesDetails
@@ -261,7 +262,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredJavadocTool.isPresent()
     }
 
-    void 'wires toolchain to java compile source compatibility if toolchain is configured'() {
+    void 'cannot set java compile source compatibility if toolchain is configured'() {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
@@ -270,9 +271,12 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         when:
         def javaCompileTask = project.tasks.named("compileJava", JavaCompile).get()
 
+        javaCompileTask.sourceCompatibility // accessing the property throws
+
+
         then:
-        javaCompileTask.javaCompiler.isPresent()
-        javaCompileTask.sourceCompatibility == javaCompileTask.javaCompiler.get().metadata.languageVersion.toString()
+        def error = thrown(InvalidUserDataException)
+        error.message == 'The new Java toolchain feature cannot be used at the project level in combination with source and/or target compatibility'
     }
 
     private void setupProjectWithToolchain(JavaVersion version) {


### PR DESCRIPTION
With this commit, it is illegal to combine setting the toolchain and the
source / target compatibility at the java extension level.