### PR TITLE
Convert BuildScanPluginPerformanceTest to new performance test infrastructure

### DIFF
--- a/subprojects/build-scan-performance/build.gradle.kts
+++ b/subprojects/build-scan-performance/build.gradle.kts
@@ -69,7 +69,6 @@ subprojects {
 }
 
 tasks.withType<PerformanceTest>().configureEach {
-    dependsOn(generateTemplate)
     systemProperties["incomingArtifactDir"] = "$rootDir/incoming/"
 
     environment("ARTIFACTORY_USERNAME", System.getenv("ARTIFACTORY_USERNAME"))

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -38,17 +38,14 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
     public static final int INVOCATIONS = 20
 
     @Unroll
-    def "large java project with and without plugin application (#scenario)"() {
+    def "with and without plugin application (#scenario)"() {
         given:
-        def sourceProject = "javaProject"
         def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
         def opts = ['-Xms4096m', '-Xmx4096m']
 
-        runner.testId = "large java project with and without plugin application ($scenario)"
         runner.baseline {
             warmUpCount WARMUPS
             invocationCount INVOCATIONS
-            projectName(sourceProject)
             displayName(WITHOUT_PLUGIN_LABEL)
             invocation {
                 args(*jobArgs)
@@ -68,7 +65,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         runner.buildSpec {
             warmUpCount WARMUPS
             invocationCount INVOCATIONS
-            projectName(sourceProject)
             displayName(WITH_PLUGIN_LABEL)
             invocation {
                 args(*jobArgs)


### PR DESCRIPTION
That also needs some changes in the build configuration of the dotcom project.