### PR TITLE
Fix incremental annotation processing when type isn't top level

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
@@ -74,11 +74,14 @@ class AggregatingProcessingStrategy extends IncrementalProcessingStrategy {
         if (orig == null || orig.isEmpty()) {
             return Collections.emptySet();
         }
-        return ElementUtils.getTopLevelTypeNames(orig.stream()
+        return orig
+            .stream()
+            .map(ElementUtils::getTopLevelType)
             .filter(Symbol.ClassSymbol.class::isInstance)
             .map(Symbol.ClassSymbol.class::cast)
             .filter(e -> e.sourcefile != null)
-            .collect(Collectors.toSet()));
+            .map(ElementUtils::getElementName)
+            .collect(Collectors.toSet());
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
@@ -60,6 +60,14 @@ public class ElementUtils {
             current = parent;
             parent = current.getEnclosingElement();
         }
+        String name = getElementName(current);
+        if (name != null) {
+            return name;
+        }
+        throw new IllegalArgumentException("Unexpected element " + originatingElement);
+    }
+
+    public static String getElementName(Element current) {
         if (current instanceof PackageElement) {
             String packageName = ((PackageElement) current).getQualifiedName().toString();
             if (packageName.isEmpty()) {
@@ -72,6 +80,16 @@ public class ElementUtils {
             TypeElement typeElement = (TypeElement) current;
             return typeElement.getQualifiedName().toString();
         }
-        throw new IllegalArgumentException("Unexpected element " + originatingElement);
+        return null;
+    }
+
+    public static Element getTopLevelType(Element originatingElement) {
+        Element current = originatingElement;
+        Element parent = originatingElement;
+        while (parent != null && !(parent instanceof PackageElement)) {
+            current = parent;
+            parent = current.getEnclosingElement();
+        }
+        return current;
     }
 }


### PR DESCRIPTION
A previous fix (#13833) introduced a regression in case an aggregating
processor works on a type which is annotated at the method level for
example: in this case we wouldn't look for the enclosing type and
detect that there's a source file, and then ignore recompilation.

