### PR TITLE
Class generator: implement name property automatically

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
@@ -58,6 +58,9 @@ public interface ExtensiblePolymorphicDomainObjectContainer<T> extends Polymorph
      * the binding's implementation type. If the implementation type has a constructor annotated with
      * {@link javax.inject.Inject}, its arguments will be injected.
      *
+     * <p>The implementation type may also be an interface that has a read-only {@code name} property of type String,
+     * and is otherwise empty or consists entirely of managed properties.</p>
+     *
      * <p>In general, registering a binding is preferable over implementing and registering a factory.
      *
      * @param type a public domain object type

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -122,7 +122,9 @@ public interface ObjectFactory {
     /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type.</p>
      *
-     * <p>The specified element type must have a public constructor which takes the name as a String parameter. The type must be non-final and a class or abstract class. Interfaces are currently not supported.</p>
+     * <p>The specified element type must have a public constructor which takes the name as a String parameter. The type must be non-final and a class or abstract class.</p>
+     *
+     * <p>Interfaces are supported if they declare a read-only {@code name} property of type String, and are otherwise empty or consist entirely of managed properties.</p>
      *
      * <p>All objects <b>MUST</b> expose their name as a bean property called "name". The name must be constant for the life of the object.</p>
      *

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -121,11 +121,24 @@ Note that for a property to be considered a read only managed nested property, _
 The property must not have any setter methods.
 In addition, the property getter must be annotated with `@link:{javadocPath}/org/gradle/api/tasks/Nested.html[Nested]`.
 
+[[read_only_managed_name_property]]
+==== Read-only managed "name" property
+
+If the type contains an abstract property called "name" of type `String`, Gradle provides an implementation for the getter
+method, and extends each constructor with a "name" parameter, which comes before all other constructor parameters. If the
+type is an interface, Gradle will provide a constructor with a single "name" parameter and `@Inject` semantics.
+
+You can have your type implement or extend the link:{javadocPath}/org/gradle/api/Named.html[Named] interface, which defines
+such a read-only "name" property.
+
 [[managed_types]]
 === Managed types
 
 A _managed type_ is an abstract class or interface with no fields and whose properties are all managed.
 That is, it is a type whose state is entirely managed by Gradle.
+
+A _named managed type_ is a managed type that additionally has an abstract property "name" of type `String`. Named
+managed types are especially useful as the element type of link:{javadocPath}/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer] (see below).
 
 == DSL support and extensibility
 
@@ -239,9 +252,14 @@ generally better to use the injected `ObjectFactory` service instead of passing 
 
 You can also create a container instance using a <<read_only_managed_properties,read-only managed property>>, described above.
 
-In order to use a type with any of the `domainObjectContainer()` methods, it must expose a property named "`name`" as the unique, and constant, name for the object.
-The `domainObjectContainer(Class)` variant of the method creates new instances by calling the constructor of the class that takes a string argument, which is the desired name of the object.
-Objects created this way are treated as custom Gradle types, and so can make use of the features discussed in this chapter, for example service injection or managed properties.
+In order to use a type with any of the `domainObjectContainer()` methods, it must either
+
+- be a <<managed_types,named managed type>>; or
+- expose a property named "`name`" as the unique, and constant, name for the object. The `domainObjectContainer(Class)`
+  variant of the method creates new instances by calling the constructor of the class that takes a string argument, which is the desired name of the object.
+
+Objects created this way are treated as custom Gradle types, and so can make use of the features discussed in this chapter, for example service injection or
+managed properties.
 
 See the above link for `domainObjectContainer()` method variants that allow custom instantiation strategies.
 
@@ -252,6 +270,18 @@ See the above link for `domainObjectContainer()` method variants that allow cust
 ----
 include::{snippetsPath}/plugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/DownloadExtension.java[]
 include::{snippetsPath}/plugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/Resource.java[tags=resource]
+----
+====
+
+To be even more concise, you can define this model entirely using interfaces, and take advantage of Gradle's managed types:
+
+.Managing a collection of objects based on interfaces
+====
+[source.multi-language-sample,java]
+.DownloadExtension.java
+----
+include::{snippetsPath}/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/DownloadExtension.java[]
+include::{snippetsPath}/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/Resource.java[tags=resource]
 ----
 ====
 

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id("org.gradle.sample.download")
+}
+
+download {
+    // Can use a block to configure the container contents
+    resources {
+        gradle {
+            uri = uri('https://gradle.org')
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id('java-gradle-plugin')
+}
+
+repositories {
+    jcenter()
+}
+
+gradlePlugin {
+    plugins {
+        download {
+            id = 'org.gradle.sample.download'
+            implementationClass = 'DownloadPlugin'
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/DownloadExtension.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/DownloadExtension.java
@@ -1,0 +1,9 @@
+import java.net.URI;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+
+public interface DownloadExtension {
+
+    // A container of `Resource` objects
+    NamedDomainObjectContainer<Resource> getResources();
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/DownloadPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/DownloadPlugin.java
@@ -1,0 +1,8 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class DownloadPlugin implements Plugin<Project> {
+    public void apply(Project project) {
+        project.getExtensions().create("download", DownloadExtension.class);
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/Resource.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/src/main/java/Resource.java
@@ -1,0 +1,13 @@
+import java.net.URI;
+import org.gradle.api.Named;
+// tag::resource[]
+
+public interface Resource extends Named {
+
+    URI getUri();
+    void setUri(URI uri);
+
+    String getUserName();
+    void setUserName(String userName);
+}
+// end::resource[]

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'containers'

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("org.gradle.sample.download")
+}
+
+download {
+    // Can use a block to configure the container contents
+    resources {
+        register("gradle") {
+            uri = uri("https://gradle.org")
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id('java-gradle-plugin')
+}
+
+repositories {
+    jcenter()
+}
+
+gradlePlugin {
+    plugins {
+        download {
+            id = 'org.gradle.sample.download'
+            implementationClass = 'DownloadPlugin'
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/DownloadExtension.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/DownloadExtension.java
@@ -1,0 +1,9 @@
+import java.net.URI;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+
+public interface DownloadExtension {
+
+    // A container of `Resource` objects
+    NamedDomainObjectContainer<Resource> getResources();
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/DownloadPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/DownloadPlugin.java
@@ -1,0 +1,8 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class DownloadPlugin implements Plugin<Project> {
+    public void apply(Project project) {
+        project.getExtensions().create("download", DownloadExtension.class);
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/Resource.java
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/src/main/java/Resource.java
@@ -1,0 +1,13 @@
+import java.net.URI;
+import org.gradle.api.Named;
+// tag::resource[]
+
+public interface Resource extends Named {
+
+    URI getUri();
+    void setUri(URI uri);
+
+    String getUserName();
+    void setUserName(String userName);
+}
+// end::resource[]

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "containers"

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/tests/namedDomainObjectContainerInterfaces.sample.conf
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/tests/namedDomainObjectContainerInterfaces.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: ""

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -178,6 +178,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         InjectAnnotationPropertyHandler injectionHandler = new InjectAnnotationPropertyHandler();
         PropertyTypePropertyHandler propertyTypedHandler = new PropertyTypePropertyHandler();
         ManagedPropertiesHandler managedPropertiesHandler = new ManagedPropertiesHandler();
+        NamePropertyHandler namePropertyHandler = new NamePropertyHandler();
         ExtensibleTypePropertyHandler extensibleTypeHandler = new ExtensibleTypePropertyHandler();
         DslMixInPropertyType dslMixInHandler = new DslMixInPropertyType(extensibleTypeHandler);
 
@@ -187,6 +188,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         handlers.add(dslMixInHandler);
         handlers.add(propertyTypedHandler);
         handlers.add(servicesHandler);
+        handlers.add(namePropertyHandler);
         handlers.add(managedPropertiesHandler);
         for (Class<? extends Annotation> annotation : enabledAnnotations) {
             customAnnotationPropertyHandlers.add(new CustomInjectAnnotationPropertyHandler(annotation));
@@ -216,11 +218,16 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 handler.applyTo(generationVisitor);
             }
 
+            boolean shouldImplementNameProperty = namePropertyHandler.hasNameProperty();
             if (type.isInterface()) {
-                generationVisitor.addDefaultConstructor();
+                if (shouldImplementNameProperty) {
+                    generationVisitor.addNameConstructor();
+                } else {
+                    generationVisitor.addDefaultConstructor();
+                }
             } else {
                 for (Constructor<?> constructor : type.getConstructors()) {
-                    generationVisitor.addConstructor(constructor);
+                    generationVisitor.addConstructor(constructor, shouldImplementNameProperty);
                 }
             }
 
@@ -377,6 +384,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         // Property is read only and getter is not final, so attach owner lazily when queried
         // This should apply to all 'managed' types however only the Provider types and @Nested value current implement OwnerAware
         return property.isReadOnly() && !property.getOverridableGetters().isEmpty() && (Provider.class.isAssignableFrom(property.getType()) || property.hasAnnotation(Nested.class));
+    }
+
+    private static boolean isNameProperty(PropertyMetadata property) {
+        // Property is read only, called "name", has type String and getter is abstract
+        return property.isReadOnly() && "name".equals(property.getName()) && property.getType() == String.class && property.getMainGetter().isAbstract();
     }
 
     private static boolean isPropertyType(Class<?> type) {
@@ -1044,6 +1056,38 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         }
     }
 
+    private static class NamePropertyHandler extends ClassGenerationHandler {
+
+        private PropertyMetadata nameProperty;
+
+        @Override
+        void visitProperty(PropertyMetadata property) {
+            if (isNameProperty(property)) {
+                nameProperty = property;
+            }
+        }
+
+        @Override
+        boolean claimPropertyImplementation(PropertyMetadata property) {
+            if (isNameProperty(property)) {
+                nameProperty = property;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        void applyTo(ClassGenerationVisitor visitor) {
+            if (nameProperty != null) {
+                visitor.addNameProperty();
+            }
+        }
+
+        boolean hasNameProperty() {
+            return nameProperty != null;
+        }
+    }
+
     private static class PropertyTypePropertyHandler extends ClassGenerationHandler {
         private final List<PropertyMetadata> propertyTyped = new ArrayList<>();
 
@@ -1325,9 +1369,15 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     protected interface ClassGenerationVisitor {
-        void addConstructor(Constructor<?> constructor);
+        void addConstructor(Constructor<?> constructor, boolean addNameParameter);
+
+        default void addConstructor(Constructor<?> constructor) {
+            addConstructor(constructor, false);
+        }
 
         void addDefaultConstructor();
+
+        void addNameConstructor();
 
         void mixInDynamicAware();
 
@@ -1372,6 +1422,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         void addActionMethod(Method method);
 
         void addPropertySetterOverloads(PropertyMetadata property, MethodMetadata getter);
+
+        void addNameProperty();
 
         Class<?> generate() throws Exception;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
@@ -93,8 +93,18 @@ public class AsmClassGeneratorUtils {
      * Generates the signature for the given constructor
      */
     public static String signature(Constructor<?> constructor) {
+        return signature(constructor, false);
+    }
+
+    /**
+     * Generates the signature for the given constructor, optionally adding a `name` parameter before all other parameters.
+     */
+    public static String signature(Constructor<?> constructor, boolean addNameParameter) {
         StringBuilder builder = new StringBuilder();
         visitFormalTypeParameters(builder, constructor.getTypeParameters());
+        if (addNameParameter) {
+            visitType(String.class, builder);
+        }
         visitParameters(builder, constructor.getGenericParameterTypes());
         builder.append("V");
         visitExceptions(builder, constructor.getGenericExceptionTypes());

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -21,6 +21,7 @@ import groovy.lang.GroovyObject;
 import groovy.lang.MissingMethodException;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -269,6 +270,17 @@ public class AsmBackedClassGeneratorTest {
     }
 
     @Test
+    public void overridesPublicConstructorsWithName() throws Exception {
+        NamedBeanWithConstructor bean = newInstance(NamedBeanWithConstructor.class, "name", "value");
+        assertThat(bean.getName(), equalTo("name"));
+        assertThat(bean.getProp(), equalTo("value"));
+
+        bean = newInstance(NamedBeanWithConstructor.class, "name");
+        assertThat(bean.getName(), equalTo("name"));
+        assertThat(bean.getProp(), equalTo("default value"));
+    }
+
+    @Test
     public void includesGenericTypeInformationForOverriddenConstructor() {
         Class<?> generatedClass = generator.generate(BeanWithComplexConstructor.class).getGeneratedClass();
         Constructor<?> constructor = generatedClass.getDeclaredConstructors()[0];
@@ -415,6 +427,15 @@ public class AsmBackedClassGeneratorTest {
     }
 
     @Test
+    public void includesAnnotationInformationForOverriddenConstructorWithName() {
+        Class<?> generatedClass = generator.generate(NamedBeanWithAnnotatedConstructor.class).getGeneratedClass();
+        Constructor<?> constructor = generatedClass.getDeclaredConstructors()[0];
+
+        assertThat(constructor.getAnnotation(Inject.class), notNullValue());
+        assertThat(constructor.getParameterTypes(), equalTo(new Class<?>[] {String.class}));
+    }
+
+    @Test
     public void canConstructInstance() throws Exception {
         Bean bean = newInstance(BeanWithConstructor.class, "value");
         assertThat(bean.getClass(), sameInstance((Object) generator.generate(BeanWithConstructor.class).getGeneratedClass()));
@@ -425,6 +446,12 @@ public class AsmBackedClassGeneratorTest {
 
         bean = newInstance(BeanWithConstructor.class, 127);
         assertThat(bean.getProp(), equalTo("127"));
+    }
+
+    @Test
+    public void implementsNamePropertyOnInterface() throws Exception {
+        InterfaceBeanWithReadOnlyName bean = newInstance(InterfaceBeanWithReadOnlyName.class, "name");
+        assertThat(bean.getName(), equalTo("name"));
     }
 
     @Test
@@ -1276,6 +1303,20 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
+    public static abstract class NamedBeanWithConstructor extends BeanWithConstructor implements Named {
+        public NamedBeanWithConstructor() {
+            super();
+        }
+
+        public NamedBeanWithConstructor(String value) {
+            super(value);
+        }
+
+        public NamedBeanWithConstructor(int value) {
+            super(value);
+        }
+    }
+
     public static class BeanWithComplexConstructor {
         private String prop;
 
@@ -1301,6 +1342,14 @@ public class AsmBackedClassGeneratorTest {
 
         @Inject
         public BeanWithAnnotatedConstructor() {
+        }
+    }
+
+    public static abstract class NamedBeanWithAnnotatedConstructor implements Named {
+        private String prop;
+
+        @Inject
+        public NamedBeanWithAnnotatedConstructor() {
         }
     }
 
@@ -1555,6 +1604,9 @@ public class AsmBackedClassGeneratorTest {
 
     public interface SomeType {
         String getInterfaceProperty();
+    }
+
+    public interface SomeNamedType extends SomeType, Named {
     }
 
     @NonExtensible
@@ -1825,6 +1877,11 @@ public class AsmBackedClassGeneratorTest {
         Set<Number> getNumbers();
 
         void setNumbers(Set<Number> values);
+    }
+
+    public interface InterfaceBeanWithReadOnlyName {
+
+        String getName();
     }
 
     public interface InterfacePrimitiveBean {


### PR DESCRIPTION
Signed-off-by: Till Krullmann <till.krullmann@gmx.net>

<!--- The issue this PR addresses -->
Fixes #14652 

### Context

Added convenience for plugin authors. It will be possible to define an entire DSL model using only interfaces and managed properties, without having to inject `ObjectFactory` to construct containers and named objects.

Approach:

- AsmBackedClassGenerator will support an abstract read-only property "name" of type String, and implement it based on a backing field.
- If the type is an interface, it will receive a single `@Inject` constructor with a single String parameter that initializes the name property.
- If the type is an abstract class, each existing constructor will be extended by inserting a String parameter (before all other parameters) that initializes the name property.
- It should be possible to use such a "named managed" interface type to `NamedDomainObjectContainer` and `PolymorphicDomainObjectContainer` without using a custom factory method.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
