### PR TITLE
Use the same `AbsolutePathFileCollectionFingerprinter` for all task inputs

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.fingerprint
 
 import org.gradle.api.execution.internal.TaskInputsListeners
-import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
@@ -25,7 +24,6 @@ import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.configurationcache.BuildTreeListenerManager
 import org.gradle.configurationcache.extensions.hashCodeOf
-import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.serialization.ReadContext
@@ -189,12 +187,6 @@ class ConfigurationCacheFingerprintController internal constructor(
             fileSystemAccess.hashCodeOf(file)
 
         override fun fingerprintOf(
-            fileCollection: FileCollectionInternal,
-            owner: TaskInternal
-        ): HashCode =
-            fileCollectionFingerprinterFor(owner).fingerprint(fileCollection).hash
-
-        override fun fingerprintOf(
             fileCollection: FileCollectionInternal
         ): HashCode =
             fileCollectionFingerprinter.fingerprint(fileCollection).hash
@@ -208,10 +200,6 @@ class ConfigurationCacheFingerprintController internal constructor(
                 obtainedValue.valueSourceParametersType,
                 obtainedValue.valueSourceParameters
             )
-
-        private
-        fun fileCollectionFingerprinterFor(task: TaskInternal) =
-            task.serviceOf<AbsolutePathFileCollectionFingerprinter>()
 
         private
         val rootDirectory

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -52,19 +52,15 @@ class ConfigurationCacheFingerprintWriter(
     private val writeContext: DefaultWriteContext,
     private val fileCollectionFactory: FileCollectionFactory,
     private val directoryFileTreeFactory: DirectoryFileTreeFactory
-) : ValueSourceProviderFactory.Listener, TaskInputsListener, ScriptExecutionListener, UndeclaredBuildInputListener, ChangingValueDependencyResolutionListener, FileResourceListener {
+) : ValueSourceProviderFactory.Listener, TaskInputsListener, ScriptExecutionListener,
+    UndeclaredBuildInputListener, ChangingValueDependencyResolutionListener, FileResourceListener {
 
     interface Host {
-
         val gradleUserHomeDir: File
-
         val allInitScripts: List<File>
-
         val buildStartTime: Long
-
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
-
     }
 
     @Volatile

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -62,12 +62,9 @@ class ConfigurationCacheFingerprintWriter(
 
         val buildStartTime: Long
 
+        fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
 
-        fun fingerprintOf(
-            fileCollection: FileCollectionInternal,
-            owner: TaskInternal
-        ): HashCode
     }
 
     @Volatile
@@ -207,7 +204,7 @@ class ConfigurationCacheFingerprintWriter(
             ConfigurationCacheFingerprint.TaskInputs(
                 task.identityPath.path,
                 simplify(fileSystemInputs),
-                host.fingerprintOf(fileSystemInputs, task)
+                host.fingerprintOf(fileSystemInputs)
             )
         )
     }


### PR DESCRIPTION
What the title says.