### PR TITLE
Use daemon for parallel download tests

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -46,7 +46,6 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.minimumBaseVersion = "4.9"
         runner.warmUpRuns = 5
         runner.runs = 15
-        runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
             new BuildMutator() {
                 @Override


### PR DESCRIPTION
The daemon should be able to deal with disappearing
downloaded artifacts. Let's leave this test
as is.

Reverts some changes from #14690.