### PR TITLE
Clarify insecure protocol deprecation warnings

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -249,7 +249,7 @@ class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec imple
         executer.expectDeprecationWarning()
         withBuildCache().run "jar"
         succeeds "clean"
-        executer.expectDocumentedDeprecationWarning("Using insecure protocols with remote build cache has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("Using insecure protocols with remote build cache, without explicit opt-in, has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
             "Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols. " +
             "See https://docs.gradle.org/current/dsl/org.gradle.caching.http.HttpBuildCache.html#org.gradle.caching.http.HttpBuildCache:allowInsecureProtocol for more details.")
 

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
@@ -106,7 +106,7 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
             .create(
                 url,
                 allowInsecureProtocol,
-                () -> DeprecationLogger.deprecate("Using insecure protocols with remote build cache")
+                () -> DeprecationLogger.deprecate("Using insecure protocols with remote build cache, without explicit opt-in,")
                     .withAdvice("Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols.")
                     .willBeRemovedInGradle7()
                     .withDslReference(HttpBuildCache.class, "allowInsecureProtocol")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveIntegrationTest.groovy
@@ -52,7 +52,7 @@ abstract class AbstractRedirectResolveIntegrationTest extends AbstractHttpDepend
 
     void optionallyExpectDeprecation() {
         if (shouldWarnAboutDeprecation()) {
-            outputContains("Following insecure redirects has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+            outputContains("Following insecure redirects, without explicit opt-in, has been deprecated. This is scheduled to be removed in Gradle 7.0.")
             outputContains("Switch "); outputContains(" repository ")
             outputContains(" to redirect to a secure protocol (like HTTPS) or allow insecure protocols.")
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
@@ -86,7 +86,7 @@ public class DefaultUrlArtifactRepository implements UrlArtifactRepository {
 
     private void nagUserOfInsecureProtocol() {
         DeprecationLogger
-            .deprecate("Using insecure protocols with repositories")
+            .deprecate("Using insecure protocols with repositories, without explicit opt-in,")
             .withAdvice(String.format(
                 "Switch %s repository '%s' to a secure protocol (like HTTPS) or allow insecure protocols.",
                 repositoryType,
@@ -106,7 +106,7 @@ public class DefaultUrlArtifactRepository implements UrlArtifactRepository {
             );
         }
         DeprecationLogger
-            .deprecate("Following insecure redirects")
+            .deprecate("Following insecure redirects, without explicit opt-in,")
             .withAdvice(String.format(
                 "Switch %s repository '%s' to redirect to a secure protocol (like HTTPS) or allow insecure protocols.",
                 repositoryType,


### PR DESCRIPTION
We received feedback that our current warning was confusing as it led users to believe that we were removing support completely. This clarifies that, moving forward, using HTTP will require opt-in.