### PR TITLE
Improve `ServiceRegistration.add(Class<?>)` injection logic

### DIFF
--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.commonsLang)
     implementation(libs.commonsIo)
     implementation(libs.asm)
+    implementation(libs.inject)
 
     integTestImplementation(project(":logging"))
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/InjectUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/InjectUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import javax.inject.Inject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+
+final class InjectUtil {
+
+    /**
+     * Selects the single injectable constructor for the given type.
+     * The type must either have only one public or package-private default constructor,
+     * or it should have a single non-private constructor annotated with {@literal @}{@link Inject}.
+     *
+     * @param type the type to find the injectable constructor of.
+     */
+    static Constructor<?> selectConstructor(final Class<?> type) {
+        if (isInnerClass(type)) {
+            // The DI system doesn't support injecting non-static inner classes.
+            throw new ServiceValidationException(
+                String.format(
+                    "Unable to select constructor for non-static inner class %s.",
+                    format(type)
+                )
+            );
+        }
+
+        final Constructor<?>[] constructors = type.getDeclaredConstructors();
+        if (constructors.length == 1) {
+            Constructor<?> constructor = constructors[0];
+            if (isPublicOrPackageScoped(constructor)) {
+                // If there is a single constructor, and that constructor is public or package private we select it.
+                return constructor;
+            }
+            if (constructor.getAnnotation(Inject.class) != null) {
+                // Otherwise, if there is a single constructor that is annotated with `@Inject`, we select it (short-circuit).
+                return constructor;
+            }
+        }
+
+        // Search for a valid `@Inject` constructor to use instead.
+        Constructor<?> match = null;
+        for (Constructor<?> constructor : constructors) {
+            if (constructor.getAnnotation(Inject.class) != null) {
+                if (match != null) {
+                    // There was a previously found a match. This means a second constructor with `@Inject` has been found.
+                    throw new ServiceValidationException(
+                        String.format(
+                            "Multiple constructor annotated with @Inject for %s.",
+                            format(type)
+                        )
+                    );
+                }
+                // A valid match was found.
+                match = constructor;
+            }
+        }
+        if (match == null) {
+            // No constructor annotated with `@Inject` was found.
+            throw new ServiceValidationException(
+                String.format(
+                    "Expected a single non-private constructor, or one constructor annotated with @Inject for %s.",
+                    format(type)
+                )
+            );
+        }
+
+        return match;
+    }
+
+    private static boolean isInnerClass(Class<?> clazz) {
+        return clazz.isMemberClass() && !Modifier.isStatic(clazz.getModifiers());
+    }
+
+    private static boolean isPublicOrPackageScoped(Constructor<?> constructor) {
+        return Modifier.isPublic(constructor.getModifiers()) || isPackagePrivate(constructor.getModifiers());
+    }
+
+    static boolean isPackagePrivate(int modifiers) {
+        return !Modifier.isPrivate(modifiers) && !Modifier.isProtected(modifiers) && !Modifier.isPublic(modifiers);
+    }
+
+    private static String format(Type type) {
+        return TypeStringFormatter.format(type);
+    }
+
+    private InjectUtil() {
+        /* no-op */
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/TypeStringFormatter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/TypeStringFormatter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+class TypeStringFormatter {
+
+    static String format(Type type) {
+        if (type instanceof Class) {
+            Class<?> aClass = (Class) type;
+            Class<?> enclosingClass = aClass.getEnclosingClass();
+            if (enclosingClass != null) {
+                return format(enclosingClass) + "$" + aClass.getSimpleName();
+            } else {
+                return aClass.getSimpleName();
+            }
+        } else if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            StringBuilder builder = new StringBuilder();
+            builder.append(format(parameterizedType.getRawType()));
+            builder.append("<");
+            for (int i = 0; i < parameterizedType.getActualTypeArguments().length; i++) {
+                Type typeParam = parameterizedType.getActualTypeArguments()[i];
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                builder.append(format(typeParam));
+            }
+            builder.append(">");
+            return builder.toString();
+        }
+
+        return type.toString();
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/AccessModifierDefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/AccessModifierDefaultServiceRegistryTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import org.gradle.internal.service.internal.ModifierStubs
+import spock.lang.Specification
+
+class AccessModifierDefaultServiceRegistryTest extends Specification {
+
+    def "can add type to registry that has package private constructor"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(String, "Potato")
+            it.add(ModifierStubs.PackagePrivateConstructor)
+        }
+        then:
+        noExceptionThrown()
+        registry.get(ModifierStubs.PackagePrivateConstructor) instanceof ModifierStubs.PackagePrivateConstructor
+    }
+
+    def "fails to register that has a package private constructor and a private constructor"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.PackagePrivateConstructorWithPrivateConstructor)
+        }
+        then:
+        def exception = thrown(ServiceValidationException)
+        exception.message.contains("Expected a single non-private constructor, or one constructor annotated with @Inject for")
+    }
+
+    def "can add a type to registry that has an annotated package private constructor and a private constructor"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.AnnotatedPackagePrivateConstructorWithPrivateConstructor)
+        }
+        then:
+        noExceptionThrown()
+        registry.get(ModifierStubs.AnnotatedPackagePrivateConstructorWithPrivateConstructor) instanceof ModifierStubs.AnnotatedPackagePrivateConstructorWithPrivateConstructor
+    }
+
+    def "fails to register that has a public constructor and a private constructor"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.PublicConstructorWithPrivateConstructor)
+        }
+        then:
+        def exception = thrown(ServiceValidationException)
+        exception.message.contains("Expected a single non-private constructor, or one constructor annotated with @Inject for")
+    }
+
+    def "can add a type to registry that has an annotated public constructor and a private constructor"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.AnnotatedPublicConstructorWithPrivateConstructor)
+        }
+        then:
+        noExceptionThrown()
+        registry.get(ModifierStubs.AnnotatedPublicConstructorWithPrivateConstructor) instanceof ModifierStubs.AnnotatedPublicConstructorWithPrivateConstructor
+    }
+
+    def "fails to register class that is non-static inner class"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.NonStaticInnerClass)
+        }
+        then:
+        def exception = thrown(ServiceValidationException)
+        exception.message.contains("Unable to select constructor for non-static inner class")
+    }
+
+    def "can add a type to registry that has just the default constructor without one being explicitly declared"() {
+        when:
+        def registry = new DefaultServiceRegistry()
+        registry.register {
+            it.add(ModifierStubs.DefaultConstructor)
+        }
+        then:
+        noExceptionThrown()
+        registry.get(ModifierStubs.DefaultConstructor) instanceof ModifierStubs.DefaultConstructor
+    }
+
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/internal/ModifierStubs.java
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/internal/ModifierStubs.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.internal;
+
+import javax.inject.Inject;
+
+/**
+ * Intentionally exists in a different package than {@link org.gradle.internal.service.DefaultServiceRegistry}
+ * to verify reflection is able to instantiate classes in a different package.
+ */
+@SuppressWarnings("unused")
+public class ModifierStubs {
+
+    public static class DefaultConstructor {
+        // Default constructor
+    }
+
+    public static class PackagePrivateConstructor {
+        final String testData;
+
+        // This will be injected
+        PackagePrivateConstructor(String testData) {
+            this.testData = testData;
+        }
+    }
+
+    public static class PackagePrivateConstructorWithPrivateConstructor {
+        final String testData;
+
+        // This is still ambiguous and will require the @Inject annotation to be fixed
+        PackagePrivateConstructorWithPrivateConstructor() {
+            this("Potato");
+        }
+
+        private PackagePrivateConstructorWithPrivateConstructor(String testData) {
+            this.testData = testData;
+        }
+    }
+
+    public static class AnnotatedPackagePrivateConstructorWithPrivateConstructor {
+        final String testData;
+
+        // This will be injected
+        @Inject
+        AnnotatedPackagePrivateConstructorWithPrivateConstructor() {
+            this("Potato");
+        }
+
+        // This will not get injected
+        private AnnotatedPackagePrivateConstructorWithPrivateConstructor(String testData) {
+            this.testData = testData;
+        }
+    }
+
+    public static class PublicConstructorWithPrivateConstructor {
+        final String testData;
+
+        // This is still ambiguous and will require the @Inject annotation to be fixed
+        public PublicConstructorWithPrivateConstructor() {
+            this("Potato");
+        }
+
+        private PublicConstructorWithPrivateConstructor(String testData) {
+            this.testData = testData;
+        }
+    }
+
+    public static class AnnotatedPublicConstructorWithPrivateConstructor {
+        final String testData;
+
+        // This will be injected
+        @Inject
+        public AnnotatedPublicConstructorWithPrivateConstructor() {
+            this("Potato");
+        }
+
+        private AnnotatedPublicConstructorWithPrivateConstructor(String testData) {
+            this.testData = testData;
+        }
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    public class NonStaticInnerClass {
+        // This will fail to be injected because this is not a static inner class
+        NonStaticInnerClass() {
+            /* no-op */
+        }
+    }
+}


### PR DESCRIPTION
 - Supports picking `@Inject` constructors when multiple constructors exist
 - Supports injecting package-private and private constructors

### Context

I'm finding that our current injection strategy overly restrictive. Currently, you can't have more than one public constructor, nor can you inject a private or package-private constructor. I'm finding that I'm attempting to build classes with constructors that I'd like to write such that they are not called except by the service injector.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
