### PR TITLE
Jacoco documentation: fix a small issue

### DIFF
--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
@@ -33,6 +33,9 @@ test {
 // end::testtask-configuration[]
 
 // tag::testtask-dependency[]
+tasks.named("check").configure {
+    dependsOn jacocoTestReport // running check task generates the report
+}
 tasks.named("jacocoTestReport").configure {
     dependsOn test // tests are required to run before generating the report
 }

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
@@ -33,10 +33,7 @@ test {
 // end::testtask-configuration[]
 
 // tag::testtask-dependency[]
-test {
-    finalizedBy jacocoTestReport // report is always generated after tests run
-}
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     dependsOn test // tests are required to run before generating the report
 }
 // end::testtask-dependency[]

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
@@ -32,6 +32,9 @@ tasks.test {
 // end::testtask-configuration[]
 
 // tag::testtask-dependency[]
+tasks.named("check").configure {
+    dependsOn(tasks["jacocoTestReport"]) // running check task generates the report
+}
 tasks.named("jacocoTestReport").configure {
     dependsOn(tasks.test) // tests are required to run before generating the report
 }

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
@@ -32,10 +32,7 @@ tasks.test {
 // end::testtask-configuration[]
 
 // tag::testtask-dependency[]
-tasks.test {
-    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
-}
-tasks.jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     dependsOn(tasks.test) // tests are required to run before generating the report
 }
 // end::testtask-dependency[]


### PR DESCRIPTION
### Context

While integrating the Jacoco plugin into our repo, I realized a small build performance issue with the suggestion provided in the docs.

When `test` task is always finalized with `jacocoTestReport`, it causes jacoco report to be generated when not needed. Example: Recent versions of IntelliJ IDEA delegates to Gradle to run a single test. This is done during development workflow and supposed to be very fast. In this case, we don't need to generate jacoco report every time a single test is run.


### Solution

Remove the suggestion to make tests being finalized by jacoco task. Making `jacocoTestReport` depend on the test task should be enough. 

Also change the example usage to use Task configuration avoidance APIs.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] *N/A* Provide** integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] *N/A* Provide** unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
