### PR TITLE
Use JUnit 4 for testing

### DIFF
--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -200,12 +200,6 @@ fun configureTests() {
 
         maxParallelForks = project.maxParallelForks
 
-        if (!BuildEnvironment.isIntelliJIDEA) {
-            // JUnit 5 Vintage engine can't recognize Spock @Unroll test method correctly
-            // So if running an @Unroll method in IDEA with include pattern "SomeClass.methodName"
-            // The result will be incorrect. In this case we fallback to JUnit
-            useJUnitPlatform()
-        }
         configureJvmForTest()
         addOsAsInputs()
 


### PR DESCRIPTION
Current Spock doesn't support JUnit vintage well, especially for @Unroll
tests. Let's fallback to JUnit 4 for now.
