### PR TITLE
Add support for additional asdf directories

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
@@ -47,6 +47,10 @@ public abstract class AutoDetectingInstallationSupplier implements InstallationS
         return factory.environmentVariable(propertyName).forUseAtConfigurationTime();
     }
 
+    protected Provider<String> getSystemProperty(String propertyName) {
+        return factory.systemProperty(propertyName).forUseAtConfigurationTime();
+    }
+
     protected abstract Set<InstallationLocation> findCandidates();
 
     private boolean isAutoDetectionEnabled() {


### PR DESCRIPTION
### Context

`asdf` is storing installations in the path configured in the `$ASDF_DATA_DIR` environment variable or `$HOME/.asdf` as fallback.

The environment variable `$ASDF_DIR` only points to the directory in which `asdf` itself was installed.

https://asdf-vm.com/#/core-configuration?id=environment-variables
https://github.com/asdf-vm/asdf/blob/v0.8.0/lib/utils.bash#L39-L68

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
