### PR TITLE
Replace UUID with a fixed string in generated build files

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -16,7 +16,8 @@
 
 package gradlebuild.performance.generator.tasks
 
-
+import gradlebuild.performance.generator.RepositoryBuilder
+import gradlebuild.performance.generator.TestProject
 import groovy.text.SimpleTemplateEngine
 import groovy.text.Template
 import org.gradle.api.GradleException
@@ -29,8 +30,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import gradlebuild.performance.generator.RepositoryBuilder
-import gradlebuild.performance.generator.TestProject
 
 /**
  * Original tangled mess of a project generator.
@@ -302,7 +301,7 @@ abstract class AbstractProjectGeneratorTask extends TemplateProjectGeneratorTask
         destFile.parentFile.mkdirs()
         destFile.withWriter { Writer writer ->
             if (templateName.endsWith('.gradle')) {
-                writer << "// Generated ${UUID.randomUUID()}\n"
+                writer << "// Generated for subproject ${templateArgs.projectName}\n"
             }
             getTemplate(templateFiles.last()).make(templateArgs).writeTo(writer)
         }

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
@@ -16,9 +16,8 @@
 
 package gradlebuild.performance.generator.tasks
 
-
-import org.gradle.api.tasks.Internal
 import gradlebuild.performance.generator.TestProject
+import org.gradle.api.tasks.Internal
 
 // TODO: Remove this and replace it with a BuildBuilderGenerator instead.
 class CppMultiProjectGeneratorTask extends AbstractProjectGeneratorTask {
@@ -33,6 +32,7 @@ class CppMultiProjectGeneratorTask extends AbstractProjectGeneratorTask {
                                "project${it}"
                            },
                            sourceFiles: testProject.sourceFiles,
+                           projectName: testProject.name,
                            useMacroIncludes: false
         ] + args
         generateWithTemplate(projectDir, 'build.gradle', 'build.gradle', projectArgs)


### PR DESCRIPTION
for performance test projects. This currently causes cache
misses for our performance test tasks.

See https://ge.gradle.org/c/v7s5jwlcdof7m/na7gjasf7vyoc/task-inputs?expanded=WyI2M25xcHE0ZGtydmFpLXJvb3RzcGVjJDEkMSIsIjYzbnFwcTRka3J2YWktcm9vdFNwZWMkMSQxLTAtMCIsImk0NHh3Z2F2czM0eTItdGVzdHByb2plY3RmaWxlcyIsImk0NHh3Z2F2czM0eTItdGVzdFByb2plY3RGaWxlcy0wLTAiLCJjZGgyM3c0dmFqbXh3LWFydGlmYWN0cyJd#i44xwgavs34y2