### PR TITLE
Work around a potential deadlock while running Android lint task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -27,6 +27,7 @@ import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
+import java.util.function.Consumer;
 
 /**
  * A registry of all of the projects present in a build tree.
@@ -67,14 +68,21 @@ public interface ProjectStateRegistry {
     /**
      * Allows a section of code to run against the mutable state of all projects. No other thread will be able to access the state of any project while the given action is running.
      *
-     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#withMutableState(Runnable)}.
+     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#applyToMutableState(Consumer)}.
      */
     void withMutableStateOfAllProjects(Runnable runnable);
 
     /**
      * Allows a section of code to run against the mutable state of all projects. No other thread will be able to access the state of any project while the given action is running.
      *
-     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#withMutableState(Runnable)}.
+     * <p>Any attempt to lock a project by some other thread will fail while the given action is running. This includes calls to {@link ProjectState#applyToMutableState(Consumer)}.
      */
     <T> T withMutableStateOfAllProjects(Factory<T> factory);
+
+    /**
+     * Allows the given code to access the mutable state of any project, regardless of which other threads may be accessing the project.
+     *
+     * DO NOT USE THIS METHOD. It is here to allow some very specific backwards compatibility.
+     */
+    <T> T allowUncontrolledAccessToAnyProject(Factory<T> factory);
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
@@ -21,10 +21,15 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 import org.gradle.tooling.provider.model.UnknownModelException;
 
+import javax.annotation.Nullable;
+
 @ServiceScope(Scopes.Build.class)
 public interface ToolingModelBuilderLookup {
+    @Nullable
+    ToolingModelBuilder find(String modelName);
+
     /**
-     * Locates a model builder that runs as a top level build operation.
+     * Locates a model builder to be used to handle a tooling API client request.
      */
-    ToolingModelBuilder locate(String modelName) throws UnknownModelException;
+    ToolingModelBuilder locateForClientOperation(String modelName) throws UnknownModelException;
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -111,7 +111,7 @@ public class BuildModelActionRunner implements BuildActionRunner {
         private ToolingModelBuilder getModelBuilder(GradleInternal gradle, String modelName) {
             ToolingModelBuilderLookup builderRegistry = getToolingModelBuilderRegistry(gradle);
             try {
-                return builderRegistry.locate(modelName);
+                return builderRegistry.locateForClientOperation(modelName);
             } catch (UnknownModelException e) {
                 modelFailure = e;
                 throw e;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -150,7 +150,7 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
 
         ToolingModelBuilder builder;
         try {
-            builder = modelBuilderRegistry.locate(modelIdentifier.getName());
+            builder = modelBuilderRegistry.locateForClientOperation(modelIdentifier.getName());
         } catch (UnknownModelException e) {
             throw (InternalUnsupportedModelException) (new InternalUnsupportedModelException()).initCause(e);
         }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -55,7 +55,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.locate('some.model') >> { throw failure }
+        _ * registry.locateForClientOperation('some.model') >> { throw failure }
 
         when:
         controller.getModel(null, modelId)
@@ -77,7 +77,7 @@ class DefaultBuildControllerTest extends Specification {
         _ * gradle.rootProject >> rootProject
         _ * rootProject.project(":some:path") >> project
         _ * rootProject.getProjectDir() >> rootDir
-        _ * registry.locate("some.model") >> modelBuilder
+        _ * registry.locateForClientOperation("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -92,7 +92,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.locate("some.model") >> modelBuilder
+        _ * registry.locateForClientOperation("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -119,7 +119,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.locate("some.model") >> modelBuilder
+        _ * registry.locateForClientOperation("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:
@@ -144,7 +144,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.locate("some.model") >> parameterizedModelBuilder
+        _ * registry.locateForClientOperation("some.model") >> parameterizedModelBuilder
         _ * parameterizedModelBuilder.getParameterType() >> parameterType
         _ * parameterizedModelBuilder.buildAll("some.model", _, project) >> { def modelName, CustomParameter param, projectInternal ->
             assert param != null
@@ -165,7 +165,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * gradle.defaultProject >> project
-        _ * registry.locate("some.model") >> modelBuilder
+        _ * registry.locateForClientOperation("some.model") >> modelBuilder
         _ * modelBuilder.buildAll("some.model", project) >> model
 
         when:


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

This PR does not fix the deadlock, but instead reverts some behaviour back to how it worked in Gradle 6.6 in order to make the deadlock much less likely to happen (but other weird things more likely to happen). A really fix will happen in the future. See the commit description for some more details.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
