### PR TITLE
Fallback to current VM for JavaExecHandleBuilder

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -123,7 +123,11 @@ public class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public JavaForkOptionsInternal newJavaForkOptions() {
-        return new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
+        final DefaultJavaForkOptions forkOptions = new DefaultJavaForkOptions(fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions());
+        if (forkOptions.getExecutable() == null) {
+            forkOptions.setExecutable(Jvm.current().getJavaExecutable());
+        }
+        return forkOptions;
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -57,7 +57,6 @@ class JavaExecHandleBuilderTest extends Specification {
         builder.minHeapSize = "64m"
         builder.maxHeapSize = "1g"
         builder.defaultCharacterEncoding = inputEncoding
-        builder.setExecutable(Jvm.current().getJavaExecutable().getAbsolutePath())
 
         when:
         List jvmArgs = builder.getAllJvmArgs()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -547,7 +547,6 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
     @Requires(TestPrecondition.JDK13_OR_EARLIER)
     @Issue('https://plugins.gradle.org/plugin/io.freefair.aspectj')
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
-    @Ignore
     def 'freefair aspectj plugin'() {
         given:
         buildFile << """

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.util.VersionNumber
 import org.gradle.util.ports.ReleasingPortAllocator
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 


### PR DESCRIPTION
Some plugins use these internals and rely on the fact
that the executable is configured.