### PR TITLE
Make search for java compiler classpath lazy.

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaToolChainServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaToolChainServiceRegistry.java
@@ -20,9 +20,7 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.CurrentJvmJavaToolChain;
 import org.gradle.api.internal.tasks.JavaToolChainFactory;
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompilerFactory;
-import org.gradle.api.internal.tasks.compile.JavaHomeBasedJavaCompilerFactory;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
-import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -35,27 +33,15 @@ import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 import org.gradle.workers.internal.ActionExecutionSpecFactory;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
-import javax.tools.JavaCompiler;
-
 public class JavaToolChainServiceRegistry extends AbstractPluginServiceRegistry {
-    @Override
-    public void registerBuildSessionServices(ServiceRegistration registration) {
-        registration.addProvider(new BuildSessionScopeCompileServices());
-    }
     @Override
     public void registerProjectServices(ServiceRegistration registration) {
         registration.addProvider(new ProjectScopeCompileServices());
     }
 
-    private static class BuildSessionScopeCompileServices {
-        Factory<JavaCompiler> createJavaHomeBasedJavaCompilerFactory(ClassPathRegistry classPathRegistry) {
-            return new JavaHomeBasedJavaCompilerFactory(classPathRegistry.getClassPath("JAVA-COMPILER-PLUGIN").getAsFiles());
-        }
-    }
-
     private static class ProjectScopeCompileServices {
-        JavaCompilerFactory createJavaCompilerFactory(WorkerDaemonFactory workerDaemonFactory, Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerDirectoryProvider workerDirectoryProvider, ExecHandleFactory execHandleFactory, AnnotationProcessorDetector processorDetector, ClassPathRegistry classPathRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
-            return new DefaultJavaCompilerFactory(workerDirectoryProvider, workerDaemonFactory, javaHomeBasedJavaCompilerFactory, forkOptionsFactory, execHandleFactory, processorDetector, classPathRegistry, actionExecutionSpecFactory);
+        JavaCompilerFactory createJavaCompilerFactory(WorkerDaemonFactory workerDaemonFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerDirectoryProvider workerDirectoryProvider, ExecHandleFactory execHandleFactory, AnnotationProcessorDetector processorDetector, ClassPathRegistry classPathRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
+            return new DefaultJavaCompilerFactory(workerDirectoryProvider, workerDaemonFactory, forkOptionsFactory, execHandleFactory, processorDetector, classPathRegistry, actionExecutionSpecFactory);
         }
 
         JavaToolChainInternal createJavaToolChain(JavaCompilerFactory compilerFactory, ExecActionFactory execActionFactory) {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -17,20 +17,16 @@ package org.gradle.api.internal.tasks.compile
 
 import org.gradle.api.internal.ClassPathRegistry
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector
-import org.gradle.internal.Factory
 import org.gradle.process.internal.ExecHandleFactory
 import org.gradle.process.internal.JavaForkOptionsFactory
 import org.gradle.workers.internal.ActionExecutionSpecFactory
 import org.gradle.workers.internal.WorkerDaemonFactory
 import spock.lang.Specification
 
-import javax.tools.JavaCompiler
-
 class DefaultJavaCompilerFactoryTest extends Specification {
-    Factory<JavaCompiler> javaCompilerFinder = Mock()
     def factory = new DefaultJavaCompilerFactory({
         new File("daemon-work-dir")
-    }, Mock(WorkerDaemonFactory), javaCompilerFinder, Mock(JavaForkOptionsFactory), Mock(ExecHandleFactory), Stub(AnnotationProcessorDetector), Stub(ClassPathRegistry), Stub(ActionExecutionSpecFactory))
+    }, Mock(WorkerDaemonFactory), Mock(JavaForkOptionsFactory), Mock(ExecHandleFactory), Stub(AnnotationProcessorDetector), Stub(ClassPathRegistry), Stub(ActionExecutionSpecFactory))
 
     def "creates in-process compiler when JavaCompileSpec is provided"() {
         expect:


### PR DESCRIPTION
With toolchains, the service accessing the java compiler classpath is
created sooner in the lifecycle. In order to not request the java
compiler classpath too early, it is now computed lazily.

Still to be discussed whether or not this is mandatory for 6.7.