### PR TITLE
Rename method for clarity

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
@@ -59,7 +59,7 @@ public class DefaultBuildableCompositeBuildContext implements CompositeBuildCont
     }
 
     @Override
-    public boolean hasRules() {
+    public boolean rulesMayAddProjectDependency() {
         return !(availableModules.isEmpty() && substitutionRules.isEmpty());
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -55,7 +55,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
 
     public void build(IncludedBuildState build) {
         DependencySubstitutionsInternal substitutions = resolveDependencySubstitutions(build);
-        if (!substitutions.hasRules()) {
+        if (!substitutions.rulesMayAddProjectDependency()) {
             // Configure the included build to discover available modules
             LOGGER.info("[composite-build] Configuring build: " + build.getRootDirectory());
             context.addAvailableModules(build.getAvailableModules());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultGlobalDependencyResolutionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultGlobalDependencyResolutionRules.java
@@ -65,9 +65,9 @@ public class DefaultGlobalDependencyResolutionRules implements GlobalDependencyR
         }
 
         @Override
-        public boolean hasRules() {
+        public boolean rulesMayAddProjectDependency() {
             for (DependencySubstitutionRules ruleProvider : ruleProviders) {
-                if (ruleProvider.hasRules()) {
+                if (ruleProvider.rulesMayAddProjectDependency()) {
                     return true;
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -75,7 +75,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     private final NotationParser<Object, Capability> capabilityNotationParser;
 
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
-    private boolean hasDependencySubstitutionRule;
+    private boolean rulesMayAddProjectDependency;
 
     public static DefaultDependencySubstitutions forResolutionStrategy(ComponentIdentifierFactory componentIdentifierFactory,
                                                                        NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
@@ -140,8 +140,8 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     }
 
     @Override
-    public boolean hasRules() {
-        return hasDependencySubstitutionRule;
+    public boolean rulesMayAddProjectDependency() {
+        return rulesMayAddProjectDependency;
     }
 
     @Override
@@ -152,7 +152,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     protected void addSubstitution(Action<? super DependencySubstitution> rule, boolean projectInvolved) {
         addRule(rule);
         if (projectInvolved) {
-            hasDependencySubstitutionRule = true;
+            rulesMayAddProjectDependency = true;
         }
     }
 
@@ -164,7 +164,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     @Override
     public DependencySubstitutions all(Action<? super DependencySubstitution> rule) {
         addRule(rule);
-        hasDependencySubstitutionRule = true;
+        rulesMayAddProjectDependency = true;
         return this;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DependencySubstitutionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DependencySubstitutionRules.java
@@ -31,12 +31,12 @@ public interface DependencySubstitutionRules {
         }
 
         @Override
-        public boolean hasRules() {
+        public boolean rulesMayAddProjectDependency() {
             return false;
         }
     };
 
     Action<DependencySubstitution> getRuleAction();
 
-    boolean hasRules();
+    boolean rulesMayAddProjectDependency();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -233,7 +233,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     @Override
     public boolean resolveGraphToDetermineTaskDependencies() {
-        return assumeFluidDependencies || dependencySubstitutions.hasRules() || globalDependencySubstitutionRules.hasRules() || vcsResolver.hasRules();
+        return assumeFluidDependencies
+                || dependencySubstitutions.rulesMayAddProjectDependency()
+                || globalDependencySubstitutionRules.rulesMayAddProjectDependency()
+                || vcsResolver.hasRules();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -179,7 +179,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     }
 
     private boolean isSubstitutedInComposite(ModuleComponentIdentifier lockedIdentifier) {
-        if (dependencySubstitutionRules.hasRules()) {
+        if (dependencySubstitutionRules.rulesMayAddProjectDependency()) {
             LockingDependencySubstitution lockingDependencySubstitution = new LockingDependencySubstitution(toComponentSelector(lockedIdentifier));
             dependencySubstitutionRules.getRuleAction().execute(lockingDependencySubstitution);
             return lockingDependencySubstitution.didSubstitute();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -278,7 +278,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.all(action)
 
         then:
-        substitutions.hasRules()
+        substitutions.rulesMayAddProjectDependency()
     }
 
     @Unroll
@@ -292,7 +292,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.substitute(fromComponent).with(toComponent)
 
         then:
-        substitutions.hasRules() == result
+        substitutions.rulesMayAddProjectDependency() == result
 
         where:
         from       | to             | result

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -205,7 +205,7 @@ empty=
     @Unroll
     def 'can filter lock entries impacted by dependency substitutions (Unique: #unique)'() {
         given:
-        dependencySubstitutionRules.hasRules() >> true
+        dependencySubstitutionRules.rulesMayAddProjectDependency() >> true
         Action< DependencySubstitution> substitutionAction = Mock()
         dependencySubstitutionRules.ruleAction >> substitutionAction
         substitutionAction.execute(_ as DependencySubstitution) >> { DependencySubstitution ds ->


### PR DESCRIPTION
Renamed `DependendencySubstitutions.hasRules` to `.rulesMayAddProjectDependency`,
since this better reflects the method intent. Hopefully this will add a little
clarity to this often misunderstood area of functionality.
