### PR TITLE
Fix javadoc with toolchain up to date state

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -243,7 +243,8 @@ public class Javadoc extends SourceTask {
      * @since 6.7
      */
     @Incubating
-    @Internal
+    @Nested
+    @Optional
     public Property<JavadocTool> getJavadocTool() {
         return javadocTool;
     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
@@ -20,6 +20,8 @@ import org.apache.commons.io.FileUtils
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.javadoc.internal.JavadocToolAdapter
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.platform.base.internal.toolchain.ToolProvider
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -60,6 +62,7 @@ class JavadocTest extends AbstractProjectBuilderSpec {
 
     def usesToolchainIfConfigured() {
         def tool = Mock(JavadocToolAdapter)
+        def toolMetadata = Mock(JavaInstallationMetadata)
         task.setDestinationDir(destDir)
         task.source(srcDir)
 
@@ -70,6 +73,8 @@ class JavadocTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
+        1 * tool.metadata >> toolMetadata
+        1 * toolMetadata.languageVersion >> JavaLanguageVersion.of(11)
         1 * tool.execute(!null)
     }
 


### PR DESCRIPTION
Prior to this commit, the javadoc task did not take into account the
toolchain as an input.

If we do an RC3, this should go in. If not, it will be for 6.8.
The `Javadoc` task has known issues with up-to-date checks, see #9104