### PR TITLE
Improve linking between 'init projects', 'samples' and 'user manual'

### DIFF
--- a/buildSrc/subprojects/build-init-samples/src/main/kotlin/gradlebuild/generate-samples.gradle.kts
+++ b/buildSrc/subprojects/build-init-samples/src/main/kotlin/gradlebuild/generate-samples.gradle.kts
@@ -48,7 +48,7 @@ fun setupGeneratorTask(language: Language, kind: String, modularizationOption: M
     val capKind = kind.capitalize().replace("y", "ie") + "s"
     val languageDisplayName = language.toString().replace("C++", "{cpp}")
     val sampleName = "building$capName$capKind" + if (modularizationOption.isMulti()) "MultiProject" else ""
-    val multiProjectSuffix = if (modularizationOption.isMulti()) " with Libraries" else ""
+    val multiProjectSuffix = if (modularizationOption.isMulti()) " with libraries" else ""
     val generateSampleTask = project.tasks.register<GenerateSample>("generateSample${sampleName.capitalize()}") {
         readmeTemplates.convention(layout.projectDirectory.dir("src/samples/readme-templates"))
         target.convention(layout.buildDirectory.dir("generated-samples/$buildInitType" + if (modularizationOption.isMulti()) "-with-libraries" else ""))

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -47,4 +47,8 @@ public class DocumentationRegistry {
     public String getSampleIndex() {
         return String.format("https://docs.gradle.org/%s/samples", gradleVersion.getVersion());
     }
+
+    public String getSampleFor(String id) {
+        return String.format("https://docs.gradle.org/%s/samples/sample_%s.html", gradleVersion.getVersion(), id);
+    }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BasicProjectGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BasicProjectGenerator.java
@@ -86,7 +86,7 @@ public class BasicProjectGenerator implements ProjectGenerator {
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
+    public Optional<String> getFurtherReading(InitSettings settings) {
         return Optional.empty();
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BasicProjectGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BasicProjectGenerator.java
@@ -87,6 +87,6 @@ public class BasicProjectGenerator implements ProjectGenerator {
 
     @Override
     public Optional<String> getFurtherReading(InitSettings settings) {
-        return Optional.empty();
+        return Optional.of("Learn more about Gradle by exploring our samples at " + documentationRegistry.getSampleIndex());
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildInitializer.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildInitializer.java
@@ -78,5 +78,5 @@ public interface BuildInitializer extends BuildContentGenerator {
     /**
      * Returns a collection of further reading related to this type of build (may be empty).
      */
-    Optional<String> getFurtherReading();
+    Optional<String> getFurtherReading(InitSettings settings);
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CompositeProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CompositeProjectInitDescriptor.java
@@ -89,8 +89,8 @@ public class CompositeProjectInitDescriptor implements BuildInitializer {
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
-        return descriptor.getFurtherReading();
+    public Optional<String> getFurtherReading(InitSettings settings) {
+        return descriptor.getFurtherReading(settings);
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CppProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CppProjectInitDescriptor.java
@@ -74,8 +74,8 @@ public abstract class CppProjectInitDescriptor extends LanguageLibraryProjectIni
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
-        return Optional.of(documentationRegistry.getDocumentationFor("building_cpp_projects"));
+    public Optional<String> getFurtherReading(InitSettings settings) {
+        return Optional.of(documentationRegistry.getSampleFor("building_cpp_" + getComponentType().pluralName()));
     }
 
     protected abstract TemplateOperation sourceTemplateOperation(InitSettings settings);

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
@@ -89,7 +89,7 @@ public abstract class JvmGradlePluginProjectInitDescriptor extends LanguageLibra
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
+    public Optional<String> getFurtherReading(InitSettings settings) {
         return Optional.of(documentationRegistry.getDocumentationFor("custom_plugins"));
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
@@ -84,9 +84,9 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
-        return description.getUserManualId() == null ? Optional.empty() :
-            Optional.of(documentationRegistry.getDocumentationFor(description.getUserManualId()));
+    public Optional<String> getFurtherReading(InitSettings settings) {
+        String multi = isSingleProject(settings) ? "" : "_multi_project";
+        return Optional.of(documentationRegistry.getSampleFor("building_" + getLanguage().getName() + "_" + getComponentType().pluralName() + multi));
     }
 
     @Override
@@ -101,10 +101,9 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
             }
 
             buildScriptBuilder.fileComment("This generated file contains a sample " + getLanguage() + " " + getComponentType() + " project to get you started.");
-            if (description.getUserManualId() != null) {
-                buildScriptBuilder.fileComment("For more details take a look at the " + description.getChapterName() + " chapter in the Gradle")
-                    .fileComment("User Manual available at " + documentationRegistry.getDocumentationFor(description.getUserManualId()));
-            }
+            buildScriptBuilder.fileComment("For more details take a look at the 'Building Java & JVM projects' chapter in the Gradle")
+                .fileComment("User Manual available at " + documentationRegistry.getDocumentationFor("building_java_projects"));
+
             addStandardDependencies(buildScriptBuilder);
             addTestFramework(settings.getTestFramework(), buildScriptBuilder);
         }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageLibraryProjectInitDescriptor.java
@@ -37,7 +37,7 @@ public abstract class LanguageLibraryProjectInitDescriptor implements LanguageSp
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
+    public Optional<String> getFurtherReading(InitSettings settings) {
         return Optional.empty();
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
@@ -66,8 +66,8 @@ public class LanguageSpecificAdaptor implements ProjectGenerator {
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
-        return descriptor.getFurtherReading();
+    public Optional<String> getFurtherReading(InitSettings settings) {
+        return descriptor.getFurtherReading(settings);
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificProjectGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificProjectGenerator.java
@@ -33,7 +33,7 @@ public interface LanguageSpecificProjectGenerator {
 
     Set<ModularizationOption> getModularizationOptions();
 
-    Optional<String> getFurtherReading();
+    Optional<String> getFurtherReading(InitSettings settings);
 
     Set<BuildInitTestFramework> getTestFrameworks();
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/ProjectGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/ProjectGenerator.java
@@ -37,7 +37,7 @@ public interface ProjectGenerator extends BuildContentGenerator {
 
     Set<ModularizationOption> getModularizationOptions();
 
-    Optional<String> getFurtherReading();
+    Optional<String> getFurtherReading(InitSettings settings);
 
     /**
      * Does a source package name make sense for this type of project?

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SwiftProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SwiftProjectInitDescriptor.java
@@ -74,8 +74,8 @@ public abstract class SwiftProjectInitDescriptor extends LanguageLibraryProjectI
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
-        return Optional.of(documentationRegistry.getDocumentationFor("building_swift_projects"));
+    public Optional<String> getFurtherReading(InitSettings settings) {
+        return Optional.of(documentationRegistry.getSampleFor("building_swift_" + getComponentType().pluralName()));
     }
 
     protected abstract TemplateOperation sourceTemplateOperation(InitSettings settings);

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
@@ -122,7 +122,7 @@ public class PomProjectInitDescriptor implements BuildConverter {
     }
 
     @Override
-    public Optional<String> getFurtherReading() {
+    public Optional<String> getFurtherReading(InitSettings settings) {
         return Optional.of(documentationRegistry.getDocumentationFor("migrating_from_maven"));
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
@@ -34,21 +34,10 @@ import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFrame
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework.TESTNG;
 
 public class Description {
-    public final static Description JAVA_APPLICATION = new Description(
+    public final static Description JAVA = new Description(
         Language.JAVA,
         JUNIT,
         Arrays.asList(JUNIT, JUNIT_JUPITER, TESTNG, SPOCK),
-        "Java Quickstart",
-        "tutorial_java_projects",
-        null, null
-    );
-
-    public final static Description JAVA_LIBRARY = new Description(
-        Language.JAVA,
-        JUNIT,
-        Arrays.asList(JUNIT, JUNIT_JUPITER, TESTNG, SPOCK),
-        "Java Libraries",
-        "java_library_plugin",
         null, null
     );
 
@@ -56,8 +45,6 @@ public class Description {
         Language.GROOVY,
         SPOCK,
         Collections.singletonList(SPOCK),
-        "Groovy Quickstart",
-        "tutorial_groovy_projects",
         "groovy", null
     );
 
@@ -65,8 +52,6 @@ public class Description {
         Language.SCALA,
         SCALATEST,
         Collections.singletonList(SCALATEST),
-        "Scala plugin",
-        "scala_plugin",
         "scala", null
     );
 
@@ -74,26 +59,20 @@ public class Description {
         Language.KOTLIN,
         KOTLINTEST,
         Collections.singletonList(KOTLINTEST),
-        null,
-        null,
         "org.jetbrains.kotlin.jvm", "kotlin"
     );
 
     private final Language language;
     private final BuildInitTestFramework defaultTestFramework;
     private final Set<BuildInitTestFramework> supportedTestFrameworks;
-    private final String chapterName;
-    private final String userManualId;
     private final String pluginName;
     private final String pluginVersionProperty;
 
     private Description(Language language, BuildInitTestFramework defaultTestFramework, List<BuildInitTestFramework> supportedTestFrameworks,
-                        String chapterName, String userManualId, String pluginName, String pluginVersionProperty) {
+                        String pluginName, String pluginVersionProperty) {
         this.language = language;
         this.defaultTestFramework = defaultTestFramework;
         this.supportedTestFrameworks = new TreeSet<>(supportedTestFrameworks);
-        this.chapterName = chapterName;
-        this.userManualId = userManualId;
         this.pluginName = pluginName;
         this.pluginVersionProperty = pluginVersionProperty;
     }
@@ -108,16 +87,6 @@ public class Description {
 
     public Set<BuildInitTestFramework> getSupportedTestFrameworks() {
         return supportedTestFrameworks;
-    }
-
-    @Nullable
-    public String getChapterName() {
-        return chapterName;
-    }
-
-    @Nullable
-    public String getUserManualId() {
-        return userManualId;
     }
 
     @Nullable

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/ComponentType.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/ComponentType.java
@@ -44,4 +44,8 @@ public enum ComponentType {
     public String toString() {
         return Names.displayNameFor(this);
     }
+
+    public String pluralName() {
+        return (toString() + "s").replace("ys", "ies");
+    }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/services/ProjectLayoutSetupRegistryFactory.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/services/ProjectLayoutSetupRegistryFactory.java
@@ -73,8 +73,8 @@ public class ProjectLayoutSetupRegistryFactory {
         BuildInitializer basicType = of(new BasicProjectGenerator(scriptBuilderFactory, documentationRegistry), commonGenerators);
         PomProjectInitDescriptor mavenBuildConverter = new PomProjectInitDescriptor(mavenSettingsProvider, scriptBuilderFactory, documentationRegistry);
         ProjectLayoutSetupRegistry registry = new ProjectLayoutSetupRegistry(basicType, mavenBuildConverter, templateOperationBuilder);
-        registry.add(of(new JvmApplicationProjectInitDescriptor(Description.JAVA_APPLICATION, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
-        registry.add(of(new JvmLibraryProjectInitDescriptor(Description.JAVA_LIBRARY, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
+        registry.add(of(new JvmApplicationProjectInitDescriptor(Description.JAVA, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
+        registry.add(of(new JvmLibraryProjectInitDescriptor(Description.JAVA, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
         registry.add(of(new JvmApplicationProjectInitDescriptor(Description.GROOVY, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
         registry.add(of(new JvmLibraryProjectInitDescriptor(Description.GROOVY, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));
         registry.add(of(new JvmApplicationProjectInitDescriptor(Description.SCALA, libraryVersionProvider, documentationRegistry), jvmProjectGenerators, libraryVersionProvider));

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -243,10 +243,11 @@ public class InitBuild extends DefaultTask {
         }
 
         List<String> subprojectNames = initDescriptor.getComponentType().getDefaultProjectNames();
-        initDescriptor.generate(new InitSettings(projectName, subprojectNames,
-            modularizationOption, dsl, packageName, testFramework, projectDir));
+        InitSettings settings = new InitSettings(projectName, subprojectNames,
+            modularizationOption, dsl, packageName, testFramework, projectDir);
+        initDescriptor.generate(settings);
 
-        initDescriptor.getFurtherReading().ifPresent(link -> getLogger().lifecycle("Get more help with your project: {}", link));
+        initDescriptor.getFurtherReading(settings).ifPresent(link -> getLogger().lifecycle("Get more help with your project: {}", link));
     }
 
     @Option(option = "type", description = "Set the type of project to generate.")

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.buildinit.tasks
 import org.gradle.api.GradleException
 import org.gradle.buildinit.plugins.internal.BuildConverter
 import org.gradle.buildinit.plugins.internal.BuildInitializer
+import org.gradle.buildinit.plugins.internal.InitSettings
 import org.gradle.buildinit.plugins.internal.ProjectLayoutSetupRegistry
 import org.gradle.buildinit.plugins.internal.modifiers.ComponentType
 import org.gradle.buildinit.plugins.internal.modifiers.Language
@@ -69,7 +70,7 @@ class InitBuildSpec extends Specification {
         projectSetupDescriptor.defaultDsl >> GROOVY
         projectSetupDescriptor.testFrameworks >> [NONE]
         projectSetupDescriptor.defaultTestFramework >> NONE
-        projectSetupDescriptor.furtherReading >> Optional.empty()
+        projectSetupDescriptor.getFurtherReading(_ as InitSettings) >> Optional.empty()
 
         when:
         init.setupProjectLayout()
@@ -84,7 +85,7 @@ class InitBuildSpec extends Specification {
         projectSetupDescriptor.modularizationOptions >> [ModularizationOption.SINGLE_PROJECT]
         projectSetupDescriptor.testFrameworks >> [SPOCK]
         projectSetupDescriptor.dsls >> [GROOVY, KOTLIN]
-        projectSetupDescriptor.furtherReading >> Optional.empty()
+        projectSetupDescriptor.getFurtherReading(_ as InitSettings) >> Optional.empty()
         projectSetupDescriptor.componentType >> ComponentType.LIBRARY
         init.type = "java-library"
         init.dsl = "kotlin"

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -17,7 +17,7 @@
 
 Gradle uses a convention-over-configuration approach to building JVM-based projects that borrows several conventions from Apache Maven. In particular, it uses the same default directory structure for source files and resources, and it works with Maven-compatible repositories.
 
-We will look at Java projects in detail in this chapter, but most of the topics apply to other supported JVM languages as well, such as https://guides.gradle.org/building-kotlin-jvm-libraries/[Kotlin], <<groovy_plugin.adoc#groovy_plugin,Groovy>> and <<scala_plugin.adoc#scala_plugin,Scala>>.
+We will look at Java projects in detail in this chapter, but most of the topics apply to other supported JVM languages as well, such as link:https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm[Kotlin], <<groovy_plugin.adoc#groovy_plugin,Groovy>> and <<scala_plugin.adoc#scala_plugin,Scala>>.
 If you don't have much experience with building JVM-based projects with Gradle, take a look at the link:../samples/index.html#java[Java samples] for step-by-step instructions on how to build various types of basic Java projects.
 
 [NOTE]
@@ -492,7 +492,7 @@ Gradle manages this distinction via the <<java_library_plugin.adoc#java_library_
 If the types from a dependency appear in public fields or methods of your library's public classes, then that dependency is exposed via your library's public API and should therefore be added to the _api_ configuration.
 Otherwise, the dependency is an internal implementation detail and should be added to _implementation_.
 
-If you're unsure of the difference between an API and implementation dependency, the <<java_library_plugin.adoc#sec:java_library_recognizing_dependencies,Java Library Plugin chapter>> has a detailed explanation. In addition, you can see a basic, practical example of building a Java library in the corresponding https://guides.gradle.org/building-java-libraries/[_guide_].
+If you're unsure of the difference between an API and implementation dependency, the <<java_library_plugin.adoc#sec:java_library_recognizing_dependencies,Java Library Plugin chapter>> has a detailed explanation. In addition, you can explore a basic, practical link:../samples/sample_building_java_libraries.html[sample of building a Java library].
 
 [[sec:building_java_applications]]
 == Building Java applications

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -27,6 +27,15 @@ However the described features are shared by all JVM plugins.
 Specifics of the different plugins are available in their dedicated documentation.
 ====
 
+[NOTE]
+====
+There are a number of hands-on samples that you can explore for
+link:../samples/index.html#java[Java],
+link:../samples/index.html#groovy[Groovy],
+link:../samples/index.html#scala[Scala] and
+link:../samples/index.html#kotlin[Kotlin]
+====
+
 == Introduction
 
 The simplest build script for a Java project applies the <<java_library_plugin.adoc#,Java Library Plugin>> and optionally sets the project version and Java compatibility versions:

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -206,7 +206,7 @@ Running `gradle projects` gives you a list of the sub-projects of the selected p
 $ gradle projects
 ----
 
-You also get a project report within build scans. Learn more about https://guides.gradle.org/creating-build-scans/[creating build scans].
+You also get a project report within build scans. Learn more about https://scans.gradle.com/[creating build scans].
 
 [[sec:listing_tasks]]
 === Listing tasks

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -145,7 +145,7 @@
                 </ul>
             </li>
             <li><a href="../userguide/intro_multi_project_builds.html">Executing Multi-Project Builds</a></li>
-            <li><a href="https://guides.gradle.org/creating-build-scans/">Inspecting Gradle Builds</a></li>
+            <li><a href="https://scans.gradle.com/">Inspecting Gradle Builds</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#optimizing-build-performance" aria-expanded="false" aria-controls="optimizing-build-performance">Optimizing Build Times</a>
                 <ul id="optimizing-build-performance">
                     <li><a href="https://guides.gradle.org/performance/">Build Performance Guide</a></li>

--- a/subprojects/docs/src/samples/readme-templates/application-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/application-summary.adoc.template
@@ -1,3 +1,10 @@
 * Run the build and view the test report
 * Execute a ${language.raw} application using the `run` task from the `application` plugin
 * Bundle the application in an archive
+
+== Next steps
+
+To learn more about how you can further customize ${language.raw} application projects, check out the following user manual chapters:
+
+ - link:{userManualPath}/building_java_projects.html[Building Java & JVM projects]
+ - link:{userManualPath}/application_plugin.html[Java Application Plugin documentation]

--- a/subprojects/docs/src/samples/readme-templates/library-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/library-summary.adoc.template
@@ -5,8 +5,11 @@ Now you could complete this exercise by trying to compile some ${language.raw} c
 
 == Next steps
 
-Building a library is just one aspect of reusing code across project boundaries. From here, you may be interested in:
+Building a library is just one aspect of reusing code across project boundaries.
+From here, you may be interested in:
 
- - link:{userManualPath}/artifact_dependencies_tutorial.html[Consuming JVM libraries]
+ - link:{userManualPath}/building_java_projects.html[Building Java & JVM projects]
+ - link:{userManualPath}/java_library_plugin.html[Java Library Plugin documentation]
+ - Consuming JVM libraries using link:{userManualPath}/core_dependency_management.html[dependency management]
  - link:{userManualPath}/publishing_setup.html[Publishing JVM libraries]
  - link:{userManualPath}/multi_project_builds.html[Working with multi-project builds]

--- a/subprojects/docs/src/samples/readme-templates/multi-common-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/multi-common-summary.adoc.template
@@ -6,7 +6,8 @@
 
 == Next steps
 
-When your project grows, you might be interested in more details about multi-project builds and dependency management:
+When your project grows, you might be interested in more details how to configure JVM projects, structuring multi-project builds and dependency management:
 
+ - link:{userManualPath}/building_java_projects.html[Building Java & JVM projects]
  - link:{userManualPath}/multi_project_builds.html[Working with multi-project builds]
  - link:{userManualPath}/core_dependency_management.html[Dependency management in Gradle]

--- a/subprojects/docs/src/samples/readme-templates/native-application-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/native-application-summary.adoc.template
@@ -1,1 +1,6 @@
 * Build, bundle and run the application
+
+== Next steps
+
+To learn more about how you can further customize ${language.raw} application projects, check out the user manual chapter on
+link:{userManualPath}/building_${languageLC.raw}_projects.html[Building ${language.raw} projects].

--- a/subprojects/docs/src/samples/readme-templates/native-library-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/native-library-summary.adoc.template
@@ -3,5 +3,5 @@
 == Next Steps
 
 * Make your way to the https://github.com/gradle/native-samples/[native samples repository] to see the C++ plugins in action for common scenarios such as https://github.com/gradle/native-samples/tree/master/cpp/transitive-dependencies[transitive dependencies], https://github.com/gradle/native-samples/tree/master/cpp/swift-package-manager[custom source layout], and https://github.com/gradle/native-samples/tree/master/cpp/static-library[static library].
-* Checkout the user manual chapter on link:{userManualPath}/building_${languageLC.raw}_projects.html[Building ${language.raw} projects]
+* Check out the user manual chapter on link:{userManualPath}/building_${languageLC.raw}_projects.html[Building ${language.raw} projects]
 

--- a/subprojects/docs/src/samples/readme-templates/native-library-summary.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/native-library-summary.adoc.template
@@ -3,3 +3,5 @@
 == Next Steps
 
 * Make your way to the https://github.com/gradle/native-samples/[native samples repository] to see the C++ plugins in action for common scenarios such as https://github.com/gradle/native-samples/tree/master/cpp/transitive-dependencies[transitive dependencies], https://github.com/gradle/native-samples/tree/master/cpp/swift-package-manager[custom source layout], and https://github.com/gradle/native-samples/tree/master/cpp/static-library[static library].
+* Checkout the user manual chapter on link:{userManualPath}/building_${languageLC.raw}_projects.html[Building ${language.raw} projects]
+


### PR DESCRIPTION
init-generated project --> corresponding sample
sample --> all relevant user manual chapters in "next steps"

**Rendered docs**: https://builds.gradle.org/repository/download/Gradle_Check_BuildDistributions/37990174:id/distributions/gradle-6.7-docs.zip!/gradle-6.7-20200910085659%2B0000/docs/samples/index.html