### PR TITLE
Increase heap size for ScriptCachingIntegrationTest

### DIFF
--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -228,7 +228,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
             import org.gradle.api.tasks.*
 
             class MyTask extends DefaultTask {
-                static final byte[][] MEMORY_HOG = new byte[1024][1024 * 64]
+                static final byte[][] MEMORY_HOG = new byte[1024][1024 * 128]
                 @TaskAction void runAction0() {}
             }
         """)
@@ -250,7 +250,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
         // expect: memory hog released
         for (run in 1..4) {
             myTask.writeText(myTask.readText().replace("runAction${run - 1}", "runAction$run"))
-            buildWithDaemonHeapSize(256, "myTask").apply {
+            buildWithDaemonHeapSize(512, "myTask").apply {
                 compilationCache {
                     assertCacheHits(run)
                 }


### PR DESCRIPTION
We see a lot of flaky `in-memory script class loading cache releases memory of unused entries`
which expects the class to be loaded from in-memory cache but actually cache-missed.

After analyzing the daemon log, it seems like that sometimes daemon is shut down without finishing
all iterations because of:

```
[DEBUG] heap: GC rate: 2.67/s heap usage: 98%
[WARN] Expiring Daemon because JVM heap space is exhausted
LIFECYCLE] Daemon will be stopped at the end of the build after running out of JVM memory
```

Thus, there're actually different daemons in the build, resulting the flakiness.

In the test, there're 256-64=192M heap for Gradle daemon, which seems not enough.
Now we increase the test daemon size to 512M.

