### PR TITLE
Add infrastructure to run split performance tests

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package Gradle_Check.configurations
+
+import common.Os
+import common.applyPerformanceTestSettings
+import common.buildToolGradleParameters
+import common.checkCleanM2
+import common.gradleWrapper
+import common.killGradleProcessesStep
+import common.performanceTestCommandLine
+import common.removeSubstDirOnWindows
+import common.substDirOnWindows
+import configurations.BaseGradleBuildType
+import configurations.buildScanTag
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import model.CIBuildModel
+import model.PerformanceTestType
+import model.Stage
+
+class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Stage, uuid: String, description: String, performanceSubProject: String, testProjects: List<String>, os: Os = Os.LINUX, extraParameters: String = "", preBuildSteps: BuildSteps.() -> Unit = {}) : BaseGradleBuildType(model, stage = stage, init = {
+    this.uuid = uuid
+    this.id = AbsoluteId(uuid)
+    this.name = description
+    val performanceTestTaskNames = getPerformanceTestTaskNames(performanceSubProject, testProjects)
+    applyPerformanceTestSettings(os = os, timeout = type.timeout)
+
+    params {
+        param("performance.baselines", type.defaultBaselines)
+        param("env.ANDROID_HOME", os.androidHome)
+        when (os) {
+            Os.WINDOWS -> param("env.PATH", "%env.PATH%;C:/Program Files/7-zip")
+            else -> param("env.PATH", "%env.PATH%:/opt/swift/4.2.3/usr/bin")
+        }
+    }
+    if (testProjects.isNotEmpty()) {
+        steps {
+            preBuildSteps()
+            killGradleProcessesStep(os)
+            substDirOnWindows(os)
+            gradleWrapper {
+                name = "GRADLE_RUNNER"
+                tasks = ""
+                workingDir = os.perfTestWorkingDir
+                gradleParams = (
+                    performanceTestCommandLine(
+                        "clean ${performanceTestTaskNames.joinToString(" ")}",
+                        "%baselines%",
+                        """--channel %channel%$extraParameters""",
+                        os
+                    ) +
+                        buildToolGradleParameters(isContinue = false, os = os) +
+                        buildScanTag("PerformanceTest") +
+                        model.parentBuildCache.gradleParameters(os)
+                    ).joinToString(separator = " ")
+            }
+            removeSubstDirOnWindows(os)
+            checkCleanM2(os)
+        }
+    }
+})
+
+fun getPerformanceTestTaskNames(performanceSubProject: String, testProjects: List<String>): List<String> {
+    return testProjects.map {
+        ":$performanceSubProject:${it}PerformanceTest"
+    }
+}

--- a/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package Gradle_Check.configurations
+
+import common.applyDefaultSettings
+import configurations.BaseGradleBuildType
+import configurations.publishBuildStatusToGithub
+import configurations.snapshotDependencies
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import model.CIBuildModel
+import projects.PerformanceTestProject
+
+class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(model, init = {
+    uuid = performanceTestProject.uuid + "_Trigger"
+    id = AbsoluteId(uuid)
+    name = performanceTestProject.name + " (Trigger)"
+
+    applyDefaultSettings()
+
+    features {
+        publishBuildStatusToGithub(model)
+    }
+
+    dependencies {
+        snapshotDependencies(performanceTestProject.performanceTests)
+    }
+})

--- a/.teamcity/Gradle_Check/model/BucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/BucketProvider.kt
@@ -177,9 +177,12 @@ class StatisticBasedGradleBuildBucketProvider(private val model: CIBuildModel, t
  * @param smallElementAggregateFunction the function used to aggregate tiny elements into a large bucket
  * @param expectedBucketNumber the return value's size should be expectedBucketNumber
  */
-fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSplitFunction: (T, Int) -> List<R>, smallElementAggregateFunction: (List<T>) -> R, expectedBucketNumber: Int, maxNumberInBucket: Int): List<R> {
+fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSplitFunction: (T, Int) -> List<R>, smallElementAggregateFunction: (List<T>) -> R, expectedBucketNumber: Int, maxNumberInBucket: Int, noElementSplitFunction: (Int) -> List<R> = { throw IllegalArgumentException("More buckets than things to split") }): List<R> {
     if (expectedBucketNumber == 1) {
         return listOf(smallElementAggregateFunction(list))
+    }
+    if (list.isEmpty()) {
+        return noElementSplitFunction(expectedBucketNumber)
     }
 
     val expectedBucketSize = list.sumBy(toIntFunction) / expectedBucketNumber
@@ -190,7 +193,7 @@ fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSpl
 
     return if (largestElementSize >= expectedBucketSize) {
         val bucketsOfFirstElement = largeElementSplitFunction(largestElement, if (largestElementSize % expectedBucketSize == 0) largestElementSize / expectedBucketSize else largestElementSize / expectedBucketSize + 1)
-        val bucketsOfRestElements = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket)
+        val bucketsOfRestElements = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket, noElementSplitFunction)
         bucketsOfFirstElement + bucketsOfRestElements
     } else {
         val buckets = arrayListOf(largestElement)
@@ -200,7 +203,7 @@ fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSpl
             buckets.add(smallestElement)
             restCapacity -= toIntFunction(smallestElement)
         }
-        listOf(smallElementAggregateFunction(buckets)) + split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket)
+        listOf(smallElementAggregateFunction(buckets)) + split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket, noElementSplitFunction)
     }
 }
 

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -25,7 +25,8 @@ enum class StageNames(override val stageName: String, override val description: 
     HISTORICAL_PERFORMANCE("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions", "HistoricalPerformance"),
     EXPERIMENTAL("Experimental", "On demand: Run experimental tests", "Experimental"),
     EXPERIMENTAL_VFS_RETENTION("Experimental FS Watching", "On demand checks to run tests with file system watching enabled", "ExperimentalVfsRetention"),
-    EXPERIMENTAL_JDK("Experimental JDK", "On demand checks to run tests with latest experimental JDK", "ExperimentalJDK")
+    EXPERIMENTAL_JDK("Experimental JDK", "On demand checks to run tests with latest experimental JDK", "ExperimentalJDK"),
+    EXPERIMENTAL_PERFORMANCE("Experimental Performance", "Try out new performance test running", "ExperimentalPerformance")
 }
 
 data class CIBuildModel(
@@ -140,7 +141,11 @@ data class CIBuildModel(
                 TestCoverage(67, TestType.allVersionsCrossVersion, Os.WINDOWS, JvmCategory.EXPERIMENTAL_VERSION),
                 TestCoverage(68, TestType.noDaemon, Os.LINUX, JvmCategory.EXPERIMENTAL_VERSION),
                 TestCoverage(69, TestType.noDaemon, Os.WINDOWS, JvmCategory.EXPERIMENTAL_VERSION)
-            ))
+            )),
+        Stage(StageNames.EXPERIMENTAL_PERFORMANCE,
+            trigger = Trigger.never,
+            runsIndependent = true
+        )
     ),
     val subprojects: GradleSubprojectProvider
 )

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package Gradle_Check.model
+
+import Gradle_Check.configurations.PerformanceTest
+import common.Os
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import model.CIBuildModel
+import model.PerformanceTestType
+import model.Stage
+import model.StageNames
+import model.TestCoverage
+import java.io.File
+import java.util.LinkedList
+
+interface PerformanceTestBucketProvider {
+    fun createPerformanceTestsFor(stage: Stage, os: Os): List<PerformanceTest>
+}
+
+typealias OperatingSystemToTestProjectPerformanceTestTimes = Map<String, Map<String, List<PerformanceTestTime>>>
+
+const val PERFORMANCE_TEST_BUCKET_NUMBER = 40
+
+data class PerformanceTestCoverage(val stageId: String, val os: Os) {
+    fun asConfigurationId(model: CIBuildModel, bucket: String = "") = "${model.projectPrefix}$stageId${os.asName()}PerformanceTest$bucket"
+    fun asName(): String =
+        "Performance tests in $stageId - ${os.asName()}"
+}
+
+private
+val upToDateParallel = Scenario("org.gradle.performance.regression.java.JavaUpToDatePerformanceTest", "up-to-date assemble (parallel true)")
+
+private
+val upToDateNonParallel = Scenario("org.gradle.performance.regression.java.JavaUpToDatePerformanceTest", "up-to-date assemble (parallel false)")
+
+class StatisticsBasedPerformanceTestBucketProvider(private val model: CIBuildModel, performanceTestTimeDataCsv: File) : PerformanceTestBucketProvider {
+    private val buckets: Map<PerformanceTestCoverage, List<PerformanceTestBucket>> = buildBuckets(performanceTestTimeDataCsv, model)
+
+    override fun createPerformanceTestsFor(stage: Stage, os: Os): List<PerformanceTest> {
+        val performanceTestCoverage = PerformanceTestCoverage(stage.id, os)
+        return buckets.getValue(performanceTestCoverage).mapIndexed { bucketIndex: Int, bucket: PerformanceTestBucket ->
+            bucket.createPerformanceTestsFor(model, stage, performanceTestCoverage, bucketIndex)
+        }
+    }
+
+    private
+    fun buildBuckets(performanceTestTimeDataCsv: File, model: CIBuildModel): Map<PerformanceTestCoverage, List<PerformanceTestBucket>> {
+        val performanceTestTimes: OperatingSystemToTestProjectPerformanceTestTimes = mapOf(
+            "Linux" to mapOf(
+                "largeJavaMultiProject" to listOf(
+                    PerformanceTestTime(upToDateParallel, 476000),
+                    PerformanceTestTime(upToDateNonParallel, 700000)
+                ),
+                "largeMonolithicJavaProject" to listOf(
+                    PerformanceTestTime(upToDateNonParallel, 308000)
+                )
+            )
+        )
+
+        val result = mutableMapOf<PerformanceTestCoverage, List<PerformanceTestBucket>>()
+        for (stage in model.stages) {
+            val performanceTestCoverage = PerformanceTestCoverage(stage.id, Os.LINUX)
+            result[performanceTestCoverage] = splitBucketsByScenarios(performanceTestCoverage, performanceTestTimes)
+        }
+        return result
+    }
+}
+
+private
+fun splitBucketsByScenarios(performanceTestCoverage: PerformanceTestCoverage, performanceTestTimes: OperatingSystemToTestProjectPerformanceTestTimes): List<PerformanceTestBucket> {
+    val scenarios = determineScenariosFor(performanceTestCoverage)
+
+    val testProjectToScenarioTimes: Map<String, List<PerformanceTestTime>> = determineScenarioTestTimes(performanceTestCoverage, performanceTestTimes)
+
+    val testProjectTimes = scenarios
+        .groupBy({ it.testProject }, { testProjectToScenarioTimes.getValue(it.testProject).first { times -> times.scenario == it.scenario } })
+        .entries
+        .map { TestProjectTime(it.key, it.value) }
+        .sortedBy { -it.totalTime }
+    if (testProjectTimes.isEmpty()) {
+        return emptyList()
+    }
+    return split(
+        LinkedList(testProjectTimes),
+        TestProjectTime::totalTime,
+        { largeElement: TestProjectTime, size: Int -> largeElement.split(size) },
+        { list: List<TestProjectTime> -> MultipleTestProjectBucket(list) },
+        PERFORMANCE_TEST_BUCKET_NUMBER,
+        MAX_PROJECT_NUMBER_IN_BUCKET,
+        { numEmptyBuckets -> (0 until numEmptyBuckets).map { EmptyTestProjectBucket(it) }.toList() }
+    )
+}
+
+fun determineScenarioTestTimes(performanceTestCoverage: PerformanceTestCoverage, performanceTestTimes: OperatingSystemToTestProjectPerformanceTestTimes): Map<String, List<PerformanceTestTime>> = performanceTestTimes.getValue(performanceTestCoverage.os.asName())
+
+fun determineScenariosFor(performanceTestCoverage: PerformanceTestCoverage): List<PerformanceScenario> = when (performanceTestCoverage) {
+    PerformanceTestCoverage(StageNames.EXPERIMENTAL_PERFORMANCE.id, Os.LINUX) -> listOf(
+        PerformanceScenario(upToDateParallel, "largeJavaMultiProject"),
+        PerformanceScenario(upToDateNonParallel, "largeJavaMultiProject"),
+        PerformanceScenario(upToDateNonParallel, "largeMonolithicJavaProject")
+    )
+    else -> listOf()
+}
+
+class PerformanceTestTime(val scenario: Scenario, val buildTimeMs: Int) {
+    fun toCsvLine() = "${scenario.className};${scenario.scenario}"
+}
+
+data class PerformanceScenario(val scenario: Scenario, val testProject: String)
+
+interface PerformanceTestBucket {
+    fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest
+
+    fun getUuid(model: CIBuildModel, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): String = performanceTestCoverage.asConfigurationId(model, "bucket${bucketIndex + 1}")
+
+    fun getName(testCoverage: TestCoverage): String = throw UnsupportedOperationException()
+
+    fun getDescription(testCoverage: TestCoverage): String = throw UnsupportedOperationException()
+}
+
+class TestProjectTime(val testProject: String, val scenarioTimes: List<PerformanceTestTime>) {
+    val totalTime: Int = scenarioTimes.sumBy { it.buildTimeMs }
+
+    fun split(expectedBucketNumber: Int): List<PerformanceTestBucket> {
+        return if (expectedBucketNumber == 1 || scenarioTimes.size == 1) {
+            listOf(SingleTestProjectBucket(testProject, scenarioTimes.map { it.scenario }))
+        } else {
+            val list = LinkedList(scenarioTimes.sortedBy { -it.buildTimeMs })
+            val toIntFunction = PerformanceTestTime::buildTimeMs
+            val largeElementSplitFunction: (PerformanceTestTime, Int) -> List<List<PerformanceTestTime>> = { performanceTestTime: PerformanceTestTime, number: Int -> listOf(listOf(performanceTestTime)) }
+            val smallElementAggregateFunction: (List<PerformanceTestTime>) -> List<PerformanceTestTime> = { it }
+
+            val buckets: List<List<PerformanceTestTime>> = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE, { listOf() })
+
+            buckets.mapIndexed { index: Int, classesInBucket: List<PerformanceTestTime> ->
+                TestProjectSplitBucket(testProject, index + 1, classesInBucket)
+            }
+        }
+    }
+
+    override fun toString(): String {
+        return "TestProjectScenarioTime(testProject=$testProject, totalTime=$totalTime)"
+    }
+}
+
+data class Scenario(val className: String, val scenario: String)
+
+class SingleTestProjectBucket(val testProject: String, val scenarios: List<Scenario>) : PerformanceTestBucket {
+    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+        val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
+        return PerformanceTest(
+            model,
+            PerformanceTestType.test,
+            stage,
+            uuid,
+            "Performance tests for $testProject",
+            "performance",
+            listOf(testProject),
+            performanceTestCoverage.os,
+            extraParameters = " -PincludePerformanceTestScenarios=true",
+            preBuildSteps = prepareScenariosStep(testProject, scenarios, performanceTestCoverage.os)
+        )
+    }
+}
+
+class MultipleTestProjectBucket(val testProjects: List<TestProjectTime>) : PerformanceTestBucket {
+    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+        val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
+        return PerformanceTest(
+            model,
+            PerformanceTestType.test,
+            stage,
+            uuid,
+            "Performance tests for ${testProjects.joinToString(", ")}",
+            "performance",
+            testProjects.map { it.testProject }.distinct(),
+            performanceTestCoverage.os,
+            extraParameters = " -PincludePerformanceTestScenarios=true",
+            preBuildSteps = {
+                testProjects.forEach { testProject ->
+                    prepareScenariosStep(testProject.testProject, testProject.scenarioTimes.map(PerformanceTestTime::scenario), performanceTestCoverage.os)()
+                }
+            }
+        )
+    }
+}
+
+class EmptyTestProjectBucket(private val index: Int) : PerformanceTestBucket {
+    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+        val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
+        return PerformanceTest(
+            model,
+            PerformanceTestType.test,
+            stage,
+            uuid,
+            "EmptyPerformanceTestsFor$index",
+            "performance",
+            listOf(),
+            performanceTestCoverage.os
+        )
+    }
+}
+
+class TestProjectSplitBucket(val testProject: String, val number: Int, val scenarios: List<PerformanceTestTime>) : PerformanceTestBucket {
+    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+        val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
+        return PerformanceTest(
+            model,
+            PerformanceTestType.test,
+            stage,
+            uuid,
+            "Performance test for $testProject (bucket $number)",
+            "performance",
+            listOf(testProject),
+            performanceTestCoverage.os,
+            extraParameters = " -PincludePerformanceTestScenarios=true",
+            preBuildSteps = prepareScenariosStep(testProject, scenarios.map(PerformanceTestTime::scenario), performanceTestCoverage.os)
+        )
+    }
+}
+
+private fun prepareScenariosStep(testProject: String, scenarios: List<Scenario>, os: Os): BuildSteps.() -> Unit {
+    val csvLines = scenarios.map { "${it.className};${it.scenario}" }
+    val action = "include"
+    val fileNamePostfix = "$testProject-performance-scenarios.csv"
+    val unixScript = """
+mkdir -p build
+rm -rf build/*-$fileNamePostfix
+cat > build/$action-$fileNamePostfix << EOL
+${csvLines.joinToString("\n")}
+EOL
+
+echo "Performance tests to be ${action}d in this build"
+cat build/$action-$fileNamePostfix
+"""
+
+    val linesWithEcho = csvLines.joinToString("\n") { "echo $it" }
+
+    val windowsScript = """
+mkdir build
+del /f /q build\include-$fileNamePostfix
+del /f /q build\exclude-$fileNamePostfix
+(
+$linesWithEcho
+) > build\$action-$fileNamePostfix
+
+echo "Performance tests to be ${action}d in this build"
+type build\$action-$fileNamePostfix
+"""
+
+    return {
+        script {
+            name = "PREPARE_TEST_CLASSES"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = if (os == Os.WINDOWS) windowsScript else unixScript
+        }
+    }
+}

--- a/.teamcity/Gradle_Check/projects/PerformanceTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/PerformanceTestProject.kt
@@ -1,0 +1,23 @@
+package projects
+
+import Gradle_Check.configurations.PerformanceTest
+import Gradle_Check.model.PerformanceTestBucketProvider
+import Gradle_Check.model.PerformanceTestCoverage
+import common.Os
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import model.CIBuildModel
+import model.Stage
+
+class PerformanceTestProject(model: CIBuildModel, performanceTestBucketProvider: PerformanceTestBucketProvider, os: Os, stage: Stage) : Project({
+    val performanceTestCoverage = PerformanceTestCoverage(stage.id, os)
+    this.uuid = performanceTestCoverage.asConfigurationId(model)
+    this.id = AbsoluteId(uuid)
+    this.name = performanceTestCoverage.asName()
+}) {
+    val performanceTests: List<PerformanceTest> = performanceTestBucketProvider.createPerformanceTestsFor(stage, os)
+
+    init {
+        performanceTests.forEach(this::buildType)
+    }
+}

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -1,6 +1,7 @@
 package projects
 
 import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.StatisticsBasedPerformanceTestBucketProvider
 import common.failedTestArtifactDestination
 import configurations.StagePasses
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
@@ -9,12 +10,14 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.VersionedSet
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.versionedSettings
 import model.CIBuildModel
 import model.Stage
+import java.io.File
 
 class RootProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBucketProvider) : Project({
     uuid = model.projectPrefix.removeSuffix("_")
     id = AbsoluteId(uuid)
     parentId = AbsoluteId("Gradle")
     name = model.rootProjectName
+    val performanceTestBucketProvider = StatisticsBasedPerformanceTestBucketProvider(model, File("../subprojects/performance/some-file.csv"))
 
     features {
         versionedSettings {
@@ -34,7 +37,7 @@ class RootProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBuc
 
     var prevStage: Stage? = null
     model.stages.forEach { stage ->
-        val stageProject = StageProject(model, gradleBuildBucketProvider, stage, uuid)
+        val stageProject = StageProject(model, gradleBuildBucketProvider, performanceTestBucketProvider, stage, uuid)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)


### PR DESCRIPTION
This only creates the buckets to run performance tests in the "new way", the code to make this
actually work in the Gradle build itself is still missing.

We need to add the buckets to `master`, so we can
try out the build logic on a branch, since Teamcity
does not support adding build types or dependencies
on branches.
