### PR TITLE
Restore Kotlin DSL subproject editing in IDEA

### DIFF
--- a/subprojects/kotlin-compiler-embeddable/build.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/build.gradle.kts
@@ -8,10 +8,9 @@ description = "Kotlin Compiler Embeddable - patched for Gradle"
 moduleIdentity.baseName.set("kotlin-compiler-embeddable-${libs.kotlinVersion}-patched-for-gradle")
 
 dependencies {
-    api(libs.futureKotlin("stdlib"))
-    api(libs.futureKotlin("reflect"))
-    api(libs.futureKotlin("script-runtime"))
-    api(libs.futureKotlin("daemon-embeddable"))
-
-    runtimeOnly(libs.trove4j)
+    implementation(libs.futureKotlin("stdlib"))
+    implementation(libs.futureKotlin("reflect"))
+    implementation(libs.futureKotlin("script-runtime"))
+    implementation(libs.futureKotlin("daemon-embeddable"))
+    implementation(libs.trove4j)
 }

--- a/subprojects/kotlin-dsl/build.gradle.kts
+++ b/subprojects/kotlin-dsl/build.gradle.kts
@@ -23,8 +23,13 @@ plugins {
 description = "Kotlin DSL Provider"
 
 dependencies {
+
+    compileOnlyApi(libs.futureKotlin("compiler-embeddable"))
+    compileOnlyApi(libs.futureKotlin("reflect"))
+
+    runtimeOnly(project(":kotlin-compiler-embeddable"))
+
     api(project(":kotlin-dsl-tooling-models"))
-    api(project(":kotlin-compiler-embeddable"))
     api(libs.futureKotlin("stdlib-jdk8"))
 
     implementation(project(":base-services"))
@@ -49,6 +54,12 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.inject)
 
+    implementation(libs.futureKotlin("script-runtime")) {
+        isTransitive = false
+    }
+    implementation(libs.futureKotlin("daemon-embeddable")) {
+        isTransitive = false
+    }
     implementation(libs.futureKotlin("scripting-common")) {
         isTransitive = false
     }

--- a/subprojects/kotlin-dsl/build.gradle.kts
+++ b/subprojects/kotlin-dsl/build.gradle.kts
@@ -54,12 +54,9 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.inject)
 
-    implementation(libs.futureKotlin("script-runtime")) {
-        isTransitive = false
-    }
-    implementation(libs.futureKotlin("daemon-embeddable")) {
-        isTransitive = false
-    }
+    implementation(libs.futureKotlin("script-runtime"))
+    implementation(libs.futureKotlin("daemon-embeddable"))
+
     implementation(libs.futureKotlin("scripting-common")) {
         isTransitive = false
     }


### PR DESCRIPTION
by using vanilla kotlin-compiler-embeddable as `compileOnlyApi`
and patched one as `runtimeOnly`

also fixing dependencies declaration of the patched compiler to match published metadata
