### PR TITLE
Restore backwards compatibility for Tooling API build actions 

### DIFF
--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
@@ -33,4 +33,10 @@ abstract class UnitTestAndCompileExtension(private val java: JavaPluginExtension
         java.sourceCompatibility = JavaVersion.VERSION_1_6
         java.disableAutoTargetJvm()
     }
+
+    fun usedInToolingApi() {
+        java.targetCompatibility = JavaVersion.VERSION_1_6
+        java.sourceCompatibility = JavaVersion.VERSION_1_6
+        java.disableAutoTargetJvm()
+    }
 }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/shaded-jar.gradle.kts
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/gradlebuild/shaded-jar.gradle.kts
@@ -146,7 +146,7 @@ fun addShadedJarVariant(shadedJarTask: TaskProvider<ShadedJar>) {
             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 6)
         }
         extendsFrom(shadedImplementation)
         outgoing.artifact(shadedJarTask) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/DefaultCountdownTimer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/DefaultCountdownTimer.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.time;
 
-import com.google.common.base.Preconditions;
-
 import java.util.concurrent.TimeUnit;
 
 class DefaultCountdownTimer extends DefaultTimer implements CountdownTimer {
@@ -26,7 +24,9 @@ class DefaultCountdownTimer extends DefaultTimer implements CountdownTimer {
 
     DefaultCountdownTimer(TimeSource timeSource, long timeout, TimeUnit unit) {
         super(timeSource);
-        Preconditions.checkArgument(timeout > 0);
+        if (timeout <= 0) {
+            throw new IllegalArgumentException();
+        }
         this.timeoutMillis = unit.toMillis(timeout);
     }
 

--- a/subprojects/tooling-api/build.gradle.kts
+++ b/subprojects/tooling-api/build.gradle.kts
@@ -96,3 +96,5 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 integrationTestUsesSampleDir("subprojects/tooling-api/src/main")
+
+gradlebuildJava.usedInToolingApi()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
@@ -38,7 +38,7 @@ public class ParameterizedLoadCompositeEclipseModels<T> implements BuildAction<C
 
     @Override
     public Collection<T> execute(BuildController controller) {
-        Collection<T> models = new ArrayList<>();
+        Collection<T> models = new ArrayList<T>();
         collectRootModels(controller, controller.getBuildModel(), models);
         return models;
     }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
@@ -238,7 +238,7 @@ public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
         setup:
         def tapiClientCompilerJdk = AvailableJavaHomes.getJdk(compilerJdkVersion)
         def gradleDaemonJdk = AvailableJavaHomes.getJdk(gradleDaemonJdkVersion)
-        Assume.assumeTrue(tapiClientCompilerJdk && AvailableJavaHomes.getJdk(clientJdkVersion) && gradleDaemonJdk)
+        Assume.assumeTrue(tapiClientCompilerJdk && gradleDaemonJdk)
         setupProject(tapiClientCompilerJdk.getJavaHome())
 
         if (compilerJdkVersion == JavaVersion.VERSION_1_6 && clientJdkVersion in [JavaVersion.VERSION_1_8, JavaVersion.VERSION_11] && gradleDaemonJdkVersion == JavaVersion.VERSION_1_6 && gradleVersion == "2.14.1") {

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
@@ -120,7 +120,7 @@ public class ToolingApiCompatibilityClient {
         GradleConnector connector = GradleConnector.newConnector();
         connector.useGradleVersion(gradleVersion);
 
-        ProjectConnection connection = connector.forProjectDirectory(projectLocation).connect();
+        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$executer.gradleUserHomeDir.absolutePath")).connect();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -140,7 +140,7 @@ public class ToolingApiCompatibilityClient {
         GradleConnector connector = GradleConnector.newConnector();
         connector.useGradleVersion(gradleVersion);
 
-        ProjectConnection connection = connector.forProjectDirectory(projectLocation).connect();
+        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$executer.gradleUserHomeDir.absolutePath")).connect();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
@@ -136,7 +136,7 @@ public class ToolingApiCompatibilityClient {
         succeeds("runTask",
                 "-PclientJdk=" + clientJdkVersion.majorVersion,
                 "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
-                "-PcompilerJdk=" + compilerJdkVersion.majorVersion,
+                "-PcompilerJdk=" + compilerJdkVersion.majorVersion, //compilerJdkVersion.name()
                 "-PgradleVersion=" + gradleVersion)
 
         then:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiJdkCompatibilityTest.groovy
@@ -23,6 +23,9 @@ import spock.lang.Unroll
 
 class ToolingApiJdkCompatibilityTest extends AbstractIntegrationSpec {
     def setupProject(File compilerJavaHome) {
+
+        String gradleUserHome = executer.gradleUserHomeDir.absolutePath.replaceAll("\\\\\\\\", "/").replaceAll("\\\\", "/")
+        String compilerJavaHomePath = compilerJavaHome.absolutePath.replaceAll("\\\\\\\\", "/").replaceAll("\\\\", "/")
         buildFile << """
             plugins {
                 id 'java'
@@ -72,7 +75,7 @@ class ToolingApiJdkCompatibilityTest extends AbstractIntegrationSpec {
             }
         """
         settingsFile << "rootProject.name = 'client-runner'"
-        file('gradle.properties') << "org.gradle.java.installations.paths=$compilerJavaHome.absolutePath"
+        file('gradle.properties') << "org.gradle.java.installations.paths=${compilerJavaHomePath}"
         file("test-project/build.gradle") << "println 'Hello from ' + gradle.gradleVersion"
         file("test-project/settings.gradle") << "rootProject.name = 'target-project'"
         file("src/main/java/ToolingApiCompatibilityClient.java") << """
@@ -120,7 +123,7 @@ public class ToolingApiCompatibilityClient {
         GradleConnector connector = GradleConnector.newConnector();
         connector.useGradleVersion(gradleVersion);
 
-        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$executer.gradleUserHomeDir.absolutePath")).connect();
+        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$gradleUserHome")).connect();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -140,7 +143,7 @@ public class ToolingApiCompatibilityClient {
         GradleConnector connector = GradleConnector.newConnector();
         connector.useGradleVersion(gradleVersion);
 
-        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$executer.gradleUserHomeDir.absolutePath")).connect();
+        ProjectConnection connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(new File("$gradleUserHome")).connect();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/adapter/TypeInspector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/adapter/TypeInspector.java
@@ -65,13 +65,13 @@ class TypeInspector {
             return;
         }
 
-        Set<Type> preventEndlessRecursiveSetInClassDefinition = new HashSet<>();
+        Set<Type> preventEndlessRecursiveSetInClassDefinition = new HashSet<Type>();
         for (Type superType : type.getGenericInterfaces()) {
             visit(superType, types, preventEndlessRecursiveSetInClassDefinition);
         }
 
         for (Method method : type.getDeclaredMethods()) {
-            Set<Type> methodSet = new HashSet<>();
+            Set<Type> methodSet = new HashSet<Type>();
             visit(method.getGenericReturnType(), types, methodSet);
             for (TypeVariable<Method> typeVariable : method.getTypeParameters()) {
                 visit(typeVariable, types, methodSet);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
@@ -62,7 +62,7 @@ class DefaultBuildActionExecuter<T> extends AbstractLongRunningOperation<Default
 
     @Override
     public T run() throws GradleConnectionException {
-        BlockingResultHandler<Object> handler = new BlockingResultHandler<>(Object.class);
+        BlockingResultHandler<Object> handler = new BlockingResultHandler<Object>(Object.class);
         run(handler);
         return Cast.uncheckedNonnullCast(handler.getResult());
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
@@ -34,7 +34,7 @@ public class DefaultGradleConnector extends GradleConnector implements ProjectCo
     private final DistributionFactory distributionFactory;
     private Distribution distribution;
 
-    private final List<DefaultProjectConnection> connections = new ArrayList<>(4);
+    private final List<DefaultProjectConnection> connections = new ArrayList<DefaultProjectConnection>(4);
     private boolean stopped = false;
 
     private final DefaultConnectionParameters.Builder connectionParamsBuilder = DefaultConnectionParameters.builder();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultPhasedActionResultListener.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultPhasedActionResultListener.java
@@ -49,7 +49,7 @@ public class DefaultPhasedActionResultListener implements PhasedActionResultList
 
     private <T> void onComplete(Object result, @Nullable IntermediateResultHandler<T> handler) {
         if (handler != null) {
-            handler.onComplete(Cast.uncheckedNonnullCast(result));
+            handler.onComplete(Cast.<T>uncheckedNonnullCast(result));
         }
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultProjectConnection.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.tooling.internal.consumer;
 
+import org.gradle.api.Transformer;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildLauncher;
@@ -77,12 +78,12 @@ class DefaultProjectConnection implements ProjectConnection {
         if (!modelType.isInterface()) {
             throw new IllegalArgumentException(String.format("Cannot fetch a model of type '%s' as this type is not an interface.", modelType.getName()));
         }
-        return new DefaultModelBuilder<>(modelType, connection, parameters);
+        return new DefaultModelBuilder<T>(modelType, connection, parameters);
     }
 
     @Override
     public <T> BuildActionExecuter<T> action(final BuildAction<T> buildAction) {
-        return new DefaultBuildActionExecuter<>(buildAction, connection, parameters);
+        return new DefaultBuildActionExecuter<T>(buildAction, connection, parameters);
     }
 
     @Override
@@ -92,14 +93,14 @@ class DefaultProjectConnection implements ProjectConnection {
 
     @Override
     public void notifyDaemonsAboutChangedPaths(List<Path> changedPaths) {
-        List<String> absolutePaths = new ArrayList<>(changedPaths.size());
+        final List<String> absolutePaths = new ArrayList<String>(changedPaths.size());
         for (Path changedPath : changedPaths) {
             if (!changedPath.isAbsolute()) {
                 throw new IllegalArgumentException(String.format("Changed path '%s' is not absolute", changedPath));
             }
             absolutePaths.add(changedPath.toString());
         }
-        ConsumerOperationParameters.Builder operationParamsBuilder = ConsumerOperationParameters.builder();
+        final ConsumerOperationParameters.Builder operationParamsBuilder = ConsumerOperationParameters.builder();
         operationParamsBuilder.setCancellationToken(new DefaultCancellationTokenSource().token());
         operationParamsBuilder.setParameters(parameters);
         operationParamsBuilder.setEntryPoint("Notify daemons about changed paths API");
@@ -116,8 +117,13 @@ class DefaultProjectConnection implements ProjectConnection {
                     return null;
                 }
             },
-            new ResultHandlerAdapter<>(new BlockingResultHandler<>(Void.class),
-                new ExceptionTransformer(throwable -> String.format("Could not notify daemons about changed paths: %s.", connection.getDisplayName()))
+            new ResultHandlerAdapter<Void>(new BlockingResultHandler<Void>(Void.class),
+                new ExceptionTransformer(new Transformer<String, Throwable>() {
+                    @Override
+                    public String transform(Throwable throwable) {
+                        return String.format("Could not notify daemons about changed paths: %s.", connection.getDisplayName());
+                    }
+                })
             ));
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -47,7 +47,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     private final Set<String> testClassNames = new LinkedHashSet<String>();
     private final Set<InternalJvmTestRequest> internalJvmTestRequests = new LinkedHashSet<InternalJvmTestRequest>();
     private final DefaultDebugOptions debugOptions = new DefaultDebugOptions();
-    private final Map<String, List<InternalJvmTestRequest>> tasksAndTests = new HashMap<>();
+    private final Map<String, List<InternalJvmTestRequest>> tasksAndTests = new HashMap<String, List<InternalJvmTestRequest>>();
 
     public DefaultTestLauncher(AsyncConsumerActionExecutor connection, ConnectionParameters parameters) {
         super(parameters);
@@ -125,7 +125,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     }
 
     @Override
-    public TestLauncher withTaskAndTestMethods(String task, String testClass, Iterable<String> methods) {
+    public TestLauncher withTaskAndTestMethods(String task, final String testClass, Iterable<String> methods) {
         List<InternalJvmTestRequest> tests = CollectionUtils.collect(methods, new Transformer<InternalJvmTestRequest, String>() {
             @Override
             public InternalJvmTestRequest transform(String methodName) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
@@ -56,15 +56,23 @@ public class DefaultAsyncConsumerActionExecutor implements AsyncConsumerActionEx
 
     @Override
     public <T> void run(final ConsumerAction<? extends T> action, final ResultHandlerVersion1<? super T> handler) {
-        lifecycle.use(() -> executor.execute(() -> {
-            T result;
-            try {
-                result = actionExecutor.run(action);
-            } catch (Throwable t) {
-                handler.onFailure(t);
-                return;
+        lifecycle.use(new Runnable() {
+            @Override
+            public void run() {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        T result;
+                        try {
+                            result = actionExecutor.run(action);
+                        } catch (Throwable t) {
+                            handler.onFailure(t);
+                            return;
+                        }
+                        handler.onComplete(result);
+                    }
+                });
             }
-            handler.onComplete(result);
-        }));
+        });
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
@@ -96,7 +96,7 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     }
 
     private void sendStopWhenIdleMessageToDaemons() {
-        ConsumerOperationParameters.Builder builder = ConsumerOperationParameters.builder();
+        final ConsumerOperationParameters.Builder builder = ConsumerOperationParameters.builder();
         builder.setCancellationToken(new DefaultCancellationTokenSource().token());
         builder.setParameters(connectionParameters);
         builder.setEntryPoint("Request daemon shutdown when idle");


### PR DESCRIPTION
This is a follow-up PR to #14444 fixing the Tooling API backward compatibility with older Gradle versions.

### Expected behavior

The Toolin API client should be able to send build actions to any Gradle versions running on any supported Gradle versions.

The combinations expected to work:

- The lowest supported Gradle version is 2.6

- The target Gradle can run on the following Java versions

  - [2.6, 2.14.1] can run on Java 6-8
  - [3.0, 4.6] can run on Java 7-9
  - [5.0, 5.3.1] can run on Java 8-11	
  - [5.4, 5.6.4] can run on Java 8-12
  - [6.0, 6.2.2] can run on Java 8-13
  - [6.0, 6.2.2] can run on Java 8-13
  - [6.3, 6.6.1] can run on Java 8-14

- The build action should be compiled with the same or lower Java target compatibility as the JDK hosting the target Gradle version

- The build action should be compiled to the same or lower Java version the target Gradle version is running on

### Actual behavior

A large subset of the expected combination is not working. There are several reports indicating that older Gradle versions running on Java 6 and on java 7 cannot work with build actions. IntelliJ IDEA is heavily affected: https://youtrack.jetbrains.com/issue/IDEA-248727

### Implementation details

The main issue is that the Java version requirement for the Tooling API implementation is bumped to Java 8. This includes the `BuildAction` interface to be compiled with Java 8 target compatibility. Even if the concrete `BuildAction` implementation was compiled with Java 6, the provider side (the target Gradle version) was not able to load it due to the incompatible superclass, which is loaded from the client.

To fix this issue, the Tooling API subproject is now compiled with Java 6 source and target compatibility. 

Changing the compatibility to 6 is not a complete solution on its own. The `ProtocolToModelAdapter` class had some dependencies that are compiled with Java 8 and are part of the Tooling API jar. All those dependencies needed to be inlined to the `tooling-api` subproject in order to restore the backward compatibility.