### PR TITLE
Stabilize test setup with toolchains

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
@@ -16,8 +16,23 @@
 
 package org.gradle.integtests.fixtures
 
+import org.junit.Assume
+
 abstract class AbstractSampleIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.withRepositoryMirrors()
+        // Disable toolchain detection and download - we want to be specific
+        executer.beforeExecute {
+            withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            withArgument("-Porg.gradle.java.installations.auto-download=false")
+        }
+    }
+
+    def configureExecuterForToolchains(String... versions) {
+        def jdks = AvailableJavaHomes.getJdks(versions)
+        Assume.assumeTrue(versions.length == jdks.size())
+        executer.beforeExecute {
+            withArgument("-Porg.gradle.java.installations.paths=" + jdks.collect { it.javaHome.absolutePath }.join(","))
+        }
     }
 }

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -36,6 +36,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can execute simple Java tests with #dsl dsl"() {
         given:
+        configureExecuterForToolchains('11')
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)
 
@@ -326,6 +327,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can run simple Java integration tests with #dsl dsl"() {
         given:
+        configureExecuterForToolchains('11')
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)
 
@@ -349,6 +351,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can skip the tests with an `onlyIf` condition with #dsl dsl"() {
         given:
+        configureExecuterForToolchains('11')
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir).withArgument("-PmySkipTests")
 


### PR DESCRIPTION
This commits makes sure that samples are never tested with toolchains
auto detection or download enabled. This will prevent flakiness on CI.