### PR TITLE
Fix regressions in project state access that affect the Android plugin

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeActionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeActionCodec.kt
@@ -18,6 +18,7 @@ package org.gradle.configurationcache.serialization.codecs
 
 import org.gradle.api.Project
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
+import org.gradle.api.internal.artifacts.transform.DefaultExecutionGraphDependenciesResolver
 import org.gradle.api.internal.tasks.NodeExecutionContext
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.internal.tasks.WorkNodeAction
@@ -29,7 +30,7 @@ import org.gradle.configurationcache.serialization.logNotImplemented
 
 object WorkNodeActionCodec : Codec<WorkNodeAction> {
     override suspend fun WriteContext.encode(value: WorkNodeAction) {
-        if (value is DefaultConfiguration.ResolveGraphAction) {
+        if (value is DefaultConfiguration.ResolveGraphAction || value is DefaultExecutionGraphDependenciesResolver.FinalizeTransformDependencies) {
             // Can ignore
             return
         } else {

--- a/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilder.java
@@ -33,6 +33,8 @@ import org.gradle.api.Project;
  *
  * <p>Although it is not enforced, the model object should be immutable, as the tooling API will do some caching and other performance optimizations on the
  * assumption that the model is effectively immutable. The tooling API does not make any guarantees about how the client application will use the model object.</p>
+ *
+ * <p>Plugins can register their own tooling model builder implementations using {@link ToolingModelBuilderRegistry}.</p>
  */
 public interface ToolingModelBuilder {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilderRegistry.java
+++ b/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilderRegistry.java
@@ -21,6 +21,8 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * A registry of tooling model builders. Adding a builder to this registry makes a model (or models) available via the tooling API.
+ *
+ * <p>An instance of this type can be injected into a task, plugin or other object by annotating a public constructor or property getter method with {@code javax.inject.Inject}.
  */
 @ServiceScope(Scopes.Build.class)
 public interface ToolingModelBuilderRegistry {

--- a/subprojects/core/src/integTest/groovy/org/gradle/tooling/provider/model/CustomToolingModelIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/tooling/provider/model/CustomToolingModelIntegrationTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.provider.model
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+
+import javax.inject.Inject
+
+class CustomToolingModelIntegrationTest extends AbstractIntegrationSpec {
+    // This is not an intended usage, but the Android plugin currently does this
+    @UnsupportedWithConfigurationCache(
+        because = "Tooling model builders require access to the project state, and this is not available when loading from cache")
+    def "task that use a custom tooling model can run concurrently"() {
+        settingsFile << """
+            include 'a', 'b'
+        """
+        buildFile << """
+            import ${Inject.name}
+            import ${ToolingModelBuilderRegistry.name}
+            import ${ToolingModelBuilder.name}
+
+            abstract class SomePlugin implements Plugin<Project> {
+                @Inject
+                abstract ToolingModelBuilderRegistry getRegistry();
+
+                void apply(Project project) {
+                    registry.register(new SomeModelBuilder())
+                    project.tasks.register("thing", SomeTask)
+                }
+            }
+
+            class SomeModelBuilder implements ToolingModelBuilder {
+                boolean canBuild(String modelName) {
+                    return modelName == "thing"
+                }
+
+                Object buildAll(String modelName, Project project) {
+                    return "model"
+                }
+            }
+
+            abstract class SomeTask extends DefaultTask {
+                @Inject
+                abstract ToolingModelBuilderRegistry getRegistry();
+
+                @TaskAction
+                void run() {
+                    registry.getBuilder("thing").buildAll("thing", project)
+                }
+            }
+
+            subprojects {
+                apply plugin: SomePlugin
+            }
+        """
+
+        when:
+        run("thing", "--parallel")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -186,7 +186,6 @@ import org.gradle.plugin.management.internal.autoapply.AutoAppliedPluginHandler;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
 import org.gradle.process.internal.DefaultExecOperations;
 import org.gradle.process.internal.ExecFactory;
-import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.internal.BuildScopeToolingModelBuilderRegistryAction;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 
@@ -588,10 +587,10 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new DefaultAuthenticationSchemeRegistry();
     }
 
-    protected ToolingModelBuilderRegistry createBuildScopedToolingModelBuilders(List<BuildScopeToolingModelBuilderRegistryAction> registryActions,
+    protected DefaultToolingModelBuilderRegistry createBuildScopedToolingModelBuilders(List<BuildScopeToolingModelBuilderRegistryAction> registryActions,
                                                                                 final BuildOperationExecutor buildOperationExecutor,
                                                                                 ProjectStateRegistry projectStateRegistry) {
-        ToolingModelBuilderRegistry registry = new DefaultToolingModelBuilderRegistry(buildOperationExecutor, projectStateRegistry);
+        DefaultToolingModelBuilderRegistry registry = new DefaultToolingModelBuilderRegistry(buildOperationExecutor, projectStateRegistry);
         for (BuildScopeToolingModelBuilderRegistryAction registryAction : registryActions) {
             registryAction.execute(registry);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -96,7 +96,6 @@ import org.gradle.normalization.internal.DefaultRuntimeClasspathNormalization;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.process.internal.ExecFactory;
-import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 import org.gradle.util.Path;
 
@@ -172,7 +171,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultAntBuilderFactory(project, new DefaultAntLoggingAdapterFactory());
     }
 
-    protected ToolingModelBuilderRegistry decorateToolingModelRegistry(ToolingModelBuilderRegistry buildScopedToolingModelBuilders, BuildOperationExecutor buildOperationExecutor, ProjectStateRegistry projectStateRegistry) {
+    protected DefaultToolingModelBuilderRegistry decorateToolingModelRegistry(DefaultToolingModelBuilderRegistry buildScopedToolingModelBuilders, BuildOperationExecutor buildOperationExecutor, ProjectStateRegistry projectStateRegistry) {
         return new DefaultToolingModelBuilderRegistry(buildOperationExecutor, projectStateRegistry, buildScopedToolingModelBuilders);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.provider.model.internal;
+
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.tooling.provider.model.ToolingModelBuilder;
+import org.gradle.tooling.provider.model.UnknownModelException;
+
+@ServiceScope(Scopes.Build.class)
+public interface ToolingModelBuilderLookup {
+    /**
+     * Locates a model builder that runs as a top level build operation.
+     */
+    ToolingModelBuilder locate(String modelName) throws UnknownModelException;
+}

--- a/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
@@ -43,7 +43,24 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         builder2.canBuild("model") >> true
 
         expect:
-        def actualBuilder = registry.getBuilder("model")
+        def builder = registry.getBuilder("model")
+        builder == builder2
+    }
+
+    def "wraps builder when locating for execution"() {
+        def builder1 = Mock(ToolingModelBuilder)
+        def builder2 = Mock(ToolingModelBuilder)
+
+        given:
+        registry.register(builder1)
+        registry.register(builder2)
+
+        and:
+        builder1.canBuild("model") >> false
+        builder2.canBuild("model") >> true
+
+        expect:
+        def actualBuilder = registry.locate("model")
         actualBuilder instanceof DefaultToolingModelBuilderRegistry.BuildOperationWrappingToolingModelBuilder
         actualBuilder.delegate == builder2
     }
@@ -82,7 +99,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         e.message == "Multiple builders are available to build a model of type 'model'."
     }
 
-    def "can register parameterized model builder"() {
+    def "wraps parameterized model builder"() {
         def builder = Mock(ParameterizedToolingModelBuilder)
 
         given:
@@ -95,9 +112,8 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         registry.getBuilder("model")
 
         then:
-        def foundBuilder = registry.getBuilder("model")
-        foundBuilder instanceof DefaultToolingModelBuilderRegistry.ParameterizedBuildOperationWrappingToolingModelBuilder
-        foundBuilder.delegate == builder
-        foundBuilder.delegate instanceof ParameterizedToolingModelBuilder
+        def actualBuilder = registry.locate("model")
+        actualBuilder instanceof DefaultToolingModelBuilderRegistry.ParameterizedBuildOperationWrappingToolingModelBuilder
+        actualBuilder.delegate == builder
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -708,7 +708,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver() {
-        return new DefaultExtraExecutionGraphDependenciesResolverFactory(this::getResultsForBuildDependencies, this::getResultsForArtifacts, new ResolveGraphAction(this),
+        return new DefaultExtraExecutionGraphDependenciesResolverFactory(this::getResultsForBuildDependencies, this::getResultsForArtifacts, owner,
             (attributes, filter) -> new ConfigurationFileCollection(Specs.satisfyAll(), attributes, filter, false, false));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -17,25 +17,25 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ResolverResults;
-import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.Factory;
 
 public class DefaultExtraExecutionGraphDependenciesResolverFactory implements ExtraExecutionGraphDependenciesResolverFactory {
     private final Factory<ResolverResults> graphResults;
     private final Factory<ResolverResults> artifactResults;
-    private final WorkNodeAction graphResolveAction;
+    private final DomainObjectContext owner;
     private final FilteredResultFactory filteredResultFactory;
 
-    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, WorkNodeAction graphResolveAction, FilteredResultFactory filteredResultFactory) {
+    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, DomainObjectContext owner, FilteredResultFactory filteredResultFactory) {
         this.graphResults = graphResults;
         this.artifactResults = artifactResults;
-        this.graphResolveAction = graphResolveAction;
+        this.owner = owner;
         this.filteredResultFactory = filteredResultFactory;
     }
 
     @Override
     public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier) {
-        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction, filteredResultFactory);
+        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, owner, filteredResultFactory);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -164,9 +164,9 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     public static class InitialTransformationNode extends TransformationNode {
         private final ResolvedArtifactSet.LocalArtifactSet artifacts;
 
-        public InitialTransformationNode(TransformationStep transformationStep, ResolvedArtifactSet.LocalArtifactSet localArtifacts, ExecutionGraphDependenciesResolver dependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
+        public InitialTransformationNode(TransformationStep transformationStep, ResolvedArtifactSet.LocalArtifactSet artifacts, ExecutionGraphDependenciesResolver dependenciesResolver, BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
             super(transformationStep, dependenciesResolver, buildOperationExecutor, transformListener);
-            this.artifacts = localArtifacts;
+            this.artifacts = artifacts;
         }
 
         @Override

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -155,6 +155,7 @@ The following services are available for injection:
 - link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html[FileSystemOperations] - Allows a task to run operations on the filesystem such as deleting files, copying files or syncing directories.
 - link:{javadocPath}/org/gradle/api/file/ArchiveOperations.html[ArchiveOperations] - Allows a task to run operations on archive files such as ZIP or TAR files.
 - link:{javadocPath}/org/gradle/process/ExecOperations.html[ExecOperations] - Allows a task to run external processes with dedicated support for running external `java` programs.
+- link:{javadocPath}/org/gradle/tooling/provider/model/ToolingModelBuilderRegistry.html[ToolingModelBuilderRegistry] - Allows a plugin to registers a Gradle tooling API model.
 
 Out of the above, `ProjectLayout` and `WorkerExecutor` services are only available for injection in project plugins.
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -29,8 +29,8 @@ import org.gradle.internal.invocation.BuildController;
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException;
 import org.gradle.tooling.internal.provider.BuildModelAction;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
-import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.UnknownModelException;
+import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 
 public class BuildModelActionRunner implements BuildActionRunner {
     @Override
@@ -109,18 +109,17 @@ public class BuildModelActionRunner implements BuildActionRunner {
         }
 
         private ToolingModelBuilder getModelBuilder(GradleInternal gradle, String modelName) {
-            ToolingModelBuilderRegistry builderRegistry = getToolingModelBuilderRegistry(gradle);
+            ToolingModelBuilderLookup builderRegistry = getToolingModelBuilderRegistry(gradle);
             try {
-                return builderRegistry.getBuilder(modelName);
+                return builderRegistry.locate(modelName);
             } catch (UnknownModelException e) {
                 modelFailure = e;
                 throw e;
             }
         }
 
-        private static ToolingModelBuilderRegistry getToolingModelBuilderRegistry(GradleInternal gradle) {
-            return gradle.getDefaultProject().getServices().get(ToolingModelBuilderRegistry.class);
+        private static ToolingModelBuilderLookup getToolingModelBuilderRegistry(GradleInternal gradle) {
+            return gradle.getDefaultProject().getServices().get(ToolingModelBuilderLookup.class);
         }
-
     }
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -34,8 +34,8 @@ import org.gradle.tooling.internal.protocol.ModelIdentifier;
 import org.gradle.tooling.internal.provider.connection.ProviderBuildResult;
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
-import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.UnknownModelException;
+import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 
 @SuppressWarnings("deprecation")
 class DefaultBuildController implements org.gradle.tooling.internal.protocol.InternalBuildController, InternalBuildControllerVersion2 {
@@ -146,11 +146,11 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
     }
 
     private ToolingModelBuilder getToolingModelBuilder(ProjectInternal project, ModelIdentifier modelIdentifier) {
-        ToolingModelBuilderRegistry modelBuilderRegistry = project.getServices().get(ToolingModelBuilderRegistry.class);
+        ToolingModelBuilderLookup modelBuilderRegistry = project.getServices().get(ToolingModelBuilderLookup.class);
 
         ToolingModelBuilder builder;
         try {
-            builder = modelBuilderRegistry.getBuilder(modelIdentifier.getName());
+            builder = modelBuilderRegistry.locate(modelIdentifier.getName());
         } catch (UnknownModelException e) {
             throw (InternalUnsupportedModelException) (new InternalUnsupportedModelException()).initCause(e);
         }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -24,10 +24,10 @@ import org.gradle.internal.service.ServiceRegistry
 import org.gradle.tooling.internal.gradle.GradleProjectIdentity
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException
 import org.gradle.tooling.internal.protocol.ModelIdentifier
-import org.gradle.tooling.provider.model.ToolingModelBuilder
-import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder
+import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.UnknownModelException
+import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup
 import spock.lang.Specification
 
 class DefaultBuildControllerTest extends Specification {
@@ -37,10 +37,10 @@ class DefaultBuildControllerTest extends Specification {
             get(BuildCancellationToken) >> cancellationToken
         }
     }
-    def registry = Stub(ToolingModelBuilderRegistry)
+    def registry = Stub(ToolingModelBuilderLookup)
     def project = Stub(ProjectInternal) {
         getServices() >> Stub(ServiceRegistry) {
-            get(ToolingModelBuilderRegistry) >> registry
+            get(ToolingModelBuilderLookup) >> registry
         }
     }
     def modelId = Stub(ModelIdentifier) {
@@ -55,7 +55,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.getBuilder('some.model') >> { throw failure }
+        _ * registry.locate('some.model') >> { throw failure }
 
         when:
         controller.getModel(null, modelId)
@@ -77,7 +77,7 @@ class DefaultBuildControllerTest extends Specification {
         _ * gradle.rootProject >> rootProject
         _ * rootProject.project(":some:path") >> project
         _ * rootProject.getProjectDir() >> rootDir
-        _ * registry.getBuilder("some.model") >> modelBuilder
+        _ * registry.locate("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -92,7 +92,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.getBuilder("some.model") >> modelBuilder
+        _ * registry.locate("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -119,7 +119,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.getBuilder("some.model") >> modelBuilder
+        _ * registry.locate("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -144,7 +144,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.getBuilder("some.model") >> parameterizedModelBuilder
+        _ * registry.locate("some.model") >> parameterizedModelBuilder
         _ * parameterizedModelBuilder.getParameterType() >> parameterType
         _ * parameterizedModelBuilder.buildAll("some.model", _, project) >> { def modelName, CustomParameter param, projectInternal ->
             assert param != null
@@ -165,7 +165,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.getBuilder("some.model") >> modelBuilder
+        _ * registry.locate("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Fix a couple of regressions introduced by changes to tighten up access to project state in Gradle 6.7:

- Ensure that the parameters of a transform applied only to external artifacts are correctly isolated prior to attempting to run the transform.
- Do not exclusively lock all projects when a task action uses a tooling model builder.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
