### PR TITLE
Add experimental projects for the new performance test infrastructure

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -21,6 +21,7 @@ import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2
 import common.gradleWrapper
+import common.individualPerformanceTestArtifactRules
 import common.killGradleProcessesStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
@@ -39,6 +40,7 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
     this.name = description
     val performanceTestTaskNames = getPerformanceTestTaskNames(performanceSubProject, testProjects)
     applyPerformanceTestSettings(os = os, timeout = type.timeout)
+    artifactRules = individualPerformanceTestArtifactRules
 
     params {
         param("performance.baselines", type.defaultBaselines)

--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -60,8 +60,8 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
                 gradleParams = (
                     performanceTestCommandLine(
                         "clean ${performanceTestTaskNames.joinToString(" ")}",
-                        "%baselines%",
-                        """--channel %channel%$extraParameters""",
+                        "%performance.baselines%",
+                        extraParameters,
                         os
                     ) +
                         buildToolGradleParameters(isContinue = false, os = os) +

--- a/.teamcity/Gradle_Check/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/FunctionalTestBucketProvider.kt
@@ -127,7 +127,7 @@ class StatisticBasedFunctionalTestBucketProvider(private val model: CIBuildModel
         if (testCoverage.testType == TestType.platform) {
             val docsSubproject = validSubprojects.filter { it.name == "docs" }
             val otherSubProjectTestClassTimes = subProjectTestClassTimes.filter { it.subProject.name != "docs" }
-            return docsSubproject + split(
+            return docsSubproject + splitIntoBuckets(
                 LinkedList(otherSubProjectTestClassTimes),
                 SubprojectTestClassTime::totalTime,
                 { largeElement: SubprojectTestClassTime, size: Int -> largeElement.split(size) },
@@ -136,7 +136,7 @@ class StatisticBasedFunctionalTestBucketProvider(private val model: CIBuildModel
                 MAX_PROJECT_NUMBER_IN_BUCKET
             )
         } else {
-            return split(
+            return splitIntoBuckets(
                 LinkedList(subProjectTestClassTimes),
                 SubprojectTestClassTime::totalTime,
                 { largeElement: SubprojectTestClassTime, size: Int -> largeElement.split(size) },
@@ -289,7 +289,7 @@ class SubprojectTestClassTime(val subProject: GradleSubproject, private val test
             val largeElementSplitFunction: (TestClassTime, Int) -> List<List<TestClassTime>> = { testClassTime: TestClassTime, number: Int -> listOf(listOf(testClassTime)) }
             val smallElementAggregateFunction: (List<TestClassTime>) -> List<TestClassTime> = { it }
 
-            val buckets: List<List<TestClassTime>> = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE)
+            val buckets: List<List<TestClassTime>> = splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE)
 
             buckets.mapIndexed { index: Int, classesInBucket: List<TestClassTime> ->
                 val include = index != buckets.size - 1

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -168,6 +168,7 @@ class TestProjectTime(val testProject: String, val scenarioTimes: List<Performan
             val smallElementAggregateFunction: (List<PerformanceTestTime>) -> List<PerformanceTestTime> = { it }
 
             val buckets: List<List<PerformanceTestTime>> = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE, { listOf() })
+                .filter { it.isNotEmpty() }
 
             buckets.mapIndexed { index: Int, classesInBucket: List<PerformanceTestTime> ->
                 TestProjectSplitBucket(testProject, index + 1, classesInBucket)
@@ -270,6 +271,9 @@ class TestProjectSplitBucket(val testProject: String, val number: Int, val scena
 
 private
 fun prepareScenariosStep(testProject: String, scenarios: List<Scenario>, os: Os): BuildSteps.() -> Unit {
+    if (scenarios.isEmpty()) {
+        throw IllegalArgumentException("Scenarios list must not be empty for $testProject")
+    }
     val csvLines = scenarios.map { "${it.className};${it.scenario}" }
     val action = "include"
     val fileNamePostfix = "$testProject-performance-scenarios.csv"

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -154,7 +154,8 @@ class TestProjectTime(val testProject: String, val scenarioTimes: List<Performan
         }
     }
 
-    override fun toString(): String {
+    override
+    fun toString(): String {
         return "TestProjectScenarioTime(testProject=$testProject, totalTime=$totalTime)"
     }
 }
@@ -162,7 +163,8 @@ class TestProjectTime(val testProject: String, val scenarioTimes: List<Performan
 data class Scenario(val className: String, val scenario: String)
 
 class SingleTestProjectBucket(val testProject: String, val scenarios: List<Scenario>) : PerformanceTestBucket {
-    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+    override
+    fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
         val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
         return PerformanceTest(
             model,
@@ -180,7 +182,8 @@ class SingleTestProjectBucket(val testProject: String, val scenarios: List<Scena
 }
 
 class MultipleTestProjectBucket(val testProjects: List<TestProjectTime>) : PerformanceTestBucket {
-    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+    override
+    fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
         val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
         return PerformanceTest(
             model,
@@ -202,7 +205,8 @@ class MultipleTestProjectBucket(val testProjects: List<TestProjectTime>) : Perfo
 }
 
 class EmptyTestProjectBucket(private val index: Int) : PerformanceTestBucket {
-    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+    override
+    fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
         val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
         return PerformanceTest(
             model,
@@ -218,7 +222,8 @@ class EmptyTestProjectBucket(private val index: Int) : PerformanceTestBucket {
 }
 
 class TestProjectSplitBucket(val testProject: String, val number: Int, val scenarios: List<PerformanceTestTime>) : PerformanceTestBucket {
-    override fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
+    override
+    fun createPerformanceTestsFor(model: CIBuildModel, stage: Stage, performanceTestCoverage: PerformanceTestCoverage, bucketIndex: Int): PerformanceTest {
         val uuid = getUuid(model, performanceTestCoverage, bucketIndex)
         return PerformanceTest(
             model,
@@ -235,7 +240,8 @@ class TestProjectSplitBucket(val testProject: String, val number: Int, val scena
     }
 }
 
-private fun prepareScenariosStep(testProject: String, scenarios: List<Scenario>, os: Os): BuildSteps.() -> Unit {
+private
+fun prepareScenariosStep(testProject: String, scenarios: List<Scenario>, os: Os): BuildSteps.() -> Unit {
     val csvLines = scenarios.map { "${it.className};${it.scenario}" }
     val action = "include"
     val fileNamePostfix = "$testProject-performance-scenarios.csv"

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -245,29 +245,30 @@ fun prepareScenariosStep(testProject: String, scenarios: List<Scenario>, os: Os)
     val csvLines = scenarios.map { "${it.className};${it.scenario}" }
     val action = "include"
     val fileNamePostfix = "$testProject-performance-scenarios.csv"
+    val performanceTestSplitDirectoryName = "performance-test-splits"
     val unixScript = """
-mkdir -p build
-rm -rf build/*-$fileNamePostfix
-cat > build/$action-$fileNamePostfix << EOL
+mkdir -p $performanceTestSplitDirectoryName
+rm -rf $performanceTestSplitDirectoryName/*-$fileNamePostfix
+cat > $performanceTestSplitDirectoryName/$action-$fileNamePostfix << EOL
 ${csvLines.joinToString("\n")}
 EOL
 
 echo "Performance tests to be ${action}d in this build"
-cat build/$action-$fileNamePostfix
+cat $performanceTestSplitDirectoryName/$action-$fileNamePostfix
 """
 
     val linesWithEcho = csvLines.joinToString("\n") { "echo $it" }
 
     val windowsScript = """
-mkdir build
-del /f /q build\include-$fileNamePostfix
-del /f /q build\exclude-$fileNamePostfix
+mkdir $performanceTestSplitDirectoryName
+del /f /q $performanceTestSplitDirectoryName\include-$fileNamePostfix
+del /f /q $performanceTestSplitDirectoryName\exclude-$fileNamePostfix
 (
 $linesWithEcho
-) > build\$action-$fileNamePostfix
+) > $performanceTestSplitDirectoryName\$action-$fileNamePostfix
 
 echo "Performance tests to be ${action}d in this build"
-type build\$action-$fileNamePostfix
+type $performanceTestSplitDirectoryName\$action-$fileNamePostfix
 """
 
     return {

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -116,7 +116,7 @@ fun splitBucketsByScenarios(performanceTestCoverage: PerformanceTestCoverage, sc
         .entries
         .map { TestProjectTime(it.key, it.value) }
         .sortedBy { -it.totalTime }
-    return split(
+    return splitIntoBuckets(
         LinkedList(testProjectTimes),
         TestProjectTime::totalTime,
         { largeElement: TestProjectTime, size: Int -> largeElement.split(size) },
@@ -164,7 +164,7 @@ class TestProjectTime(val testProject: String, val scenarioTimes: List<Performan
             val largeElementSplitFunction: (PerformanceTestTime, Int) -> List<List<PerformanceTestTime>> = { performanceTestTime: PerformanceTestTime, number: Int -> listOf(listOf(performanceTestTime)) }
             val smallElementAggregateFunction: (List<PerformanceTestTime>) -> List<PerformanceTestTime> = { it }
 
-            val buckets: List<List<PerformanceTestTime>> = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE, { listOf() })
+            val buckets: List<List<PerformanceTestTime>> = splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE, { listOf() })
                 .filter { it.isNotEmpty() }
 
             buckets.mapIndexed { index: Int, classesInBucket: List<PerformanceTestTime> ->

--- a/.teamcity/Gradle_Check/model/bucket-extensions.kt
+++ b/.teamcity/Gradle_Check/model/bucket-extensions.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package Gradle_Check.model
+
+import java.util.LinkedList
+
+/**
+ * Split a list of elements into nearly even sublist. If an element is too large, largeElementSplitFunction will be used to split the large element into several smaller pieces;
+ * if some elements are too small, they will be aggregated by smallElementAggregateFunction.
+ *
+ * @param list the list to split, must be ordered by size desc
+ * @param toIntFunction the function used to map the element to its "size"
+ * @param largeElementSplitFunction the function used to further split the large element into smaller pieces
+ * @param smallElementAggregateFunction the function used to aggregate tiny elements into a large bucket
+ * @param expectedBucketNumber the return value's size should be expectedBucketNumber
+ */
+fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSplitFunction: (T, Int) -> List<R>, smallElementAggregateFunction: (List<T>) -> R, expectedBucketNumber: Int, maxNumberInBucket: Int, noElementSplitFunction: (Int) -> List<R> = { throw IllegalArgumentException("More buckets than things to split") }): List<R> {
+    if (expectedBucketNumber == 1) {
+        return listOf(smallElementAggregateFunction(list))
+    }
+    if (list.isEmpty()) {
+        return noElementSplitFunction(expectedBucketNumber)
+    }
+
+    val expectedBucketSize = list.sumBy(toIntFunction) / expectedBucketNumber
+
+    val largestElement = list.removeFirst()!!
+
+    val largestElementSize = toIntFunction(largestElement)
+
+    return if (largestElementSize >= expectedBucketSize) {
+        val bucketsOfFirstElement = largeElementSplitFunction(largestElement, if (largestElementSize % expectedBucketSize == 0) largestElementSize / expectedBucketSize else largestElementSize / expectedBucketSize + 1)
+        val bucketsOfRestElements = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket, noElementSplitFunction)
+        bucketsOfFirstElement + bucketsOfRestElements
+    } else {
+        val buckets = arrayListOf(largestElement)
+        var restCapacity = expectedBucketSize - toIntFunction(largestElement)
+        while (restCapacity > 0 && list.isNotEmpty() && buckets.size < maxNumberInBucket) {
+            val smallestElement = list.removeLast()
+            buckets.add(smallestElement)
+            restCapacity -= toIntFunction(smallestElement)
+        }
+        listOf(smallElementAggregateFunction(buckets)) + split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket, noElementSplitFunction)
+    }
+}

--- a/.teamcity/Gradle_Check/model/bucket-extensions.kt
+++ b/.teamcity/Gradle_Check/model/bucket-extensions.kt
@@ -28,7 +28,15 @@ import java.util.LinkedList
  * @param smallElementAggregateFunction the function used to aggregate tiny elements into a large bucket
  * @param expectedBucketNumber the return value's size should be expectedBucketNumber
  */
-fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSplitFunction: (T, Int) -> List<R>, smallElementAggregateFunction: (List<T>) -> R, expectedBucketNumber: Int, maxNumberInBucket: Int, noElementSplitFunction: (Int) -> List<R> = { throw IllegalArgumentException("More buckets than things to split") }): List<R> {
+fun <T, R> splitIntoBuckets(
+    list: LinkedList<T>,
+    toIntFunction: (T) -> Int,
+    largeElementSplitFunction: (T, Int) -> List<R>,
+    smallElementAggregateFunction: (List<T>) -> R,
+    expectedBucketNumber: Int,
+    maxNumberInBucket: Int,
+    noElementSplitFunction: (Int) -> List<R> = { throw IllegalArgumentException("More buckets than things to split") }
+): List<R> {
     if (expectedBucketNumber == 1) {
         return listOf(smallElementAggregateFunction(list))
     }
@@ -44,7 +52,7 @@ fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSpl
 
     return if (largestElementSize >= expectedBucketSize) {
         val bucketsOfFirstElement = largeElementSplitFunction(largestElement, if (largestElementSize % expectedBucketSize == 0) largestElementSize / expectedBucketSize else largestElementSize / expectedBucketSize + 1)
-        val bucketsOfRestElements = split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket, noElementSplitFunction)
+        val bucketsOfRestElements = splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket, noElementSplitFunction)
         bucketsOfFirstElement + bucketsOfRestElements
     } else {
         val buckets = arrayListOf(largestElement)
@@ -54,6 +62,6 @@ fun <T, R> split(list: LinkedList<T>, toIntFunction: (T) -> Int, largeElementSpl
             buckets.add(smallestElement)
             restCapacity -= toIntFunction(smallestElement)
         }
-        listOf(smallElementAggregateFunction(buckets)) + split(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket, noElementSplitFunction)
+        listOf(smallElementAggregateFunction(buckets)) + splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket, noElementSplitFunction)
     }
 }

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -1,6 +1,6 @@
 package projects
 
-import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.FunctionalTestBucketProvider
 import configurations.FunctionalTest
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
@@ -8,12 +8,12 @@ import model.CIBuildModel
 import model.Stage
 import model.TestCoverage
 
-class FunctionalTestProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBucketProvider, testConfig: TestCoverage, stage: Stage) : Project({
+class FunctionalTestProject(model: CIBuildModel, functionalTestBucketProvider: FunctionalTestBucketProvider, testConfig: TestCoverage, stage: Stage) : Project({
     this.uuid = testConfig.asId(model)
     this.id = AbsoluteId(uuid)
     this.name = testConfig.asName()
 }) {
-    val functionalTests: List<FunctionalTest> = gradleBuildBucketProvider.createFunctionalTestsFor(stage, testConfig)
+    val functionalTests: List<FunctionalTest> = functionalTestBucketProvider.createFunctionalTestsFor(stage, testConfig)
 
     init {
         functionalTests.forEach(this::buildType)

--- a/.teamcity/Gradle_Check/projects/PerformanceTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/PerformanceTestProject.kt
@@ -3,19 +3,17 @@ package projects
 import Gradle_Check.configurations.PerformanceTest
 import Gradle_Check.model.PerformanceTestBucketProvider
 import Gradle_Check.model.PerformanceTestCoverage
-import common.Os
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import model.CIBuildModel
 import model.Stage
 
-class PerformanceTestProject(model: CIBuildModel, performanceTestBucketProvider: PerformanceTestBucketProvider, os: Os, stage: Stage) : Project({
-    val performanceTestCoverage = PerformanceTestCoverage(stage.id, os)
+class PerformanceTestProject(model: CIBuildModel, performanceTestBucketProvider: PerformanceTestBucketProvider, stage: Stage, performanceTestCoverage: PerformanceTestCoverage) : Project({
     this.uuid = performanceTestCoverage.asConfigurationId(model)
     this.id = AbsoluteId(uuid)
     this.name = performanceTestCoverage.asName()
 }) {
-    val performanceTests: List<PerformanceTest> = performanceTestBucketProvider.createPerformanceTestsFor(stage, os)
+    val performanceTests: List<PerformanceTest> = performanceTestBucketProvider.createPerformanceTestsFor(stage, performanceTestCoverage)
 
     init {
         performanceTests.forEach(this::buildType)

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -1,6 +1,6 @@
 package projects
 
-import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.FunctionalTestBucketProvider
 import Gradle_Check.model.StatisticsBasedPerformanceTestBucketProvider
 import common.failedTestArtifactDestination
 import configurations.StagePasses
@@ -12,7 +12,7 @@ import model.CIBuildModel
 import model.Stage
 import java.io.File
 
-class RootProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBucketProvider) : Project({
+class RootProject(model: CIBuildModel, functionalTestBucketProvider: FunctionalTestBucketProvider) : Project({
     uuid = model.projectPrefix.removeSuffix("_")
     id = AbsoluteId(uuid)
     parentId = AbsoluteId("Gradle")
@@ -37,7 +37,7 @@ class RootProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBuc
 
     var prevStage: Stage? = null
     model.stages.forEach { stage ->
-        val stageProject = StageProject(model, gradleBuildBucketProvider, performanceTestBucketProvider, stage, uuid)
+        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage, uuid)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -17,7 +17,7 @@ class RootProject(model: CIBuildModel, functionalTestBucketProvider: FunctionalT
     id = AbsoluteId(uuid)
     parentId = AbsoluteId("Gradle")
     name = model.rootProjectName
-    val performanceTestBucketProvider = StatisticsBasedPerformanceTestBucketProvider(model, File("../subprojects/performance/some-file.csv"))
+    val performanceTestBucketProvider = StatisticsBasedPerformanceTestBucketProvider(model, File("performance-test-runtimes.csv"), File("performance-tests-ci.json"))
 
     features {
         versionedSettings {

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -2,7 +2,7 @@ package projects
 
 import Gradle_Check.configurations.FunctionalTestsPass
 import Gradle_Check.configurations.PerformanceTestsPass
-import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.FunctionalTestBucketProvider
 import Gradle_Check.model.PerformanceTestBucketProvider
 import common.Os
 import configurations.FunctionalTest
@@ -20,7 +20,7 @@ import model.Stage
 import model.StageNames
 import model.TestType
 
-class StageProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBucketProvider, performanceTestBucketProvider: PerformanceTestBucketProvider, stage: Stage, rootProjectUuid: String) : Project({
+class StageProject(model: CIBuildModel, functionalTestBucketProvider: FunctionalTestBucketProvider, performanceTestBucketProvider: PerformanceTestBucketProvider, stage: Stage, rootProjectUuid: String) : Project({
     this.uuid = "${model.projectPrefix}Stage_${stage.stageName.uuid}"
     this.id = AbsoluteId("${model.projectPrefix}Stage_${stage.stageName.id}")
     this.name = stage.stageName.stageName
@@ -64,7 +64,7 @@ class StageProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBu
 
         val functionalTestProjects = allCoverage
             .map { testCoverage ->
-                val functionalTestProject = FunctionalTestProject(model, gradleBuildBucketProvider, testCoverage, stage)
+                val functionalTestProject = FunctionalTestProject(model, functionalTestBucketProvider, testCoverage, stage)
                 if (stage.functionalTestsDependOnSpecificBuilds) {
                     specificBuildTypes.forEach { specificBuildType ->
                         functionalTestProject.addDependencyForAllBuildTypes(specificBuildType)
@@ -81,7 +81,7 @@ class StageProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBu
             this@StageProject.buildType(FunctionalTestsPass(model, functionalTestProject))
         }
 
-        val deferredTestsForThisStage = gradleBuildBucketProvider.createDeferredFunctionalTestsFor(stage)
+        val deferredTestsForThisStage = functionalTestBucketProvider.createDeferredFunctionalTestsFor(stage)
         if (deferredTestsForThisStage.isNotEmpty()) {
             val deferredTestsProject = Project {
                 uuid = "${rootProjectUuid}_deferred_tests"

--- a/.teamcity/Gradle_Check/settings.kts
+++ b/.teamcity/Gradle_Check/settings.kts
@@ -1,7 +1,7 @@
 package Gradle_Check
 
 import Gradle_Check.model.JsonBasedGradleSubprojectProvider
-import Gradle_Check.model.StatisticBasedGradleBuildBucketProvider
+import Gradle_Check.model.StatisticBasedFunctionalTestBucketProvider
 import jetbrains.buildServer.configs.kotlin.v2019_2.project
 import jetbrains.buildServer.configs.kotlin.v2019_2.version
 import model.CIBuildModel
@@ -30,5 +30,5 @@ calling the subProjects() method in this project.
 
 version = "2020.1"
 val model = CIBuildModel(buildScanTags = listOf("Check"), subprojects = JsonBasedGradleSubprojectProvider(File("./subprojects.json")))
-val gradleBuildBucketProvider = StatisticBasedGradleBuildBucketProvider(model, File("./test-class-data.json"))
+val gradleBuildBucketProvider = StatisticBasedFunctionalTestBucketProvider(model, File("./test-class-data.json"))
 project(RootProject(model, gradleBuildBucketProvider))

--- a/.teamcity/performance-test-runtimes.csv
+++ b/.teamcity/performance-test-runtimes.csv
@@ -1,0 +1,10 @@
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel true);largeJavaMultiProject;linux;476000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel false);largeJavaMultiProject;linux;700000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel false);largeMonolithicJavaProject;linux;308000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel true);largeJavaMultiProject;linux;308000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeJavaMultiProject;linux;308000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeMonolithicJavaProject;linux;308000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeJavaMultiProject;linux;30000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeMonolithicJavaProject;linux;30000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeJavaMultiProject;linux;30000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeMonolithicJavaProject;linux;30000

--- a/.teamcity/performance-test-runtimes.csv
+++ b/.teamcity/performance-test-runtimes.csv
@@ -1,10 +1,110 @@
 org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel true);largeJavaMultiProject;linux;476000
 org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel false);largeJavaMultiProject;linux;700000
 org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble (parallel false);largeMonolithicJavaProject;linux;308000
-org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel true);largeJavaMultiProject;linux;308000
-org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeJavaMultiProject;linux;308000
-org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeMonolithicJavaProject;linux;308000
-org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeJavaMultiProject;linux;30000
-org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeMonolithicJavaProject;linux;30000
-org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeJavaMultiProject;linux;30000
-org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeMonolithicJavaProject;linux;30000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel true);largeJavaMultiProject;linux;473000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeJavaMultiProject;linux;672000
+org.gradle.performance.regression.java.JavaUpToDatePerformanceTest;up-to-date assemble with local build cache enabled (parallel false);largeMonolithicJavaProject;linux;305000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeJavaMultiProject;linux;272000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks;largeMonolithicJavaProject;linux;141000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeJavaMultiProject;linux;308000
+org.gradle.performance.regression.java.JavaTasksPerformanceTest;tasks --all;largeMonolithicJavaProject;linux;139000
+org.gradle.performance.regression.java.JavaTestChangePerformanceTest;test for non-abi change;largeMonolithicJavaProject;linux;1415000
+org.gradle.performance.regression.java.JavaTestChangePerformanceTest;test for non-abi change;largeJavaMultiProject;linux;584000
+org.gradle.performance.regression.java.JavaTestChangePerformanceTest;test for non-abi change;mediumJavaMultiProjectWithTestNG;linux;290000
+org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest;assemble for non-abi change;largeJavaMultiProject;linux;486000
+org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest;assemble for non-abi change;largeGroovyMultiProject;linux;613000
+org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest;assemble for non-abi change;largeMonolithicJavaProject;linux;1013000
+org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest;assemble for non-abi change;largeMonolithicGroovyProject;linux;1680000
+org.gradle.performance.regression.java.JavaABIChangePerformanceTest;assemble for abi change;largeJavaMultiProject;linux;504000
+org.gradle.performance.regression.java.JavaABIChangePerformanceTest;assemble for abi change;largeGroovyMultiProject;linux;704000
+org.gradle.performance.regression.java.JavaABIChangePerformanceTest;assemble for abi change;largeMonolithicJavaProject;linux;1018000
+org.gradle.performance.regression.java.JavaABIChangePerformanceTest;assemble for abi change;largeMonolithicGroovyProject;linux;1670000
+org.gradle.performance.regression.java.JavaIDEModelPerformanceTest;get IDE model for Eclipse;largeJavaMultiProject;linux;480000
+org.gradle.performance.regression.java.JavaIDEModelPerformanceTest;get IDE model for Eclipse;largeMonolithicJavaProject;linux;116000
+org.gradle.performance.regression.java.JavaIDEModelPerformanceTest;get IDE model for IDEA;largeJavaMultiProject;linux;454000
+org.gradle.performance.regression.java.JavaIDEModelPerformanceTest;get IDE model for IDEA;largeMonolithicJavaProject;linux;116000
+org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest;generate dependency report;largeMonolithicJavaProject;linux;141000
+org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest;generate dependency report;largeJavaMultiProject;linux;272000
+org.gradle.performance.regression.java.JavaConfigurationPerformanceTest;configure;largeJavaMultiProject;linux;253000
+org.gradle.performance.regression.java.JavaConfigurationPerformanceTest;configure;largeJavaMultiProjectKotlinDsl;linux;395000
+org.gradle.performance.regression.java.JavaConfigurationPerformanceTest;configure;largeMonolithicJavaProject;linux;141000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble loading configuration cache state with hot daemon;largeJavaMultiProjectNoBuildSrc;linux;386000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble loading configuration cache state with cold daemon;largeJavaMultiProjectNoBuildSrc;linux;626000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble loading configuration cache state with hot daemon;smallJavaMultiProject;linux;188000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble storing configuration cache state with hot daemon;largeJavaMultiProjectNoBuildSrc;linux;383000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble storing configuration cache state with cold daemon;largeJavaMultiProjectNoBuildSrc;linux;628000
+org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest;assemble storing configuration cache state with hot daemon;smallJavaMultiProject;linux;184000
+org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest;clean assemble;largeJavaMultiProject;linux;499000
+org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest;clean assemble;largeMonolithicJavaProject;linux;529000
+org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest;clean assemble;mediumJavaCompositeBuild;linux;259000
+org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest;clean assemble;mediumJavaPredefinedCompositeBuild;linux;260000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with remote http cache;largeJavaMultiProject;linux;905000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with remote http cache;largeMonolithicJavaProject;linux;1012000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with remote https cache;largeJavaMultiProject;linux;896000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with remote https cache;largeMonolithicJavaProject;linux;1022000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with empty local cache;largeJavaMultiProject;linux;877000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with empty local cache;largeMonolithicJavaProject;linux;975000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with empty remote http cache;largeJavaMultiProject;linux;863000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with empty remote http cache;largeMonolithicJavaProject;linux;977000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with local cache;largeJavaMultiProject;linux;985000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble with local cache;largeMonolithicJavaProject;linux;1018000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble for abi change with local cache;largeJavaMultiProject;linux;993000
+org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest;clean assemble for non-abi change with local cache;largeJavaMultiProject;linux;927000
+org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest;clean assemble with local cache (native project);bigCppApp;linux;234000
+org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest;clean assemble with local cache (native project);bigCppMulti;linux;497000
+org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest;clean assemble with local cache (native project);bigNative;linux;233000
+org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest;clean assemble with local cache (swift);bigSwiftApp;linux;315000
+org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest;clean assemble with local cache (swift);mediumSwiftMulti;linux;522000
+org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest;visiting zip trees;archivePerformanceProject;linux;229000
+org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest;visiting tar trees;archivePerformanceProject;linux;163000
+org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest;visiting gzip tar trees;archivePerformanceProject;linux;167000
+org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest;create many deprecation warnings;generateLotsOfDeprecationWarnings;linux;106000
+org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest;merge exclude rules;excludeRuleMergingBuild;linux;292000
+org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest;merge exclude rules (parallel);excludeRuleMergingBuild;linux;243000
+org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest;eclipse;largeMonolithicJavaProject;linux;144000
+org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest;eclipse;largeJavaMultiProject;linux;404000
+org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest;idea;largeMonolithicJavaProject;linux;147000
+org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest;idea;largeJavaMultiProject;linux;365000
+org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest;resolve large dependency graph from file repo;excludeRuleMergingBuild;linux;388000
+org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest;resolve large dependency graph (parallel = false, locking = false);excludeRuleMergingBuild;linux;275000
+org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest;resolve large dependency graph (parallel = false, locking = true);excludeRuleMergingBuild;linux;229000
+org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest;resolve large dependency graph (parallel = true, locking = false);excludeRuleMergingBuild;linux;227000
+org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest;resolve large dependency graph (parallel = true, locking = true);excludeRuleMergingBuild;linux;207000
+org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest;resolves dependencies from external repository;springBootApp;linux;324000
+org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest;resolves dependencies from external repository (parallel);springBootApp;linux;267000
+org.gradle.performance.regression.corefeature.RichConsolePerformanceTest;clean assemble with rich console;largeJavaMultiProject;linux;723000
+org.gradle.performance.regression.corefeature.RichConsolePerformanceTest;clean assemble with rich console;largeMonolithicJavaProject;linux;819000
+org.gradle.performance.regression.corefeature.RichConsolePerformanceTest;clean assemble with rich console;bigNative;linux;186000
+org.gradle.performance.regression.corefeature.RichConsolePerformanceTest;cleanTest test with rich console;withVerboseJUnit;linux;67000
+org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest;create many tasks;createLotsOfTasks;linux;135000
+org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest;cleanTest test with verbose test output;withVerboseTestNG;linux;172000
+org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest;cleanTest test with verbose test output;withVerboseJUnit;linux;190000
+org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest;libA0:buildDependentsLibA0;nativeDependents;linux;549000
+org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest;libA0:dependentComponents;nativeDependents;linux;546000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;up-to-date assemble (native);bigCppMulti;linux;271000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;up-to-date assemble (native);bigCppApp;linux;111000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;assemble with header file change;bigCppMulti;linux;279000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;assemble with header file change;bigCppApp;linux;240000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;assemble with source file change;bigCppMulti;linux;277000
+org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest;assemble with source file change;bigCppApp;linux;146000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with 0 parallel workers;nativeMonolithic;linux;969000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with 12 parallel workers;nativeMonolithic;linux;769000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with 0 parallel workers;nativeMonolithicOverlapping;linux;966000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with 12 parallel workers;nativeMonolithicOverlapping;linux;772000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with header file change;mediumNativeMonolithic;linux;270000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with source file change;mediumNativeMonolithic;linux;270000
+org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest;build with build file change;smallNativeMonolithic;linux;620000
+org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest;up-to-date assemble (swift);mediumSwiftMulti;linux;174000
+org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest;up-to-date assemble (swift);bigSwiftApp;linux;114000
+org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest;incremental compile;mediumSwiftMulti;linux;534000
+org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest;incremental compile;bigSwiftApp;linux;184000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;help;k9AndroidBuild;linux;133000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;help;largeAndroidBuild;linux;217000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;assembleDebug;k9AndroidBuild;linux;170000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;assembleDebug;largeAndroidBuild;linux;694000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;assembleDebug;santaTrackerAndroidBuild;linux;476000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;clean phthalic:assembleDebug;largeAndroidBuild;linux;608000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;abi change;santaTrackerAndroidBuild;linux;883000
+org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest;non-abi change;santaTrackerAndroidBuild;linux;591000
+org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest;get IDE model for Android Studio;largeAndroidBuild;linux;1251000
+org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest;get IDE model for Android Studio;k9AndroidBuild;linux;253000

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -1,0 +1,105 @@
+{
+    "performanceTests" :
+    [
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -6,9 +6,8 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -18,16 +17,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -37,9 +34,8 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -49,16 +45,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -68,16 +62,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -87,16 +79,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -106,23 +96,20 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "mediumJavaMultiProjectWithTestNG",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -132,30 +119,26 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeGroovyMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicGroovyProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -165,16 +148,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -184,16 +165,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -203,16 +182,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -222,23 +199,20 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeJavaMultiProjectKotlinDsl",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -248,16 +222,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "smallJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -267,16 +239,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "smallJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -286,9 +256,8 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -298,9 +267,8 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -310,30 +278,26 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "mediumJavaCompositeBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "mediumJavaPredefinedCompositeBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -343,30 +307,26 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicGroovyProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeGroovyMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -376,16 +336,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -395,16 +353,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -414,16 +370,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -433,16 +387,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -452,16 +404,14 @@
             "groups" : [
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -472,9 +422,8 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "comment": "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -485,9 +434,8 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "comment": "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"],
-                        "ReadyForRelease": ["windows"]
+                    "coverage" : {
+                        "test":  ["linux", "windows"]
                     }
                 }
             ]
@@ -497,20 +445,20 @@
             "groups" : [
                 {
                     "testProject" : "bigCppApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigCppMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigNative",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -520,14 +468,14 @@
             "groups" : [
                 {
                     "testProject" : "mediumSwiftMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigSwiftApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -537,8 +485,8 @@
             "groups" : [
                 {
                     "testProject" : "archivePerformanceProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -548,8 +496,8 @@
             "groups" : [
                 {
                     "testProject" : "archivePerformanceProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -559,8 +507,8 @@
             "groups" : [
                 {
                     "testProject" : "archivePerformanceProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -570,8 +518,8 @@
             "groups" : [
                 {
                     "testProject" : "generateLotsOfDeprecationWarnings",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -581,8 +529,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -592,8 +540,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -603,14 +551,14 @@
             "groups" : [
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -620,14 +568,14 @@
             "groups" : [
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -637,8 +585,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -648,8 +596,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -659,8 +607,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -670,8 +618,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -681,8 +629,8 @@
             "groups" : [
                 {
                     "testProject" : "excludeRuleMergingBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -692,8 +640,8 @@
             "groups" : [
                 {
                     "testProject" : "springBootApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -703,8 +651,8 @@
             "groups" : [
                 {
                     "testProject" : "springBootApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -714,20 +662,20 @@
             "groups" : [
                 {
                     "testProject" : "largeMonolithicJavaProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "largeJavaMultiProject",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigNative",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -737,8 +685,8 @@
             "groups" : [
                 {
                     "testProject" : "withVerboseJUnit",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -748,8 +696,8 @@
             "groups" : [
                 {
                     "testProject" : "createLotsOfTasks",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -759,14 +707,14 @@
             "groups" : [
                 {
                     "testProject" : "withVerboseTestNG",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "withVerboseJUnit",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -776,8 +724,8 @@
             "groups" : [
                 {
                     "testProject" : "nativeDependents",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -787,8 +735,8 @@
             "groups" : [
                 {
                     "testProject" : "nativeDependents",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -798,14 +746,14 @@
             "groups" : [
                 {
                     "testProject" : "bigCppApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigCppMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -815,14 +763,14 @@
             "groups" : [
                 {
                     "testProject" : "bigCppApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigCppMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -832,14 +780,14 @@
             "groups" : [
                 {
                     "testProject" : "bigCppApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigCppMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -849,14 +797,14 @@
             "groups" : [
                 {
                     "testProject" : "nativeMonolithic",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "nativeMonolithicOverlapping",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -866,14 +814,14 @@
             "groups" : [
                 {
                     "testProject" : "nativeMonolithic",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "nativeMonolithicOverlapping",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -883,8 +831,8 @@
             "groups" : [
                 {
                     "testProject" : "mediumNativeMonolithic",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -894,8 +842,8 @@
             "groups" : [
                 {
                     "testProject" : "mediumNativeMonolithic",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -905,8 +853,8 @@
             "groups" : [
                 {
                     "testProject" : "smallNativeMonolithic",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -916,14 +864,14 @@
             "groups" : [
                 {
                     "testProject" : "mediumSwiftMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigSwiftApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -933,14 +881,14 @@
             "groups" : [
                 {
                     "testProject" : "mediumSwiftMulti",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "bigSwiftApp",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -950,14 +898,14 @@
             "groups" : [
                 {
                     "testProject" : "k9AndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "largeAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -967,20 +915,20 @@
             "groups" : [
                 {
                     "testProject" : "k9AndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "largeAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "santaTrackerAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -990,8 +938,8 @@
             "groups" : [
                 {
                     "testProject" : "largeAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -1001,8 +949,8 @@
             "groups" : [
                 {
                     "testProject" : "santaTrackerAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -1012,8 +960,8 @@
             "groups" : [
                 {
                     "testProject" : "santaTrackerAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]
@@ -1023,14 +971,14 @@
             "groups" : [
                 {
                     "testProject" : "largeAndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 },
                 {
                     "testProject" : "k9AndroidBuild",
-                    "stages" : {
-                        "ExperimentalPerformance":  ["linux"]
+                    "coverage" : {
+                        "test":  ["linux"]
                     }
                 }
             ]

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -100,6 +100,940 @@
                     }
                 }
             ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "mediumJavaMultiProjectWithTestNG",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeGroovyMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicGroovyProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaConfigurationPerformanceTest.configure",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProjectKotlinDsl",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with hot daemon",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "smallJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "smallJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "mediumJavaCompositeBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "mediumJavaPredefinedCompositeBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.java.JavaABIChangePerformanceTest.assemble for abi change",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicGroovyProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeGroovyMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote https cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty remote http cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                },
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for abi change with local cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "comment": "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
+            "groups" : [
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "comment": "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"],
+                        "ReadyForRelease": ["windows"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
+            "groups" : [
+                {
+                    "testProject" : "bigCppApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigCppMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigNative",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
+            "groups" : [
+                {
+                    "testProject" : "mediumSwiftMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigSwiftApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
+            "groups" : [
+                {
+                    "testProject" : "archivePerformanceProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
+            "groups" : [
+                {
+                    "testProject" : "archivePerformanceProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
+            "groups" : [
+                {
+                    "testProject" : "archivePerformanceProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest.create many deprecation warnings",
+            "groups" : [
+                {
+                    "testProject" : "generateLotsOfDeprecationWarnings",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules (parallel)",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
+            "groups" : [
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
+            "groups" : [
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = true)",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
+            "groups" : [
+                {
+                    "testProject" : "excludeRuleMergingBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
+            "groups" : [
+                {
+                    "testProject" : "springBootApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository (parallel)",
+            "groups" : [
+                {
+                    "testProject" : "springBootApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
+            "groups" : [
+                {
+                    "testProject" : "largeMonolithicJavaProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigNative",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
+            "groups" : [
+                {
+                    "testProject" : "withVerboseJUnit",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
+            "groups" : [
+                {
+                    "testProject" : "createLotsOfTasks",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
+            "groups" : [
+                {
+                    "testProject" : "withVerboseTestNG",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "withVerboseJUnit",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.libA0:buildDependentsLibA0",
+            "groups" : [
+                {
+                    "testProject" : "nativeDependents",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.libA0:dependentComponents",
+            "groups" : [
+                {
+                    "testProject" : "nativeDependents",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
+            "groups" : [
+                {
+                    "testProject" : "bigCppApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigCppMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
+            "groups" : [
+                {
+                    "testProject" : "bigCppApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigCppMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
+            "groups" : [
+                {
+                    "testProject" : "bigCppApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigCppMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
+            "groups" : [
+                {
+                    "testProject" : "nativeMonolithic",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "nativeMonolithicOverlapping",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
+            "groups" : [
+                {
+                    "testProject" : "nativeMonolithic",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "nativeMonolithicOverlapping",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",
+            "groups" : [
+                {
+                    "testProject" : "mediumNativeMonolithic",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
+            "groups" : [
+                {
+                    "testProject" : "mediumNativeMonolithic",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
+            "groups" : [
+                {
+                    "testProject" : "smallNativeMonolithic",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
+            "groups" : [
+                {
+                    "testProject" : "mediumSwiftMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigSwiftApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.incremental compile",
+            "groups" : [
+                {
+                    "testProject" : "mediumSwiftMulti",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "bigSwiftApp",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.help",
+            "groups" : [
+                {
+                    "testProject" : "k9AndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.assembleDebug",
+            "groups" : [
+                {
+                    "testProject" : "k9AndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "santaTrackerAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.clean phthalic:assembleDebug",
+            "groups" : [
+                {
+                    "testProject" : "largeAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.abi change",
+            "groups" : [
+                {
+                    "testProject" : "santaTrackerAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.non-abi change",
+            "groups" : [
+                {
+                    "testProject" : "santaTrackerAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
+            "groups" : [
+                {
+                    "testProject" : "largeAndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "k9AndroidBuild",
+                    "stages" : {
+                        "ExperimentalPerformance":  ["linux"]
+                    }
+                }
+            ]
         }
     ]
 }

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -1,7 +1,7 @@
 import Gradle_Check.model.CROSS_VERSION_BUCKETS
-import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.FunctionalTestBucketProvider
 import Gradle_Check.model.JsonBasedGradleSubprojectProvider
-import Gradle_Check.model.StatisticBasedGradleBuildBucketProvider
+import Gradle_Check.model.StatisticBasedFunctionalTestBucketProvider
 import Gradle_Check.model.ignoredSubprojects
 import common.JvmVendor
 import common.JvmVersion
@@ -29,7 +29,7 @@ import java.io.File
 class CIConfigIntegrationTests {
     private val subprojectProvider = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     private val model = CIBuildModel(buildScanTags = listOf("Check"), subprojects = subprojectProvider)
-    private val gradleBuildBucketProvider = StatisticBasedGradleBuildBucketProvider(model, File("./test-class-data.json").absoluteFile)
+    private val gradleBuildBucketProvider = StatisticBasedFunctionalTestBucketProvider(model, File("./test-class-data.json").absoluteFile)
     private val rootProject = RootProject(model, gradleBuildBucketProvider)
 
     private
@@ -98,9 +98,9 @@ class CIConfigIntegrationTests {
         }
     }
 
-    class SubProjectBucketProvider(private val model: CIBuildModel) : GradleBuildBucketProvider {
-        override fun createFunctionalTestsFor(stage: Stage, testConfig: TestCoverage) =
-            model.subprojects.subprojects.map { it.createFunctionalTestsFor(model, stage, testConfig, Int.MAX_VALUE) }
+    class SubProjectBucketProvider(private val model: CIBuildModel) : FunctionalTestBucketProvider {
+        override fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage) =
+            model.subprojects.subprojects.map { it.createFunctionalTestsFor(model, stage, testCoverage, Int.MAX_VALUE) }
 
         override fun createDeferredFunctionalTestsFor(stage: Stage) = emptyList<FunctionalTest>()
     }
@@ -221,7 +221,7 @@ class CIConfigIntegrationTests {
 
     private fun toTriggerId(id: String) = "Gradle_Check_Stage_${id}_Trigger"
     private fun subProjectFolderList(): List<File> {
-        val subProjectFolders = File("../subprojects").listFiles().filter { it.isDirectory }
+        val subProjectFolders = File("../subprojects").listFiles()!!.filter { it.isDirectory }
         assertFalse(subProjectFolders.isEmpty())
         return subProjectFolders
     }


### PR DESCRIPTION
This adds build types and projects for the remaining performance test types we run. It doesn't add the code to actually run them, for this see https://github.com/gradle/gradle/pull/14511.

We need to add the buckets to `master`, so we can configure them on the branch, since the Teamcity DSL does not create dependencies of new build types from the teamcity configuration on branches.