### PR TITLE
PerformanceExecutionDataProvider again uses real Git commit ID

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceExecutionDataProvider.java
@@ -22,6 +22,7 @@ import org.gradle.performance.results.MeasuredOperationList;
 import org.gradle.performance.results.PerformanceTestExecution;
 import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ScenarioBuildResultData;
+import org.gradle.performance.util.Git;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +42,7 @@ public abstract class PerformanceExecutionDataProvider {
     protected TreeSet<ScenarioBuildResultData> scenarioExecutionData;
     protected final ResultsStore resultsStore;
     private final List<File> resultJsons;
-    protected final String commitId = "testCommitId";
+    protected final String commitId = Git.current().getCommitId();
 
     public PerformanceExecutionDataProvider(ResultsStore resultsStore, List<File> resultJsons) {
         this.resultJsons = resultJsons;


### PR DESCRIPTION
This reverts an accidental change in 1832b39

Now the commit is back in the header here:
https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestTestLinux_Trigger/38419064:id/report/index.html

`Scenarios (111 successful, 1 failed) 27cfe638df2d31def0d12d74ad2064ce1585185b`