### PR TITLE
Avoid construction of full component metadata for included projects

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -29,9 +29,9 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ForeignBuildIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskReference;
@@ -42,7 +42,6 @@ import org.gradle.internal.Pair;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -164,10 +163,8 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     }
 
     private void registerProject(Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules, ProjectInternal project) {
-        LocalComponentRegistry localComponentRegistry = project.getServices().get(LocalComponentRegistry.class);
         ProjectComponentIdentifier projectIdentifier = new DefaultProjectComponentIdentifier(buildIdentifier, project.getIdentityPath(), project.getProjectPath(), project.getName());
-        DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(projectIdentifier);
-        ModuleVersionIdentifier moduleId = originalComponent.getModuleVersionId();
+        ModuleVersionIdentifier moduleId = DefaultModuleVersionIdentifier.newId(project.getModule());
         LOGGER.info("Registering " + project + " in composite build. Will substitute for module '" + moduleId.getModule() + "'.");
         availableModules.add(Pair.of(moduleId, projectIdentifier));
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -147,4 +147,28 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
             outputContains("configuring :help")
         }
     }
+
+    @ToBeFixedForConfigurationCache(because = "composite builds")
+    def "does not realize all possible tasks if the build is included"() {
+        Assume.assumeFalse(pluginName in ['xctest', 'visual-studio', 'xcode', 'play-application'])
+
+        def includedBuildFile = file("included/build.gradle")
+
+        settingsFile << """
+            includeBuild 'included'
+        """
+
+        applyPlugin(includedBuildFile)
+        includedBuildFile << """
+            tasks.configureEach {
+                println("configuring \${it.path}")
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        assert output.count("configuring :") == 0
+    }
 }


### PR DESCRIPTION
This causes the full metadata, including all variants, to be built eagerly which may cause task realization when the attributes for the variants are calculated. For example: artifact type is retrieved from AbstractArchiveTask, Java target version is retrieved from JavaCompile task.

The only reason to construct the metadata here was to obtain the module ID. We can shortcut by calculating it directly based on the configured project's state.

