### PR TITLE
Fix ordering issues with artifact transforms loaded from the configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -235,6 +235,7 @@ class FixedArtifactCollection(
                     }
                 }
                 is TransformedLocalArtifactSpec -> {
+                    element.transformation.isolateParameters()
                     val displayName = Describables.of(element.ownerId, element.variantAttributes)
                     for (output in element.transformation.createInvocation(TransformationSubject.initial(element.origin), noDependencies, null).invoke().get().files) {
                         val artifactId = ComponentFileArtifactIdentifier(element.ownerId, output.name)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -90,7 +90,7 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     }
 
     private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
-        private T value;
+        private volatile T value;
 
         CalculatedModelValueImpl(@Nullable T initialValue) {
             value = initialValue;

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -240,10 +240,10 @@ trait TasksWithInputsAndOutputs {
 
                 @TaskAction
                 def log() {
-                    println("files = \${collection.artifactFiles.files.name}")
                     println("artifacts = \${collection.artifacts.id}")
                     println("components = \${collection.artifacts.id.componentIdentifier}")
                     println("variants = \${collection.artifacts.variant.attributes}")
+                    println("files = \${collection.artifactFiles.files.name}")
                 }
             }
         """


### PR DESCRIPTION
Fix concurrency issue in artifact transforms loaded from the configuration cache.

Fix the case where an `ArtifactCollection` is loaded from the configuration cache and contains only the output of artifact transforms applied to file dependencies.
