### PR TITLE
Fix task action resolving dependency artifacts via FileCollection created by another project

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -219,7 +219,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithSimpleColorTransform()
+        setupBuildWithLegacyColorTransformImplementation()
         buildFile << """
             dependencies.artifactTypes {
                 green {
@@ -320,7 +320,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         withColorVariants(remoteRepo.module("group", "thing1", "1.2")).publish().allowAll()
         withColorVariants(remoteRepo.module("group", "thing2", "1.2")).publish().allowAll()
 
-        setupBuildWithSimpleColorTransform()
+        setupBuildWithLegacyColorTransformImplementation()
         buildFile << """
             repositories {
                 maven {
@@ -385,7 +385,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         settingsFile << """
             include 'a'
         """
-        setupBuildWithSimpleColorTransform()
+        setupBuildWithLegacyColorTransformImplementation()
         buildFile << """
             dependencies.artifactTypes {
                 blue {
@@ -459,7 +459,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
             rootProject.name = 'root'
             include 'a'
         """
-        setupBuildWithSimpleColorTransform()
+        setupBuildWithLegacyColorTransformImplementation()
         buildFile << """
             allprojects {
                 task additionalFile(type: FileProducer) {
@@ -882,7 +882,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
             include 'producer'
         """
         def buildSrcBuildFile = file("buildSrc/build.gradle")
-        setupBuildWithSimpleColorTransform(buildSrcBuildFile)
+        setupBuildWithLegacyColorTransformImplementation(buildSrcBuildFile)
         buildSrcBuildFile << """
             repositories {
                 maven { url = '${mavenRepo.uri}' }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeActionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeActionCodec.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.serialization.codecs
 
 import org.gradle.api.Project
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
 import org.gradle.api.internal.artifacts.transform.DefaultExecutionGraphDependenciesResolver
 import org.gradle.api.internal.tasks.NodeExecutionContext
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
@@ -30,7 +29,7 @@ import org.gradle.configurationcache.serialization.logNotImplemented
 
 object WorkNodeActionCodec : Codec<WorkNodeAction> {
     override suspend fun WriteContext.encode(value: WorkNodeAction) {
-        if (value is DefaultConfiguration.ResolveGraphAction || value is DefaultExecutionGraphDependenciesResolver.FinalizeTransformDependencies) {
+        if (value is DefaultExecutionGraphDependenciesResolver.FinalizeTransformDependencies) {
             // Can ignore
             return
         } else {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ReachingAcrossProjectBoundariesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ReachingAcrossProjectBoundariesIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+
+class ReachingAcrossProjectBoundariesIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
+    // This tests current behaviour, not desired behaviour
+    @UnsupportedWithConfigurationCache(because = "Task does not declare that it uses the transform outputs")
+    def "can consume transform outputs produced by another project without declaring this access"() {
+        settingsFile << """
+            include 'a', 'b', 'sneaky'
+        """
+        setupBuildWithColorTransformImplementation()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                }
+                task prepare {
+                    inputs.files configurations.implementation
+                    doFirst {
+                        configurations.implementation.files.name
+                    }
+                }
+            }
+            def files = project(':a').tasks.resolveArtifacts.collection.artifactFiles
+            project(':sneaky') {
+                task sneaky {
+                    // Need to make sure that the configuration in the other project has been resolved but the transforms have not run yet
+                    dependsOn(":a:prepare")
+                    doLast {
+                        println("result = " + files.files.name)
+                    }
+                }
+            }
+        """
+
+        when:
+        run("sneaky:sneaky", "--parallel")
+
+        then:
+        outputContains("result = [b.jar.green]")
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -25,7 +25,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
@@ -87,9 +86,7 @@ import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
-import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
@@ -1854,34 +1851,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         @Override
         public PublishArtifactSet getPublishArtifactSet() {
             return getAllArtifacts();
-        }
-    }
-
-    public static class ResolveGraphAction implements WorkNodeAction {
-        private final DefaultConfiguration configuration;
-
-        public ResolveGraphAction(DefaultConfiguration configuration) {
-            this.configuration = configuration;
-        }
-
-        @Override
-        public String toString() {
-            return "resolve graph for " + configuration;
-        }
-
-        @Nullable
-        @Override
-        public Project getProject() {
-            return configuration.owner.getProject();
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-        }
-
-        @Override
-        public void run(NodeExecutionContext context) {
-            configuration.resolveExclusively(ARTIFACTS_RESOLVED);
         }
     }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -236,8 +236,30 @@ class JarProducer extends DefaultTask {
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'green'.
      * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
      */
-    void setupBuildWithSimpleColorTransform(TestFile buildFile = getBuildFile()) {
+    void setupBuildWithLegacyColorTransformImplementation(TestFile buildFile = getBuildFile()) {
         setupBuildWithColorTransformAction(buildFile)
+        buildFile << """
+            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    println "processing \${input.name}"
+                    assert input.file
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+    }
+
+    /**
+     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'green'.
+     * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
+     */
+    void setupBuildWithColorTransformImplementation(TestFile buildFile = getBuildFile()) {
+        setupBuildWithColorTransform(buildFile)
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
@@ -360,12 +382,12 @@ allprojects {
      * Caller will need to provide an implementation of 'MakeGreen' transform configuration and use {@link TransformBuilder#params(java.lang.String)} to specify the configuration to
      * apply to the parameters.
      */
-    void setupBuildWithColorTransform(@DelegatesTo(TransformBuilder) Closure cl = {}) {
+    void setupBuildWithColorTransform(TestFile buildFile, @DelegatesTo(TransformBuilder) Closure cl = {}) {
         def builder = new TransformBuilder()
         cl.delegate = builder
         cl.call()
 
-        setupBuildWithColorAttributes(builder)
+        setupBuildWithColorAttributes(buildFile, builder)
         buildFile << """
 allprojects { p ->
     dependencies {
@@ -381,6 +403,10 @@ allprojects { p ->
     }
 }
 """
+    }
+
+    void setupBuildWithColorTransform(@DelegatesTo(TransformBuilder) Closure cl = {}) {
+        setupBuildWithColorTransform(buildFile, cl)
     }
 
     static class Builder {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #14516

### Context

Although this behaviour is not intended to be supported, and is mostly deprecated, there are some edge cases where the deprecation check is not triggered and no deprecation warning is emitted. These edge cases also happened to more-or-less work in previous Gradle versions, largely by coincidence. The AGP's lint task happens to trigger and (indirectly) rely on such an edge case. This PR restores this behaviour. It does not make any changes to the deprecation check, as this is not generally a good thing to do in an RC2. The deprecation can happen in a later Gradle release.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
