### PR TITLE
Fix handling of deleted files when using verification

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -917,7 +917,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         javaLibrary()
         uncheckedModule("org", "foo")
         uncheckedModule("org", "bar", "1.0") {
-            artifact(classifier:'classy')
+            artifact(classifier: 'classy')
         }
         buildFile << """
             dependencies {
@@ -1013,7 +1013,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         )
         MavenFileModule otherFile = alternateRepo.module("org", "foo", "1.0")
             .publish()
-        otherFile.artifactFile.bytes = [0,0,0,0]
+        otherFile.artifactFile.bytes = [0, 0, 0, 0]
 
         buildFile << """
             dependencies {
@@ -1309,15 +1309,8 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         run ":help", "--offline"
 
         then:
-        hasModules(["org:foo"])
+        hasModules(artifact == 'pom' ? [] : ["org:foo"])
 
-        and:
-        if (artifact == 'pom') {
-            // there's a technical limitation due to the code path used for regular artifacts
-            // which makes it that we don't even try to snapshot if the file is missing so we can't
-            // provide an error message
-            outputContains("Cannot compute checksum for")
-        }
         where:
         artifact << ['jar', 'pom']
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
@@ -57,7 +57,7 @@ public class WritableArtifactCacheLockingManager implements ArtifactCacheLocking
     }
 
     private CleanupAction createCleanupAction(ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, UsedGradleVersions usedGradleVersions) {
-        long maxAgeInDays = DEFAULT_MAX_AGE_IN_DAYS_FOR_EXTERNAL_CACHE_ENTRIES;
+        long maxAgeInDays = Long.getLong("org.gradle.internal.cleanup.external.max.age", DEFAULT_MAX_AGE_IN_DAYS_FOR_EXTERNAL_CACHE_ENTRIES);
         return CompositeCleanupAction.builder()
                 .add(UnusedVersionsCacheCleanup.create(CacheLayout.ROOT.getName(), CacheLayout.ROOT.getVersionMapping(), usedGradleVersions))
                 .add(cacheMetaData.getExternalResourcesStoreDirectory(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -48,10 +48,12 @@ import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResu
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
+import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DependencyVerifyingModuleComponentRepository implements ModuleComponentRepository {
     private final ModuleComponentRepository delegate;
@@ -117,20 +119,28 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
 
         @Override
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
-            delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
-            if (hasUsableResult(result)) {
-                result.getMetaData().getSources().withSources(DefaultMetadataFileSource.class, metadataFileSource -> {
+            // For metadata, because the local file can be deleted we have to proceed in two steps
+            // First resolve with a tmp result, and if it's found and that the file is still present
+            // we can perform verification. If it's missing, then we do nothing so that it's downloaded
+            // and verified later.
+            BuildableModuleComponentMetaDataResolveResult tmp = new DefaultBuildableModuleComponentMetaDataResolveResult();
+            delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, tmp);
+            AtomicBoolean ignore = new AtomicBoolean();
+            if (hasUsableResult(tmp)) {
+                tmp.getMetaData().getSources().withSources(DefaultMetadataFileSource.class, metadataFileSource -> {
                     ModuleComponentArtifactIdentifier artifact = metadataFileSource.getArtifactId();
                     if (isExternalArtifactId(artifact)) {
-                        result.getMetaData().getSources().withSource(ModuleDescriptorHashModuleSource.class, hashSource -> {
+                        tmp.getMetaData().getSources().withSource(ModuleDescriptorHashModuleSource.class, hashSource -> {
                             if (hashSource.isPresent()) {
                                 boolean changingModule = requestMetaData.isChanging() || hashSource.get().isChangingModule();
                                 if (!changingModule) {
                                     File artifactFile = metadataFileSource.getArtifactFile();
-                                    if (artifactFile != null) {
+                                    if (artifactFile != null && artifactFile.exists()) {
                                         // it's possible that the file is null if it has been removed from the cache
                                         // for example
                                         operation.onArtifact(ArtifactVerificationOperation.ArtifactKind.METADATA, artifact, artifactFile, () -> maybeFetchSignatureFile(moduleComponentIdentifier, result.getMetaData().getSources(), artifact), getName(), getId());
+                                    } else {
+                                        ignore.set(true);
                                     }
                                 }
                             }
@@ -138,6 +148,10 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
                         });
                     }
                 });
+            }
+
+            if (!ignore.get()) {
+                delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
             }
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -32,4 +32,11 @@ trait CachingIntegrationFixture {
     TestFile getMetadataCacheDir() {
         return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME).file(CacheLayout.ROOT.key)
     }
+
+    void markForArtifactCacheCleanup() {
+        executer.withArgument("-Dorg.gradle.internal.cleanup.external.max.age=-1")
+        def gcFile = executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME).file(CacheLayout.ROOT.key).file("gc.properties")
+        gcFile.createFile()
+        assert gcFile.setLastModified(0)
+    }
 }


### PR DESCRIPTION
Previously, dependency verification was failing whenever an artifact
wasn't found in the local cache. This caused problems for artifacts
and metadata deleted legitimately by the automated cache cleanup
process.

This commit makes sure that if an artifact is deleted, we, instead,
try to redownload it and verify the result of downloading, as if
it was a newly downloaded artifact.

Fixes #12713
