### PR TITLE
Fix project dependency substitution in generated metadata files

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -598,6 +598,7 @@ $append
     // Ideally we should warn when such things happen (linting).
     @Unroll
     @Issue("https://github.com/gradle/gradle/issues/14039")
+    @ToBeFixedForConfigurationCache
     def "substituted project dependencies are also substituted in the generated Ivy file"() {
         createBuildScripts("""
             dependencies {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -596,7 +596,6 @@ $append
     // for a first level dependency? However it may be that you implicitly get a
     // substitution rule (via a plugin for example) that you are not aware of.
     // Ideally we should warn when such things happen (linting).
-    @Unroll
     @Issue("https://github.com/gradle/gradle/issues/14039")
     @ToBeFixedForConfigurationCache
     def "substituted project dependencies are also substituted in the generated Ivy file"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.publish.ivy
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublication
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.ivy.IvyJavaModule
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTest  {
@@ -590,4 +591,67 @@ $append
         javaLibrary.assertApiDependencies("org:foo:1.1")
         javaLibrary.assertRuntimeDependencies("org:foo:1.0")
     }
+
+    // This is a weird test case, because why would you have a substitution rule
+    // for a first level dependency? However it may be that you implicitly get a
+    // substitution rule (via a plugin for example) that you are not aware of.
+    // Ideally we should warn when such things happen (linting).
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/14039")
+    def "substituted project dependencies are also substituted in the generated Ivy file"() {
+        createBuildScripts("""
+            dependencies {
+                implementation project(":a")
+            }
+
+            configurations.all {
+                resolutionStrategy.dependencySubstitution {
+                    substitute(project(':a')).with(project(':b'))
+                }
+            }
+
+            publishing {
+                publications {
+                    maven(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            ${apiUsingUsage()}
+                            ${runtimeUsingUsage()}
+                        }
+                    }
+
+                }
+            }
+        """)
+        settingsFile << """
+            include 'a'
+            include 'b'
+        """
+        file("a/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'com.first'
+            version = '1.1'
+        """
+        file("b/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'com.second'
+            version = '1.2'
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'com.second:b:1.2')
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            dependency("com.second", "b", "1.2")
+            noMoreDependencies()
+        }
+    }
+
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
@@ -105,4 +105,9 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     public ImmutableAttributes getAttributes() {
         return attributes;
     }
+
+    @Override
+    public String getProjectPath() {
+        return null;
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyProjectDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyProjectDependency.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.ivy.internal.dependency;
+
+import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+public class DefaultIvyProjectDependency implements IvyDependencyInternal {
+    private final IvyDependencyInternal delegate;
+    private final String projectPath;
+
+    public DefaultIvyProjectDependency(IvyDependencyInternal delegate, String projectPath) {
+        this.delegate = delegate;
+        this.projectPath = projectPath;
+    }
+
+    @Override
+    public Iterable<DependencyArtifact> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public Iterable<ExcludeRule> getExcludeRules() {
+        return delegate.getExcludeRules();
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public String getOrganisation() {
+        return delegate.getOrganisation();
+    }
+
+    @Override
+    public String getModule() {
+        return delegate.getModule();
+    }
+
+    @Override
+    public String getRevision() {
+        return delegate.getRevision();
+    }
+
+    @Override
+    public String getConfMapping() {
+        return delegate.getConfMapping();
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return delegate.isTransitive();
+    }
+
+    @Override
+    public String getProjectPath() {
+        return projectPath;
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
@@ -27,4 +27,6 @@ public interface IvyDependencyInternal extends IvyDependency {
     Iterable<ExcludeRule> getExcludeRules();
 
     ImmutableAttributes getAttributes();
+
+    String getProjectPath();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -68,6 +68,7 @@ import org.gradle.api.publish.ivy.internal.artifact.SingleOutputTaskIvyArtifact;
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependency;
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependencySet;
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyExcludeRule;
+import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyProjectDependency;
 import org.gradle.api.publish.ivy.internal.dependency.IvyDependencyInternal;
 import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
@@ -424,8 +425,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     private void addProjectDependency(ProjectDependency dependency, String confMapping) {
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, dependency);
-        ivyDependencies.add(new DefaultIvyDependency(
-                identifier.getGroup(), identifier.getName(), identifier.getVersion(), confMapping, dependency.isTransitive(), Collections.<DependencyArtifact>emptyList(), dependency.getExcludeRules()));
+        DefaultIvyDependency moduleDep = new DefaultIvyDependency(
+            identifier.getGroup(), identifier.getName(), identifier.getVersion(), confMapping, dependency.isTransitive(), Collections.<DependencyArtifact>emptyList(), dependency.getExcludeRules());
+        ivyDependencies.add(new DefaultIvyProjectDependency(moduleDep, dependency.getDependencyProject().getPath()));
     }
 
     private void addExternalDependency(ExternalDependency dependency, String confMapping, ImmutableAttributes attributes) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -260,7 +260,8 @@ public class IvyDescriptorFileGenerator {
         for (IvyDependencyInternal dependency : dependencies) {
             String org = dependency.getOrganisation();
             String module = dependency.getModule();
-            ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(dependency.getAttributes()).maybeResolveVersion(org, module);
+            String projectPath  = dependency.getProjectPath();
+            ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(dependency.getAttributes()).maybeResolveVersion(org, module, projectPath);
             if (resolvedVersion != null) {
                 org = resolvedVersion.getGroup();
                 module = resolvedVersion.getName();

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy.internal.publication
 
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
@@ -160,7 +161,9 @@ class DefaultIvyPublicationTest extends Specification {
     def "maps project dependency to ivy dependency"() {
         given:
         def publication = createPublication()
-        def projectDependency = Mock(ProjectDependency)
+        def projectDependency = Mock(ProjectDependency) {
+            getDependencyProject() >> Mock(Project)
+        }
         def exclude = Mock(ExcludeRule)
 
         and:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -605,7 +605,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     // for a first level dependency? However it may be that you implicitly get a
     // substitution rule (via a plugin for example) that you are not aware of.
     // Ideally we should warn when such things happen (linting).
-    @Unroll
     @Issue("https://github.com/gradle/gradle/issues/14039")
     def "substituted project dependencies are also substituted in the generated POM file"() {
         createBuildScripts("""

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.publish.maven
 import org.gradle.api.attributes.Category
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenJavaModule
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishIntegTest {
@@ -598,6 +599,75 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
             }
             """
         ]
+    }
+
+    // This is a weird test case, because why would you have a substitution rule
+    // for a first level dependency? However it may be that you implicitly get a
+    // substitution rule (via a plugin for example) that you are not aware of.
+    // Ideally we should warn when such things happen (linting).
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/14039")
+    def "substituted project dependencies are also substituted in the generated POM file"() {
+        createBuildScripts("""
+            dependencies {
+                implementation project(":a")
+            }
+
+            configurations.all {
+                resolutionStrategy.dependencySubstitution {
+                    substitute(project(':a')).with(project(':b'))
+                }
+            }
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                        versionMapping {
+                            ${apiUsingUsage()}
+                            ${runtimeUsingUsage()}
+                        }
+                    }
+
+                }
+            }
+        """)
+        settingsFile << """
+            include 'a'
+            include 'b'
+        """
+        file("a/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'com.first'
+            version = '1.1'
+        """
+        file("b/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'com.second'
+            version = '1.2'
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
+        javaLibrary.assertPublished()
+        javaLibrary.parsedPom.scope("runtime") {
+            assert dependencies.size() == 1
+            def deps = dependencies.values()
+            assert deps[0].artifactId == 'b' // because of substitution
+            assert deps[0].groupId == 'com.second'
+            assert deps[0].version == '1.2'
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            dependency("com.second", "b", "1.2")
+            noMoreDependencies()
+        }
     }
 
     def "can substitute with a project dependency"() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/DefaultMavenDependency.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/DefaultMavenDependency.java
@@ -77,9 +77,14 @@ public class DefaultMavenDependency implements MavenDependencyInternal {
     public Collection<DependencyArtifact> getArtifacts() {
         return artifacts;
     }
-    
+
     @Override
     public Collection<ExcludeRule> getExcludeRules() {
         return excludeRules;
+    }
+
+    @Override
+    public String getProjectPath() {
+        return null;
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/DefaultMavenProjectDependency.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/DefaultMavenProjectDependency.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.maven.internal.dependencies;
+
+import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class DefaultMavenProjectDependency implements MavenDependencyInternal {
+    private final MavenDependencyInternal delegate;
+    private final String projectPath;
+
+    public DefaultMavenProjectDependency(MavenDependencyInternal delegate, String projectPath) {
+        this.delegate = delegate;
+        this.projectPath = projectPath;
+    }
+
+    @Override
+    public Collection<DependencyArtifact> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public Collection<ExcludeRule> getExcludeRules() {
+        return delegate.getExcludeRules();
+    }
+
+    @Override
+    public String getProjectPath() {
+        return projectPath;
+    }
+
+    @Override
+    public String getGroupId() {
+        return delegate.getGroupId();
+    }
+
+    @Override
+    public String getArtifactId() {
+        return delegate.getArtifactId();
+    }
+
+    @Override
+    public String getVersion() {
+        return delegate.getVersion();
+    }
+
+    @Override
+    @Nullable
+    public String getType() {
+        return delegate.getType();
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenDependencyInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenDependencyInternal.java
@@ -24,4 +24,5 @@ import java.util.Collection;
 public interface MavenDependencyInternal extends MavenDependency {
     Collection<DependencyArtifact> getArtifacts();
     Collection<ExcludeRule> getExcludeRules();
+    String getProjectPath();
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -74,6 +74,7 @@ import org.gradle.api.publish.maven.internal.artifact.DefaultMavenArtifactSet;
 import org.gradle.api.publish.maven.internal.artifact.DerivedMavenArtifact;
 import org.gradle.api.publish.maven.internal.artifact.SingleOutputTaskMavenArtifact;
 import org.gradle.api.publish.maven.internal.dependencies.DefaultMavenDependency;
+import org.gradle.api.publish.maven.internal.dependencies.DefaultMavenProjectDependency;
 import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MutableMavenProjectIdentity;
@@ -457,7 +458,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     private void addProjectDependency(ProjectDependency dependency, Set<ExcludeRule> globalExcludes, Set<MavenDependencyInternal> dependencies) {
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, dependency);
-        dependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion(), Collections.emptyList(), getExcludeRules(globalExcludes, dependency)));
+        DefaultMavenDependency moduleDependency = new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion(), Collections.emptyList(), getExcludeRules(globalExcludes, dependency));
+        dependencies.add(new DefaultMavenProjectDependency(moduleDependency, dependency.getDependencyProject().getPath()));
     }
 
     private void addModuleDependency(ModuleDependency dependency, Set<ExcludeRule> globalExcludes, Set<MavenDependencyInternal> dependencies) {
@@ -471,7 +473,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private void addDependencyConstraint(DefaultProjectDependencyConstraint dependency, Set<MavenDependency> dependencies) {
         ProjectDependency projectDependency = dependency.getProjectDependency();
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, projectDependency);
-        dependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion()));
+        DefaultMavenDependency moduleDependency = new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion());
+        dependencies.add(new DefaultMavenProjectDependency(moduleDependency, projectDependency.getDependencyProject().getPath()));
     }
 
     private static Set<ExcludeRule> getExcludeRules(Set<ExcludeRule> globalExcludes, ModuleDependency dependency) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -260,15 +260,15 @@ public class MavenPomFileGenerator {
     }
 
     public void addApiDependencyManagement(MavenDependency apiDependency) {
-        addDependencyManagement(apiDependency, "compile");
+        addDependencyManagement((MavenDependencyInternal) apiDependency, "compile");
     }
 
     public void addRuntimeDependencyManagement(MavenDependency dependency) {
-        addDependencyManagement(dependency, "runtime");
+        addDependencyManagement((MavenDependencyInternal) dependency, "runtime");
     }
 
     public void addImportDependencyManagement(MavenDependency dependency) {
-        addDependencyManagement(dependency, "import");
+        addDependencyManagement((MavenDependencyInternal) dependency, "import");
     }
 
     public void addRuntimeDependency(MavenDependencyInternal dependency) {
@@ -303,8 +303,9 @@ public class MavenPomFileGenerator {
         Dependency mavenDependency = new Dependency();
         String groupId = dependency.getGroupId();
         String dependencyVersion = dependency.getVersion();
+        String projectPath = dependency.getProjectPath();
         ImmutableAttributes attributes = attributesForScope(scope);
-        ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(attributes).maybeResolveVersion(groupId, artifactId);
+        ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(attributes).maybeResolveVersion(groupId, artifactId, projectPath);
         mavenDependency.setGroupId(resolvedVersion != null ? resolvedVersion.getGroup() : groupId);
         mavenDependency.setArtifactId(resolvedVersion != null ? resolvedVersion.getName() : artifactId);
         mavenDependency.setVersion(resolvedVersion != null ? resolvedVersion.getVersion() : mapToMavenSyntax(dependencyVersion));
@@ -335,12 +336,13 @@ public class MavenPomFileGenerator {
         throw new IllegalStateException("Unexpected scope : " + scope);
     }
 
-    private void addDependencyManagement(MavenDependency dependency, String scope) {
+    private void addDependencyManagement(MavenDependencyInternal dependency, String scope) {
         Dependency mavenDependency = new Dependency();
         String groupId = dependency.getGroupId();
         String artifactId = dependency.getArtifactId();
+        String projectPath = dependency.getProjectPath();
         ImmutableAttributes attributes = attributesForScope(scope);
-        ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(attributes).maybeResolveVersion(groupId, artifactId);
+        ModuleVersionIdentifier resolvedVersion = versionMappingStrategy.findStrategyForVariant(attributes).maybeResolveVersion(groupId, artifactId, projectPath);
         mavenDependency.setGroupId(resolvedVersion != null ? resolvedVersion.getGroup() : groupId);
         mavenDependency.setArtifactId(resolvedVersion != null ? resolvedVersion.getName() : artifactId);
         mavenDependency.setVersion(resolvedVersion == null ? mapToMavenSyntax(dependency.getVersion()) : resolvedVersion.getVersion());

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.publish.maven.internal.publication
 
 import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
@@ -391,7 +392,9 @@ class DefaultMavenPublicationTest extends Specification {
     def "maps project dependency to maven dependency"() {
         given:
         def publication = createPublication()
-        def projectDependency = Mock(ProjectDependency)
+        def projectDependency = Mock(ProjectDependency) {
+            getDependencyProject() >> Mock(Project)
+        }
 
         and:
         projectDependency.excludeRules >> []

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
@@ -52,7 +52,7 @@ class MavenPomFileGeneratorTest extends Specification {
     def rangeMapper = Stub(VersionRangeMapper)
     def strategy = Stub(VersionMappingStrategyInternal) {
         findStrategyForVariant(_) >> Stub(VariantVersionMappingStrategyInternal) {
-            maybeResolveVersion(_, _) >> null
+            maybeResolveVersion(_, _, _) >> null
         }
     }
     def generator = new MavenPomFileGenerator(projectIdentity, rangeMapper, strategy, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, false)

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -285,7 +285,7 @@ class ModuleMetadataSpecBuilder {
         String name = dependency.getName();
         String resolvedVersion = null;
         if (versionMappingStrategy != null) {
-            ModuleVersionIdentifier resolvedVersionId = versionMappingStrategy.maybeResolveVersion(group, name);
+            ModuleVersionIdentifier resolvedVersionId = versionMappingStrategy.maybeResolveVersion(group, name, null);
             if (resolvedVersionId != null) {
                 group = resolvedVersionId.getGroup();
                 name = resolvedVersionId.getName();
@@ -309,7 +309,8 @@ class ModuleMetadataSpecBuilder {
             ModuleVersionIdentifier resolved =
                 versionMappingStrategy.maybeResolveVersion(
                     identifier.getGroup(),
-                    identifier.getName()
+                    identifier.getName(),
+                    projectDependency.getDependencyProject().getPath()
                 );
             if (resolved != null) {
                 identifier = resolved;
@@ -373,23 +374,26 @@ class ModuleMetadataSpecBuilder {
         return dependencyConstraints;
     }
 
-    private ModuleMetadataSpec.DependencyConstraint dependencyConstraintFor(DependencyConstraint dependencyConstraint, VariantVersionMappingStrategyInternal variantVersionMappingStrategy) {
+    private ModuleMetadataSpec.DependencyConstraint dependencyConstraintFor(DependencyConstraint dependencyConstraint,
+                                                                            VariantVersionMappingStrategyInternal variantVersionMappingStrategy) {
         String group;
         String module;
         String resolvedVersion = null;
+        String projectPath = null;
         if (dependencyConstraint instanceof DefaultProjectDependencyConstraint) {
             DefaultProjectDependencyConstraint dependency = (DefaultProjectDependencyConstraint) dependencyConstraint;
             ProjectDependency projectDependency = dependency.getProjectDependency();
             ModuleVersionIdentifier identifier = moduleIdentifierFor(projectDependency);
             group = identifier.getGroup();
             module = identifier.getName();
+            projectPath = projectDependency.getDependencyProject().getPath();
             resolvedVersion = identifier.getVersion();
         } else {
             group = dependencyConstraint.getGroup();
             module = dependencyConstraint.getName();
         }
         ModuleVersionIdentifier resolvedVersionId = variantVersionMappingStrategy != null
-            ? variantVersionMappingStrategy.maybeResolveVersion(group, module)
+            ? variantVersionMappingStrategy.maybeResolveVersion(group, module, projectPath)
             : null;
         String effectiveGroup = resolvedVersionId != null ? resolvedVersionId.getGroup() : group;
         String effectiveModule = resolvedVersionId != null ? resolvedVersionId.getName() : module;

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/VariantVersionMappingStrategyInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/VariantVersionMappingStrategyInternal.java
@@ -18,6 +18,8 @@ package org.gradle.api.publish.internal.versionmapping;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 
+import javax.annotation.Nullable;
+
 public interface VariantVersionMappingStrategyInternal extends VariantVersionMappingStrategy {
-    ModuleVersionIdentifier maybeResolveVersion(String group, String module);
+    ModuleVersionIdentifier maybeResolveVersion(String group, String module, @Nullable String projectPath);
 }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -985,7 +985,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         def publication = publication(component, id, mappingStrategy)
 
         mappingStrategy.findStrategyForVariant(_) >> variantMappingStrategy
-        variantMappingStrategy.maybeResolveVersion(_ as String, _ as String) >> { String group, String name ->
+        variantMappingStrategy.maybeResolveVersion(_ as String, _ as String, _) >> { String group, String name, String projectPath ->
             DefaultModuleVersionIdentifier.newId(group, name, 'v99')
         }
 


### PR DESCRIPTION
This commit adds handling of project dependency substitutions to
other projects. Previously, if a project was substituted with
another project, then when publishing resolved versions, the
substituted project wouldn't be replaced with the target project
in the generated metadata files (pom.xml, ivy.xml and Gradle
Module Metadata). While this is certainly an edge case that
shouldn't be encouraged, this properly handles the bug.

Fixes #14039

