### PR TITLE
Explicitly keep Kotlin compiler environment alive when compiling buildscripts

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -16,9 +16,11 @@
 
 package org.gradle.kotlin.dsl.support
 
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.io.NullOutputStream
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY
 
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
@@ -373,11 +375,16 @@ fun CompilerConfiguration.addScriptDefinition(scriptDef: ScriptDefinition) {
 private
 fun Disposable.kotlinCoreEnvironmentFor(configuration: CompilerConfiguration): KotlinCoreEnvironment {
     org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
-    return KotlinCoreEnvironment.createForProduction(
-        this,
-        configuration,
-        EnvironmentConfigFiles.JVM_CONFIG_FILES
-    )
+    return SystemProperties.getInstance().withSystemProperty(
+        KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY,
+        "true"
+    ) {
+        KotlinCoreEnvironment.createForProduction(
+            this,
+            configuration,
+            EnvironmentConfigFiles.JVM_CONFIG_FILES
+        )
+    }
 }
 
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -32,6 +32,7 @@ import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClass
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClassParameterizedType
 import org.gradle.kotlin.dsl.fixtures.codegen.GroovyNamedArguments
 import org.gradle.kotlin.dsl.support.normaliseLineSeparators
+import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
@@ -52,6 +53,7 @@ import java.util.jar.Manifest
 import kotlin.reflect.KClass
 
 
+@LeaksFileHandles("embedded Kotlin compiler environment keepalive")
 class GradleApiExtensionsTest : TestWithClassPath() {
 
     @Test

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -14,6 +14,7 @@ import org.gradle.api.internal.classpath.Module
 import org.gradle.internal.classpath.DefaultClassPath
 
 import org.gradle.kotlin.dsl.accessors.TestWithClassPath
+import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -21,6 +22,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
 
+@LeaksFileHandles("embedded Kotlin compiler environment keepalive")
 class KotlinScriptClassPathProviderTest : TestWithClassPath() {
 
     @Test


### PR DESCRIPTION
https://github.com/gradle/gradle/pull/14276 enabled Kotlin compiler environment reuse across buildscript compilation, which reduced the overhead of creating a new Kotlin compiler environment for each build script compilation.

It turned out that the environments are only reused whenever the `kotlin.environment.keepalive` system property is set:
https://github.com/JetBrains/kotlin/blob/726c66e0bfd168360f50848e0a80f1b826732468/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt#L479-L491

`kotlin.environment.keepalive` is currently not set when the Kotlin buildscripts are compiled and it happened that applying the `kotlin-dsl` plugin to a buildSrc buildscript did set that property which made builds that do apply `kotlin-dsl` plugin benefit from compiler environment reuse while others remained unaffected.

This change will enable the benefits of https://github.com/gradle/gradle/pull/14276 on all Gradle builds using Kotlin buildscripts.
Performance tests show a significant improvement for use cases where Kotlin build scripts need to be recompiled: https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestSlowLinux_Trigger/38367505:id/report/index.html

