### PR TITLE
Cache detected java installations

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -69,8 +69,11 @@ public class JavaToolchainQueryService {
 
     private JavaToolchain downloadToolchain(JavaToolchainSpec spec) {
         final Optional<File> installation = installService.tryInstall(spec);
-        return installation.map(this::asToolchain).orElseThrow(() ->
-            new NoToolchainAvailableException(spec, detectEnabled.getOrElse(true), downloadEnabled.getOrElse(true)));
+        return installation.map(this::asToolchain).orElseThrow(() -> noToolchainAvailable(spec));
+    }
+
+    private NoToolchainAvailableException noToolchainAvailable(JavaToolchainSpec spec) {
+        return new NoToolchainAvailableException(spec, detectEnabled.getOrElse(true), downloadEnabled.getOrElse(true));
     }
 
     private Predicate<JavaToolchain> matchingToolchain(JavaToolchainSpec spec) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
@@ -25,7 +25,6 @@ import org.gradle.api.logging.Logging;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,12 +46,8 @@ public class SharedJavaInstallationRegistry {
     }
 
     @VisibleForTesting
-    static SharedJavaInstallationRegistry withLogger(Logger logger) {
-        return new SharedJavaInstallationRegistry(Collections.emptyList(), logger);
-    }
-
-    void add(InstallationSupplier provider) {
-        suppliers.add(provider);
+    static SharedJavaInstallationRegistry withLogger(List<InstallationSupplier> suppliers, Logger logger) {
+        return new SharedJavaInstallationRegistry(suppliers, logger);
     }
 
     public Set<File> listInstallations() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
@@ -22,12 +22,11 @@ import spock.lang.Unroll
 
 class SharedJavaInstallationRegistryTest extends Specification {
 
-    def registry = new SharedJavaInstallationRegistry(Collections.emptyList())
     def tempFolder = createTempDir()
 
-    def "registry keeps track of newly added installations"() {
+    def "registry keeps track of initial installations"() {
         when:
-        registry.add(forDirectory(tempFolder))
+        def registry = newRegistry(tempFolder)
 
         then:
         registry.listInstallations() == [tempFolder] as Set
@@ -35,8 +34,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
 
     def "registry filters non-unique locations"() {
         when:
-        registry.add(forDirectory(tempFolder))
-        registry.add(forDirectory(tempFolder))
+        def registry = newRegistry(tempFolder, tempFolder)
 
         then:
         registry.listInstallations() == [tempFolder] as Set
@@ -44,8 +42,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
 
     def "duplicates are detected using canonical form"() {
         given:
-        registry.add(forDirectory(tempFolder))
-        registry.add(forDirectory(new File(tempFolder, "/.")))
+        def registry = newRegistry(tempFolder, new File(tempFolder, "/."))
 
         when:
         def installations = registry.listInstallations()
@@ -60,33 +57,15 @@ class SharedJavaInstallationRegistryTest extends Specification {
         def tmpDir3 = createTempDir()
 
         when:
-        def registry = new SharedJavaInstallationRegistry([forDirectory(tmpDir2), forDirectory(tmpDir3)])
-        registry.add(forDirectory(tempFolder))
+        def registry = newRegistry(tempFolder, tmpDir2, tmpDir3)
 
         then:
         registry.listInstallations().containsAll(tempFolder, tmpDir2, tmpDir2)
     }
 
-    @SuppressWarnings('GroovyAccessibility')
-    def "registry can be mutated at later point"() {
-        given:
-        def tmpDir2 = createTempDir()
-        def registry = new SharedJavaInstallationRegistry([forDirectory(tmpDir2)])
-
-        when:
-        def before = registry.listInstallations()
-        registry.add(forDirectory(tempFolder))
-        def after = registry.listInstallations()
-
-        then:
-        before.containsAll(tmpDir2)
-        after.containsAll(tmpDir2, tempFolder)
-    }
-
     def "list of installations is not cached"() {
         given:
-        registry.add(forDirectory(tempFolder))
-        registry.add(forDirectory(tempFolder))
+        def registry = newRegistry(tempFolder)
 
         when:
         def installations = registry.listInstallations()
@@ -104,8 +83,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
         file.isDirectory() >> directory
         file.absolutePath >> path
         def logger = Mock(Logger)
-        def registry = SharedJavaInstallationRegistry.withLogger(logger)
-        registry.add(forDirectory(file))
+        def registry = SharedJavaInstallationRegistry.withLogger([forDirectory(file)], logger)
 
         when:
         def installations = registry.listInstallations()
@@ -128,5 +106,9 @@ class SharedJavaInstallationRegistryTest extends Specification {
         def file = File.createTempDir()
         file.deleteOnExit()
         file.canonicalFile
+    }
+
+    private SharedJavaInstallationRegistry newRegistry(File... location) {
+        new SharedJavaInstallationRegistry(location.collect { forDirectory(it) })
     }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
@@ -63,7 +63,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
         registry.listInstallations().containsAll(tempFolder, tmpDir2, tmpDir2)
     }
 
-    def "list of installations is not cached"() {
+    def "list of installations is cached"() {
         given:
         def registry = newRegistry(tempFolder)
 
@@ -72,7 +72,7 @@ class SharedJavaInstallationRegistryTest extends Specification {
         def installations2 = registry.listInstallations()
 
         then:
-        !installations.is(installations2)
+        installations.is(installations2)
     }
 
     @Unroll


### PR DESCRIPTION
In order to avoid scanning files/registry multiple times per build,
reuse the already detected installations. JDKs that are dynamically
added during the build (e.g. jdk download) will be handled and
short-circuited via the `JavaToolchainProvisioningService`.