### PR TITLE
Fix typo for daemon memory in generated `gradle.properties`

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -119,7 +119,7 @@ abstract class FileContentGenerator {
             return null
         }
         """
-        org.gradle.jvmargs=-Xmxs${config.daemonMemory} -Xmx${config.daemonMemory}
+        org.gradle.jvmargs=-Xms${config.daemonMemory} -Xmx${config.daemonMemory} -Dfile.encoding=UTF-8
         org.gradle.parallel=${config.parallel}
         org.gradle.workers.max=${config.maxWorkers}
         compilerMemory=${config.compilerMemory}


### PR DESCRIPTION
And add the file encoding.