### PR TITLE
Make asdf supplier use the correct installation location

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -30,7 +30,8 @@ We would like to thank the following community contributors to this release of G
 [Vladimir Sitnikov](https://github.com/vlsi),
 [Stefan Oehme](https://github.com/oehme),
 [Thad House](https://github.com/ThadHouse),
-and [Michał Mlak](https://github.com/Miehau).
+[Michał Mlak](https://github.com/Miehau)
+and [Jochen Schalanda](https://github.com/joschi).
 
 ## Upgrade instructions
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplier.java
@@ -29,7 +29,6 @@ public class AsdfInstallationSupplier extends AutoDetectingInstallationSupplier 
 
     private final Provider<String> asdfDataDir;
     private final Provider<String> asdfUserHome;
-    private final Provider<String> asdfHome;
 
     @Inject
     public AsdfInstallationSupplier(ProviderFactory factory) {
@@ -37,14 +36,12 @@ public class AsdfInstallationSupplier extends AutoDetectingInstallationSupplier 
         asdfDataDir = getEnvironmentProperty("ASDF_DATA_DIR");
         asdfUserHome = getSystemProperty("user.home")
             .map(home -> new File(home, ".asdf").getAbsolutePath());
-        asdfHome = getEnvironmentProperty("ASDF_DIR");
     }
 
     @Override
     protected Set<InstallationLocation> findCandidates() {
         return asdfDataDir.map(findJavaCandidates())
             .orElse(asdfUserHome.map(findJavaCandidates()))
-            .orElse(asdfHome.map(findJavaCandidates()))
             .getOrElse(Collections.emptySet());
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
@@ -47,6 +47,10 @@ public abstract class AutoDetectingInstallationSupplier implements InstallationS
         return factory.environmentVariable(propertyName).forUseAtConfigurationTime();
     }
 
+    protected Provider<String> getSystemProperty(String propertyName) {
+        return factory.systemProperty(propertyName).forUseAtConfigurationTime();
+    }
+
     protected abstract Set<InstallationLocation> findCandidates();
 
     private boolean isAutoDetectionEnabled() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AsdfInstallationSupplierTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 class AsdfInstallationSupplierTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def asdfHomeDirectory = temporaryFolder.createDir("asdf")
 
@@ -82,7 +82,7 @@ class AsdfInstallationSupplierTest extends Specification {
 
     def "supplies no installations for all empty directories"() {
         given:
-        def supplier = createSupplier(asdfHomeDirectory.absolutePath, asdfHomeDirectory.absolutePath, asdfHomeDirectory.absolutePath)
+        def supplier = createSupplier(asdfHomeDirectory.absolutePath, asdfHomeDirectory.absolutePath)
 
         when:
         def directories = supplier.get()
@@ -104,23 +104,10 @@ class AsdfInstallationSupplierTest extends Specification {
         directories*.source == ["asdf-vm"]
     }
 
-    def "supplies single installations for single candidate in ASDF_DATA_DIR"() {
-        given:
-        asdfHomeDirectory.createDir("installs/java/11.0.6.hs-adpt")
-        def supplier = createSupplier(asdfHomeDirectory.absolutePath, null, null)
-
-        when:
-        def directories = supplier.get()
-
-        then:
-        directoriesAsStablePaths(directories) == stablePaths([new File(asdfHomeDirectory, "installs/java/11.0.6.hs-adpt").absolutePath])
-        directories*.source == ["asdf-vm"]
-    }
-
     def "supplies single installations for single candidate in user.home"() {
         given:
         asdfHomeDirectory.createDir(".asdf/installs/java/11.0.6.hs-adpt")
-        def supplier = createSupplier(null, null, asdfHomeDirectory.absolutePath)
+        def supplier = createSupplier(null, asdfHomeDirectory.absolutePath)
 
         when:
         def directories = supplier.get()
@@ -182,23 +169,13 @@ class AsdfInstallationSupplierTest extends Specification {
         new AsdfInstallationSupplier(createProviderFactory(propertyValue))
     }
 
-    AsdfInstallationSupplier createSupplier(String asdfDataDir, String asdfDir, String userHome) {
-        new AsdfInstallationSupplier(createProviderFactory(asdfDataDir, asdfDir, userHome))
+    AsdfInstallationSupplier createSupplier(String asdfDataDir, String userHome) {
+        new AsdfInstallationSupplier(createProviderFactory(asdfDataDir, userHome))
     }
 
-    ProviderFactory createProviderFactory(String propertyValue) {
-        def providerFactory = Mock(ProviderFactory)
-        providerFactory.environmentVariable("ASDF_DIR") >> Providers.ofNullable(propertyValue)
-        providerFactory.environmentVariable("ASDF_DATA_DIR") >> Providers.notDefined()
-        providerFactory.systemProperty("user.home") >> Providers.notDefined()
-        providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
-        providerFactory
-    }
-
-    ProviderFactory createProviderFactory(String asdfDataDir, String asdfDir, String userHome) {
+    ProviderFactory createProviderFactory(String asdfDataDir, String userHome = null) {
         def providerFactory = Mock(ProviderFactory)
         providerFactory.environmentVariable("ASDF_DATA_DIR") >> Providers.ofNullable(asdfDataDir)
-        providerFactory.environmentVariable("ASDF_DIR") >> Providers.ofNullable(asdfDir)
         providerFactory.systemProperty("user.home") >> Providers.ofNullable(userHome)
         providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
         providerFactory


### PR DESCRIPTION
`asdf` is storing installations in the path configured in the `$ASDF_DATA_DIR` environment variable or `$HOME/.asdf` as fallback.
The environment variable `$ASDF_DIR` only points to the `asdf` directory itself.

https://asdf-vm.com/#/core-configuration?id=environment-variables
https://github.com/asdf-vm/asdf/blob/v0.8.0/lib/utils.bash#L39-L68

Contributed by: Jochen Schalanda <jochen@schalanda.name>