### PR TITLE
Always run flakiness detection

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
@@ -23,6 +23,7 @@ import configurations.gradleRunnerStep
 import configurations.publishBuildStatusToGithub
 import configurations.snapshotDependencies
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.ReuseBuilds
 import model.CIBuildModel
 import model.PerformanceTestType
 import projects.PerformanceTestProject
@@ -74,7 +75,11 @@ subprojects/$performanceProjectName/build/$taskName => report/
     )
 
     dependencies {
-        snapshotDependencies(performanceTestProject.performanceTests)
+        snapshotDependencies(performanceTestProject.performanceTests) {
+            if (type == PerformanceTestType.flakinessDetection) {
+                reuseBuilds = ReuseBuilds.NO
+            }
+        }
         performanceTestProject.performanceTests.forEach {
             if (it.testProjects.isNotEmpty()) {
                 artifacts(it.id!!) {

--- a/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
@@ -27,7 +27,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ReuseBuilds
 import model.CIBuildModel
 import model.PerformanceTestType
 import projects.PerformanceTestProject
-import java.util.Locale
 
 class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(model, init = {
     uuid = performanceTestProject.uuid + "_Trigger"
@@ -43,7 +42,7 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
         param("env.JAVA_HOME", os.buildJavaHome())
         param("env.BUILD_BRANCH", "%teamcity.build.branch%")
         param("performance.db.username", "tcagent")
-        param("performance.channel", "${type.channel}${if (os == Os.LINUX) "" else "-${os.name.toLowerCase(Locale.US)}"}-%teamcity.build.branch%")
+        param("performance.channel", performanceTestProject.performanceTestCoverage.channel())
     }
 
     features {

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -11,6 +11,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Dependencies
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
+import jetbrains.buildServer.configs.kotlin.v2019_2.SnapshotDependency
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.ScheduleTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
@@ -108,10 +109,12 @@ fun stageTriggerId(model: CIBuildModel, stage: Stage) = stageTriggerId(model, st
 
 fun stageTriggerId(model: CIBuildModel, stageName: StageName) = AbsoluteId("${model.projectPrefix}Stage_${stageName.id}_Trigger")
 
-fun Dependencies.snapshotDependencies(buildTypes: Iterable<BuildType>) {
+fun Dependencies.snapshotDependencies(buildTypes: Iterable<BuildType>, snapshotConfig: SnapshotDependency.() -> Unit = {}) {
     buildTypes.forEach {
         dependency(it.id!!) {
-            snapshot {}
+            snapshot {
+                snapshotConfig()
+            }
         }
     }
 }

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -113,15 +113,20 @@ abstract class PerformanceTest extends DistributionTest {
 
     PerformanceTest() {
         getJvmArgumentProviders().add(new PerformanceTestJvmArgumentsProvider())
-        getOutputs().cacheIf("baselines don't contain version 'flakiness-detection-commit', 'last' or 'nightly'", { notContainsSpecialVersions() })
-        getOutputs().upToDateWhen { notContainsSpecialVersions() }
+        getOutputs().doNotCacheIf("baselines contain version 'flakiness-detection-commit', 'last' or 'nightly'", { containsSpecialVersions() })
+        getOutputs().doNotCacheIf("flakiness detection", { flakinessDetection })
+        getOutputs().upToDateWhen { !containsSpecialVersions() && !flakinessDetection }
     }
 
-    private boolean notContainsSpecialVersions() {
-        return !baselines.getOrElse("")
+    private boolean containsSpecialVersions() {
+        return baselines.getOrElse("")
             .split(",")
             .collect { it.toString().trim() }
             .any { NON_CACHEABLE_VERSIONS.contains(it) }
+    }
+
+    private boolean isFlakinessDetection() {
+        return channel.startsWith("flakiness-detection")
     }
 
     @Override


### PR DESCRIPTION
Flakiness detection builds should not be re-used, so flakiness detection can be re-triggered. Moreover, the performance test task should always re-run when it is executed and never use the build cache.