### PR TITLE
Use less memory for the perf test JVM

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -370,7 +370,7 @@ class PerformanceTestExtension(
 
             maxParallelForks = 1
             useJUnitPlatform()
-            jvmArgs("-Xmx5g", "-XX:+HeapDumpOnOutOfMemoryError")
+            jvmArgs("-Xmx1g", "-XX:+HeapDumpOnOutOfMemoryError")
             if (project.hasProperty(PropertyNames.performanceTestVerbose)) {
                 testLogging.showStandardStreams = true
             }


### PR DESCRIPTION
5G seems to be too much. Let's see what happens if we run with 1G.