### PR TITLE
Simplify `ProblemsListener` structure

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -25,6 +25,7 @@ import org.gradle.configurationcache.initialization.DefaultConfigurationCachePro
 import org.gradle.configurationcache.initialization.DefaultInjectedClasspathInstrumentationStrategy
 import org.gradle.configurationcache.initialization.NoOpConfigurationCacheProblemsListener
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
+import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.serialization.beans.BeanConstructors
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.ServiceRegistration
@@ -76,7 +77,7 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
 class BuildServicesProvider {
     fun createConfigurationCacheProblemsListener(
         buildEnablement: ConfigurationCacheBuildEnablement,
-        problemsListener: ConfigurationCacheProblems,
+        problemsListener: ProblemsListener,
         userCodeApplicationContext: UserCodeApplicationContext
     ): ConfigurationCacheProblemsListener {
         return if (buildEnablement.isEnabledForCurrentBuild) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/SystemPropertyAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/SystemPropertyAccessListener.kt
@@ -18,8 +18,8 @@ package org.gradle.configurationcache
 
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.configuration.internal.UserCodeApplicationContext
-import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.problems.DocumentationSection.RequirementsUndeclaredSysPropRead
+import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.StructuredMessage
 import org.gradle.configurationcache.problems.location
@@ -64,7 +64,7 @@ val allowedProperties = setOf(
 
 
 class SystemPropertyAccessListener(
-    private val problems: ConfigurationCacheProblems,
+    private val problems: ProblemsListener,
     private val userCodeContext: UserCodeApplicationContext,
     listenerManager: ListenerManager
 ) : Instrumented.Listener {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
@@ -23,9 +23,9 @@ import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.configuration.internal.UserCodeApplicationContext
-import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.problems.DocumentationSection.RequirementsBuildListeners
 import org.gradle.configurationcache.problems.DocumentationSection.RequirementsUseProjectDuringExecution
+import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.problems.StructuredMessage
@@ -40,7 +40,7 @@ interface ConfigurationCacheProblemsListener : TaskExecutionAccessListener, Buil
 
 
 class DefaultConfigurationCacheProblemsListener internal constructor(
-    private val problems: ConfigurationCacheProblems,
+    private val problems: ProblemsListener,
     private val userCodeApplicationContext: UserCodeApplicationContext
 ) : ConfigurationCacheProblemsListener {
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/DefaultInjectedClasspathInstrumentationStrategy.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/DefaultInjectedClasspathInstrumentationStrategy.kt
@@ -17,7 +17,7 @@
 package org.gradle.configurationcache.initialization
 
 import org.gradle.configurationcache.problems.DocumentationSection
-import org.gradle.configurationcache.problems.ConfigurationCacheProblems
+import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.problems.StructuredMessage
@@ -26,7 +26,10 @@ import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathInstrumen
 import java.lang.management.ManagementFactory
 
 
-class DefaultInjectedClasspathInstrumentationStrategy(private val startParameter: ConfigurationCacheStartParameter, private val problems: ConfigurationCacheProblems) : InjectedClasspathInstrumentationStrategy {
+class DefaultInjectedClasspathInstrumentationStrategy(
+    private val startParameter: ConfigurationCacheStartParameter,
+    private val problems: ProblemsListener
+) : InjectedClasspathInstrumentationStrategy {
     override fun getTransform(): CachedClasspathTransformer.StandardTransform {
         val isAgentPresent = ManagementFactory.getRuntimeMXBean().inputArguments.find { it.startsWith("-javaagent:") } != null
         return if (!startParameter.isEnabled && isAgentPresent) {


### PR DESCRIPTION
By having `ConfigurationCacheProblems` directly handle `onProblem` notifications and decoupling problem "providers" from the concrete implementation of `ProblemsListener`.