### PR TITLE
Fix failure attribution for performance tests when a performance test is retried

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -242,9 +242,8 @@ abstract class PerformanceTest extends DistributionTest {
         FileUtils.write(resultsJson, JsonOutput.toJson(resultData), Charset.defaultCharset())
     }
 
-    static String collectFailures(JUnitTestSuite testSuite) {
-        List<JUnitTestCase> testCases = testSuite.testCases ?: []
-        List<JUnitFailure> failures = testCases.collect { it.failures ?: [] }.flatten() as List<JUnitFailure>
+    static String collectFailures(JUnitTestCase testCase) {
+        List<JUnitFailure> failures = testCase.failures ?: []
         return failures.collect { it.value }.join("\n")
     }
 
@@ -260,7 +259,7 @@ abstract class PerformanceTest extends DistributionTest {
                 teamCityBuildId: buildId,
                 agentName: agentName,
                 status: (it.errors || it.failures) ? "FAILURE" : "SUCCESS",
-                testFailure: collectFailures(testSuite))
+                testFailure: collectFailures(it))
         }
     }
 

--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -289,7 +289,7 @@ class PerformanceTestPlugin : Plugin<Project> {
                     setTestProjectGenerationTask(sampleGenerator)
 
                     retry {
-                        maxRetries.set(3)
+                        maxRetries.set(1)
                     }
 
                     if (shouldLoadScenariosFromFile) {


### PR DESCRIPTION
We now only add the failures of the failed test case to the JSON which we use to generate the report.

Not doing so may have caused test failures when the retry plugin retries a performance test: https://builds.gradle.org/buildConfiguration/Gradle_Check_PerformanceTestTestLinuxbucket16/38367108

This PR also reduces the number of retries to 1, as we had before.