### PR TITLE
Write performance runtime for all operating systems to json file

### DIFF
--- a/.teamcity/performance-test-runtimes.json
+++ b/.teamcity/performance-test-runtimes.json
@@ -1,500 +1,143 @@
 [ {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native)",
-  "runtimes" : [ {
-    "testProject" : "multiNative",
-    "linux" : 1856000
-  }, {
-    "testProject" : "mediumCppMulti",
-    "linux" : 486000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 753000
-  }, {
-    "testProject" : "smallNative",
-    "linux" : 309000
-  }, {
-    "testProject" : "smallCppApp",
-    "linux" : 304000
-  }, {
-    "testProject" : "bigCppMulti",
-    "linux" : 1491000
-  }, {
-    "testProject" : "mediumCppMultiWithMacroIncludes",
-    "linux" : 496000
-  }, {
-    "testProject" : "smallCppMulti",
-    "linux" : 320000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 620000
-  }, {
-    "testProject" : "mediumNative",
-    "linux" : 272000
-  }, {
-    "testProject" : "mediumCppAppWithMacroIncludes",
-    "linux" : 229000
-  }, {
-    "testProject" : "mediumCppApp",
-    "linux" : 228000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 111000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 473000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
-  "runtimes" : [ {
-    "testProject" : "mediumJavaMultiProjectWithTestNG",
-    "linux" : 289000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 575000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1427000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
   "runtimes" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 485000
-  }, {
-    "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1670000
-  }, {
-    "testProject" : "largeGroovyMultiProject",
-    "linux" : 617000
+    "linux" : 693000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1019000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.assemble for non-abi change (Gradle vs Maven)",
-  "runtimes" : [ {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 286000
-  }, {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 679000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.java.ParallelBuildPerformanceTest.clean assemble with 4 parallel workers",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 449000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 351000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.clean checkout",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 427000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1130000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1045000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativePreCompiledHeaderPerformanceTest.clean assemble with precompiled headers",
-  "runtimes" : [ {
-    "testProject" : "bigPCHNative",
-    "linux" : 1081000
-  }, {
-    "testProject" : "mediumPCHNative",
-    "linux" : 295000
-  }, {
-    "testProject" : "smallPCHNative",
-    "linux" : 124000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
-  "runtimes" : [ {
-    "testProject" : "bigSwiftApp",
-    "linux" : 111000
-  }, {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 172000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
-  "runtimes" : [ {
-    "testProject" : "mediumJavaPredefinedCompositeBuild",
-    "linux" : 297000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 522000
-  }, {
-    "testProject" : "mediumJavaCompositeBuild",
-    "linux" : 296000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 483000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
-  "runtimes" : [ {
-    "testProject" : "withVerboseTestNG",
-    "linux" : 178000
-  }, {
-    "testProject" : "withVerboseJUnit",
-    "linux" : 191000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
-  "runtimes" : [ {
-    "testProject" : "smallNativeMonolithic",
-    "linux" : 623000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean test (Gradle vs Maven)",
-  "runtimes" : [ {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 1225000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 537000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
-  "runtimes" : [ {
-    "testProject" : "createLotsOfTasks",
-    "linux" : 132000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster non-abi change (build comparison)",
-  "runtimes" : [ {
-    "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 385000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 422000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 652000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftCleanBuildPerformanceTest.clean assemble (swift)",
-  "runtimes" : [ {
-    "testProject" : "bigSwiftApp",
-    "linux" : 739000
-  }, {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 1073000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean assemble (Gradle vs Maven)",
-  "runtimes" : [ {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 419000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 190000
+    "linux" : 308000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaABIChangePerformanceTest.assemble for abi change",
   "runtimes" : [ {
     "testProject" : "largeGroovyMultiProject",
-    "linux" : 716000
+    "linux" : 705000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 520000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1013000
+    "linux" : 1024000
   }, {
     "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1689000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 513000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules (parallel)",
-  "runtimes" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 233000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 143000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 360000
+    "linux" : 1710000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.nativeplatform.NativeParallelPerformanceTest.clean assemble with parallel workers",
   "runtimes" : [ {
+    "testProject" : "bigNative",
+    "linux" : 670000
+  }, {
     "testProject" : "smallNative",
-    "linux" : 118000
+    "linux" : 114000
   }, {
     "testProject" : "mediumNative",
-    "linux" : 187000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 671000
+    "linux" : 186000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native, parallel)",
-  "runtimes" : [ {
-    "testProject" : "manyProjectsNative",
-    "linux" : 700000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.test for non-abi change (Gradle vs Maven)",
-  "runtimes" : [ {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 881000
-  }, {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 1865000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1338000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1438000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 288000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 140000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean phthalic:assembleDebug with clean transforms cache",
-  "runtimes" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 897000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 469000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 111000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.abi change",
-  "runtimes" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 753000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
   "runtimes" : [ {
     "testProject" : "bigCppMulti",
-    "linux" : 276000
+    "linux" : 278000
   }, {
     "testProject" : "bigCppApp",
-    "linux" : 235000
+    "linux" : 143000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
   "runtimes" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 880000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1010000
+    "linux" : 951000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean test (Gradle vs Maven)",
   "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 971000
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 1221000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 857000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
-  "runtimes" : [ {
-    "testProject" : "archivePerformanceProject",
-    "linux" : 166000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean assembleDebug with clean transforms cache",
-  "runtimes" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 1592000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 1861000
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 535000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.first use",
   "runtimes" : [ {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 989000
+  }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 776000
+    "linux" : 765000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 427000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1090000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
-  "runtimes" : [ {
-    "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 964000
-  }, {
-    "testProject" : "nativeMonolithic",
-    "linux" : 972000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.java.JavaLibraryPluginPerformanceTest.java-library vs java",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 370000
+    "linux" : 425000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationPerformanceTest.configure",
   "runtimes" : [ {
     "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 376000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 141000
+    "linux" : 375000
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 256000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
-  "runtimes" : [ {
-    "testProject" : "springBootApp",
-    "linux" : 328000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
-  "runtimes" : [ {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 513000
-  }, {
-    "testProject" : "bigSwiftApp",
-    "linux" : 313000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
-  "runtimes" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 206000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 895000
+    "linux" : 264000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1014000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
-  "runtimes" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 464000
-  }, {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 680000
-  }, {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 172000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
-  "runtimes" : [ {
-    "testProject" : "archivePerformanceProject",
-    "linux" : 162000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
-  "runtimes" : [ {
-    "testProject" : "bigCppMulti",
-    "linux" : 271000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 108000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 658000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 288000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster abi change (build comparison)",
-  "runtimes" : [ {
-    "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 419000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 800000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run clean phthalic:assembleDebug",
-  "runtimes" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 605000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
-  "runtimes" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 218000
-  }, {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 128000
+    "linux" : 139000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
   "runtimes" : [ {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 208000
-  }, {
     "testProject" : "largeAndroidBuild",
-    "linux" : 1320000
+    "linux" : 1261000
+  }, {
+    "testProject" : "k9AndroidBuild",
+    "linux" : 197000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
+  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
   "runtimes" : [ {
-    "testProject" : "bigNative",
-    "linux" : 231000
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 117000
   }, {
-    "testProject" : "bigCppApp",
-    "linux" : 231000
-  }, {
-    "testProject" : "bigCppMulti",
-    "linux" : 494000
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 469000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
+  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.cold daemon",
   "runtimes" : [ {
-    "testProject" : "withVerboseJUnit",
-    "linux" : 67000
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 986000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1083000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 374000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
+  "runtimes" : [ {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 142000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 279000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean assemble (Gradle vs Maven)",
+  "runtimes" : [ {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 416000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 193000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty remote http cache",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 882000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 988000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with hot daemon",
@@ -503,171 +146,45 @@
     "linux" : 186000
   }, {
     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 385000
+    "linux" : 386000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.non-abi change",
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native)",
   "runtimes" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 497000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 382000
+    "testProject" : "mediumCppAppWithMacroIncludes",
+    "linux" : 230000
   }, {
-    "testProject" : "smallJavaMultiProject",
-    "linux" : 187000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 802000
+    "testProject" : "smallNative",
+    "linux" : 307000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 726000
+    "testProject" : "mediumCppMultiWithMacroIncludes",
+    "linux" : 489000
   }, {
     "testProject" : "bigNative",
-    "linux" : 185000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 910000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
-  "runtimes" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 291000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 306000
+    "linux" : 753000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 672000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1951000
+    "testProject" : "bigCppApp",
+    "linux" : 574000
   }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 244000
+    "testProject" : "mediumCppMulti",
+    "linux" : 486000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1001000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.cold daemon",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1014000
+    "testProject" : "bigCppMulti",
+    "linux" : 1482000
   }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 386000
+    "testProject" : "smallCppApp",
+    "linux" : 298000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1073000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
-  "runtimes" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 391000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:dependentComponents",
-  "runtimes" : [ {
-    "testProject" : "nativeDependents",
-    "linux" : 545000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository (parallel)",
-  "runtimes" : [ {
-    "testProject" : "springBootApp",
-    "linux" : 272000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
-  "runtimes" : [ {
-    "testProject" : "archivePerformanceProject",
-    "linux" : 226000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for abi change with local cache",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1000000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 653000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 141000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 78000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
-  "runtimes" : [ {
-    "testProject" : "mediumNativeMonolithic",
+    "testProject" : "mediumNative",
     "linux" : 270000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 143000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 384000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 139000
+    "testProject" : "multiNative",
+    "linux" : 1855000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 323000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
-  "runtimes" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 141000
+    "testProject" : "smallCppMulti",
+    "linux" : 319000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 281000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.incremental compile",
-  "runtimes" : [ {
-    "testProject" : "bigSwiftApp",
-    "linux" : 183000
-  }, {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 534000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
-  "runtimes" : [ {
-    "testProject" : "excludeRuleMergingBuild",
+    "testProject" : "mediumCppApp",
     "linux" : 227000
   } ]
 }, {
@@ -677,75 +194,558 @@
     "linux" : 246000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
+  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
   "runtimes" : [ {
-    "testProject" : "nativeMonolithic",
-    "linux" : 768000
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 717000
   }, {
-    "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 762000
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 820000
+  }, {
+    "testProject" : "bigNative",
+    "linux" : 185000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:dependentComponents",
+  "runtimes" : [ {
+    "testProject" : "nativeDependents",
+    "linux" : 535000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
+  "runtimes" : [ {
+    "testProject" : "springBootApp",
+    "linux" : 332000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native, parallel)",
+  "runtimes" : [ {
+    "testProject" : "manyProjectsNative",
+    "linux" : 696000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 492000
+  }, {
+    "testProject" : "largeGroovyMultiProject",
+    "linux" : 617000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1024000
+  }, {
+    "testProject" : "largeMonolithicGroovyProject",
+    "linux" : 1700000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest.create many deprecation warnings",
   "runtimes" : [ {
     "testProject" : "generateLotsOfDeprecationWarnings",
-    "linux" : 106000
+    "linux" : 108000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
+  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster non-abi change (build comparison)",
+  "runtimes" : [ {
+    "testProject" : "santaTrackerAndroidJavaBuild",
+    "linux" : 377000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 413000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
+  "runtimes" : [ {
+    "testProject" : "smallNativeMonolithic",
+    "linux" : 619000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.incremental compile",
+  "runtimes" : [ {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 533000
+  }, {
+    "testProject" : "bigSwiftApp",
+    "linux" : 184000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
   "runtimes" : [ {
     "testProject" : "bigCppMulti",
-    "linux" : 275000
+    "linux" : 278000
   }, {
     "testProject" : "bigCppApp",
-    "linux" : 142000
+    "linux" : 109000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty remote http cache",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 854000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 967000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
-  "runtimes" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 457000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote https cache",
+  "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
   "runtimes" : [ {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1000000
+    "linux" : 1442000
+  }, {
+    "testProject" : "mediumJavaMultiProjectWithTestNG",
+    "linux" : 288000
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 898000
+    "linux" : 588000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",
+  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
   "runtimes" : [ {
-    "testProject" : "mediumNativeMonolithic",
-    "linux" : 271000
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 148000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 360000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.assemble for non-abi change (Gradle vs Maven)",
+  "runtimes" : [ {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 295000
+  }, {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 682000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
+  "runtimes" : [ {
+    "testProject" : "mediumJavaCompositeBuild",
+    "linux" : 302000
+  }, {
+    "testProject" : "mediumJavaPredefinedCompositeBuild",
+    "linux" : 303000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 479000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 529000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
+  "runtimes" : [ {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 513000
+  }, {
+    "testProject" : "bigSwiftApp",
+    "linux" : 315000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
+  "runtimes" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 204000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
   "runtimes" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 464000
+    "linux" : 469000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
+  "runtimes" : [ {
+    "testProject" : "bigCppMulti",
+    "linux" : 497000
+  }, {
+    "testProject" : "bigNative",
+    "linux" : 232000
+  }, {
+    "testProject" : "bigCppApp",
+    "linux" : 234000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftCleanBuildPerformanceTest.clean assemble (swift)",
+  "runtimes" : [ {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 1067000
+  }, {
+    "testProject" : "bigSwiftApp",
+    "linux" : 730000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1333000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1419000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
+  "runtimes" : [ {
+    "testProject" : "createLotsOfTasks",
+    "linux" : 135000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean phthalic:assembleDebug with clean transforms cache",
+  "runtimes" : [ {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 910000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.java.JavaLibraryPluginPerformanceTest.java-library vs java",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 343000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.non-abi change",
+  "runtimes" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 580000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 384000
+  }, {
+    "testProject" : "smallJavaMultiProject",
+    "linux" : 187000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
+  "runtimes" : [ {
+    "testProject" : "nativeMonolithic",
+    "linux" : 969000
+  }, {
+    "testProject" : "nativeMonolithicOverlapping",
+    "linux" : 968000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 877000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1016000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.abi change",
+  "runtimes" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 822000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules (parallel)",
   "runtimes" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 270000
+    "linux" : 238000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1564000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 241000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1034000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean assembleDebug with clean transforms cache",
+  "runtimes" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 1875000
+  }, {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 1636000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 655000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
+  "runtimes" : [ {
+    "testProject" : "k9AndroidBuild",
+    "linux" : 171000
+  }, {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 682000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 490000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:buildDependentsLibA0",
   "runtimes" : [ {
     "testProject" : "nativeDependents",
-    "linux" : 554000
+    "linux" : 550000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
+  "runtimes" : [ {
+    "testProject" : "withVerboseJUnit",
+    "linux" : 187000
+  }, {
+    "testProject" : "withVerboseTestNG",
+    "linux" : 172000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativePreCompiledHeaderPerformanceTest.clean assemble with precompiled headers",
+  "runtimes" : [ {
+    "testProject" : "smallPCHNative",
+    "linux" : 123000
+  }, {
+    "testProject" : "mediumPCHNative",
+    "linux" : 302000
+  }, {
+    "testProject" : "bigPCHNative",
+    "linux" : 1079000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
+  "runtimes" : [ {
+    "testProject" : "nativeMonolithic",
+    "linux" : 766000
+  }, {
+    "testProject" : "nativeMonolithicOverlapping",
+    "linux" : 766000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
+  "runtimes" : [ {
+    "testProject" : "archivePerformanceProject",
+    "linux" : 167000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.clean checkout",
+  "runtimes" : [ {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 418000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1114000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1027000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
+  "runtimes" : [ {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 216000
+  }, {
+    "testProject" : "k9AndroidBuild",
+    "linux" : 125000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote https cache",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 910000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1024000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.test for non-abi change (Gradle vs Maven)",
+  "runtimes" : [ {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 1880000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 880000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 326000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 144000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",
+  "runtimes" : [ {
+    "testProject" : "mediumNativeMonolithic",
+    "linux" : 270000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 670000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
+  "runtimes" : [ {
+    "testProject" : "archivePerformanceProject",
+    "linux" : 228000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for abi change with local cache",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 998000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 467000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 114000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository (parallel)",
+  "runtimes" : [ {
+    "testProject" : "springBootApp",
+    "linux" : 270000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
+  "runtimes" : [ {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1010000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 894000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
+  "runtimes" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 226000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
+  "runtimes" : [ {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 82000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 141000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 291000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 149000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
+  "runtimes" : [ {
+    "testProject" : "archivePerformanceProject",
+    "linux" : 162000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 652000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 289000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
+  "runtimes" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 388000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.java.ParallelBuildPerformanceTest.clean assemble with 4 parallel workers",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 488000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 351000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster abi change (build comparison)",
+  "runtimes" : [ {
+    "testProject" : "santaTrackerAndroidJavaBuild",
+    "linux" : 406000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 799000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
+  "runtimes" : [ {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 972000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 874000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 393000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 150000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
+  "runtimes" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 273000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run clean phthalic:assembleDebug",
+  "runtimes" : [ {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 597000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
+  "runtimes" : [ {
+    "testProject" : "bigSwiftApp",
+    "linux" : 110000
+  }, {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 172000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
+  "runtimes" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 236000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 281000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
+  "runtimes" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 294000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
+  "runtimes" : [ {
+    "testProject" : "mediumNativeMonolithic",
+    "linux" : 268000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
+  "runtimes" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 462000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
+  "runtimes" : [ {
+    "testProject" : "withVerboseJUnit",
+    "linux" : 65000
   } ]
 } ]

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
@@ -44,8 +44,8 @@ public class AllResultsStore implements ResultsStore, Closeable {
     }
 
     @Override
-    public Map<PerformanceExperiment, Long> getEstimatedExperimentTimesInMillis(OperatingSystem operatingSystem) {
-        return store.getEstimatedExperimentTimesInMillis(operatingSystem);
+    public Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentTimesInMillis() {
+        return store.getEstimatedExperimentTimesInMillis();
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
@@ -50,9 +50,9 @@ public class CompositeResultsStore implements ResultsStore {
     }
 
     @Override
-    public Map<PerformanceExperiment, Long> getEstimatedExperimentTimesInMillis(OperatingSystem operatingSystem) {
+    public Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentTimesInMillis() {
         return stores.stream()
-            .flatMap(store -> store.getEstimatedExperimentTimesInMillis(operatingSystem).entrySet().stream())
+            .flatMap(store -> store.getEstimatedExperimentTimesInMillis().entrySet().stream())
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Math::max));
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -44,7 +44,7 @@ class NoResultsStore<T extends PerformanceTestResult> implements WritableResults
     }
 
     @Override
-    Map<PerformanceExperiment, Long> getEstimatedExperimentTimesInMillis(OperatingSystem operatingSystem) {
+    Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentTimesInMillis() {
         return Collections.emptyMap()
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExperimentOnOs.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExperimentOnOs.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import java.util.Objects;
+
+public class PerformanceExperimentOnOs {
+    private final PerformanceExperiment performanceExperiment;
+    private final OperatingSystem operatingSystem;
+
+    public PerformanceExperimentOnOs(PerformanceExperiment performanceExperiment, OperatingSystem operatingSystem) {
+        this.performanceExperiment = performanceExperiment;
+        this.operatingSystem = operatingSystem;
+    }
+
+    public PerformanceExperiment getPerformanceExperiment() {
+        return performanceExperiment;
+    }
+
+    public OperatingSystem getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PerformanceExperimentOnOs that = (PerformanceExperimentOnOs) o;
+        return performanceExperiment.equals(that.performanceExperiment) &&
+            operatingSystem == that.operatingSystem;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(performanceExperiment, operatingSystem);
+    }
+
+    @Override
+    public String toString() {
+        return "PerformanceExperimentOnOs{" +
+            "performanceExperiment=" + performanceExperiment +
+            ", operatingSystem=" + operatingSystem +
+            '}';
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
@@ -39,5 +39,5 @@ public interface ResultsStore extends Closeable {
     /**
      * Returns the estimated runtime for each experiment in milliseconds.
      */
-    Map<PerformanceExperiment, Long> getEstimatedExperimentTimesInMillis(OperatingSystem operatingSystem);
+    Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentTimesInMillis();
 }


### PR DESCRIPTION
When we run tests on Windows or macOS, we should also read their times from the database and update the JSON file accordingly.