### PR TITLE
Set thread name for DaemonConnectionBackedEventConsumer.ForwardEvents

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/DaemonConnectionBackedEventConsumer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/DaemonConnectionBackedEventConsumer.java
@@ -49,6 +49,10 @@ class DaemonConnectionBackedEventConsumer implements BuildEventConsumer {
         private volatile boolean stopped;
         private boolean ableToSend = true;
 
+        public ForwardEvents() {
+            super("Daemon client event forwarder");
+        }
+
         @Override
         public void run() {
             while (moreMessagesToSend()) {


### PR DESCRIPTION
These were showing up as `Thread-765` etc.