### PR TITLE
Remove release bias in LatestModuleConflictResolver

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -531,7 +531,8 @@ class DependencyManagementBuildScopeServices {
                                                                 VersionParser versionParser,
                                                                 ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
                                                                 InstantiatorFactory instantiatorFactory,
-                                                                ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory) {
+                                                                ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
+                                                                FeaturePreviews featurePreviews) {
         return new DefaultArtifactDependencyResolver(
             buildOperationExecutor,
             resolverFactories,
@@ -546,7 +547,8 @@ class DependencyManagementBuildScopeServices {
             versionParser,
             componentMetadataSupplierRuleExecutor,
             instantiatorFactory,
-            componentSelectionDescriptorFactory);
+            componentSelectionDescriptorFactory,
+            featurePreviews);
     }
 
     ProjectPublicationRegistry createProjectPublicationRegistry() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -24,14 +25,20 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.
 public class ConflictResolverFactory {
     private final VersionComparator versionComparator;
     private final VersionParser versionParser;
+    private final FeaturePreviews featurePreviews;
 
-    public ConflictResolverFactory(VersionComparator versionComparator, VersionParser versionParser) {
+    public ConflictResolverFactory(VersionComparator versionComparator, VersionParser versionParser, FeaturePreviews featurePreviews) {
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
+        this.featurePreviews = featurePreviews;
     }
 
     public ModuleConflictResolver<ComponentState> createConflictResolver(ConflictResolution conflictResolution) {
-        ModuleConflictResolver<ComponentState> conflictResolver = new LatestModuleConflictResolver<>(versionComparator, versionParser);
+        boolean releaseBias = true;
+        if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.VERSION_ORDERING_V2)) {
+            releaseBias = false;
+        }
+        ModuleConflictResolver<ComponentState> conflictResolver = new LatestModuleConflictResolver<>(versionComparator, versionParser, releaseBias);
         if (conflictResolution == ConflictResolution.preferProjectModules) {
             conflictResolver = new ProjectDependencyForcingResolver<>(conflictResolver);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
@@ -91,6 +92,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
     private final Instantiator instantiator;
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;
+    private final FeaturePreviews featurePreviews;
 
     public DefaultArtifactDependencyResolver(BuildOperationExecutor buildOperationExecutor,
                                              List<ResolverProviderFactory> resolverFactories,
@@ -105,7 +107,8 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
                                              VersionParser versionParser,
                                              ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
                                              InstantiatorFactory instantiatorFactory,
-                                             ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory) {
+                                             ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
+                                             FeaturePreviews featurePreviews) {
         this.resolverFactories = resolverFactories;
         this.projectDependencyResolver = projectDependencyResolver;
         this.ivyFactory = ivyFactory;
@@ -120,6 +123,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         this.componentMetadataSupplierRuleExecutor = componentMetadataSupplierRuleExecutor;
         this.instantiator = instantiatorFactory.decorateScheme().instantiator();
         this.componentSelectionDescriptorFactory = componentSelectionDescriptorFactory;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
@@ -200,7 +204,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     private ModuleConflictHandler createModuleConflictHandler(ResolutionStrategyInternal resolutionStrategy, GlobalDependencyResolutionRules metadataHandler) {
         ConflictResolution conflictResolution = resolutionStrategy.getConflictResolution();
         ModuleConflictResolver<ComponentState> conflictResolver =
-            new ConflictResolverFactory(versionComparator, versionParser).createConflictResolver(conflictResolution);
+            new ConflictResolverFactory(versionComparator, versionParser, featurePreviews).createConflictResolver(conflictResolution);
         return new DefaultConflictHandler(conflictResolver, metadataHandler.getModuleMetadataProcessor().getModuleReplacements());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
@@ -30,10 +30,12 @@ import java.util.Map;
 class LatestModuleConflictResolver<T extends ComponentResolutionState> implements ModuleConflictResolver<T> {
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
+    private final boolean releaseBias;
 
-    LatestModuleConflictResolver(VersionComparator versionComparator, VersionParser versionParser) {
+    LatestModuleConflictResolver(VersionComparator versionComparator, VersionParser versionParser, boolean releaseBias) {
         this.versionComparator = versionComparator.asVersionComparator();
         this.versionParser = versionParser;
+        this.releaseBias = releaseBias;
     }
 
     @Override
@@ -66,10 +68,12 @@ class LatestModuleConflictResolver<T extends ComponentResolutionState> implement
                 details.select(component);
                 return;
             }
-            ComponentResolveMetadata metaData = component.getMetadata();
-            if (metaData != null && "release".equals(metaData.getStatus())) {
-                details.select(component);
-                return;
+            if (releaseBias) {
+                ComponentResolveMetadata metaData = component.getMetadata();
+                if (metaData != null && "release".equals(metaData.getStatus())) {
+                    details.select(component);
+                    return;
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolverTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 class LatestModuleConflictResolverTest extends AbstractConflictResolverTest {
 
     def setup() {
-        resolver = new LatestModuleConflictResolver(new DefaultVersionComparator(new FeaturePreviews()), new VersionParser())
+        resolver = new LatestModuleConflictResolver(new DefaultVersionComparator(new FeaturePreviews()), new VersionParser(), true)
     }
 
     @Unroll
@@ -70,6 +70,19 @@ class LatestModuleConflictResolverTest extends AbstractConflictResolverTest {
 
         then:
         selected '1.0-beta-1'
+    }
+
+    def "does not select a release version over unqualified"() {
+        resolver = new LatestModuleConflictResolver(new DefaultVersionComparator(new FeaturePreviews()), new VersionParser(), false)
+        given:
+        prefer('1.0-beta-1').release()
+        prefer('1.0-beta-2')
+
+        when:
+        resolveConflicts()
+
+        then:
+        selected '1.0-beta-2'
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -70,8 +70,9 @@ import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCEN
 class SelectorStateResolverTest extends Specification {
     private final TestComponentResolutionState root = new TestComponentResolutionState(DefaultModuleVersionIdentifier.newId("other", "root", "1"))
     private final componentIdResolver = new TestDependencyToComponentIdResolver()
-    private final DefaultVersionComparator versionComparator = new DefaultVersionComparator(new FeaturePreviews())
-    private final conflictResolver = new ConflictResolverFactory(versionComparator, new VersionParser()).createConflictResolver(ConflictResolution.latest)
+    private final FeaturePreviews featurePreviews = new FeaturePreviews()
+    private final DefaultVersionComparator versionComparator = new DefaultVersionComparator(featurePreviews)
+    private final conflictResolver = new ConflictResolverFactory(versionComparator, new VersionParser(), featurePreviews).createConflictResolver(ConflictResolution.latest)
     private final componentFactory = new TestComponentFactory()
     private final ModuleIdentifier moduleId = DefaultModuleIdentifier.newId("org", "module")
     private final ResolveOptimizations resolveOptimizations = new ResolveOptimizations()


### PR DESCRIPTION
Prior to this commit, when comparing two versions having the same base
version, if one was a release status, it would win even if it was not
the most recent version.
This check is now conditional and removed when opting in the new version
sorting.