### PR TITLE
Introduce a lazy GUtil version of elvis

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -21,6 +21,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.io.StreamByteBuffer;
 
@@ -151,9 +152,18 @@ public class GUtil {
         }
         return true;
     }
-
-    public static <T> T elvis(@Nullable T object, T defaultValue) {
+    /**
+     * Prefer {@link #getOrDefault(Object, Factory)} if the value is expensive to compute or
+     * would trigger early configuration.
+     */
+    @Nullable
+    public static <T> T elvis(@Nullable T object, @Nullable T defaultValue) {
         return isTrue(object) ? object : defaultValue;
+    }
+
+    @Nullable
+    public static <T> T getOrDefault(@Nullable T object, Factory<T> defaultValueSupplier) {
+        return isTrue(object) ? object : defaultValueSupplier.create();
     }
 
     public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V> src) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifact.java
@@ -62,27 +62,27 @@ public class ArchivePublishArtifact extends AbstractPublishArtifact implements C
 
     @Override
     public String getExtension() {
-        return GUtil.elvis(extension, archiveTask.getArchiveExtension().getOrNull());
+        return GUtil.getOrDefault(extension, () -> archiveTask.getArchiveExtension().getOrNull());
     }
 
     @Override
     public String getType() {
-        return GUtil.elvis(type, archiveTask.getArchiveExtension().getOrNull());
+        return GUtil.getOrDefault(type, () -> archiveTask.getArchiveExtension().getOrNull());
     }
 
     @Override
     public String getClassifier() {
-        return GUtil.elvis(classifier, archiveTask.getArchiveClassifier().getOrNull());
+        return GUtil.getOrDefault(classifier, () -> archiveTask.getArchiveClassifier().getOrNull());
     }
 
     @Override
     public File getFile() {
-        return GUtil.elvis(file, archiveTask.getArchiveFile().get().getAsFile());
+        return GUtil.getOrDefault(file, () -> archiveTask.getArchiveFile().get().getAsFile());
     }
 
     @Override
     public Date getDate() {
-        return GUtil.elvis(date, new Date(archiveTask.getArchiveFile().get().getAsFile().lastModified()));
+        return GUtil.getOrDefault(date, () -> new Date(archiveTask.getArchiveFile().get().getAsFile().lastModified()));
     }
 
     public AbstractArchiveTask getArchiveTask() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
@@ -48,17 +48,17 @@ public class DecoratingPublishArtifact extends AbstractPublishArtifact implement
 
     @Override
     public String getName() {
-        return GUtil.elvis(name, publishArtifact.getName());
+        return GUtil.getOrDefault(name, publishArtifact::getName);
     }
 
     @Override
     public String getExtension() {
-        return GUtil.elvis(extension, publishArtifact.getExtension());
+        return GUtil.getOrDefault(extension, publishArtifact::getExtension);
     }
 
     @Override
     public String getType() {
-        return GUtil.elvis(type, publishArtifact.getType());
+        return GUtil.getOrDefault(type, publishArtifact::getType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
@@ -103,7 +103,7 @@ public class DefaultProjectRegistry<T extends ProjectIdentifier> implements Proj
 
     @Override
     public Set<T> getSubProjects(String path) {
-        return GUtil.elvis(subProjects.get(path), new HashSet<T>());
+        return GUtil.getOrDefault(subProjects.get(path), HashSet::new);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifactTest.groovy
@@ -17,7 +17,10 @@
 package org.gradle.api.internal.artifacts.publish
 
 import org.gradle.api.Task
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.tasks.TaskDependency
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class DecoratingPublishArtifactTest extends Specification {
     def "can override properties"() {
@@ -54,5 +57,28 @@ class DecoratingPublishArtifactTest extends Specification {
 
         then:
         decorator.classifier == null
+    }
+
+    @Unroll
+    def "if an explicit #field is set don't query the publish artifact"() {
+        def delegate = Mock(PublishArtifact) {
+            getBuildDependencies() >> Stub(TaskDependency)
+        }
+        def decorator = new DecoratingPublishArtifact(delegate)
+        decorator."$field" = 'foo'
+
+        when:
+        decorator."$field"
+
+        then:
+        0 * delegate."$field"
+        0 * _
+
+        where:
+        field << [
+            'name',
+            'extension',
+            'type'
+        ]
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocExecHandleBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocExecHandleBuilder.java
@@ -75,7 +75,7 @@ public class JavadocExecHandleBuilder {
 
         ExecAction execAction = execActionFactory.newExecAction();
         execAction.workingDir(execDirectory);
-        execAction.executable(GUtil.elvis(executable, Jvm.current().getJavadocExecutable()));
+        execAction.executable(GUtil.getOrDefault(executable, () -> Jvm.current().getJavadocExecutable()));
         execAction.args("@" + optionsFile.getAbsolutePath());
 
         options.contributeCommandLineOptions(execAction);

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
@@ -92,8 +92,8 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
         Set<String> allSections = Sets.union(baseManifest.getSections().keySet(), toMergeManifest.getSections().keySet());
         for (String section : allSections) {
             mergeSection(section, mergedManifest,
-                    GUtil.elvis(baseManifest.getSections().get(section), new DefaultAttributes()),
-                    GUtil.elvis(toMergeManifest.getSections().get(section), new DefaultAttributes()));
+                    GUtil.getOrDefault(baseManifest.getSections().get(section), DefaultAttributes::new),
+                    GUtil.getOrDefault(toMergeManifest.getSections().get(section), DefaultAttributes::new));
         }
         return mergedManifest;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/AbstractNativeComponentSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/AbstractNativeComponentSpec.java
@@ -30,7 +30,7 @@ public abstract class AbstractNativeComponentSpec extends BaseComponentSpec impl
 
     @Override
     public String getBaseName() {
-        return GUtil.elvis(baseName, getName());
+        return GUtil.getOrDefault(baseName, this::getName);
     }
 
     @Override

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -52,7 +52,6 @@ import org.gradle.util.VersionNumber;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,11 +63,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2012;
-import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2013;
-import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2015;
-import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2017;
-import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2019;
+import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.*;
 
 public class AvailableToolChains {
     private static final Comparator<ToolChainCandidate> LATEST_RELEASED_FIRST = Collections.reverseOrder(new Comparator<ToolChainCandidate>() {
@@ -268,12 +263,7 @@ public class AvailableToolChains {
 
         // On Linux, we assume swift is installed into /opt/swift
         File rootSwiftInstall = new File("/opt/swift");
-        File[] swiftCandidates = GUtil.elvis(rootSwiftInstall.listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File swiftInstall) {
-                return swiftInstall.isDirectory() && !swiftInstall.getName().equals("latest");
-            }
-        }), new File[0]);
+        File[] swiftCandidates = GUtil.getOrDefault(rootSwiftInstall.listFiles(swiftInstall -> swiftInstall.isDirectory() && !swiftInstall.getName().equals("latest")), () -> new File[0]);
 
         for (File swiftInstall : swiftCandidates) {
             File swiftc = new File(swiftInstall, "/usr/bin/swiftc");
@@ -743,7 +733,7 @@ public class AvailableToolChains {
 
         // On macOS, we assume co-located Xcode is installed into /opt/xcode
         File rootXcodeInstall = new File("/opt/xcode");
-        List<File> xcodeCandidates = Lists.newArrayList(Arrays.asList(GUtil.elvis(rootXcodeInstall.listFiles(xcodeInstall -> xcodeInstall.isDirectory()), new File[0])));
+        List<File> xcodeCandidates = Lists.newArrayList(Arrays.asList(GUtil.getOrDefault(rootXcodeInstall.listFiles(File::isDirectory), () -> new File[0])));
         xcodeCandidates.add(new File("/Applications/Xcode.app")); // Default Xcode installation
         xcodeCandidates.stream().filter(File::exists).forEach(xcodeInstall -> {
             TestFile xcodebuild = new TestFile("/usr/bin/xcodebuild");

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/PlayPlatformResolver.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/PlayPlatformResolver.java
@@ -75,7 +75,7 @@ public class PlayPlatformResolver implements PlatformResolver<PlayPlatform> {
     }
 
     private ScalaPlatform getScalaPlatform(PlayMajorVersion playMajorVersion, String preferredScalaVersion) {
-        String scalaVersion = GUtil.elvis(preferredScalaVersion, playMajorVersion.getDefaultScalaPlatform());
+        String scalaVersion = GUtil.getOrDefault(preferredScalaVersion, playMajorVersion::getDefaultScalaPlatform);
         ScalaPlatform scalaPlatform = createScalaPlatform(scalaVersion);
 
         playMajorVersion.validateCompatible(scalaPlatform);


### PR DESCRIPTION
The GUtil.elvis method had the drawback of requiring
to provide a _value_ in case the tested value wasn't null.
In short, it works differently from an `if` because it forces
the compute the "else" value even if we never need it.

This commit introduces `getOrDefault` which uses a lambda
for the "default" value instead, which is lazy.

It also fixes the contract of `elvis` which could effectively
take a nullable as the default value _and_ return `null`.

Fixes #14237
