### PR TITLE
Always configure intermediate parents when a child project is configured

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -512,4 +512,23 @@ allprojects {
         result.assertTasksExecuted(":a:one")
         fixture.assertProjectsConfigured(":", ":b", ":b:child", ":a")
     }
+
+    def "extra properties defined in parent project are accessible to child"() {
+        settingsFile << "include 'a', 'a:child'"
+        file('a/build.gradle') << """
+ext.foo = "Moo!!!"
+"""
+        file('a/child/build.gradle') << """
+task printExt {
+    doLast {
+        println "The Foo says " + foo
+    }
+}
+"""
+        when:
+        run(":a:child:printExt")
+
+        then:
+        outputContains("The Foo says Moo!!!")
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -72,18 +72,14 @@ class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "evaluates only project referenced in the task list"() {
-        // The util project's classloaders will be created eagerly because util:impl
-        // will be evaluated before it
-        executer.withEagerClassLoaderCreationCheckDisabled()
-
         settingsFile << "include 'api', 'impl', 'util', 'util:impl'"
         buildFile << "allprojects { task foo }"
 
         when:
-        run(":foo", ":util:impl:foo")
+        run(":util:impl:foo")
 
         then:
-        fixture.assertProjectsConfigured(":", ":util:impl")
+        fixture.assertProjectsConfigured(":", ":util", ":util:impl")
     }
 
     def "does not show configuration on demand incubating message in a regular mode"() {

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -33,6 +33,11 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
         if (cancellationToken.isCancellationRequested()) {
             throw new BuildCancelledException();
         }
+        // Need to configure intermediate parent projects for configure-on-demand
+        ProjectInternal parentProject = project.getParent();
+        if (parentProject != null) {
+            configure(parentProject);
+        }
         project.evaluate();
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
@@ -90,7 +90,7 @@ class BuildTestFixture {
         rootMulti.with(cl)
         rootMulti.file("src/main/${language.name}/Dummy.${language.name}") << "public class Dummy {}"
         subprojects.each {
-            rootMulti.file(it, "src/main/${language.name}/Dummy.${language.name}") << "public class Dummy {}"
+            rootMulti.file(it.replace(':' as char, File.separatorChar), "src/main/${language.name}/Dummy.${language.name}") << "public class Dummy {}"
         }
         return rootMulti
     }


### PR DESCRIPTION
When configure-on-demand is enabled, a project is evaluated only when required. In a nested
project structure, this can mean that a child project is configured without it's parent.
However, in a nested project structure, the parent project contributes a classloader that is used
by the child.

These 2 effects combined can result in:
- The parent project scope class loader is defined before the scope is locked.
  This violates the check enabled by `org.gradle.classloaderscope.strict`.
- In a composite build, plugins applied to the parent project may not be visible.

This commit fixes this by ensuring that intermediate parent projects are always configured
before a child project. (The root project is already configured before any children).

Fixes #14552

