### PR TITLE
Lock only once when dispatching messages

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/IncomingConnectionHandler.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/IncomingConnectionHandler.java
@@ -16,8 +16,7 @@
 package org.gradle.launcher.daemon.server;
 
 import org.gradle.launcher.daemon.protocol.Message;
-import org.gradle.internal.remote.internal.RemoteConnection;
 
 public interface IncomingConnectionHandler {
-    void handle(RemoteConnection<Message> connection);
+    void handle(SynchronizedDispatchConnection<Message> connection);
 }


### PR DESCRIPTION
Previously we locked once for dispatching and once again for flushing. This is unnecessary, and we should do the two together.

(From the investigation in https://github.com/gradle/gradle/pull/14612.)