### PR TITLE
Add --profiler option to performance test tasks

### DIFF
--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -49,13 +49,13 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
             allowEmpty = false,
             description = "Which performance test to run. Should be the fully qualified class name dot (unrolled) method name. E.g. org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)"
         )
-
+        val profilerDescription = "Command line option for the performance test task to enable profiling. For example `--profiler jfr` and `--profiler async-profiler`."
         when (os) {
             Os.WINDOWS -> {
-                param("flamegraphs", "--flamegraphs false")
+                text("profiler", "", description = profilerDescription)
             }
             else -> {
-                param("flamegraphs", "--flamegraphs true")
+                text("profiler", "--profiler jfr", description = profilerDescription)
                 param("env.FG_HOME_DIR", "/opt/FlameGraph")
                 param("env.PATH", "%env.PATH%:/opt/swift/4.2.3/usr/bin")
                 param("env.HP_HOME_DIR", "/opt/honest-profiler")
@@ -76,7 +76,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
                 performanceTestCommandLine(
                     "clean performance:%testProject%PerformanceAdHocTest --tests \"%scenario%\"",
                     "%baselines%",
-                    """--warmups %warmups% --runs %runs% --checks %checks% --channel %channel% %flamegraphs% %additional.gradle.parameters%""",
+                    """--warmups %warmups% --runs %runs% --checks %checks% --channel %channel% %profiler% %additional.gradle.parameters%""",
                     os
                 ) +
                     buildToolGradleParameters(isContinue = false) +

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -93,9 +93,6 @@ abstract class PerformanceTest extends DistributionTest {
     @Input
     String channel
 
-    @Input
-    boolean flamegraphs
-
     /************** properties configured by PerformanceTestPlugin ***************/
     @Internal
     String buildId
@@ -200,10 +197,10 @@ abstract class PerformanceTest extends DistributionTest {
         this.channel = channel
     }
 
-    @Option(option = "flamegraphs", description = "If set to 'true', activates flamegraphs and stores them into the 'flames' directory name under the debug artifacts directory.")
-    void setFlamegraphs(String flamegraphs) {
-        this.flamegraphs = Boolean.parseBoolean(flamegraphs)
-    }
+    @Option(option = "profiler", description = "Allows configuring a profiler to use. The same options as for Gradle profilers --profiler command line option are available")
+    @Optional
+    @Input
+    abstract Property<String> getProfiler()
 
     @Optional
     @Input
@@ -283,9 +280,10 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel)
             addSystemPropertyIfExist(result, "org.gradle.performance.debugArtifactsDirectory", getDebugArtifactsDirectory())
 
-            if (flamegraphs) {
+            if (profiler.isPresent()) {
                 File artifactsDirectory = new File(getDebugArtifactsDirectory(), "flames")
                 addSystemPropertyIfExist(result, "org.gradle.performance.flameGraphTargetDir", artifactsDirectory.getAbsolutePath())
+                addSystemPropertyIfExist(result, "org.gradle.performance.profiler", profiler.get())
             }
         }
 


### PR DESCRIPTION
This allows running any profiler Gradle profiler supports,
as long as no further options are necessary.

This is an example for `--profiler async-profiler`: https://builds.gradle.org/buildConfiguration/Gradle_Util_Performance_AdHocPerformanceScenarioLinux/38377735