### PR TITLE
Clean up language-java subproject

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/AbstractJavaToolChain.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/AbstractJavaToolChain.java
@@ -70,8 +70,7 @@ public abstract class AbstractJavaToolChain implements JavaToolChainInternal {
         @Override
         public <T extends CompileSpec> Compiler<T> newCompiler(Class<T> spec) {
             if (JavaCompileSpec.class.isAssignableFrom(spec)) {
-                @SuppressWarnings({"unchecked", "cast"}) Compiler<T> compiler = (Compiler<T>) compilerFactory.create(spec);
-                return compiler;
+                return compilerFactory.create(spec);
             }
             if (JavadocSpec.class.isAssignableFrom(spec)) {
                 @SuppressWarnings("unchecked") Compiler<T> compiler = (Compiler<T>) new JavadocCompilerAdapter(execActionFactory);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/CachingClassDependenciesAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/CachingClassDependenciesAnalyzer.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile.incremental.analyzer;
 
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
-import org.gradle.internal.Factory;
 import org.gradle.internal.hash.HashCode;
 
 public class CachingClassDependenciesAnalyzer implements ClassDependenciesAnalyzer {
@@ -32,11 +31,6 @@ public class CachingClassDependenciesAnalyzer implements ClassDependenciesAnalyz
 
     @Override
     public ClassAnalysis getClassAnalysis(final HashCode classFileHash, final FileTreeElement classFile) {
-        return cache.get(classFileHash, new Factory<ClassAnalysis>() {
-            @Override
-            public ClassAnalysis create() {
-                return analyzer.getClassAnalysis(classFileHash, classFile);
-            }
-        });
+        return cache.get(classFileHash, () -> analyzer.getClassAnalysis(classFileHash, classFile));
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
@@ -34,7 +34,7 @@ public class ClassAnalysisSerializer extends AbstractSerializer<ClassAnalysis> {
     private final SetSerializer<String> stringSetSerializer;
 
     public ClassAnalysisSerializer(StringInterner interner) {
-        stringSetSerializer = new SetSerializer<String>(new InterningStringSerializer(interner), false);
+        stringSetSerializer = new SetSerializer<>(new InterningStringSerializer(interner), false);
         this.interner = interner;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzer.java
@@ -43,13 +43,8 @@ public class DefaultClassDependenciesAnalyzer implements ClassDependenciesAnalyz
 
     @Override
     public ClassAnalysis getClassAnalysis(HashCode classFileHash, FileTreeElement classFile) {
-        try {
-            InputStream input = classFile.open();
-            try {
-                return getClassAnalysis(input);
-            } finally {
-                input.close();
-            }
+        try (InputStream input = classFile.open()) {
+            return getClassAnalysis(input);
         } catch (IOException e) {
             throw new RuntimeException("Problems loading class analysis for " + classFile.toString());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -16,8 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.asm;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Sets;
+import java.util.function.Predicate;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import org.gradle.api.internal.cache.StringInterner;
@@ -32,6 +31,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
 
 import java.lang.annotation.RetentionPolicy;
+import java.util.HashSet;
 import java.util.Set;
 
 public class ClassDependenciesVisitor extends ClassVisitor {
@@ -50,8 +50,8 @@ public class ClassDependenciesVisitor extends ClassVisitor {
     private ClassDependenciesVisitor(Predicate<String> typeFilter, ClassReader reader, StringInterner interner) {
         super(API);
         this.constants = new IntOpenHashSet(2);
-        this.privateTypes = Sets.newHashSet();
-        this.accessibleTypes = Sets.newHashSet();
+        this.privateTypes = new HashSet<>();
+        this.accessibleTypes = new HashSet<>();
         this.retentionPolicyVisitor = new RetentionPolicyVisitor();
         this.typeFilter = typeFilter;
         this.interner = interner;
@@ -118,7 +118,7 @@ public class ClassDependenciesVisitor extends ClassVisitor {
     }
 
     protected void maybeAddDependentType(Set<String> types, String type) {
-        if (typeFilter.apply(type)) {
+        if (typeFilter.test(type)) {
             types.add(intern(type));
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.asm;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
@@ -42,7 +42,7 @@ class ClassRelevancyFilter implements Predicate<String> {
     }
 
     @Override
-    public boolean apply(String className) {
+    public boolean test(String className) {
         return !className.startsWith("java.")
             && !excludedClassName.equals(className)
             && !PRIMITIVES.contains(className);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshot.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshot.java
@@ -40,7 +40,7 @@ public class ClasspathEntrySnapshot {
     }
 
     public DependentsSet getAllClasses() {
-        final Set<String> result = new HashSet<String>();
+        final Set<String> result = new HashSet<>();
         for (Map.Entry<String, HashCode> cls : getHashes().entrySet()) {
             String className = cls.getKey();
             DependentsSet dependents = getClassAnalysis().getRelevantDependents(className, IntSets.EMPTY_SET);
@@ -77,7 +77,7 @@ public class ClasspathEntrySnapshot {
     }
 
     private Set<String> modifiedSince(ClasspathEntrySnapshot other) {
-        final Set<String> modified = new HashSet<String>();
+        final Set<String> modified = new HashSet<>();
         for (Map.Entry<String, HashCode> otherClass : other.getHashes().entrySet()) {
             String otherClassName = otherClass.getKey();
             HashCode otherClassBytes = otherClass.getValue();
@@ -90,7 +90,7 @@ public class ClasspathEntrySnapshot {
     }
 
     private Set<String> addedSince(ClasspathEntrySnapshot other) {
-        Set<String> addedClasses = new HashSet<String>(getClasses());
+        Set<String> addedClasses = new HashSet<>(getClasses());
         addedClasses.removeAll(other.getClasses());
         return addedClasses;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotDataSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotDataSerializer.java
@@ -38,7 +38,7 @@ public class ClasspathEntrySnapshotDataSerializer extends AbstractSerializer<Cla
 
     public ClasspathEntrySnapshotDataSerializer(StringInterner interner) {
         hashCodeSerializer = new HashCodeSerializer();
-        mapSerializer = new MapSerializer<String, HashCode>(new InterningStringSerializer(interner), hashCodeSerializer);
+        mapSerializer = new MapSerializer<>(new InterningStringSerializer(interner), hashCodeSerializer);
         analysisSerializer = new ClassSetAnalysisData.Serializer(interner);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotDataSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotDataSerializer.java
@@ -33,8 +33,8 @@ import static org.gradle.internal.serialize.BaseSerializerFactory.FILE_SERIALIZE
 import static org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER;
 
 public class ClasspathSnapshotDataSerializer extends AbstractSerializer<ClasspathSnapshotData> {
-    private final MapSerializer<File, HashCode> mapSerializer = new MapSerializer<File, HashCode>(FILE_SERIALIZER, new HashCodeSerializer());
-    private final SetSerializer<String> setSerializer = new SetSerializer<String>(STRING_SERIALIZER, false);
+    private final MapSerializer<File, HashCode> mapSerializer = new MapSerializer<>(FILE_SERIALIZER, new HashCodeSerializer());
+    private final SetSerializer<String> setSerializer = new SetSerializer<>(STRING_SERIALIZER, false);
 
     @Override
     public ClasspathSnapshotData read(Decoder decoder) throws Exception {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -27,7 +25,9 @@ import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class ClasspathSnapshotFactory {
@@ -43,10 +43,10 @@ public class ClasspathSnapshotFactory {
     ClasspathSnapshot createSnapshot(final Iterable<File> entries) {
         final Set<CreateSnapshot> snapshotOperations = snapshotAll(entries);
 
-        final LinkedHashMap<File, ClasspathEntrySnapshot> snapshots = Maps.newLinkedHashMap();
-        final LinkedHashMap<File, HashCode> hashes = Maps.newLinkedHashMap();
-        final Set<String> allClasses = Sets.newHashSet();
-        final Set<String> duplicateClasses = Sets.newHashSet();
+        final LinkedHashMap<File, ClasspathEntrySnapshot> snapshots = new LinkedHashMap<>();
+        final LinkedHashMap<File, HashCode> hashes = new LinkedHashMap<>();
+        final Set<String> allClasses = new HashSet<>();
+        final Set<String> duplicateClasses = new HashSet<>();
 
         for (CreateSnapshot operation : snapshotOperations) {
             File entry = operation.entry;
@@ -67,16 +67,13 @@ public class ClasspathSnapshotFactory {
     }
 
     private Set<CreateSnapshot> snapshotAll(final Iterable<File> entries) {
-        final Set<CreateSnapshot> snapshotOperations = Sets.newLinkedHashSet();
+        final Set<CreateSnapshot> snapshotOperations = new LinkedHashSet<>();
 
-        buildOperationExecutor.runAll(new Action<BuildOperationQueue<CreateSnapshot>>() {
-            @Override
-            public void execute(BuildOperationQueue<CreateSnapshot> buildOperationQueue) {
-                for (File entry : entries) {
-                    CreateSnapshot operation = new CreateSnapshot(entry);
-                    snapshotOperations.add(operation);
-                    buildOperationQueue.add(operation);
-                }
+        buildOperationExecutor.runAll((Action<BuildOperationQueue<CreateSnapshot>>) buildOperationQueue -> {
+            for (File entry : entries) {
+                CreateSnapshot operation = new CreateSnapshot(entry);
+                snapshotOperations.add(operation);
+                buildOperationQueue.add(operation);
             }
         });
         return snapshotOperations;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotter.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import com.google.common.collect.Maps;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.FileOperations;
@@ -31,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.gradle.internal.FileUtils.hasExtension;
@@ -51,7 +51,7 @@ public class DefaultClasspathEntrySnapshotter {
     }
 
     public ClasspathEntrySnapshot createSnapshot(HashCode hash, File classpathEntry) {
-        final Map<String, HashCode> hashes = Maps.newHashMap();
+        final Map<String, HashCode> hashes = new HashMap<>();
         final ClassDependentsAccumulator accumulator = new ClassDependentsAccumulator();
 
         try {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -23,7 +23,6 @@ import org.gradle.internal.hash.HashCode;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 
 /**
  * A {@link ClasspathEntrySnapshotCache} that delegates to the global cache for files that are known to be immutable.
@@ -59,7 +58,7 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         CompositeStoppable.stoppable(localCache).stop();
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -19,22 +19,21 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class ClassDependentsAccumulator {
 
-    private final Set<String> dependenciesToAll = Sets.newHashSet();
-    private final Map<String, Set<String>> privateDependents = new HashMap<String, Set<String>>();
-    private final Map<String, Set<String>> accessibleDependents = new HashMap<String, Set<String>>();
+    private final Set<String> dependenciesToAll = new HashSet<>();
+    private final Map<String, Set<String>> privateDependents = new HashMap<>();
+    private final Map<String, Set<String>> accessibleDependents = new HashMap<>();
     private final ImmutableMap.Builder<String, IntSet> classesToConstants = ImmutableMap.builder();
-    private final Set<String> seenClasses = Sets.newHashSet();
+    private final Set<String> seenClasses = new HashSet<>();
     private String fullRebuildCause;
 
     public void addClass(ClassAnalysis classAnalysis) {
@@ -71,7 +70,7 @@ public class ClassDependentsAccumulator {
     private Set<String> rememberClass(Map<String, Set<String>> dependents, String className) {
         Set<String> d = dependents.get(className);
         if (d == null) {
-            d = Sets.newHashSet();
+            d = new HashSet<>();
             dependents.put(className, d);
         }
         return d;
@@ -86,7 +85,7 @@ public class ClassDependentsAccumulator {
         for (String s : dependenciesToAll) {
             builder.put(s, DependentsSet.dependencyToAll());
         }
-        Set<String> collected = Sets.newHashSet();
+        Set<String> collected = new HashSet<>();
         for (Map.Entry<String, Set<String>> entry : accessibleDependents.entrySet()) {
             if (collected.add(entry.getKey())) {
                 builder.put(entry.getKey(), DependentsSet.dependentClasses(privateDependents.getOrDefault(entry.getKey(), Collections.emptySet()), entry.getValue()));
@@ -118,11 +117,4 @@ public class ClassDependentsAccumulator {
         return new ClassSetAnalysisData(ImmutableSet.copyOf(seenClasses), getDependentsMap(), getClassesToConstants(), fullRebuildCause);
     }
 
-    private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
-        ImmutableMap.Builder<K, Set<V>> builder = ImmutableMap.builder();
-        for (K key : multimap.keySet()) {
-            builder.put(key, ImmutableSet.copyOf(multimap.get(key)));
-        }
-        return builder.build();
-    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -27,6 +27,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -69,9 +70,9 @@ public class ClassSetAnalysis {
     }
 
     public DependentsSet getRelevantDependents(Iterable<String> classes, IntSet constants) {
-        final Set<String> accessibleResultClasses = Sets.newLinkedHashSet();
-        final Set<String> privateResultClasses = Sets.newLinkedHashSet();
-        final Set<GeneratedResource> resultResources = Sets.newLinkedHashSet();
+        final Set<String> accessibleResultClasses = new LinkedHashSet<>();
+        final Set<String> privateResultClasses = new LinkedHashSet<>();
+        final Set<GeneratedResource> resultResources = new LinkedHashSet<>();
         for (String cls : classes) {
             DependentsSet d = getRelevantDependents(cls, constants);
             if (d.isDependencyToAll()) {
@@ -109,11 +110,11 @@ public class ClassSetAnalysis {
             return deps;
         }
 
-        Set<String> privateResultClasses = new HashSet<String>();
-        Set<String> accessibleResultClasses = new HashSet<String>();
-        Set<GeneratedResource> resultResources = new HashSet<GeneratedResource>(resourcesDependingOnAllOthers);
-        processDependentClasses(new HashSet<String>(), privateResultClasses, accessibleResultClasses, resultResources, deps.getPrivateDependentClasses(), deps.getAccessibleDependentClasses());
-        processDependentClasses(new HashSet<String>(), privateResultClasses, accessibleResultClasses, resultResources, Collections.emptySet(), classesDependingOnAllOthers);
+        Set<String> privateResultClasses = new HashSet<>();
+        Set<String> accessibleResultClasses = new HashSet<>();
+        Set<GeneratedResource> resultResources = new HashSet<>(resourcesDependingOnAllOthers);
+        processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, deps.getPrivateDependentClasses(), deps.getAccessibleDependentClasses());
+        processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, Collections.emptySet(), classesDependingOnAllOthers);
         accessibleResultClasses.remove(className);
         privateResultClasses.remove(className);
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import org.apache.commons.lang.StringUtils;
@@ -31,6 +30,7 @@ import org.gradle.internal.serialize.IntSetSerializer;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,7 +62,7 @@ public class ClassSetAnalysisData {
     }
 
     private DependentsSet getDependentsOfPackage(String packageName) {
-        Set<String> typesInPackage = Sets.newHashSet();
+        Set<String> typesInPackage = new HashSet<>();
         for (String type : classes) {
             int i = type.lastIndexOf(".");
             if (i < 0 && packageName == null || i > 0 && type.substring(0, i).equals(packageName)) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/DependentsSet.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/DependentsSet.java
@@ -17,17 +17,17 @@
 package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.gradle.api.internal.tasks.compile.incremental.processing.GeneratedResource;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public abstract class DependentsSet {
 
     public static DependentsSet dependentClasses(Set<String> privateDependentClasses, Set<String> accessibleDependentClasses) {
-        return dependents(privateDependentClasses, accessibleDependentClasses, Collections.<GeneratedResource>emptySet());
+        return dependents(privateDependentClasses, accessibleDependentClasses, Collections.emptySet());
     }
 
     public static DependentsSet dependents(Set<String> privateDependentClasses, Set<String> accessibleDependentClasses, Set<GeneratedResource> dependentResources) {
@@ -154,7 +154,7 @@ public abstract class DependentsSet {
             if (accessibleDependentClasses.isEmpty()) {
                 return privateDependentClasses;
             }
-            Set<String> r = Sets.newHashSet(accessibleDependentClasses);
+            Set<String> r = new HashSet<>(accessibleDependentClasses);
             r.addAll(privateDependentClasses);
             return r;
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingData.java
@@ -38,7 +38,7 @@ public class AnnotationProcessingData {
     private final String fullRebuildCause;
 
     public AnnotationProcessingData() {
-        this(ImmutableMap.<String, Set<String>>of(), ImmutableSet.<String>of(), ImmutableSet.<String>of(), ImmutableMap.<String, Set<GeneratedResource>>of(), ImmutableSet.<GeneratedResource>of(), null);
+        this(ImmutableMap.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableMap.of(), ImmutableSet.of(), null);
     }
 
     public AnnotationProcessingData(Map<String, Set<String>> generatedTypesByOrigin, Set<String> aggregatedTypes, Set<String> generatedTypesDependingOnAllOthers, Map<String,
@@ -84,12 +84,12 @@ public class AnnotationProcessingData {
 
         public Serializer(StringInterner interner) {
             InterningStringSerializer stringSerializer = new InterningStringSerializer(interner);
-            typesSerializer = new SetSerializer<String>(stringSerializer);
-            generatedTypesSerializer = new MapSerializer<String, Set<String>>(stringSerializer, typesSerializer);
+            typesSerializer = new SetSerializer<>(stringSerializer);
+            generatedTypesSerializer = new MapSerializer<>(stringSerializer, typesSerializer);
 
             GeneratedResourceSerializer resourceSerializer = new GeneratedResourceSerializer(stringSerializer);
-            this.resourcesSerializer = new SetSerializer<GeneratedResource>(resourceSerializer);
-            this.generatedResourcesSerializer = new MapSerializer<String, Set<GeneratedResource>>(stringSerializer, resourcesSerializer);
+            this.resourcesSerializer = new SetSerializer<>(resourceSerializer);
+            this.generatedResourcesSerializer = new MapSerializer<>(stringSerializer, resourcesSerializer);
         }
 
         @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingResult.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingResult.java
@@ -30,19 +30,19 @@ import java.util.Set;
  */
 public class AnnotationProcessingResult implements Serializable {
 
-    private final Map<String, Set<String>> generatedTypesByOrigin = new LinkedHashMap<String, Set<String>>();
-    private final Map<String, Set<GeneratedResource>> generatedResourcesByOrigin = new LinkedHashMap<String, Set<GeneratedResource>>();
-    private final Set<String> aggregatedTypes = new HashSet<String>();
-    private final Set<String> generatedTypesDependingOnAllOthers = new HashSet<String>();
-    private final Set<GeneratedResource> getGeneratedResourcesDependingOnAllOthers = new HashSet<GeneratedResource>();
-    private final List<AnnotationProcessorResult> annotationProcessorResults = new ArrayList<AnnotationProcessorResult>();
+    private final Map<String, Set<String>> generatedTypesByOrigin = new LinkedHashMap<>();
+    private final Map<String, Set<GeneratedResource>> generatedResourcesByOrigin = new LinkedHashMap<>();
+    private final Set<String> aggregatedTypes = new HashSet<>();
+    private final Set<String> generatedTypesDependingOnAllOthers = new HashSet<>();
+    private final Set<GeneratedResource> getGeneratedResourcesDependingOnAllOthers = new HashSet<>();
+    private final List<AnnotationProcessorResult> annotationProcessorResults = new ArrayList<>();
     private String fullRebuildCause;
 
     public void addGeneratedType(String name, Set<String> originatingElements) {
         for (String originatingElement : originatingElements) {
             Set<String> derived = generatedTypesByOrigin.get(originatingElement);
             if (derived == null) {
-                derived = new LinkedHashSet<String>();
+                derived = new LinkedHashSet<>();
                 generatedTypesByOrigin.put(originatingElement, derived);
             }
             derived.add(name);
@@ -53,7 +53,7 @@ public class AnnotationProcessingResult implements Serializable {
         for (String originatingElement : originatingElements) {
             Set<GeneratedResource> derived = generatedResourcesByOrigin.get(originatingElement);
             if (derived == null) {
-                derived = new LinkedHashSet<GeneratedResource>();
+                derived = new LinkedHashSet<>();
                 generatedResourcesByOrigin.put(originatingElement, derived);
             }
             derived.add(resource);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/GeneratedResourceSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/GeneratedResourceSerializer.java
@@ -22,8 +22,6 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
-import java.io.EOFException;
-
 public class GeneratedResourceSerializer extends AbstractSerializer<GeneratedResource> {
     private static final Serializer<GeneratedResource.Location> LOCATION_SERIALIZER = new BaseSerializerFactory().getSerializerFor(GeneratedResource.Location.class);
     private final Serializer<String> stringSerializer;
@@ -33,7 +31,7 @@ public class GeneratedResourceSerializer extends AbstractSerializer<GeneratedRes
     }
 
     @Override
-    public GeneratedResource read(Decoder decoder) throws EOFException, Exception {
+    public GeneratedResource read(Decoder decoder) throws Exception {
         return new GeneratedResource(LOCATION_SERIALIZER.read(decoder), stringSerializer.read(decoder));
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
@@ -33,6 +31,8 @@ import org.gradle.language.base.internal.tasks.StaleOutputCleaner;
 import org.gradle.work.FileChange;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -96,13 +96,13 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
     }
 
     protected void addClassesToProcess(JavaCompileSpec spec, RecompilationSpec recompilationSpec) {
-        Set<String> classesToProcess = Sets.newHashSet(recompilationSpec.getClassesToProcess());
+        Set<String> classesToProcess = new HashSet<>(recompilationSpec.getClassesToProcess());
         classesToProcess.removeAll(recompilationSpec.getClassesToCompile());
         spec.setClasses(classesToProcess);
     }
 
     protected void includePreviousCompilationOutputOnClasspath(JavaCompileSpec spec) {
-        List<File> classpath = Lists.newArrayList(spec.getCompileClasspath());
+        List<File> classpath = new ArrayList<>(spec.getCompileClasspath());
         File destinationDir = spec.getDestinationDir();
         classpath.add(destinationDir);
         spec.setCompileClasspath(classpath);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathEntrySnapshot;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathSnapshot;
@@ -27,6 +26,8 @@ import org.gradle.api.tasks.incremental.InputFileDetails;
 
 import java.io.File;
 import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 public class ClasspathChangeDependentsFinder {
@@ -96,9 +97,9 @@ public class ClasspathChangeDependentsFinder {
     }
 
     private DependentsSet collectDependentsFromClasspath(Set<String> modified) {
-        final Set<String> privateDependentClasses = Sets.newHashSet(modified);
-        final Set<String> accessibleDependentClasses = Sets.newHashSet(modified);
-        final Deque<String> queue = Lists.newLinkedList(modified);
+        final Set<String> privateDependentClasses = new HashSet<>(modified);
+        final Set<String> accessibleDependentClasses = new HashSet<>(modified);
+        final Deque<String> queue = new LinkedList<>(modified);
         while (!queue.isEmpty()) {
             final String dependentClass = queue.poll();
             for (File entry : classpathSnapshot.getEntries()) {


### PR DESCRIPTION
- Use Java's functional primitives over Guava's
- Use diamond operator when instantiating generics
- try-with-resources
- Use Java 7's constructors for collections over Guava's newXYZ()
- Remove unthrown exceptions from throws declarations
- Remove unneeded cast
