### PR TITLE
Attempt to fix hanging disconnect

### DIFF
--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.consumer;
+package org.gradle.tooling.internal.consumer
 
 
 import spock.lang.Specification
 
-public class ConnectorServicesTest extends Specification {
+class ConnectorServicesTest extends Specification {
 
     def "services sharing configuration"() {
         when:


### PR DESCRIPTION
As reported at #14634 the `GradleConnector.disconnect()` can hang the context of a slow network. The root cause seems is that the Tooling API client needs to connect to the daemon to be able to send the 'stop when idle' message to it. This PR works around this issue by sending the message on a different thread and timeout after 3 seconds. If the daemon cannot be connected the TAPI client will emit a warning about potentially hanging daemons.