### PR TITLE
Fix reproduction instructions in performance report

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -180,7 +180,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                             }
                         }
                     }
-                    return new CrossBuildPerformanceTestHistory(experiment.getScenario().getTestName(), ImmutableList.copyOf(builds), results);
+                    return new CrossBuildPerformanceTestHistory(experiment, ImmutableList.copyOf(builds), results);
                 }
             }
         });

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.performance.results;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
@@ -24,13 +23,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory {
-    private final String name;
     private final List<BuildDisplayInfo> builds;
 
     private final List<CrossBuildPerformanceResults> newestFirst;
+    private final PerformanceExperiment experiment;
 
-    public CrossBuildPerformanceTestHistory(String name, List<BuildDisplayInfo> builds, List<CrossBuildPerformanceResults> newestFirst) {
-        this.name = name;
+    public CrossBuildPerformanceTestHistory(PerformanceExperiment experiment, List<BuildDisplayInfo> builds, List<CrossBuildPerformanceResults> newestFirst) {
+        this.experiment = experiment;
         this.builds = builds;
         this.newestFirst = newestFirst;
     }
@@ -44,8 +43,8 @@ public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory 
     }
 
     @Override
-    public String getDisplayName() {
-        return name;
+    public PerformanceExperiment getExperiment() {
+        return experiment;
     }
 
     @Override
@@ -65,44 +64,46 @@ public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory 
 
     @Override
     public List<? extends ScenarioDefinition> getScenarios() {
-        return Lists.transform(builds, (Function<BuildDisplayInfo, ScenarioDefinition>) input -> new ScenarioDefinition() {
-            @Override
-            public String getDisplayName() {
-                return input.getDisplayName();
-            }
+        return builds.stream()
+            .map(input -> new ScenarioDefinition() {
+                @Override
+                public String getDisplayName() {
+                    return input.getDisplayName();
+                }
 
-            @Override
-            public String getTestProject() {
-                return input.getProjectName();
-            }
+                @Override
+                public String getTestProject() {
+                    return input.getProjectName();
+                }
 
-            @Override
-            public List<String> getTasks() {
-                return input.getTasksToRun();
-            }
+                @Override
+                public List<String> getTasks() {
+                    return input.getTasksToRun();
+                }
 
-            @Override
-            public List<String> getCleanTasks() {
-                return input.getCleanTasks();
-            }
+                @Override
+                public List<String> getCleanTasks() {
+                    return input.getCleanTasks();
+                }
 
-            @Override
-            public List<String> getArgs() {
-                return input.getArgs();
-            }
+                @Override
+                public List<String> getArgs() {
+                    return input.getArgs();
+                }
 
-            @Nullable
-            @Override
-            public List<String> getGradleOpts() {
-                return input.getGradleOpts();
-            }
+                @Nullable
+                @Override
+                public List<String> getGradleOpts() {
+                    return input.getGradleOpts();
+                }
 
-            @Nullable
-            @Override
-            public Boolean getDaemon() {
-                return input.getDaemon();
-            }
-        });
+                @Nullable
+                @Override
+                public Boolean getDaemon() {
+                    return input.getDaemon();
+                }
+            })
+            .collect(Collectors.toList());
     }
 
     private class KnownBuildSpecificationsPerformanceTestExecution implements PerformanceTestExecution {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
@@ -16,9 +16,6 @@
 
 package org.gradle.performance.results;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,8 +38,8 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
     }
 
     @Override
-    public String getDisplayName() {
-        return experiment.getScenario().getTestName();
+    public PerformanceExperiment getExperiment() {
+        return experiment;
     }
 
     public List<String> getBaselineVersions() {
@@ -91,45 +88,47 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
         if (newestFirst.isEmpty()) {
             return Collections.emptyList();
         }
-        final CrossVersionPerformanceResults mostRecent = newestFirst.get(0);
-        return Lists.transform(getKnownVersions(), (Function<String, ScenarioDefinition>) input -> new ScenarioDefinition() {
-            @Override
-            public String getDisplayName() {
-                return input;
-            }
+        CrossVersionPerformanceResults mostRecent = newestFirst.get(0);
+        return getKnownVersions().stream()
+            .map(input -> new ScenarioDefinition() {
+                @Override
+                public String getDisplayName() {
+                    return input;
+                }
 
-            @Override
-            public String getTestProject() {
-                return mostRecent.getTestProject();
-            }
+                @Override
+                public String getTestProject() {
+                    return mostRecent.getTestProject();
+                }
 
-            @Override
-            public List<String> getTasks() {
-                return mostRecent.getTasks();
-            }
+                @Override
+                public List<String> getTasks() {
+                    return mostRecent.getTasks();
+                }
 
-            @Override
-            public List<String> getCleanTasks() {
-                return mostRecent.getCleanTasks();
-            }
+                @Override
+                public List<String> getCleanTasks() {
+                    return mostRecent.getCleanTasks();
+                }
 
-            @Override
-            public List<String> getArgs() {
-                return mostRecent.getArgs();
-            }
+                @Override
+                public List<String> getArgs() {
+                    return mostRecent.getArgs();
+                }
 
-            @Nullable
-            @Override
-            public List<String> getGradleOpts() {
-                return mostRecent.getGradleOpts();
-            }
+                @Nullable
+                @Override
+                public List<String> getGradleOpts() {
+                    return mostRecent.getGradleOpts();
+                }
 
-            @Nullable
-            @Override
-            public Boolean getDaemon() {
-                return mostRecent.getDaemon();
-            }
-        });
+                @Nullable
+                @Override
+                public Boolean getDaemon() {
+                    return mostRecent.getDaemon();
+                }
+            })
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/EmptyPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/EmptyPerformanceTestHistory.java
@@ -22,15 +22,15 @@ import java.util.List;
 
 public class EmptyPerformanceTestHistory implements PerformanceTestHistory {
 
-    private final String name;
+    private final PerformanceExperiment experiment;
 
-    public EmptyPerformanceTestHistory(String name) {
-        this.name = name;
+    public EmptyPerformanceTestHistory(PerformanceExperiment experiment) {
+        this.experiment = experiment;
     }
 
     @Override
-    public String getDisplayName() {
-        return name;
+    public PerformanceExperiment getExperiment() {
+        return experiment;
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -35,12 +35,12 @@ class NoResultsStore<T extends PerformanceTestResult> implements WritableResults
 
     @Override
     PerformanceTestHistory getTestResults(PerformanceExperiment experiment, String channel) {
-        new EmptyPerformanceTestHistory(experiment.getScenario().getTestName())
+        new EmptyPerformanceTestHistory(experiment)
     }
 
     @Override
     PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
-        new EmptyPerformanceTestHistory(experiment.getScenario().getTestName())
+        new EmptyPerformanceTestHistory(experiment)
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExperiment.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExperiment.java
@@ -32,6 +32,10 @@ public class PerformanceExperiment implements Comparable<PerformanceExperiment> 
         this.scenario = scenario;
     }
 
+    public String getDisplayName() {
+        return getScenario().getTestName() + " | " + getTestProject();
+    }
+
     public String getTestProject() {
         return testProject;
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestHistory.java
@@ -36,7 +36,11 @@ public interface PerformanceTestHistory {
     /**
      * A human consumable display name for this performance test.
      */
-    String getDisplayName();
+    default String getDisplayName() {
+        return getExperiment().getDisplayName();
+    }
+
+    PerformanceExperiment getExperiment();
 
     /**
      * The results of all executions of this performance test, ordered from most recent to least recent.

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
@@ -19,6 +19,7 @@ package org.gradle.performance.results.report;
 import org.gradle.performance.measure.DataSeries;
 import org.gradle.performance.measure.Duration;
 import org.gradle.performance.results.FormatSupport;
+import org.gradle.performance.results.PerformanceExperiment;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ScenarioBuildResultData;
@@ -158,6 +159,7 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
             }
 
             private void renderScenario(int index, ScenarioBuildResultData scenario) {
+                PerformanceExperiment experiment = scenario.getPerformanceExperiment();
                 Set<Tag> tags = determineTags(scenario);
                 div().classAttr("card m-0 p-0 alert " + determineScenarioBackgroundColorCss(scenario)).attr("tag", tags.stream().map(Tag::getName).collect(joining(","))).id("scenario" + index);
                     div().id("heading" + index).classAttr("card-header");
@@ -168,12 +170,12 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
                                 end();
                             end();
                             div().classAttr("col-6");
-                                big().text(scenario.getScenarioName() + " | " + scenario.getTestProject()).end();
+                                big().text(experiment.getDisplayName()).end();
                                 tags.stream().filter(Tag::isValid).forEach(this::renderTag);
                             end();
                             div().classAttr("col-3");
                                 renderScenarioButtons(index, scenario);
-                                a().target("_blank").classAttr("btn btn-primary btn-sm").href("tests/" + urlEncode(PerformanceTestHistory.convertToId(scenario.getScenarioName()) + ".html")).text("Graph").end();
+                                a().target("_blank").classAttr("btn btn-primary btn-sm").href("tests/" + urlEncode(PerformanceTestHistory.convertToId(experiment.getDisplayName()) + ".html")).text("Graph").end();
                                 a().classAttr("btn btn-primary btn-sm collapsed").href("#").attr("data-toggle", "collapse", "data-target", "#collapse" + index).text("Detail").end();
                             end();
                             div().classAttr("col-2 p-0");

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -18,12 +18,12 @@ package org.gradle.performance.results.report;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.googlecode.jatl.Html;
 import groovy.json.JsonOutput;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.performance.results.CrossVersionPerformanceTestHistory;
 import org.gradle.performance.results.FormatSupport;
+import org.gradle.performance.results.PerformanceScenario;
 import org.gradle.performance.results.PerformanceTestExecution;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ScenarioDefinition;
@@ -34,7 +34,6 @@ import java.io.Writer;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 
 public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> implements PerformanceExecutionGraphRenderer {
     private final String projectName;
@@ -50,7 +49,6 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
 
     @Override
     public void render(final PerformanceTestHistory testHistory, Writer writer) {
-        // TODO: Add test name to the report
         // @formatter:off
         new MetricsHtml(writer) {{
             html();
@@ -284,18 +282,11 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
     }
 
     private String getReproductionInstructions(PerformanceTestHistory history) {
-        Set<String> templates = Sets.newHashSet();
-        Set<String> cleanTasks = Sets.newHashSet();
-        for (ScenarioDefinition scenario : history.getScenarios()) {
-            templates.add(scenario.getTestProject());
-            cleanTasks.add("clean" + StringUtils.capitalize(scenario.getTestProject()));
-        }
-
-        return String.format("To reproduce, run ./gradlew %s %s cleanPerformanceAdhocTest :%s:performanceAdhocTest --scenarios '%s' -PperformanceBaselines=force-defaults",
-            Joiner.on(' ').join(cleanTasks),
-            Joiner.on(' ').join(templates),
+        PerformanceScenario scenario = history.getExperiment().getScenario();
+        return String.format("To reproduce, run ./gradlew :%s:%sPerformanceAdhocTest --tests '%s' -PperformanceBaselines=force-defaults",
             projectName,
-            history.getDisplayName()
+            history.getExperiment().getTestProject(),
+            scenario.getClassName() + "." + scenario.getTestName()
         );
     }
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -130,7 +130,7 @@ abstract class ResultSpecification extends Specification {
         CrossBuildPerformanceResults result2  = crossBuildResults(startTime: 200)
         result1.buildResult(info2).addAll(measuredOperations([2]))
 
-        return new CrossBuildPerformanceTestHistory('mockCrossBuild', [info1, info2], [result2, result1])
+        return new CrossBuildPerformanceTestHistory(new PerformanceExperiment("test-project", new PerformanceScenario("org.gradle.performance.MyCrossBuildPerformanceTest", "my scenario name")), [info1, info2], [result2, result1])
     }
 
     List<MeasuredOperation> measuredOperations(List<Integer> values) {


### PR DESCRIPTION
Since we changed the setup of how we run performance tests, the reproduction instructions in the report have been wrong. This PR fixes them.