### PR TITLE
Remove link to "Guides landing page" from nav bar

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -91,7 +91,6 @@
         </div>
         <ul>
             <li><a href="../userguide/userguide.html">Docs Home</a></li>
-            <li><a href="https://guides.gradle.org">Tutorials</a></li>
             <li><a href="../samples/index.html">Samples</a></li>
             <li><a href="../release-notes.html">Release Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#gradle-api" aria-expanded="false" aria-controls="gradle-api">Gradle API</a>


### PR DESCRIPTION
We have integrated most of the guides as samples now and others are linked directly. It makes no sense to have this as a separate main entry that leads to a completely different page (loosing the left side nav bar).
