### PR TITLE
Register dependency substitutions for the root build of a composite

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.util.ToBeImplemented
+
+class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    def "can refer to own subproject by GA coordinates"() {
+        given:
+        def buildB = multiProjectBuild("buildB", ['c1', 'c2', 'c3']) {
+            buildFile << """
+            allprojects {
+                apply plugin: 'java-library'
+            }
+            """
+        }
+        dependency(buildB, "org.test:c1")
+        dependency(buildB, "org.test:c2:1.0")
+        dependency(new BuildTestFile(buildB.file('c3'), 'c3'), "org.test:buildB") // dependency to root
+
+        when:
+        execute(buildB, "c3:jar")
+
+        then:
+        result.assertTaskExecuted(":c1:compileJava")
+        result.assertTaskExecuted(":c2:compileJava")
+        result.assertTaskExecuted(":c3:compileJava")
+        result.assertTaskExecuted(":compileJava")
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/6229")
+    def "included build can depend on including build"() {
+        given:
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                apply plugin: 'java-library'
+            """
+        }
+        buildA.buildFile << """
+            // add lifecycle task here since we can not call the task of buildB directly yet - https://github.com/gradle/gradle/issues/2533
+           tasks.register("buildBJar") {
+                dependsOn(gradle.includedBuild("buildB").task(":jar"))
+            }
+        """
+
+        includeBuild(buildB)
+        dependency(buildB, "org.test:buildA")
+
+        when:
+        fails(buildA, "buildBJar")
+
+        then:
+        failure.assertHasDescription("Included build dependency cycle: build ':' -> build 'buildB' -> build ':'")
+        // result.assertTaskExecuted(":buildB:compileJava")
+        // result.assertTaskExecuted(":compileJava")
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.util.ToBeImplemented
 
 class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildIntegrationTest {
 
-    def "can refer to own subproject by GA coordinates"() {
+    def "root of a composite build can refer to own subprojects by GA coordinates"() {
         given:
         def buildB = multiProjectBuild("buildB", ['c1', 'c2', 'c3']) {
             buildFile << """
@@ -33,6 +33,10 @@ class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildInt
         dependency(buildB, "org.test:c1")
         dependency(buildB, "org.test:c2:1.0")
         dependency(new BuildTestFile(buildB.file('c3'), 'c3'), "org.test:buildB") // dependency to root
+
+        buildB.settingsFile << """
+            includeBuild('${buildA.toURI()}')
+        """
 
         when:
         execute(buildB, "c3:jar")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.util.ToBeImplemented
 
 class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildIntegrationTest {
 
+    @ToBeFixedForConfigurationCache(because = "composite builds")
     def "root of a composite build can refer to own subprojects by GA coordinates"() {
         given:
         def buildB = multiProjectBuild("buildB", ['c1', 'c2', 'c3']) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -17,9 +17,7 @@
 package org.gradle.composite.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.gradle.api.Action;
-import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -29,32 +27,22 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.ForeignBuildIdentifier;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.Pair;
-import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.util.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Set;
 
-public class DefaultIncludedBuild extends AbstractBuildState implements IncludedBuildState, IncludedBuild, Stoppable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultIncludedBuild.class);
-
+public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState implements IncludedBuildState, IncludedBuild, Stoppable {
     private final BuildIdentifier buildIdentifier;
     private final Path identityPath;
     private final BuildDefinition buildDefinition;
@@ -151,32 +139,6 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     }
 
     @Override
-    public synchronized Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules() {
-        if (availableModules == null) {
-            Gradle gradle = getConfiguredBuild();
-            availableModules = Sets.newLinkedHashSet();
-            for (Project project : gradle.getRootProject().getAllprojects()) {
-                registerProject(availableModules, (ProjectInternal) project);
-            }
-        }
-        return availableModules;
-    }
-
-    private void registerProject(Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules, ProjectInternal project) {
-        ProjectComponentIdentifier projectIdentifier = new DefaultProjectComponentIdentifier(buildIdentifier, project.getIdentityPath(), project.getProjectPath(), project.getName());
-        ModuleVersionIdentifier moduleId = DefaultModuleVersionIdentifier.newId(project.getModule());
-        LOGGER.info("Registering " + project + " in composite build. Will substitute for module '" + moduleId.getModule() + "'.");
-        availableModules.add(Pair.of(moduleId, projectIdentifier));
-    }
-
-    @Override
-    public ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier) {
-        // Need to use a 'foreign' build id to make BuildIdentifier.isCurrentBuild and BuildIdentifier.name work in dependency results
-        DefaultProjectComponentIdentifier original = (DefaultProjectComponentIdentifier) identifier;
-        return new DefaultProjectComponentIdentifier(new ForeignBuildIdentifier(buildIdentifier.getName(), getName()), original.getIdentityPath(), original.projectPath(), original.getProjectName());
-    }
-
-    @Override
     public SettingsInternal loadSettings() {
         return gradleLauncher.getLoadedSettings();
     }
@@ -189,6 +151,11 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     @Override
     public GradleInternal getConfiguredBuild() {
         return gradleLauncher.getConfiguredBuild();
+    }
+
+    @Override
+    public GradleInternal getBuild() {
+        return getConfiguredBuild();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -143,6 +143,11 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     }
 
     @Override
+    public void afterConfigureRootBuild() {
+        dependencySubstitutionsBuilder.build(rootBuild);
+    }
+
+    @Override
     public void finalizeIncludedBuilds() {
         SettingsInternal rootSettings = getRootBuild().getLoadedSettings();
         while (!pendingIncludedBuilds.isEmpty()) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -144,7 +144,9 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public void afterConfigureRootBuild() {
-        dependencySubstitutionsBuilder.build(rootBuild);
+        if (!includedBuildsByRootDir.isEmpty()) {
+            dependencySubstitutionsBuilder.build(rootBuild);
+        }
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -19,10 +19,10 @@ package org.gradle.composite.internal;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
-import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.concurrent.Stoppable;
@@ -32,7 +32,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 
-class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild, Stoppable {
+class DefaultNestedBuild extends AbstractCompositeParticipantBuildState implements StandAloneNestedBuild, Stoppable {
     private final Path identityPath;
     private final BuildState owner;
     private final BuildIdentifier buildIdentifier;
@@ -100,5 +100,10 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     @Override
     public File getBuildRootDir() {
         return gradleLauncher.getBuildRootDir();
+    }
+
+    @Override
+    public GradleInternal getBuild() {
+        return gradleLauncher.getGradle();
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -28,7 +28,6 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
-import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.concurrent.Stoppable;
@@ -39,7 +38,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 
-class DefaultRootBuildState extends AbstractBuildState implements RootBuildState, Stoppable {
+class DefaultRootBuildState extends AbstractCompositeParticipantBuildState implements RootBuildState, Stoppable {
     private final ListenerManager listenerManager;
     private final GradleLauncher gradleLauncher;
 
@@ -113,5 +112,10 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
     @Override
     public Path getIdentityPathForProject(Path path) {
         return path;
+    }
+
+    @Override
+    public GradleInternal getBuild() {
+        return gradleLauncher.getGradle();
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
@@ -20,7 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
-import org.gradle.internal.build.IncludedBuildState;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
@@ -28,8 +28,8 @@ import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import java.io.File;
 
 public class IncludedBuildDependencyMetadataBuilder {
-    public LocalComponentMetadata build(IncludedBuildState build, ProjectComponentIdentifier projectIdentifier) {
-        GradleInternal gradle = build.getConfiguredBuild();
+    public LocalComponentMetadata build(BuildState build, ProjectComponentIdentifier projectIdentifier) {
+        GradleInternal gradle = build.getBuild();
         LocalComponentRegistry localComponentRegistry = gradle.getServices().get(LocalComponentRegistry.class);
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(projectIdentifier);
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.build.IncludedBuildState;
+import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.slf4j.Logger;
@@ -63,6 +64,10 @@ public class IncludedBuildDependencySubstitutionsBuilder {
             // Register the defined substitutions for included build
             context.registerSubstitution(substitutions.getRuleAction());
         }
+    }
+
+    public void build(RootBuildState rootBuildState) {
+        context.addAvailableModules(rootBuildState.getAvailableModules());
     }
 
     private DependencySubstitutionsInternal resolveDependencySubstitutions(IncludedBuildState build) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponent
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
@@ -62,9 +63,12 @@ public class LocalComponentInAnotherBuildProvider implements LocalComponentProvi
     private LocalComponentMetadata getRegisteredProject(final ProjectComponentIdentifier projectId) {
         ProjectState projectState = projectRegistry.stateFor(projectId);
         // TODO - this should work for any build, rather than just an included build
-        IncludedBuildState includedBuild = (IncludedBuildState) projectState.getOwner();
-        includedBuild.getConfiguredBuild();
+        BuildState buildState = projectState.getOwner();
+        if (buildState instanceof IncludedBuildState) {
+            // make sure the build is configured now (not do this for the root project, as we are already configuring it right now)
+            ((IncludedBuildState) buildState).getConfiguredBuild();
+        }
         // Metadata builder uses mutable project state, so synchronize access to the project state
-        return projectState.fromMutableState(p -> dependencyMetadataBuilder.build(includedBuild, projectId));
+        return projectState.fromMutableState(p -> dependencyMetadataBuilder.build(buildState, projectId));
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
@@ -65,7 +65,7 @@ public class LocalComponentInAnotherBuildProvider implements LocalComponentProvi
         // TODO - this should work for any build, rather than just an included build
         BuildState buildState = projectState.getOwner();
         if (buildState instanceof IncludedBuildState) {
-            // make sure the build is configured now (not do this for the root project, as we are already configuring it right now)
+            // make sure the build is configured now (not do this for the root build, as we are already configuring it right now)
             ((IncludedBuildState) buildState).getConfiguredBuild();
         }
         // Metadata builder uses mutable project state, so synchronize access to the project state

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -27,7 +27,6 @@ import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RunNestedBuildBuildOperationType;
 import org.gradle.internal.InternalBuildAdapter;
-import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.NestedRootBuild;
@@ -41,7 +40,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 
-public class RootOfNestedBuildTree extends AbstractBuildState implements NestedRootBuild {
+public class RootOfNestedBuildTree extends AbstractCompositeParticipantBuildState implements NestedRootBuild {
     private final BuildIdentifier buildIdentifier;
     private final Path identityPath;
     private final BuildState owner;
@@ -140,6 +139,11 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
         } finally {
             buildController.stop();
         }
+    }
+
+    @Override
+    public GradleInternal getBuild() {
+        return gradleLauncher.getGradle();
     }
 }
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -55,6 +55,11 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         buildBuildSrcAndLockClassloader(gradle, baseProjectClassLoaderScope);
 
         delegate.prepareProjects(gradle);
+
+        // Make root build substitutions available
+        if (gradle.isRootBuild()) {
+            buildStateRegistry.afterConfigureRootBuild();
+        }
     }
 
     private void buildBuildSrcAndLockClassloader(GradleInternal gradle, ClassLoaderScope baseProjectClassLoaderScope) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -16,14 +16,18 @@
 
 package org.gradle.internal.build;
 
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.Pair;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.Set;
 
 /**
  * Encapsulates the identity and state of a particular build in a build tree.
@@ -84,4 +88,16 @@ public interface BuildState {
      * The root directory of the build.
      */
     File getBuildRootDir();
+
+    /**
+     * Identities of the modules represented by the projects of this build.
+     */
+    Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
+
+    GradleInternal getBuild();
+
+    /**
+     * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build
+     */
+    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -73,6 +73,11 @@ public interface BuildStateRegistry {
     void beforeConfigureRootBuild();
 
     /**
+     * Notification that the root build has just finished configuration.
+     */
+    void afterConfigureRootBuild();
+
+    /**
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
     IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition);

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -19,15 +19,11 @@ package org.gradle.internal.build;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.DependencySubstitutions;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.internal.Pair;
 
 import java.io.File;
-import java.util.Set;
 
 /**
  * Encapsulates the identity and state of an included build. An included build is a nested build that participates in dependency resolution and task execution with the root build and other included builds in the build tree.
@@ -37,12 +33,6 @@ public interface IncludedBuildState extends NestedBuildState {
     File getRootDirectory();
     IncludedBuild getModel();
     Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions();
-    Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
-
-    /**
-     * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build
-     */
-    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 
     SettingsInternal loadSettings();
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -19,6 +19,7 @@ package org.gradle.testfixtures.internal;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildType;
@@ -43,6 +44,7 @@ import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ProjectDescriptorRegistry;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.Pair;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -71,6 +73,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Set;
 
 import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
 
@@ -260,6 +263,21 @@ public class ProjectBuilderImpl {
         @Override
         public File getBuildRootDir() {
             return rootProjectDir;
+        }
+
+        @Override
+        public Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public GradleInternal getBuild() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier) {
+            throw new UnsupportedOperationException();
         }
     }
 }


### PR DESCRIPTION
This PR partly solves #14564 for the case where the project is a root project of a composite. It's **not** doing the same for a single project, because registering the dependency substitutions opts-into "fluid" dependency resolution. Which leads to more dependency resolution during task graph analysis - see `DefaultResolutionStrategy.resolveGraphToDetermineTaskDependencies()`.

In a composite build, this mode is **always** used in any case.

We might solve this use cases for a single project differently in a follow up PR (spike: #14633). 