### PR TITLE
Move probe service to global scope

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/services/PlatformJvmServices.java
@@ -65,10 +65,6 @@ public class PlatformJvmServices extends AbstractPluginServiceRegistry {
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.add(JarBinaryRenderer.class);
         registration.add(VariantAxisCompatibilityFactory.class, DefaultVariantAxisCompatibilityFactory.of(JavaPlatform.class, new DefaultJavaPlatformVariantAxisCompatibility()));
-    }
-
-    @Override
-    public void registerBuildTreeServices(ServiceRegistration registration) {
         registration.add(JavaInstallationProbe.class);
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -157,6 +157,7 @@ public class JavaInstallationProbe {
         if (!jdkPath.exists()) {
             return ProbeResult.failure(InstallType.NO_SUCH_DIRECTORY, "No such directory: " + jdkPath);
         }
+        jdkPath = resolveSymlink(jdkPath);
         EnumMap<SysProp, String> metadata = cache.getUnchecked(jdkPath);
         String version = metadata.get(SysProp.VERSION);
         if (UNKNOWN.equals(version)) {
@@ -172,6 +173,14 @@ public class JavaInstallationProbe {
             return ProbeResult.success(InstallType.IS_JDK, metadata);
         }
         return ProbeResult.success(InstallType.IS_JRE, metadata);
+    }
+
+    private File resolveSymlink(File jdkPath) {
+        try {
+            return jdkPath.getCanonicalFile();
+        } catch (IOException e) {
+            return jdkPath;
+        }
     }
 
     private EnumMap<SysProp, String> getCurrentJvmMetadata() {


### PR DESCRIPTION
So we can reuse the probe results across builds as java installations tend to stay stable. Fixed a small problem with the cache key to use the canonical form so we properly resolve symlinks if they happen to change (e.g. a common usecase are symlinks pointing to a "current" version).