### PR TITLE
Donat/fix tapi jdk compat test

### DIFF
--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -137,6 +137,8 @@ public class ToolingApiCompatibilityClient {
 
         assert out.toString().contains("Hello from");
         System.err.println(err.toString());
+
+        connection.close();
     }
 
    private static void buildAction(File projectLocation, String gradleVersion, File javaHome, File gradleUserHome) throws Exception {
@@ -162,6 +164,8 @@ public class ToolingApiCompatibilityClient {
             System.out.println(out.toString());
             System.err.println(err.toString());
         }
+
+        connection.close();
    }
 }
 """


### PR DESCRIPTION
A probable fix for: https://builds.gradle.org/viewLog.html?buildId=38120112&buildTypeId=Gradle_Check_Platform_4_bucket48