### PR TITLE
Remove unused `FileAccessTracker.markAccessed(Collection)` method

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStore.java
@@ -23,7 +23,6 @@ import org.gradle.internal.resource.local.FileStoreException;
 import org.gradle.internal.resource.local.LocallyAvailableResource;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.Set;
 
 public class TwoStageArtifactIdentifierFileStore implements ArtifactIdentifierFileStore {
@@ -74,12 +73,6 @@ public class TwoStageArtifactIdentifierFileStore implements ArtifactIdentifierFi
         public void markAccessed(File file) {
             readOnlyStore.getFileAccessTracker().markAccessed(file);
             writableStore.getFileAccessTracker().markAccessed(file);
-        }
-
-        @Override
-        public void markAccessed(Collection<File> files) {
-            readOnlyStore.getFileAccessTracker().markAccessed(files);
-            writableStore.getFileAccessTracker().markAccessed(files);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStore.java
@@ -22,7 +22,6 @@ import org.gradle.internal.resource.local.FileStoreException;
 import org.gradle.internal.resource.local.LocallyAvailableResource;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.Set;
 
 public class TwoStageExternalResourceFileStore implements ExternalResourceFileStore {
@@ -64,12 +63,6 @@ public class TwoStageExternalResourceFileStore implements ExternalResourceFileSt
         public void markAccessed(File file) {
             readOnlyStore.getFileAccessTracker().markAccessed(file);
             writableStore.getFileAccessTracker().markAccessed(file);
-        }
-
-        @Override
-        public void markAccessed(Collection<File> files) {
-            readOnlyStore.getFileAccessTracker().markAccessed(files);
-            writableStore.getFileAccessTracker().markAccessed(files);
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStoreTest.groovy
@@ -104,16 +104,5 @@ class TwoStageArtifactIdentifierFileStoreTest extends Specification {
         1 * writeStore.getFileAccessTracker() >> fat2
         1 * fat1.markAccessed(file)
         1 * fat2.markAccessed(file)
-
-        when:
-        twoStageStore.getFileAccessTracker().markAccessed([file])
-
-        then:
-        1 * readStore.getFileAccessTracker() >> fat1
-        1 * writeStore.getFileAccessTracker() >> fat2
-        1 * fat1.markAccessed([file])
-        1 * fat2.markAccessed([file])
     }
-
-
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStoreTest.groovy
@@ -80,14 +80,5 @@ class TwoStageExternalResourceFileStoreTest extends Specification {
         1 * writeStore.getFileAccessTracker() >> fat2
         1 * fat1.markAccessed(file)
         1 * fat2.markAccessed(file)
-
-        when:
-        twoStageStore.getFileAccessTracker().markAccessed([file])
-
-        then:
-        1 * readStore.getFileAccessTracker() >> fat1
-        1 * writeStore.getFileAccessTracker() >> fat2
-        1 * fat1.markAccessed([file])
-        1 * fat2.markAccessed([file])
     }
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileAccessTracker.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileAccessTracker.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.file;
 
 import java.io.File;
-import java.util.Collection;
 
 /**
  * Tracks access to files.
@@ -26,17 +25,10 @@ public interface FileAccessTracker {
     /**
      * Marks the supplied file as accessed.
      *
-     * @see #markAccessed(Collection)
-     */
-    void markAccessed(File file);
-
-    /**
-     * Marks the supplied files as accessed.
-     *
-     * If the supplied files are unknown to this tracker, implementations must
-     * simply ignore them instead of throwing an exception. However, depending
-     * on their use case, implementations may throw an exception when marking a
+     * If the supplied file is unknown to this tracker, implementations must
+     * simply ignore it instead of throwing an exception. However, depending
+     * on the use case, implementations may throw an exception when marking a
      * known file fails.
      */
-    void markAccessed(Collection<File> files);
+    void markAccessed(File file);
 }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/SingleDepthFileAccessTracker.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/SingleDepthFileAccessTracker.java
@@ -20,12 +20,8 @@ import com.google.common.base.Preconditions;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.file.FileAccessTracker;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Tracks access to files and directories at the supplied depth within the supplied base
@@ -49,36 +45,10 @@ public class SingleDepthFileAccessTracker implements FileAccessTracker {
 
     @Override
     public void markAccessed(File file) {
-        markAccessed(toSubPath(file));
-    }
-
-    @Override
-    public void markAccessed(Collection<File> files) {
-        for (Path path : collectSubPaths(files)) {
-            markAccessed(path);
-        }
-    }
-
-    private void markAccessed(@Nullable Path path) {
-        if (path != null) {
-            journal.setLastAccessTime(path.toFile(), System.currentTimeMillis());
-        }
-    }
-
-    private Set<Path> collectSubPaths(Collection<File> files) {
-        Set<Path> paths = new HashSet<Path>();
-        for (File file : files) {
-            paths.add(toSubPath(file));
-        }
-        return paths;
-    }
-
-    @Nullable
-    private Path toSubPath(File file) {
         Path path = file.toPath().toAbsolutePath();
         if (path.getNameCount() >= endNameIndex && path.startsWith(baseDir)) {
-            return baseDir.resolve(path.subpath(startNameIndex, endNameIndex));
+            path = baseDir.resolve(path.subpath(startNameIndex, endNameIndex));
+            journal.setLastAccessTime(path.toFile(), System.currentTimeMillis());
         }
-        return null;
     }
 }

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/SingleDepthFileAccessTrackerTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/SingleDepthFileAccessTrackerTest.groovy
@@ -46,8 +46,11 @@ class SingleDepthFileAccessTrackerTest extends Specification {
         def file2 = baseDir.file("b/bb/bbb/2")
         def expectedTouchedFiles = touchedPaths.collect { baseDir.file(it) }
 
+        def tracker = new SingleDepthFileAccessTracker(journal, baseDir, depth)
+
         when:
-        new SingleDepthFileAccessTracker(journal, baseDir, depth).markAccessed([file1, file2])
+        tracker.markAccessed(file1)
+        tracker.markAccessed(file2)
 
         then:
         expectedTouchedFiles.empty || expectedTouchedFiles.each {


### PR DESCRIPTION
Was only used from tests.

----
/cc @gradle/execution 