### PR TITLE
Add a task to read the performance test times from the performance database

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -44,6 +44,7 @@ import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskCollection
@@ -311,6 +312,15 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         tasks.register<PerformanceTestReport>("performanceTestFlakinessReport") {
             reportGeneratorClass.set("org.gradle.performance.results.report.FlakinessReportGenerator")
+        }
+
+        tasks.register<JavaExec>("writePerformanceTimes") {
+            classpath(performanceSourceSet.runtimeClasspath)
+            mainClass.set("org.gradle.performance.results.PerformanceTestRuntimesGenerator")
+            systemProperties(project.propertiesForPerformanceDb())
+            args(project.rootProject.file(".teamcity/performance-test-runtimes.json").absolutePath)
+            // Never up-to-date since it reads data from the database.
+            outputs.upToDateWhen { false }
         }
 
         tasks.withType<PerformanceTestReport>().configureEach {

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
@@ -40,6 +40,7 @@ class BuildScanPerformanceTestRunner extends AbstractCrossBuildPerformanceTestRu
     @Override
     CrossBuildPerformanceResults newResult() {
         new CrossBuildPerformanceResults(
+            testClass: testClassName,
             testId: testId,
             testProject: testProject,
             testGroup: testGroup,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
@@ -35,6 +35,7 @@ class CrossBuildPerformanceTestRunner extends AbstractCrossBuildPerformanceTestR
     @Override
     CrossBuildPerformanceResults newResult() {
         new CrossBuildPerformanceResults(
+            testClass: testClassName,
             testId: testId,
             testProject: testProject,
             testGroup: testGroup,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -117,6 +117,7 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
         assumeShouldRun()
 
         def results = new CrossVersionPerformanceResults(
+            testClass: testClassName,
             testId: testId,
             previousTestIds: previousTestIds.collect { it.toString() }, // Convert GString instances
             testProject: testProject,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -108,6 +108,7 @@ class GradleVsMavenPerformanceTestRunner extends AbstractCrossBuildPerformanceTe
     @Override
     GradleVsMavenBuildPerformanceResults newResult() {
         new GradleVsMavenBuildPerformanceResults(
+            testClass: testClassName,
             testId: testId,
             testProject: testProject,
             testGroup: testGroup,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestScenarioSelector.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestScenarioSelector.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.gradle.performance.results.PerformanceExperiment;
+import org.gradle.performance.results.PerformanceScenario;
 import org.gradle.performance.results.PerformanceTestExecution;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ResultsStore;
@@ -58,7 +59,7 @@ public class TestScenarioSelector {
 
     private static void addToScenarioList(String fullClassName, String testId, String testProject, File scenarioList, ResultsStore resultsStore) {
         try {
-            long estimatedRuntime = getEstimatedRuntime(testId, testProject, resultsStore);
+            long estimatedRuntime = getEstimatedRuntime(fullClassName, testId, testProject, resultsStore);
             List<String> args = Lists.newArrayList();
             args.add(fullClassName);
             args.add(testId);
@@ -71,9 +72,9 @@ public class TestScenarioSelector {
         }
     }
 
-    private static long getEstimatedRuntime(String testId, String testProject, ResultsStore resultsStore) {
+    private static long getEstimatedRuntime(String testClass, String testId, String testProject, ResultsStore resultsStore) {
         String channel = ResultsStoreHelper.determineChannel();
-        PerformanceTestHistory history = resultsStore.getTestResults(new PerformanceExperiment(testProject, testId), 1, 365, channel);
+        PerformanceTestHistory history = resultsStore.getTestResults(new PerformanceExperiment(testProject, new PerformanceScenario(testClass, testId)), 1, 365, channel);
         PerformanceTestExecution lastRun = Iterables.getFirst(history.getExecutions(), null);
         if (lastRun == null) {
             return 0;

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> implements WritableResultsStore<T> {
+    private final PerformanceDatabase db;
+
+    public AbstractWritableResultsStore(PerformanceDatabase db) {
+        this.db = db;
+    }
+
+    public PerformanceDatabase getDb() {
+        return db;
+    }
+
+    private static final int LATEST_EXECUTION_TIMES_DAYS = 14;
+    private static final String SELECT_LATEST_EXECUTION_TIMES = "with last as\n" +
+        "(\n" +
+        "   select\n" +
+        "   testClass,\n" +
+        "   testId,\n" +
+        "   testProject,\n" +
+        "   operatingSystem,\n" +
+        "   max(id) as lastId\n" +
+        "   from testExecution\n" +
+        "   where startTime > ?\n" +
+        "   and operatingSystem like ?\n" +
+        "   and (channel in ('commits-master','experiments-master'))\n" +
+        "   and testProject is not null\n" +
+        "   group by testClass,\n" +
+        "   testId,\n" +
+        "   testProject\n" +
+        ")\n" +
+        "select\n" +
+        "last.testClass,\n" +
+        "last.testId,\n" +
+        "last.testProject,\n" +
+        "testExecution.startTime,\n" +
+        "testExecution.endTime\n" +
+        "from last\n" +
+        "join testExecution on testExecution.id = last.lastId\n" +
+        "order by last.testClass,last.testId,last.testProject";
+
+    @Override
+    public Map<PerformanceExperiment, Long> getEstimatedExperimentTimes(OperatingSystem operatingSystem) {
+        return db.withConnection("load estimated runtimes", connection -> {
+            Timestamp since = Timestamp.valueOf(LocalDateTime.now().minusDays(LATEST_EXECUTION_TIMES_DAYS));
+            ImmutableMap.Builder<PerformanceExperiment, Long> builder = ImmutableMap.builder();
+            try (PreparedStatement statement = connection.prepareStatement(SELECT_LATEST_EXECUTION_TIMES)) {
+                statement.setTimestamp(1, since);
+                statement.setString(2, operatingSystem.getSqlMatcher());
+                try (ResultSet experimentTimes = statement.executeQuery()) {
+                    while (experimentTimes.next()) {
+                        String testClass = experimentTimes.getString(1);
+                        String testName = experimentTimes.getString(2);
+                        String testProject = experimentTimes.getString(3);
+                        long startTime = experimentTimes.getTimestamp(4).getTime();
+                        long endTime = experimentTimes.getTimestamp(5).getTime();
+                        PerformanceExperiment performanceExperiment = new PerformanceExperiment(testProject, new PerformanceScenario(testClass, testName));
+                        builder.put(performanceExperiment, endTime - startTime);
+                    }
+                    return builder.build();
+                }
+            }
+        });
+    }
+
+    protected <RESULT> RESULT withConnection(String actionName, ConnectionAction<RESULT> action) {
+        return db.withConnection(actionName, action);
+    }
+
+
+        @Override
+    public void close() {
+        db.close();
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
@@ -20,6 +20,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 
 public class AllResultsStore implements ResultsStore, Closeable {
     private final CrossVersionResultsStore crossVersion = new CrossVersionResultsStore();
@@ -40,6 +41,11 @@ public class AllResultsStore implements ResultsStore, Closeable {
     @Override
     public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
         return store.getTestResults(experiment, mostRecentN, maxDaysOld, channel);
+    }
+
+    @Override
+    public Map<PerformanceExperiment, Long> getEstimatedExperimentTimes(OperatingSystem operatingSystem) {
+        return store.getEstimatedExperimentTimes(operatingSystem);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -24,7 +24,6 @@ import org.gradle.performance.measure.Duration;
 import org.gradle.performance.measure.MeasuredOperation;
 import org.joda.time.LocalDate;
 
-import java.io.Closeable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -38,59 +37,48 @@ import static org.gradle.performance.results.ResultsStoreHelper.split;
 import static org.gradle.performance.results.ResultsStoreHelper.toArray;
 import static org.gradle.performance.results.ResultsStoreHelper.toList;
 
-public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> implements WritableResultsStore<R>, Closeable {
+public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> extends AbstractWritableResultsStore<R> {
 
-    private final PerformanceDatabase db;
     private final String resultType;
 
     public BaseCrossBuildResultsStore(String resultType) {
-        this.db = new PerformanceDatabase("cross_build_results");
+        super(new PerformanceDatabase("cross_build_results"));
         this.resultType = resultType;
     }
 
     @Override
     public void report(final R results) {
-        try {
-            db.withConnection((ConnectionAction<Void>) connection -> {
-                long executionId;
-                PreparedStatement statement = connection.prepareStatement("insert into testExecution(testClass, testId, testProject, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, resultType, channel, host, teamCityBuildId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
-                try {
-                    statement.setString(1, results.getTestClass());
-                    statement.setString(2, results.getTestId());
-                    statement.setString(3, results.getTestProject());
-                    statement.setTimestamp(4, new Timestamp(results.getStartTime()));
-                    statement.setTimestamp(5, new Timestamp(results.getEndTime()));
-                    statement.setString(6, results.getVersionUnderTest());
-                    statement.setString(7, results.getOperatingSystem());
-                    statement.setString(8, results.getJvm());
-                    statement.setString(9, results.getVcsBranch());
-                    statement.setString(10, Joiner.on(",").join(results.getVcsCommits()));
-                    statement.setString(11, results.getTestGroup());
-                    statement.setString(12, resultType);
-                    statement.setString(13, results.getChannel());
-                    statement.setString(14, results.getHost());
-                    statement.setString(15, results.getTeamCityBuildId());
-                    statement.execute();
-                    ResultSet keys = statement.getGeneratedKeys();
-                    keys.next();
-                    executionId = keys.getLong(1);
-                } finally {
-                    statement.close();
+        withConnection("write results", (ConnectionAction<Void>) connection -> {
+            long executionId;
+            try (PreparedStatement statement = connection.prepareStatement("insert into testExecution(testClass, testId, testProject, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, resultType, channel, host, teamCityBuildId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                statement.setString(1, results.getTestClass());
+                statement.setString(2, results.getTestId());
+                statement.setString(3, results.getTestProject());
+                statement.setTimestamp(4, new Timestamp(results.getStartTime()));
+                statement.setTimestamp(5, new Timestamp(results.getEndTime()));
+                statement.setString(6, results.getVersionUnderTest());
+                statement.setString(7, results.getOperatingSystem());
+                statement.setString(8, results.getJvm());
+                statement.setString(9, results.getVcsBranch());
+                statement.setString(10, Joiner.on(",").join(results.getVcsCommits()));
+                statement.setString(11, results.getTestGroup());
+                statement.setString(12, resultType);
+                statement.setString(13, results.getChannel());
+                statement.setString(14, results.getHost());
+                statement.setString(15, results.getTeamCityBuildId());
+                statement.execute();
+                ResultSet keys = statement.getGeneratedKeys();
+                keys.next();
+                executionId = keys.getLong(1);
+            }
+            try (PreparedStatement statement = connection.prepareStatement("insert into testOperation(testExecution, displayName, tasks, args, gradleOpts, daemon, totalTime, cleanTasks) values (?, ?, ?, ?, ?, ?, ?, ?)")) {
+                for (BuildDisplayInfo displayInfo : results.getBuilds()) {
+                    addOperations(statement, executionId, displayInfo, results.buildResult(displayInfo));
                 }
-                statement = connection.prepareStatement("insert into testOperation(testExecution, displayName, tasks, args, gradleOpts, daemon, totalTime, cleanTasks) values (?, ?, ?, ?, ?, ?, ?, ?)");
-                try {
-                    for (BuildDisplayInfo displayInfo : results.getBuilds()) {
-                        addOperations(statement, executionId, displayInfo, results.buildResult(displayInfo));
-                    }
-                    statement.executeBatch();
-                } finally {
-                    statement.close();
-                }
-                return null;
-            });
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Could not open results datastore '%s'.", db.getUrl()), e);
-        }
+                statement.executeBatch();
+            }
+            return null;
+        });
     }
 
     private void addOperations(PreparedStatement statement, long executionId, BuildDisplayInfo displayInfo, MeasuredOperationList operations) throws SQLException {
@@ -108,33 +96,24 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
     }
 
     @Override
-    public void close() {
-        db.close();
-    }
-
-    @Override
     public List<PerformanceExperiment> getPerformanceExperiments() {
-        try {
-            return db.withConnection((ConnectionAction<List<PerformanceExperiment>>) connection -> {
-                Set<PerformanceExperiment> testNames = Sets.newLinkedHashSet();
-                PreparedStatement testIdsStatement = connection.prepareStatement("select distinct testClass, testId, testProject from testExecution where resultType = ? order by testClass, testId, testProject");
+        return withConnection("load test history", connection -> {
+            Set<PerformanceExperiment> testNames = Sets.newLinkedHashSet();
+            try (PreparedStatement testIdsStatement = connection.prepareStatement("select distinct testClass, testId, testProject from testExecution where resultType = ? order by testClass, testId, testProject")) {
                 testIdsStatement.setString(1, resultType);
-                ResultSet testExecutions = testIdsStatement.executeQuery();
-                while (testExecutions.next()) {
-                    String testClass = testExecutions.getString(1);
-                    String testName = testExecutions.getString(2);
-                    String testProject = testExecutions.getString(3);
-                    if (testProject != null && testClass != null) {
-                        testNames.add(new PerformanceExperiment(testProject, new PerformanceScenario(testClass, testName)));
+                try (ResultSet testExecutions = testIdsStatement.executeQuery()) {
+                    while (testExecutions.next()) {
+                        String testClass = testExecutions.getString(1);
+                        String testName = testExecutions.getString(2);
+                        String testProject = testExecutions.getString(3);
+                        if (testProject != null && testClass != null) {
+                            testNames.add(new PerformanceExperiment(testProject, new PerformanceScenario(testClass, testName)));
+                        }
                     }
+                    return Lists.newArrayList(testNames);
                 }
-                testExecutions.close();
-                testIdsStatement.close();
-                return Lists.newArrayList(testNames);
-            });
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Could not load test history from datastore '%s'.", db.getUrl()), e);
-        }
+            }
+        });
     }
 
     @Override
@@ -144,12 +123,11 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
 
     @Override
     public CrossBuildPerformanceTestHistory getTestResults(final PerformanceExperiment experiment, final int mostRecentN, final int maxDaysOld, final String channel) {
-        try {
-            return db.withConnection(connection -> {
-                List<CrossBuildPerformanceResults> results = Lists.newArrayList();
-                Set<BuildDisplayInfo> builds = Sets.newTreeSet(Comparator.comparing(BuildDisplayInfo::getDisplayName));
+        return withConnection("load results", connection -> {
+            try (
                 PreparedStatement executionsForName = connection.prepareStatement("select id, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, channel, host, teamCityBuildId from testExecution where testClass = ? and testId = ? and testProject = ? and startTime >= ? and channel = ? order by startTime desc limit ?");
-                PreparedStatement operationsForExecution = connection.prepareStatement("select displayName, tasks, args, gradleOpts, daemon, totalTime, cleanTasks from testOperation where testExecution = ?");
+                PreparedStatement operationsForExecution = connection.prepareStatement("select displayName, tasks, args, gradleOpts, daemon, totalTime, cleanTasks from testOperation where testExecution = ?")
+            ) {
                 executionsForName.setString(1, experiment.getScenario().getClassName());
                 executionsForName.setString(2, experiment.getScenario().getTestName());
                 executionsForName.setString(3, experiment.getTestProject());
@@ -157,58 +135,55 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                 executionsForName.setTimestamp(4, minDate);
                 executionsForName.setString(5, channel);
                 executionsForName.setInt(6, mostRecentN);
-                ResultSet testExecutions = executionsForName.executeQuery();
-                while (testExecutions.next()) {
-                    long id = testExecutions.getLong(1);
-                    CrossBuildPerformanceResults performanceResults = new CrossBuildPerformanceResults();
-                    performanceResults.setTestClass(experiment.getScenario().getClassName());
-                    performanceResults.setTestId(experiment.getScenario().getTestName());
-                    performanceResults.setTestProject(experiment.getTestProject());
-                    performanceResults.setStartTime(testExecutions.getTimestamp(2).getTime());
-                    performanceResults.setEndTime(testExecutions.getTimestamp(3).getTime());
-                    performanceResults.setVersionUnderTest(testExecutions.getString(4));
-                    performanceResults.setOperatingSystem(testExecutions.getString(5));
-                    performanceResults.setJvm(testExecutions.getString(6));
-                    performanceResults.setVcsBranch(testExecutions.getString(7).trim());
-                    performanceResults.setVcsCommits(split(testExecutions.getString(8)));
-                    performanceResults.setTestGroup(testExecutions.getString(9));
-                    performanceResults.setChannel(testExecutions.getString(10));
-                    performanceResults.setHost(testExecutions.getString(11));
-                    performanceResults.setTeamCityBuildId(testExecutions.getString(12));
+                try (ResultSet testExecutions = executionsForName.executeQuery()) {
+                    List<CrossBuildPerformanceResults> results = Lists.newArrayList();
+                    Set<BuildDisplayInfo> builds = Sets.newTreeSet(Comparator.comparing(BuildDisplayInfo::getDisplayName));
+                    while (testExecutions.next()) {
+                        long id = testExecutions.getLong(1);
+                        CrossBuildPerformanceResults performanceResults = new CrossBuildPerformanceResults();
+                        performanceResults.setTestClass(experiment.getScenario().getClassName());
+                        performanceResults.setTestId(experiment.getScenario().getTestName());
+                        performanceResults.setTestProject(experiment.getTestProject());
+                        performanceResults.setStartTime(testExecutions.getTimestamp(2).getTime());
+                        performanceResults.setEndTime(testExecutions.getTimestamp(3).getTime());
+                        performanceResults.setVersionUnderTest(testExecutions.getString(4));
+                        performanceResults.setOperatingSystem(testExecutions.getString(5));
+                        performanceResults.setJvm(testExecutions.getString(6));
+                        performanceResults.setVcsBranch(testExecutions.getString(7).trim());
+                        performanceResults.setVcsCommits(split(testExecutions.getString(8)));
+                        performanceResults.setTestGroup(testExecutions.getString(9));
+                        performanceResults.setChannel(testExecutions.getString(10));
+                        performanceResults.setHost(testExecutions.getString(11));
+                        performanceResults.setTeamCityBuildId(testExecutions.getString(12));
 
-                    if (ignore(performanceResults)) {
-                        continue;
+                        if (ignore(performanceResults)) {
+                            continue;
+                        }
+
+                        results.add(performanceResults);
+
+                        operationsForExecution.setLong(1, id);
+                        try (ResultSet resultSet = operationsForExecution.executeQuery()) {
+                            while (resultSet.next()) {
+                                String displayName = resultSet.getString(1);
+                                List<String> tasksToRun = toList(resultSet.getObject(2));
+                                List<String> cleanTasks = toList(resultSet.getObject(7));
+                                List<String> args = toList(resultSet.getObject(3));
+                                List<String> gradleOpts = toList(resultSet.getObject(4));
+                                Boolean daemon = (Boolean) resultSet.getObject(5);
+                                BuildDisplayInfo displayInfo = new BuildDisplayInfo(experiment.getTestProject(), displayName, tasksToRun, cleanTasks, args, gradleOpts, daemon);
+
+                                MeasuredOperation operation = new MeasuredOperation();
+                                operation.setTotalTime(Duration.millis(resultSet.getBigDecimal(6)));
+                                performanceResults.buildResult(displayInfo).add(operation);
+                                builds.add(displayInfo);
+                            }
+                        }
                     }
-
-                    results.add(performanceResults);
-
-                    operationsForExecution.setLong(1, id);
-                    ResultSet resultSet = operationsForExecution.executeQuery();
-                    while (resultSet.next()) {
-                        String displayName = resultSet.getString(1);
-                        List<String> tasksToRun = toList(resultSet.getObject(2));
-                        List<String> cleanTasks = toList(resultSet.getObject(7));
-                        List<String> args = toList(resultSet.getObject(3));
-                        List<String> gradleOpts = toList(resultSet.getObject(4));
-                        Boolean daemon = (Boolean) resultSet.getObject(5);
-                        BuildDisplayInfo displayInfo = new BuildDisplayInfo(experiment.getTestProject(), displayName, tasksToRun, cleanTasks, args, gradleOpts, daemon);
-
-                        MeasuredOperation operation = new MeasuredOperation();
-                        operation.setTotalTime(Duration.millis(resultSet.getBigDecimal(6)));
-                        performanceResults.buildResult(displayInfo).add(operation);
-                        builds.add(displayInfo);
-                    }
-                    resultSet.close();
+                    return new CrossBuildPerformanceTestHistory(experiment.getScenario().getTestName(), ImmutableList.copyOf(builds), results);
                 }
-                testExecutions.close();
-                operationsForExecution.close();
-                executionsForName.close();
-
-                return new CrossBuildPerformanceTestHistory(experiment.getScenario().getTestName(), ImmutableList.copyOf(builds), results);
-            });
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Could not load results from datastore '%s'.", db.getUrl()), e);
-        }
+            }
+        });
     }
 
     protected boolean ignore(CrossBuildPerformanceResults performanceResults) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -53,22 +53,23 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
         try {
             db.withConnection((ConnectionAction<Void>) connection -> {
                 long executionId;
-                PreparedStatement statement = connection.prepareStatement("insert into testExecution(testId, testProject, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, resultType, channel, host, teamCityBuildId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
+                PreparedStatement statement = connection.prepareStatement("insert into testExecution(testClass, testId, testProject, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, resultType, channel, host, teamCityBuildId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
                 try {
-                    statement.setString(1, results.getTestId());
-                    statement.setString(2, results.getTestProject());
-                    statement.setTimestamp(3, new Timestamp(results.getStartTime()));
-                    statement.setTimestamp(4, new Timestamp(results.getEndTime()));
-                    statement.setString(5, results.getVersionUnderTest());
-                    statement.setString(6, results.getOperatingSystem());
-                    statement.setString(7, results.getJvm());
-                    statement.setString(8, results.getVcsBranch());
-                    statement.setString(9, Joiner.on(",").join(results.getVcsCommits()));
-                    statement.setString(10, results.getTestGroup());
-                    statement.setString(11, resultType);
-                    statement.setString(12, results.getChannel());
-                    statement.setString(13, results.getHost());
-                    statement.setString(14, results.getTeamCityBuildId());
+                    statement.setString(1, results.getTestClass());
+                    statement.setString(2, results.getTestId());
+                    statement.setString(3, results.getTestProject());
+                    statement.setTimestamp(4, new Timestamp(results.getStartTime()));
+                    statement.setTimestamp(5, new Timestamp(results.getEndTime()));
+                    statement.setString(6, results.getVersionUnderTest());
+                    statement.setString(7, results.getOperatingSystem());
+                    statement.setString(8, results.getJvm());
+                    statement.setString(9, results.getVcsBranch());
+                    statement.setString(10, Joiner.on(",").join(results.getVcsCommits()));
+                    statement.setString(11, results.getTestGroup());
+                    statement.setString(12, resultType);
+                    statement.setString(13, results.getChannel());
+                    statement.setString(14, results.getHost());
+                    statement.setString(15, results.getTeamCityBuildId());
                     statement.execute();
                     ResultSet keys = statement.getGeneratedKeys();
                     keys.next();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class CompositeResultsStore implements ResultsStore {
     private final List<ResultsStore> stores;
@@ -46,6 +47,13 @@ public class CompositeResultsStore implements ResultsStore {
     @Override
     public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
         return getStoreForTest(experiment).getTestResults(experiment, mostRecentN, maxDaysOld, channel);
+    }
+
+    @Override
+    public Map<PerformanceExperiment, Long> getEstimatedExperimentTimes(OperatingSystem operatingSystem) {
+        return stores.stream()
+            .flatMap(store -> store.getEstimatedExperimentTimes(operatingSystem).entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Math::max));
     }
 
     private ResultsStore getStoreForTest(PerformanceExperiment experiment) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
@@ -42,7 +42,7 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
 
     @Override
     public String getDisplayName() {
-        return experiment.getScenario();
+        return experiment.getScenario().getTestName();
     }
 
     public List<String> getBaselineVersions() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -125,29 +125,30 @@ public class CrossVersionResultsStore implements WritableResultsStore<CrossVersi
 
     private long insertExecution(Connection connection, CrossVersionPerformanceResults results) throws SQLException {
         String insertStatement = insertStatement("testExecution",
-            "testId", "startTime", "endTime", "targetVersion", "testProject", "tasks", "args", "gradleOpts", "daemon", "operatingSystem",
+            "testClass", "testId", "startTime", "endTime", "targetVersion", "testProject", "tasks", "args", "gradleOpts", "daemon", "operatingSystem",
             "jvm", "vcsBranch", "vcsCommit", "channel", "host", "cleanTasks", "teamCityBuildId", "currentMedian", "baselineMedian", "diffConfidence");
 
 
         try (PreparedStatement statement = connection.prepareStatement(insertStatement, Statement.RETURN_GENERATED_KEYS)) {
-            statement.setString(1, results.getTestId());
-            statement.setTimestamp(2, new Timestamp(results.getStartTime()));
-            statement.setTimestamp(3, new Timestamp(results.getEndTime()));
-            statement.setString(4, results.getVersionUnderTest());
-            statement.setString(5, results.getTestProject());
-            statement.setObject(6, toArray(results.getTasks()));
-            statement.setObject(7, toArray(results.getArgs()));
-            statement.setObject(8, toArray(results.getGradleOpts()));
-            statement.setBoolean(9, results.getDaemon());
-            statement.setString(10, results.getOperatingSystem());
-            statement.setString(11, results.getJvm());
-            statement.setString(12, results.getVcsBranch());
+            statement.setString(1, results.getTestClass());
+            statement.setString(2, results.getTestId());
+            statement.setTimestamp(3, new Timestamp(results.getStartTime()));
+            statement.setTimestamp(4, new Timestamp(results.getEndTime()));
+            statement.setString(5, results.getVersionUnderTest());
+            statement.setString(6, results.getTestProject());
+            statement.setObject(7, toArray(results.getTasks()));
+            statement.setObject(8, toArray(results.getArgs()));
+            statement.setObject(9, toArray(results.getGradleOpts()));
+            statement.setBoolean(10, results.getDaemon());
+            statement.setString(11, results.getOperatingSystem());
+            statement.setString(12, results.getJvm());
+            statement.setString(13, results.getVcsBranch());
             String vcs = results.getVcsCommits() == null ? null : Joiner.on(",").join(results.getVcsCommits());
-            statement.setString(13, vcs);
-            statement.setString(14, results.getChannel());
-            statement.setString(15, results.getHost());
-            statement.setObject(16, toArray(results.getCleanTasks()));
-            statement.setString(17, results.getTeamCityBuildId());
+            statement.setString(14, vcs);
+            statement.setString(15, results.getChannel());
+            statement.setString(16, results.getHost());
+            statement.setObject(17, toArray(results.getCleanTasks()));
+            statement.setString(18, results.getTeamCityBuildId());
 
             if (results.getBaselineVersions().size() == 1) {
                 MeasuredOperationList current = results.getCurrent();
@@ -156,13 +157,13 @@ public class CrossVersionResultsStore implements WritableResultsStore<CrossVersi
                 BigDecimal currentMedian = current.getTotalTime().getMedian().toUnits(Duration.MILLI_SECONDS).getValue();
                 BigDecimal baselineMedian = baseline.getTotalTime().getMedian().toUnits(Duration.MILLI_SECONDS).getValue();
                 BigDecimal diffConfidence = new BigDecimal(DataSeries.confidenceInDifference(current.getTotalTime(), baseline.getTotalTime()));
-                statement.setBigDecimal(18, currentMedian);
-                statement.setBigDecimal(19, baselineMedian);
-                statement.setBigDecimal(20, diffConfidence);
+                statement.setBigDecimal(19, currentMedian);
+                statement.setBigDecimal(20, baselineMedian);
+                statement.setBigDecimal(21, diffConfidence);
             } else {
-                statement.setBigDecimal(18, null);
                 statement.setBigDecimal(19, null);
                 statement.setBigDecimal(20, null);
+                statement.setBigDecimal(21, null);
             }
 
             statement.execute();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -44,6 +44,11 @@ class NoResultsStore<T extends PerformanceTestResult> implements WritableResults
     }
 
     @Override
+    Map<PerformanceExperiment, Long> getEstimatedExperimentTimes(OperatingSystem operatingSystem) {
+        return Collections.emptyMap()
+    }
+
+    @Override
     void close() {
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -35,12 +35,12 @@ class NoResultsStore<T extends PerformanceTestResult> implements WritableResults
 
     @Override
     PerformanceTestHistory getTestResults(PerformanceExperiment experiment, String channel) {
-        new EmptyPerformanceTestHistory(experiment.getScenario())
+        new EmptyPerformanceTestHistory(experiment.getScenario().getTestName())
     }
 
     @Override
     PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
-        new EmptyPerformanceTestHistory(experiment.getScenario())
+        new EmptyPerformanceTestHistory(experiment.getScenario().getTestName())
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/OperatingSystem.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/OperatingSystem.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+public enum OperatingSystem {
+    LINUX("linux%"),
+    MAC_OS("mac os%"),
+    WINDOWS("windows");
+
+    private final String sqlMatcher;
+
+    OperatingSystem(String sqlMatcher) {
+        this.sqlMatcher = sqlMatcher;
+    }
+
+    public String getSqlMatcher() {
+        return sqlMatcher;
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/OperatingSystem.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/OperatingSystem.java
@@ -17,17 +17,17 @@
 package org.gradle.performance.results;
 
 public enum OperatingSystem {
-    LINUX("linux%"),
-    MAC_OS("mac os%"),
-    WINDOWS("windows");
+    LINUX(""),
+    MAC_OS("-macos"),
+    WINDOWS("-windows");
 
-    private final String sqlMatcher;
+    private final String channelSuffix;
 
-    OperatingSystem(String sqlMatcher) {
-        this.sqlMatcher = sqlMatcher;
+    OperatingSystem(String channelSuffix) {
+        this.channelSuffix = channelSuffix;
     }
 
-    public String getSqlMatcher() {
-        return sqlMatcher;
+    public String getChannelSuffix() {
+        return channelSuffix;
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
@@ -72,6 +72,14 @@ public class PerformanceDatabase {
         return action.execute(connection);
     }
 
+    public <T> T withConnection(String actionName, ConnectionAction<T> action) {
+        try {
+            return withConnection(action);
+        } catch (SQLException e) {
+            throw new RuntimeException(String.format("Could not %s from datastore '%s'.", actionName, getUrl()), e);
+        }
+    }
+
     public String getUrl() {
         String baseUrl = System.getProperty(PERFORMANCE_DB_URL_PROPERTY_NAME);
         if (baseUrl == null) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceScenario.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceScenario.java
@@ -18,21 +18,21 @@ package org.gradle.performance.results;
 
 import java.util.Objects;
 
-public class PerformanceExperiment {
-    private final String testProject;
-    private final PerformanceScenario scenario;
+public class PerformanceScenario {
+    private final String className;
+    private final String testName;
 
-    public PerformanceExperiment(String testProject, PerformanceScenario scenario) {
-        this.testProject = testProject;
-        this.scenario = scenario;
+    public PerformanceScenario(String className, String testName) {
+        this.className = className;
+        this.testName = testName;
     }
 
-    public String getTestProject() {
-        return testProject;
+    public String getClassName() {
+        return className;
     }
 
-    public PerformanceScenario getScenario() {
-        return scenario;
+    public String getTestName() {
+        return testName;
     }
 
     @Override
@@ -43,21 +43,21 @@ public class PerformanceExperiment {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PerformanceExperiment that = (PerformanceExperiment) o;
-        return testProject.equals(that.testProject) &&
-            scenario.equals(that.scenario);
+        PerformanceScenario that = (PerformanceScenario) o;
+        return Objects.equals(className, that.className) &&
+            Objects.equals(testName, that.testName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(testProject, scenario);
+        return Objects.hash(className, testName);
     }
 
     @Override
     public String toString() {
-        return "PerformanceExperiment{" +
-            "testProject='" + testProject + '\'' +
-            ", scenario='" + scenario + '\'' +
+        return "PerformanceScenario{" +
+            "className='" + className + '\'' +
+            ", scenario='" + testName + '\'' +
             '}';
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestResult.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestResult.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 public abstract class PerformanceTestResult {
     private String testId;
+    private String testClass;
     private String testProject;
     private String teamCityBuildId;
     private String jvm;
@@ -50,6 +51,14 @@ public abstract class PerformanceTestResult {
     public static boolean hasRegressionChecks() {
         String check = System.getProperty("org.gradle.performance.regression.checks", "true");
         return Arrays.asList("true", "all").contains(check);
+    }
+
+    public String getTestClass() {
+        return testClass;
+    }
+
+    public void setTestClass(String testClass) {
+        this.testClass = testClass;
     }
 
     public String getTestId() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PerformanceTestRuntimesGenerator {
+
+    public static void main(String[] args) throws IOException {
+        new PerformanceTestRuntimesGenerator().generate(new File(args[0]));
+    }
+
+    public void generate(File runtimesFile) throws IOException {
+        AllResultsStore resultsStore = new AllResultsStore();
+        Map<PerformanceExperiment, Long> estimatedExperimentTimes = resultsStore.getEstimatedExperimentTimes(OperatingSystem.LINUX);
+        Map<PerformanceScenario, List<Map.Entry<PerformanceExperiment, Long>>> performanceScenarioMap =
+            estimatedExperimentTimes.entrySet().stream()
+                .collect(Collectors.groupingBy(
+                    it -> it.getKey().getScenario(),
+                    LinkedHashMap::new,
+                    Collectors.toList())
+                );
+        List<Map<String, Object>> json = performanceScenarioMap.entrySet().stream()
+            .map(entry -> {
+                PerformanceScenario scenario = entry.getKey();
+                List<Map.Entry<PerformanceExperiment, Long>> times = entry.getValue();
+                return ImmutableMap.of(
+                    "scenario", scenario.getClassName() + "." + scenario.getTestName(),
+                    "runtimes", times.stream()
+                        .map(experimentEntry -> ImmutableMap.of(
+                            "testProject", experimentEntry.getKey().getTestProject(),
+                            "linux", experimentEntry.getValue()
+                        ))
+                        .collect(Collectors.toList())
+                );
+            })
+            .collect(Collectors.toList());
+
+        new ObjectMapper().writerWithDefaultPrettyPrinter()
+            .writeValue(runtimesFile, json);
+    }
+
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
@@ -18,6 +18,7 @@ package org.gradle.performance.results;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 
 public interface ResultsStore extends Closeable {
     /**
@@ -34,4 +35,6 @@ public interface ResultsStore extends Closeable {
      * Returns the n most recent instances of the given test which are younger than the max age.
      */
     PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel);
+
+    Map<PerformanceExperiment, Long> getEstimatedExperimentTimes(OperatingSystem operatingSystem);
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -91,7 +91,7 @@ class ScenarioBuildResultData {
     }
 
     PerformanceExperiment getPerformanceExperiment() {
-        new PerformanceExperiment(getTestProject(), getScenarioName())
+        new PerformanceExperiment(getTestProject(), new PerformanceScenario(getScenarioClass(), getScenarioName()))
     }
 
     List<ExecutionData> getExecutions() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
@@ -48,6 +48,7 @@ public class DefaultPerformanceExecutionDataProvider extends PerformanceExecutio
         .thenComparing(comparing(ScenarioBuildResultData::getDifferenceSortKey).reversed())
         .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
         .thenComparing(ScenarioBuildResultData::getScenarioName)
+        .thenComparing(ScenarioBuildResultData::getScenarioClass)
         .thenComparing(ScenarioBuildResultData::getTestProject);
 
     public DefaultPerformanceExecutionDataProvider(ResultsStore resultsStore, List<File> resultJsons) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
@@ -40,7 +40,9 @@ class FlakinessDetectionPerformanceExecutionDataProvider extends PerformanceExec
             .thenComparing(comparing(ScenarioBuildResultData::isBuildFailed).reversed())
             .thenComparing(comparing(org.gradle.performance.results.report.FlakinessDetectionPerformanceExecutionDataProvider::isFlaky).reversed())
             .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
-            .thenComparing(ScenarioBuildResultData::getScenarioName);
+            .thenComparing(ScenarioBuildResultData::getScenarioName)
+            .thenComparing(ScenarioBuildResultData::getScenarioClass)
+            .thenComparing(ScenarioBuildResultData::getTestProject);
 
     public FlakinessDetectionPerformanceExecutionDataProvider(ResultsStore resultsStore, List<File> resultJsons) {
         super(resultsStore, resultJsons);

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -35,6 +35,7 @@ abstract class ResultSpecification extends Specification {
 
     CrossVersionPerformanceResults crossVersionResults(Map<String, ?> options = [:]) {
         def results = new CrossVersionPerformanceResults()
+        results.testClass = "org.gradle.performance.MyPerformanceTest"
         results.testId = "test-id"
         results.previousTestIds = []
         results.testProject = "test-project"
@@ -57,6 +58,7 @@ abstract class ResultSpecification extends Specification {
 
     CrossBuildPerformanceResults crossBuildResults(Map<String, ?> options = [:]) {
         def results = new CrossBuildPerformanceResults(
+                testClass: "org.gradle.performance.MyCrossBuildPerformanceTest",
                 testId: "test-id",
                 testGroup: "test-group",
                 testProject: "test-project",
@@ -75,6 +77,7 @@ abstract class ResultSpecification extends Specification {
 
     GradleVsMavenBuildPerformanceResults gradleVsMavenBuildResults(Map<String, ?> options = [:]) {
         def results = new GradleVsMavenBuildPerformanceResults(
+                testClass: "org.gradle.performance.MyGradleVsMavenPerformanceTest",
                 testId: "test-id",
                 testProject: 'test-project',
                 testGroup: "test-group",

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -27,6 +27,7 @@ import org.gradle.performance.results.CrossVersionPerformanceTestHistory
 import org.gradle.performance.results.GradleVsMavenBuildPerformanceResults
 import org.gradle.performance.results.MeasuredOperationList
 import org.gradle.performance.results.PerformanceExperiment
+import org.gradle.performance.results.PerformanceScenario
 import org.gradle.performance.results.PerformanceTestHistory
 import spock.lang.Specification
 
@@ -113,7 +114,7 @@ abstract class ResultSpecification extends Specification {
         result2.version('5.0-mockbaseline-2').results.addAll(measuredOperations([2, 2]))
         result2.version('master').results.addAll(measuredOperations([1, 1]))
 
-        return new CrossVersionPerformanceTestHistory(new PerformanceExperiment('test-project', 'mockScenario'),
+        return new CrossVersionPerformanceTestHistory(new PerformanceExperiment('test-project', new PerformanceScenario('org.gradle.performance.MyPerformanceTest', 'mockScenario')),
             ['5.0-mockbaseline-1', '5.0-mockbaseline-2'],
             ['master'],
             [result2, result1]

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CompositeResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CompositeResultsStoreTest.groovy
@@ -22,10 +22,11 @@ class CompositeResultsStoreTest extends Specification {
     def store1 = Mock(ResultsStore)
     def store2 = Mock(ResultsStore)
     def store = new CompositeResultsStore(store1, store2)
-    def a = new PerformanceExperiment('testProject1', 'a')
-    def b = new PerformanceExperiment('testProject2', 'b')
-    def c = new PerformanceExperiment('testProject1', 'c')
-    def d = new PerformanceExperiment('testProject1', 'd')
+    def className = 'org.gradle.performance.MyPerformanceTest'
+    def a = new PerformanceExperiment('testProject1', new PerformanceScenario(className, 'a'))
+    def b = new PerformanceExperiment('testProject2', new PerformanceScenario(className, 'b'))
+    def c = new PerformanceExperiment('testProject1', new PerformanceScenario(className, 'c'))
+    def d = new PerformanceExperiment('testProject1', new PerformanceScenario(className, 'd'))
 
     def "returns union of test names"() {
         given:

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
@@ -32,7 +32,7 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
     SetSystemProperties properties = new SetSystemProperties("org.gradle.performance.db.url": "jdbc:h2:" + tmpDir.testDirectory)
 
     final dbName = "cross-build-results"
-    def experiment1 = new PerformanceExperiment("testProject1", "test1")
+    def experiment1 = new PerformanceExperiment("testProject1", new PerformanceScenario("org.gradle.performance.MyPerformanceTest", "test1"))
 
     def "persists results"() {
         given:

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
@@ -30,8 +30,8 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule SetSystemProperties properties = new SetSystemProperties("org.gradle.performance.db.url": "jdbc:h2:" + tmpDir.testDirectory)
     final dbFile = tmpDir.file("results")
-    def experiment1 = new PerformanceExperiment("testProject1", "test1")
-    def experiment2 = new PerformanceExperiment("testProject1", "test2")
+    def experiment1 = new PerformanceExperiment("testProject1", new PerformanceScenario("org.gradle.performance.MyPerformanceTest", "test1"))
+    def experiment2 = new PerformanceExperiment("testProject1", new PerformanceScenario("org.gradle.performance.MyPerformanceTest", "test2"))
 
     @Shared long now = Calendar.getInstance().time.time
 
@@ -324,7 +324,7 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
     def "returns empty results for unknown id"() {
         given:
         def store = new CrossVersionResultsStore(dbFile.name)
-        def unknown = new PerformanceExperiment("unknown", "unknown")
+        def unknown = new PerformanceExperiment("unknown", new PerformanceScenario("unknownClass", "unknown"))
 
         expect:
         store.getTestResults(unknown, channel).baselineVersions.empty

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -19,10 +19,8 @@ package org.gradle.performance.results
 import groovy.json.JsonSlurper
 import org.gradle.performance.ResultSpecification
 import org.gradle.performance.results.report.TestDataGenerator
-import spock.lang.Ignore
 import spock.lang.Subject
 
-@Ignore
 class TestDataGeneratorTest extends ResultSpecification {
     @Subject
     TestDataGenerator generator = new TestDataGenerator()


### PR DESCRIPTION
That allows us to update the performance test times file automatically. Instead of using a CSV file we use a JSON file of the following format:

```json
[ {
  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
  "runtimes" : [ {
    "testProject" : "largeMonolithicJavaProject",
    "linux" : 120000
  }, {
    "testProject" : "largeJavaMultiProject",
    "linux" : 476000
  } ]
}, {
  "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
  "runtimes" : [ {
    "testProject" : "mediumJavaMultiProjectWithTestNG",
    "linux" : 291000
  }, {
    "testProject" : "largeJavaMultiProject",
    "linux" : 594000
  }, {
    "testProject" : "largeMonolithicJavaProject",
    "linux" : 1453000
  } ]
} ]
```

This PR also adds storing the class name of the performance test in the database. We need this to properly generate the timings file and as an additional benefit it allows having performance tests with the same method name in different test classes.

The reading of the JSON file is not yet part of this PR, since we first need to populate the database from performance build runs on `master`.