### PR TITLE
Make toolchain download use proper filename for progress logging

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloader.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloader.java
@@ -48,7 +48,7 @@ public class AdoptOpenJdkDownloader {
     }
 
     public void download(URI source, File tmpFile) {
-        final ExternalResource resource = getTransport(source).getRepository().withProgressLogging().resource(new ExternalResourceName(source));
+        final ExternalResource resource = createExternalResource(source, tmpFile.getName());
         try {
             downloadResource(source, tmpFile, resource);
         } catch (MissingResourceException e) {
@@ -57,6 +57,16 @@ public class AdoptOpenJdkDownloader {
                 "(version, architecture, release/early access, ...) for the " +
                 "requested JDK is not available.", e);
         }
+    }
+
+    private ExternalResource createExternalResource(URI source, String name) {
+        final ExternalResourceName resourceName = new ExternalResourceName(source) {
+            @Override
+            public String getShortDisplayName() {
+                return name;
+            }
+        };
+        return getTransport(source).getRepository().withProgressLogging().resource(resourceName);
     }
 
     private void downloadResource(URI source, File tmpFile, ExternalResource resource) {


### PR DESCRIPTION
Given the API doesn't expose any real filenames, we use the target filename for progress logging. The filename contains all relevant information for end users (e.g. `adoptopenjdk-11-x64-mac.tar.gz`)

Fixes #14549
