### PR TITLE
 Add classpath for all sourceSets to Eclipse by default

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -78,6 +78,14 @@ Depending on the version of Java you use, Gradle will negotiate TLS v1.2 or TLS 
 which causes the exception `javax.net.ssl.SSLException: No PSK available. Unable to resume`. If you run into this issue,
 we recommend updating to the latest minor JDK version.
 
+## IDE integration
+
+### Importing projects with custom source sets 
+
+This version of Gradle fixes problems with projects that use custom source sets, like additional functional test source sets.
+
+Custom source sets are now imported into Eclipse automatically and no longer require manual configuration in the build.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -1,4 +1,5 @@
 The Gradle team is excited to announce Gradle @version@.
+The Gradle team is excited to announce Gradle @version@.
 
 We would like to thank the following community contributors to this release of Gradle:
 
@@ -80,7 +81,7 @@ we recommend updating to the latest minor JDK version.
 
 ## IDE integration
 
-### Importing projects with custom source sets 
+### Importing projects with custom source sets into Eclipse 
 
 This version of Gradle fixes problems with projects that use custom source sets, like additional functional test source sets.
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -51,8 +51,7 @@ Some plugins will break with this new version of Gradle, for example because the
 
 Previously, projects imported by Eclipse only included dependencies for the main and test source sets. The compile and runtime classpaths of custom source sets were ignored.
 
-Since Gradle 6.8, the the default classpath automatically contains all `xxxCompileClasspath` and `xxxRuntimeClasspath` for every custom
-source sets defined by the build.
+Since Gradle 6.8, projects imported into Eclipse include the compile and runtime classpath for every source set defined by the build.
 
 [[changes_6.7]]
 == Upgrading from 6.6

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -49,7 +49,7 @@ Some plugins will break with this new version of Gradle, for example because the
 
 ==== Eclipse plugin has updated classpath
 
-Previously, the default Eclipse classpath was calcuated from a fixed set of dependency configurations: `compileClasspath`, `runtimeClasspath`,`testCompileClasspath`, and `testRuntimeClasspath`.
+Previously, projects imported by Eclipse only included dependencies for the main and test source sets. The compile and runtime classpaths of custom source sets were ignored.
 
 Since Gradle 6.8, the the default classpath automatically contains all `xxxCompileClasspath` and `xxxRuntimeClasspath` for every custom
 source sets defined by the build.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -47,6 +47,13 @@ Some plugins will break with this new version of Gradle, for example because the
 - Kotlin has been updated to https://blog.jetbrains.com/kotlin/2020/08/kotlin-1-4-released-with-a-focus-on-quality-and-performance/[Kotlin 1.4.10].
   Note that Gradle scripts are still using the Kotlin 1.3 language.
 
+==== Eclipse plugin has updated classpath
+
+Previously, the default Eclipse classpath was calcuated from a fixed set of dependency configurations: `compileClasspath`, `runtimeClasspath`,`testCompileClasspath`, and `testRuntimeClasspath`.
+
+Since Gradle 6.8, the the default classpath automatically contains all `xxxCompileClasspath` and `xxxRuntimeClasspath` for every custom
+source sets defined by the build.
+
 [[changes_6.7]]
 == Upgrading from 6.6
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -47,7 +47,7 @@ Some plugins will break with this new version of Gradle, for example because the
 - Kotlin has been updated to https://blog.jetbrains.com/kotlin/2020/08/kotlin-1-4-released-with-a-focus-on-quality-and-performance/[Kotlin 1.4.10].
   Note that Gradle scripts are still using the Kotlin 1.3 language.
 
-==== Eclipse plugin has updated classpath
+==== Projects imported into Eclipse now include custom source set classpaths
 
 Previously, projects imported by Eclipse only included dependencies for the main and test source sets. The compile and runtime classpaths of custom source sets were ignored.
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
@@ -194,4 +194,30 @@ class EclipseSourceSetIntegrationSpec extends AbstractEclipseIntegrationSpec {
         classpath.sourceDir('src/default/java').assertOutputLocation('bin/default_')
         classpath.sourceDir('src/default_/java').assertOutputLocation('bin/default__')
     }
+
+    @ToBeFixedForConfigurationCache
+    def "Custom source set defined on dependencies"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            ${jcenterRepository()}
+
+            sourceSets {
+                integTest
+            }
+
+            dependencies {
+                integTestImplementation 'com.google.guava:guava:18.0'
+            }
+        """
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.lib('guava-18.0.jar').assertHasAttribute('gradle_used_by_scope', 'integTest')
+    }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
@@ -196,7 +196,7 @@ class EclipseSourceSetIntegrationSpec extends AbstractEclipseIntegrationSpec {
     }
 
     @ToBeFixedForConfigurationCache
-    def "Custom source set defined on dependencies"() {
+    def "custom source set defined on dependencies"() {
         setup:
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -265,9 +265,9 @@ public class EclipsePlugin extends IdePlugin {
                 task.configure(new Action<GenerateEclipseClasspath>() {
                     @Override
                     public void execute(GenerateEclipseClasspath task) {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                        task.dependsOn(sourceSets.getByName("main").getOutput().getDirs());
-                        task.dependsOn(sourceSets.getByName("test").getOutput().getDirs());
+                        for (SourceSet sourceSet : project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()) {
+                            task.dependsOn(sourceSet.getOutput().getDirs());
+                        }
                     }
                 });
             }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -62,7 +62,6 @@ import org.gradle.plugins.ide.internal.configurer.UniqueProjectNameProvider;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -240,19 +240,14 @@ public class EclipsePlugin extends IdePlugin {
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             @Override
             public void execute(JavaPlugin javaPlugin) {
-                ((IConventionAware) model.getClasspath()).getConventionMapping().map("plusConfigurations", new Callable<Collection<Configuration>>() {
-                    @Override
-                    public Collection<Configuration> call() throws Exception {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                        List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
-                        ConfigurationContainer configurations = project.getConfigurations();
-                        for (SourceSet sourceSet : sourceSets) {
-                            sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
-                            sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
-                        }
-                        return sourceSetsConfigurations;
-                    }
-                });
+                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
+                ConfigurationContainer configurations = project.getConfigurations();
+                for (SourceSet sourceSet : sourceSets) {
+                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
+                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
+                }
+                model.getClasspath().setPlusConfigurations(sourceSetsConfigurations);
 
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
@@ -37,6 +38,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.xml.XmlTransformer;
@@ -237,7 +239,15 @@ public class EclipsePlugin extends IdePlugin {
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             @Override
             public void execute(JavaPlugin javaPlugin) {
-                model.getClasspath().setPlusConfigurations(Lists.newArrayList(project.getConfigurations().getByName("compileClasspath"), project.getConfigurations().getByName("runtimeClasspath"), project.getConfigurations().getByName("testCompileClasspath"), project.getConfigurations().getByName("testRuntimeClasspath")));
+                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
+                ConfigurationContainer configurations = project.getConfigurations();
+                for (SourceSet sourceSet : sourceSets) {
+                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
+                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
+                }
+                model.getClasspath().setPlusConfigurations(sourceSetsConfigurations);
+
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override
                     public List<File> call() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -62,6 +62,7 @@ import org.gradle.plugins.ide.internal.configurer.UniqueProjectNameProvider;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -239,9 +240,9 @@ public class EclipsePlugin extends IdePlugin {
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             @Override
             public void execute(JavaPlugin javaPlugin) {
-                project.afterEvaluate(new Action<Project>() {
+                ((IConventionAware) model.getClasspath()).getConventionMapping().map("plusConfigurations", new Callable<Collection<Configuration>>() {
                     @Override
-                    public void execute(Project project) {
+                    public Collection<Configuration> call() {
                         SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
                         List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
                         ConfigurationContainer configurations = project.getConfigurations();
@@ -249,9 +250,9 @@ public class EclipsePlugin extends IdePlugin {
                             sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
                             sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
                         }
-                        model.getClasspath().setPlusConfigurations(sourceSetsConfigurations);
+                        return sourceSetsConfigurations;
                     }
-                });
+                }).cache();
 
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -239,14 +239,19 @@ public class EclipsePlugin extends IdePlugin {
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             @Override
             public void execute(JavaPlugin javaPlugin) {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
-                ConfigurationContainer configurations = project.getConfigurations();
-                for (SourceSet sourceSet : sourceSets) {
-                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
-                    sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
-                }
-                model.getClasspath().setPlusConfigurations(sourceSetsConfigurations);
+                project.afterEvaluate(new Action<Project>() {
+                    @Override
+                    public void execute(Project project) {
+                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                        List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
+                        ConfigurationContainer configurations = project.getConfigurations();
+                        for (SourceSet sourceSet : sourceSets) {
+                            sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));
+                            sourceSetsConfigurations.add(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()));
+                        }
+                        model.getClasspath().setPlusConfigurations(sourceSetsConfigurations);
+                    }
+                });
 
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -257,8 +257,11 @@ public class EclipsePlugin extends IdePlugin {
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override
                     public List<File> call() {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                        return Lists.newArrayList(Iterables.concat(sourceSets.getByName("main").getOutput().getDirs(), sourceSets.getByName("test").getOutput().getDirs()));
+                        List<File> result = Lists.newArrayList();
+                        for (SourceSet sourceSet : project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()) {
+                            result.addAll(sourceSet.getOutput().getDirs().getFiles());
+                        }
+                        return result;
                     }
                 });
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -129,6 +129,17 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         folders == [project.file('generated-folder'), project.file('ws-generated'), project.file('generated-test'), project.file('test-resources'), project.file('../some/external/dir')]
     }
 
+    def "configures internal class folders for custom source sets"() {
+        when:
+        eclipsePlugin.apply(project)
+        project.apply(plugin: 'java')
+        project.sourceSets.create('custom')
+        project.sourceSets.custom.output.dir 'custom-output'
+
+        then:
+        project.eclipseClasspath.classpath.classFolders == [project.file('custom-output')]
+    }
+
     private void checkEclipseProjectTask(List buildCommands, List natures) {
         GenerateEclipseProject eclipseProjectTask = project.eclipseProject
         assert eclipseProjectTask instanceof GenerateEclipseProject


### PR DESCRIPTION
By default, the `EclipsePlugin` classpath generation only considers the dependencies assigned to the `main` and `test` source sets. At the same time, the source folders are configured for custom source set definitions as well. Clients can adjust it manually by adding the missing configurations to `eclipse.classpath.plusConfiguration`. This PR makes it the default by automatically assigning the compile/runtime classpath configurations for all source sets to the Eclipse classpath.

For more details, check: 
- https://github.com/eclipse/buildship/issues/476 
- https://gradle.slack.com/archives/C7H5CP62W/p1599811852040100