### PR TITLE
Disable daemon for performance tests that change Gradle caches

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -337,13 +337,13 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 }
             ]
@@ -354,13 +354,13 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 }
             ]
@@ -371,13 +371,13 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 }
             ]
@@ -388,13 +388,13 @@
                 {
                     "testProject" : "largeJavaMultiProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 },
                 {
                     "testProject" : "largeMonolithicJavaProject",
                     "coverage" : {
-                        "test":  ["linux", "windows"]
+                        "slow":  ["linux", "windows"]
                     }
                 }
             ]
@@ -641,7 +641,7 @@
                 {
                     "testProject" : "springBootApp",
                     "coverage" : {
-                        "test":  ["linux"]
+                        "slow":  ["linux"]
                     }
                 }
             ]
@@ -652,7 +652,7 @@
                 {
                     "testProject" : "springBootApp",
                     "coverage" : {
-                        "test":  ["linux"]
+                        "slow":  ["linux"]
                     }
                 }
             ]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildSlowPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildSlowPerformanceTest.groovy
@@ -42,6 +42,7 @@ class RealLifeAndroidBuildSlowPerformanceTest extends AbstractRealLifeAndroidBui
         runner.tasksToRun = tasks.split(' ')
         runner.args.add('-Dorg.gradle.parallel=true')
         runner.cleanTasks = ["clean"]
+        runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
             new ClearArtifactTransformCacheMutator(invocationSettings.getGradleUserHome(), AbstractCleanupMutator.CleanupSchedule.BUILD)
         }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -16,19 +16,11 @@
 
 package org.gradle.performance.regression.buildcache
 
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
-import org.gradle.internal.hash.Hashing
 import org.gradle.performance.fixture.CrossVersionPerformanceTestRunner
 import org.gradle.performance.generator.JavaTestProject
-import org.gradle.profiler.BuildContext
-import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.test.fixtures.keystore.TestKeyStore
-
-import java.util.zip.GZIPInputStream
-import java.util.zip.GZIPOutputStream
 
 class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
@@ -45,7 +37,6 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         pushToRemote = true
         runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
-        runner.addBuildMutator() { touchCacheArtifacts() }
 
         when:
         def result = runner.run()
@@ -60,7 +51,6 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         pushToRemote = true
         runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
-        runner.addBuildMutator { touchCacheArtifacts() }
 
         def keyStore = TestKeyStore.init(temporaryFolder.file('ssl-keystore'))
         keyStore.enableSslWithServerCert(buildCacheServer)
@@ -112,7 +102,6 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         setupTestProject(runner)
         runner.args += "--parallel"
         pushToRemote = false
-        runner.addBuildMutator { touchCacheArtifacts() }
 
         when:
         def result = runner.run()
@@ -128,7 +117,6 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.addBuildMutator { new ApplyAbiChangeToJavaSourceFileMutator(new File(it.projectDir, testProject.config.fileToChangeByScenario['assemble'])) }
         runner.args += "--parallel"
         pushToRemote = false
-        runner.addBuildMutator { touchCacheArtifacts() }
 
         when:
         def result = runner.run()
@@ -144,65 +132,12 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.addBuildMutator { new ApplyNonAbiChangeToJavaSourceFileMutator(new File(it.projectDir, testProject.config.fileToChangeByScenario['assemble'])) }
         runner.args += "--parallel"
         pushToRemote = false
-        runner.addBuildMutator { touchCacheArtifacts() }
 
         when:
         def result = runner.run()
 
         then:
         result.assertCurrentVersionHasNotRegressed()
-    }
-
-    private BuildMutator touchCacheArtifacts() {
-        new BuildMutator() {
-            @Override
-            void beforeBuild(BuildContext context) {
-                touchCacheArtifactsDir(cacheDir)
-                if (buildCacheServer.running) {
-                    touchCacheArtifactsDir(buildCacheServer.cacheDir)
-                }
-            }
-        }
-    }
-
-    // We change the file dates inside the archives to work around unfairness caused by
-    // reusing FileCollectionSnapshots based on the file dates in versions before Gradle 4.2
-    void touchCacheArtifactsDir(File dir) {
-        def startTime = System.currentTimeMillis()
-        int count = 0
-        dir.eachFile { File cacheArchiveFile ->
-            if (cacheArchiveFile.name ==~ /[a-z0-9]{${Hashing.defaultFunction().hexDigits}}/) {
-                def tempFile = temporaryFolder.file("re-tar-temp")
-                tempFile.withOutputStream { outputStream ->
-                    def tarOutput = new TarArchiveOutputStream(new GZIPOutputStream(outputStream))
-                    tarOutput.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
-                    tarOutput.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX)
-                    tarOutput.setAddPaxHeadersForNonAsciiNames(true)
-                    cacheArchiveFile.withInputStream { inputStream ->
-                        def tarInput = new TarArchiveInputStream(new GZIPInputStream(inputStream))
-                        while (true) {
-                            def tarEntry = tarInput.nextTarEntry
-                            if (tarEntry == null) {
-                                break
-                            }
-
-                            tarEntry.setModTime(tarEntry.modTime.time + 3743)
-                            tarOutput.putArchiveEntry(tarEntry)
-                            if (!tarEntry.directory) {
-                                tarOutput << tarInput
-                            }
-                            tarOutput.closeArchiveEntry()
-                        }
-                    }
-                    tarOutput.close()
-                }
-                assert cacheArchiveFile.delete()
-                assert tempFile.renameTo(cacheArchiveFile)
-            }
-            count++
-        }
-        def time = System.currentTimeMillis() - startTime
-        println "Changed file dates in $count cache artifacts in $dir in ${time} ms"
     }
 
     static def setupTestProject(CrossVersionPerformanceTestRunner runner) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -36,6 +36,8 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         protocol = "http"
         pushToRemote = true
         runner.useDaemon = false
+        runner.warmUpRuns = 2
+        runner.runs = 8
         runner.addBuildMutator { cleanLocalCache() }
 
         when:
@@ -50,6 +52,8 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         protocol = "https"
         pushToRemote = true
         runner.useDaemon = false
+        runner.warmUpRuns = 2
+        runner.runs = 8
         runner.addBuildMutator { cleanLocalCache() }
 
         def keyStore = TestKeyStore.init(temporaryFolder.file('ssl-keystore'))
@@ -67,7 +71,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     def "clean assemble with empty local cache"() {
         given:
         setupTestProject(runner)
-        runner.warmUpRuns = 6
+        runner.warmUpRuns = 2
         runner.runs = 8
         pushToRemote = false
         runner.useDaemon = false
@@ -83,7 +87,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     def "clean assemble with empty remote http cache"() {
         given:
         setupTestProject(runner)
-        runner.warmUpRuns = 6
+        runner.warmUpRuns = 2
         runner.runs = 8
         pushToRemote = true
         runner.useDaemon = false

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -43,6 +43,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         setupTestProject(runner)
         protocol = "http"
         pushToRemote = true
+        runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
         runner.addBuildMutator() { touchCacheArtifacts() }
 
@@ -57,6 +58,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         setupTestProject(runner)
         protocol = "https"
         pushToRemote = true
+        runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
         runner.addBuildMutator { touchCacheArtifacts() }
 
@@ -78,6 +80,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 6
         runner.runs = 8
         pushToRemote = false
+        runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
 
         when:
@@ -93,6 +96,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 6
         runner.runs = 8
         pushToRemote = true
+        runner.useDaemon = false
         runner.addBuildMutator { cleanLocalCache() }
         runner.addBuildMutator { cleanRemoteCache() }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -46,6 +46,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.minimumBaseVersion = "4.9"
         runner.warmUpRuns = 5
         runner.runs = 15
+        runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
             new BuildMutator() {
                 @Override


### PR DESCRIPTION
A running daemon is not ready to deal with changes to its caches, especially with file system watching enabled.

Therefore, we run all performance tests which mess with caches without the daemon and move them to the slow group.