### PR TITLE
Make pattern in SdkManJvmLocator compliant with sdkman version declaration convention.

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/SdkManJvmLocator.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/SdkManJvmLocator.groovy
@@ -29,7 +29,7 @@ import java.util.regex.Pattern
  */
 class SdkManJvmLocator {
 
-    private static final Pattern JDKMAN_SDK_DIR = Pattern.compile("(\\d+\\.\\d+\\.\\d+(_\\d+)?).*")
+    private static final Pattern JDKMAN_SDK_DIR = Pattern.compile("(\\d+\\.\\w+\\.\\d+(_\\d+)?).*")
     private static final String SDKMAN_CANDIDATES_DIR_ENV_NAME = "SDKMAN_CANDIDATES_DIR"
     private final FileCanonicalizer fileCanonicalizer
 


### PR DESCRIPTION
This enables `ea` JDKs

this relates to https://github.com/sdkman/sdkman-db-migrations/pull/343

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

