### PR TITLE
Ensure `ConfigurationCacheClassLoaderScopeRegisteryListener` is always disposed of

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache
 
+import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache
 
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
-import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction
 
@@ -32,12 +31,12 @@ class ConfigurationCacheBuildScopeListenerManagerAction(
     val problemsListener: ConfigurationCacheProblemsListener,
 
     private
-    val startParameter: ConfigurationCacheStartParameter
+    val buildEnablement: ConfigurationCacheBuildEnablement
 
 ) : BuildScopeListenerManagerAction {
 
     override fun execute(manager: ListenerManager) {
-        if (startParameter.isEnabled) {
+        if (buildEnablement.isEnabledForCurrentBuild) {
             scopeRegistryListener.attach(manager)
             manager.addListener(problemsListener)
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildScopeListenerManagerAction.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache
 
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
+import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction
 
@@ -28,12 +29,17 @@ class ConfigurationCacheBuildScopeListenerManagerAction(
     val scopeRegistryListener: ConfigurationCacheClassLoaderScopeRegistryListener,
 
     private
-    val problemsListener: ConfigurationCacheProblemsListener
+    val problemsListener: ConfigurationCacheProblemsListener,
+
+    private
+    val startParameter: ConfigurationCacheStartParameter
 
 ) : BuildScopeListenerManagerAction {
 
     override fun execute(manager: ListenerManager) {
-        scopeRegistryListener.attach(manager)
-        manager.addListener(problemsListener)
+        if (startParameter.isEnabled) {
+            scopeRegistryListener.attach(manager)
+            manager.addListener(problemsListener)
+        }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -28,7 +28,7 @@ import org.gradle.internal.hash.HashCode
 
 
 internal
-class ConfigurationCacheClassLoaderScopeRegistryListener : ClassLoaderScopeRegistryListener, ScopeLookup {
+class ConfigurationCacheClassLoaderScopeRegistryListener : ClassLoaderScopeRegistryListener, ScopeLookup, AutoCloseable {
     private
     val scopeSpecs = LinkedHashMap<ClassLoaderScopeId, ClassLoaderScopeSpec>()
 
@@ -59,6 +59,10 @@ class ConfigurationCacheClassLoaderScopeRegistryListener : ClassLoaderScopeRegis
         scopeSpecs.clear()
         loaders.clear()
         detach()
+    }
+
+    override fun close() {
+        dispose()
     }
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -76,39 +76,41 @@ class ConfigurationCacheClassLoaderScopeRegistryListener : ClassLoaderScopeRegis
     }
 
     override fun rootScopeCreated(rootScopeId: ClassLoaderScopeId) {
-        // Currently, receives duplicate events from other builds in the build tree, eg the root build receives events from buildSrc
-        if (!scopeSpecs.containsKey(rootScopeId)) {
-            val root = ClassLoaderScopeSpec(null, rootScopeId.name)
-            scopeSpecs[rootScopeId] = root
+        if (scopeSpecs.containsKey(rootScopeId)) {
+            // scope is being reused
+            return
         }
+        val root = ClassLoaderScopeSpec(null, rootScopeId.name)
+        scopeSpecs[rootScopeId] = root
     }
 
     override fun childScopeCreated(parentId: ClassLoaderScopeId, childId: ClassLoaderScopeId) {
-        // Currently, buildSrc does not see some of the root build scopes
-        val parent = scopeSpecs[parentId]
-        if (parent != null) {
-            if (!scopeSpecs.containsKey(childId)) {
-                val child = ClassLoaderScopeSpec(parent, childId.name)
-                scopeSpecs[childId] = child
-            }
+        if (scopeSpecs.containsKey(childId)) {
+            // scope is being reused
+            return
         }
+        val parent = scopeSpecs[parentId]
+        require(parent != null) {
+            "Cannot find parent $parentId for child scope $childId"
+        }
+        val child = ClassLoaderScopeSpec(parent, childId.name)
+        scopeSpecs[childId] = child
     }
 
     override fun classloaderCreated(scopeId: ClassLoaderScopeId, classLoaderId: ClassLoaderId, classLoader: ClassLoader, classPath: ClassPath, implementationHash: HashCode?) {
         val spec = scopeSpecs[scopeId]
-        if (spec != null) {
-            // TODO - a scope can currently potentially have multiple export and local ClassLoaders but we're assuming one here
-            //  Rather than fix the assumption here, it would be better to rework the scope implementation so that it produces no more than one export and one local ClassLoader
-            val local = scopeId is ClassLoaderScopeIdentifier && scopeId.localId() == classLoaderId
-            if (local) {
-                spec.localClassPath = classPath
-                spec.localImplementationHash = implementationHash
-            } else {
-                spec.exportClassPath = classPath
-                spec.exportImplementationHash = implementationHash
-            }
-            loaders[classLoader] = Pair(spec, ClassLoaderRole(local))
+        require(spec != null)
+        // TODO - a scope can currently potentially have multiple export and local ClassLoaders but we're assuming one here
+        //  Rather than fix the assumption here, it would be better to rework the scope implementation so that it produces no more than one export and one local ClassLoader
+        val local = scopeId is ClassLoaderScopeIdentifier && scopeId.localId() == classLoaderId
+        if (local) {
+            spec.localClassPath = classPath
+            spec.localImplementationHash = implementationHash
+        } else {
+            spec.exportClassPath = classPath
+            spec.exportImplementationHash = implementationHash
         }
+        loaders[classLoader] = Pair(spec, ClassLoaderRole(local))
     }
 }
 
@@ -118,9 +120,9 @@ class ClassLoaderScopeSpec(
     val parent: ClassLoaderScopeSpec?,
     val name: String
 ) {
-    var localClassPath = ClassPath.EMPTY
+    var localClassPath: ClassPath = ClassPath.EMPTY
     var localImplementationHash: HashCode? = null
-    var exportClassPath = ClassPath.EMPTY
+    var exportClassPath: ClassPath = ClassPath.EMPTY
     var exportImplementationHash: HashCode? = null
 
     override fun toString(): String {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -18,6 +18,7 @@ package org.gradle.configurationcache
 
 import org.gradle.configuration.internal.UserCodeApplicationContext
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
+import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.initialization.DefaultConfigurationCacheProblemsListener
@@ -25,13 +26,11 @@ import org.gradle.configurationcache.initialization.DefaultInjectedClasspathInst
 import org.gradle.configurationcache.initialization.NoOpConfigurationCacheProblemsListener
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.serialization.beans.BeanConstructors
-import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
-import org.gradle.util.Path
 
 
 class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
@@ -70,16 +69,6 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheHost::class.java)
             add(DefaultConfigurationCache::class.java)
         }
-    }
-}
-
-
-class ConfigurationCacheBuildEnablement(
-    private val buildPath: PublicBuildPath,
-    private val startParameter: ConfigurationCacheStartParameter
-) {
-    val isEnabledForCurrentBuild by lazy {
-        startParameter.isEnabled && buildPath.buildPath == Path.ROOT
     }
 }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -231,8 +231,8 @@ class ConfigurationCacheState(
     suspend fun DefaultWriteContext.writeGradleEnterprisePluginManager() {
         val manager = service<GradleEnterprisePluginManager>()
         val adapter = manager.adapter
-        val writtenAdapter = if (adapter == null) null else {
-            if (adapter.shouldSaveToConfigurationCache()) adapter else null
+        val writtenAdapter = adapter?.takeIf {
+            it.shouldSaveToConfigurationCache()
         }
         write(writtenAdapter)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -164,6 +164,7 @@ class DefaultConfigurationCache internal constructor(
                     throw error
                 } finally {
                     cacheFingerprintController.stop()
+                    scopeRegistryListener.dispose()
                 }
             }
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.ConfigurationCacheRepository.CheckedFingerprint
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.fingerprint.InvalidationReason
+import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.serialization.DefaultReadContext

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheBuildEnablement.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheBuildEnablement.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.initialization
+
+import org.gradle.internal.build.PublicBuildPath
+import org.gradle.util.Path
+
+
+class ConfigurationCacheBuildEnablement(
+    private val buildPath: PublicBuildPath,
+    private val startParameter: ConfigurationCacheStartParameter
+) {
+    val isEnabledForCurrentBuild by lazy {
+        startParameter.isEnabled && buildPath.buildPath == Path.ROOT
+    }
+}


### PR DESCRIPTION
As soon as possible.