### PR TITLE
Toolchains declaration ordering fix

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -155,6 +155,6 @@ By injecting the `JavaToolchainService` in the plugin, it is also possible to wi
 ```
 JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
 JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
-Provider<JavaCompiler> defaultCompiler = service.compilerFor(extension.getToolchain()).orElse(Providers.notDefined());
+Provider<JavaCompiler> defaultCompiler = service.compilerFor(extension.getToolchain());
 myTask.getJavaCompiler().convention(defaultCompiler);
 ```

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -61,6 +61,10 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
         buildFile << """
             apply plugin: "java"
 
+            compileJava {
+                // Make sure declaration ordering is not an issue
+            }
+
             java {
                 toolchain {
                     languageVersion = JavaLanguageVersion.of(${someJdk.javaVersion.majorVersion})

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -18,7 +18,6 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.DefaultProvider;
-import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -52,10 +51,13 @@ public class JavaToolchainQueryService {
     }
 
     Provider<JavaToolchain> findMatchingToolchain(JavaToolchainSpec filter) {
-        if (!((DefaultToolchainSpec) filter).isConfigured()) {
-            return Providers.notDefined();
-        }
-        return new DefaultProvider<>(() -> query(filter));
+        return new DefaultProvider<>(() -> {
+            if (((DefaultToolchainSpec) filter).isConfigured()) {
+                return query(filter);
+            } else {
+                return null;
+            }
+        });
     }
 
     private JavaToolchain query(JavaToolchainSpec filter) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.plugins.DistributionPlugin;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.plugins.internal.DefaultApplicationPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.provider.Provider;
@@ -172,7 +171,7 @@ public class ApplicationPlugin implements Plugin<Project> {
     private <T> Provider<T> getToolchainTool(Project project, BiFunction<JavaToolchainService, JavaToolchainSpec, Provider<T>> toolMapper) {
         final JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
         final JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
-        return toolMapper.apply(service, extension.getToolchain()).orElse(Providers.notDefined());
+        return toolMapper.apply(service, extension.getToolchain());
     }
 
     // @Todo: refactor this task configuration to extend a copy task and use replace tokens

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -32,7 +32,6 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.DefaultJavaPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaPluginExtension;
@@ -389,7 +388,7 @@ public class JavaBasePlugin implements Plugin<Project> {
     private <T> Provider<T> getToolchainTool(Project project, BiFunction<JavaToolchainService, JavaToolchainSpec, Provider<T>> toolMapper) {
         final JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
         final JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
-        return toolMapper.apply(service, extension.getToolchain()).orElse(Providers.notDefined());
+        return toolMapper.apply(service, extension.getToolchain());
     }
 
     @Inject


### PR DESCRIPTION
The value needs to be computed as late as possible so there is no
ordering issue between tasks definition and the configuration of the
extension.