### PR TITLE
Remove usages of kotlin-stdlib CharSequence.isEmpty as it conflicts with JDK 15 new API

### DIFF
--- a/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/classanalysis/ClassGraph.kt
+++ b/buildSrc/subprojects/basics/src/main/kotlin/gradlebuild/basics/classanalysis/ClassGraph.kt
@@ -30,8 +30,9 @@ class ClassGraph(
     val entryPoints: MutableSet<ClassDetails> = linkedSetOf()
 
     val shadowPackagePrefix =
-        if (shadowPackage.isEmpty()) ""
-        else shadowPackage.replace('.', '/') + "/"
+        shadowPackage.takeIf(String::isNotEmpty)
+            ?.let { it.replace('.', '/') + "/" }
+            ?: ""
 
     operator fun get(className: String) =
         classes.computeIfAbsent(className) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -378,8 +378,7 @@ fun classNamesFromTypeString(typeString: String): ClassNamesFromTypeString {
     var buffer = StringBuilder()
 
     fun nonPrimitiveKotlinType(): String? =
-        if (buffer.isEmpty()) null
-        else buffer.toString().let {
+        buffer.takeIf(StringBuilder::isNotEmpty)?.toString()?.let {
             if (it in primitiveKotlinTypeNames) null
             else it
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheFormat.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheFormat.kt
@@ -117,7 +117,8 @@ fun DataInputStream.unpackFilesTo(outputDir: File): Long {
     while (true) {
 
         val path = readUTF()
-        if (path.isEmpty()) break
+            .takeIf(String::isNotEmpty)
+            ?: break
 
         val isFile = readBoolean()
 


### PR DESCRIPTION
See https://bugs.openjdk.java.net/browse/JDK-8215402
And https://stuartmarks.wordpress.com/2020/09/22/incompatibilities-with-jdk-15-charsequence-isempty/
And https://github.com/gradle/gradle/pull/13777

This should reduce the flakiness of a configuration cache test that makes use of JDK 15:
https://ge.gradle.org/scans/tests?list.size=50&list.sortColumn=startTime&list.sortOrder=desc&search.buildToolTypes=gradle&search.buildToolTypes=maven&search.names=gitBranchName&search.relativeStartTime=P28D&search.rootProjectNames=gradle&search.tags=CI&search.timeZoneId=America/New_York&search.values=master&tests.container=org.gradle.smoketests.GradleBuildConfigurationCacheSmokeTest&tests.sortField=FLAKY&tests.unstableOnly=true