### PR TITLE
Wrap work execution in temporary build operation

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.build.event;
 
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
+import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
@@ -23,5 +25,12 @@ public class BuildEventServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.add(DefaultBuildEventsListenerRegistry.class);
+        registration.addProvider(new Object() {
+            BuildOperationAncestryTracker createBuildOperationAncestryTracker(BuildOperationListenerManager listenerManager) {
+                BuildOperationAncestryTracker tracker = new BuildOperationAncestryTracker();
+                listenerManager.addListener(tracker);
+                return tracker;
+            }
+        });
     }
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
@@ -18,6 +18,7 @@ package org.gradle.internal.build.event;
 
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.DefaultBuildOperationAncestryTracker;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
@@ -27,7 +28,7 @@ public class BuildEventServices extends AbstractPluginServiceRegistry {
         registration.add(DefaultBuildEventsListenerRegistry.class);
         registration.addProvider(new Object() {
             BuildOperationAncestryTracker createBuildOperationAncestryTracker(BuildOperationListenerManager listenerManager) {
-                BuildOperationAncestryTracker tracker = new BuildOperationAncestryTracker();
+                DefaultBuildOperationAncestryTracker tracker = new DefaultBuildOperationAncestryTracker();
                 listenerManager.addListener(tracker);
                 return tracker;
             }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,51 +17,13 @@
 package org.gradle.internal.operations;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 @SuppressWarnings("Since15")
-public class BuildOperationAncestryTracker implements BuildOperationListener {
+public interface BuildOperationAncestryTracker {
+    Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate);
 
-    private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<OperationIdentifier, OperationIdentifier>();
-
-    public Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
-        if (id == null) {
-            return Optional.empty();
-        }
-        if (predicate.test(id)) {
-            return Optional.of(id);
-        }
-        return findClosestMatchingAncestor(parents.get(id), predicate);
-    }
-
-    public <T> Optional<T> findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
-        if (id == null) {
-            return Optional.empty();
-        }
-        T value = lookupFunction.apply(id);
-        if (value != null) {
-            return Optional.of(value);
-        }
-        return findClosestExistingAncestor(parents.get(id), lookupFunction);
-    }
-
-    @Override
-    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-        if (buildOperation.getParentId() != null) {
-            parents.put(buildOperation.getId(), buildOperation.getParentId());
-        }
-    }
-
-    @Override
-    public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
-    }
-
-    @Override
-    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
-        parents.remove(buildOperation.getId());
-    }
+    <T> Optional<T> findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction);
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.provider.runner;
-
-import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationListener;
-import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationIdentifier;
-import org.gradle.internal.operations.OperationProgressEvent;
-import org.gradle.internal.operations.OperationStartEvent;
+package org.gradle.internal.operations;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -29,12 +22,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-class BuildOperationParentTracker implements BuildOperationListener {
+@SuppressWarnings("Since15")
+public class BuildOperationAncestryTracker implements BuildOperationListener {
 
-    private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<>();
+    private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<OperationIdentifier, OperationIdentifier>();
 
     @Nullable
-    OperationIdentifier findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
+    public OperationIdentifier findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
         if (id == null || predicate.test(id)) {
             return id;
         }
@@ -42,7 +36,7 @@ class BuildOperationParentTracker implements BuildOperationListener {
     }
 
     @Nullable
-    <T> T findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
+    public <T> T findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
         if (id == null) {
             return null;
         }
@@ -68,5 +62,4 @@ class BuildOperationParentTracker implements BuildOperationListener {
     public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
         parents.remove(buildOperation.getId());
     }
-
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
@@ -18,6 +18,7 @@ package org.gradle.internal.operations;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -27,22 +28,23 @@ public class BuildOperationAncestryTracker implements BuildOperationListener {
 
     private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<OperationIdentifier, OperationIdentifier>();
 
-    @Nullable
-    public OperationIdentifier findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
-        if (id == null || predicate.test(id)) {
-            return id;
+    public Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        if (predicate.test(id)) {
+            return Optional.of(id);
         }
         return findClosestMatchingAncestor(parents.get(id), predicate);
     }
 
-    @Nullable
-    public <T> T findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
+    public <T> Optional<T> findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
         if (id == null) {
-            return null;
+            return Optional.empty();
         }
         T value = lookupFunction.apply(id);
         if (value != null) {
-            return value;
+            return Optional.of(value);
         }
         return findClosestExistingAncestor(parents.get(id), lookupFunction);
     }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationAncestryTracker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationAncestryTracker.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@SuppressWarnings("Since15")
+public class DefaultBuildOperationAncestryTracker implements BuildOperationListener, BuildOperationAncestryTracker {
+
+    private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<OperationIdentifier, OperationIdentifier>();
+
+    @Override
+    public Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        if (predicate.test(id)) {
+            return Optional.of(id);
+        }
+        return findClosestMatchingAncestor(parents.get(id), predicate);
+    }
+
+    @Override
+    public <T> Optional<T> findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        T value = lookupFunction.apply(id);
+        if (value != null) {
+            return Optional.of(value);
+        }
+        return findClosestExistingAncestor(parents.get(id), lookupFunction);
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (buildOperation.getParentId() != null) {
+            parents.put(buildOperation.getId(), buildOperation.getParentId());
+        }
+    }
+
+    @Override
+    public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        parents.remove(buildOperation.getId());
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -175,7 +175,7 @@ public class ExecutionGradleServices {
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
             new CleanupOutputsStep<>(deleter, outputChangeListener,
-            new ExecuteStep<>(
+            new ExecuteStep<>(buildOperationExecutor
         ))))))))))))))))))))))));
         // @formatter:on
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -163,7 +163,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new CancelExecutionStep<>(cancellationToken,
         new ResolveInputChangesStep<>(
         new CleanupOutputsStep<>(deleter, outputChangeListener,
-        new ExecuteStep<>(
+        new ExecuteStep<>(buildOperationExecutor
     )))))))))))))))))
     // @formatter:on
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -292,7 +292,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 new TimeoutStep<>(timeoutHandler,
                 new ResolveInputChangesStep<>(
                 new CleanupOutputsStep<>(deleter, outputChangeListener,
-                new ExecuteStep<>(
+                new ExecuteStep<>(buildOperationExecutor
             ))))))))))))))))));
             // @formatter:on
         }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -153,7 +153,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new CreateOutputsStep<>(
             new ResolveInputChangesStep<>(
             new CleanupOutputsStep<>(deleter, outputChangeListener,
-            new ExecuteStep<>(
+            new ExecuteStep<>(buildOperationExecutor
         ))))))))))))))))))
         // @formatter:on
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -20,10 +20,11 @@ import org.gradle.internal.execution.ExecutionOutcome
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.history.changes.InputChangesInternal
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Unroll
 
 class ExecuteStepTest extends StepSpec<InputChangesContext> {
-    def step = new ExecuteStep<>()
+    def step = new ExecuteStep<>(new TestBuildOperationExecutor())
     def inputChanges = Mock(InputChangesInternal)
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-import javax.annotation.Nullable;
-
 @UsedByScanPlugin("test-distribution")
 public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     private final Object id;
@@ -47,12 +45,6 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
 
     @Override
     public TestDescriptorInternal getParent() {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
         return null;
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import javax.annotation.Nullable;
-
 public class DecoratingTestDescriptor implements TestDescriptorInternal {
     private final TestDescriptorInternal descriptor;
     private final TestDescriptorInternal parent;
@@ -44,12 +42,6 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     @Override
     public Object getId() {
         return descriptor.getId();
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
-        return descriptor.getOwnerBuildOperationId();
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -30,13 +30,6 @@ public interface TestDescriptorInternal extends TestDescriptor {
     Object getId();
 
     /**
-     * Returns the identifier for the build operation (eg test task) that owns this test.
-     * Not null only for a root test suite with no parent test.
-     */
-    @Nullable
-    Object getOwnerBuildOperationId();
-
-    /**
      * The class name for display. It may be the same as or different from {@link #getClassName()}
      * @return the class name for display.
      */

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.testing.processors;
 import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor;
@@ -31,23 +32,21 @@ public class TestMainAction implements Runnable {
     private final TestClassProcessor processor;
     private final TestResultProcessor resultProcessor;
     private final Clock clock;
-    private final Object testTaskOperationId;
     private final Object rootTestSuiteId;
     private final String displayName;
 
-    public TestMainAction(Runnable detector, TestClassProcessor processor, TestResultProcessor resultProcessor, Clock clock, Object testTaskOperationId, Object rootTestSuiteId, String displayName) {
+    public TestMainAction(Runnable detector, TestClassProcessor processor, TestResultProcessor resultProcessor, Clock clock, Object rootTestSuiteId, String displayName) {
         this.detector = detector;
         this.processor = processor;
         this.resultProcessor = new AttachParentTestResultProcessor(resultProcessor);
         this.clock = clock;
-        this.testTaskOperationId = testTaskOperationId;
         this.rootTestSuiteId = rootTestSuiteId;
         this.displayName = displayName;
     }
 
     @Override
     public void run() {
-        RootTestSuiteDescriptor suite = new RootTestSuiteDescriptor(rootTestSuiteId, displayName, testTaskOperationId);
+        TestDescriptorInternal suite = new RootTestSuiteDescriptor(rootTestSuiteId, displayName);
         resultProcessor.started(suite, new TestStartEvent(clock.getCurrentTime()));
         try {
             processor.startProcessing(resultProcessor);
@@ -61,18 +60,15 @@ public class TestMainAction implements Runnable {
         }
     }
 
-    public static final class RootTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
-        private final Object testTaskOperationId;
-
-        private RootTestSuiteDescriptor(Object id, String name, Object testTaskOperationId) {
+    private static final class RootTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
+        private RootTestSuiteDescriptor(Object id, String name) {
             super(id, name);
-            this.testTaskOperationId = testTaskOperationId;
         }
 
         @Nullable
         @Override
         public Object getOwnerBuildOperationId() {
-            return testTaskOperationId;
+            return null;
         }
 
         @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -25,8 +25,6 @@ import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor;
 import org.gradle.internal.time.Clock;
 
-import javax.annotation.Nullable;
-
 public class TestMainAction implements Runnable {
     private final Runnable detector;
     private final TestClassProcessor processor;
@@ -63,12 +61,6 @@ public class TestMainAction implements Runnable {
     private static final class RootTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
         private RootTestSuiteDescriptor(Object id, String name) {
             super(id, name);
-        }
-
-        @Nullable
-        @Override
-        public Object getOwnerBuildOperationId() {
-            return null;
         }
 
         @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -17,8 +17,6 @@ package org.gradle.api.internal.tasks.testing.results;
 
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 
-import javax.annotation.Nullable;
-
 public class UnknownTestDescriptor implements TestDescriptorInternal {
 
     @Override
@@ -43,12 +41,6 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
 
     @Override
     public TestDescriptorInternal getParent() {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
         return null;
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -24,7 +24,6 @@ class SimpleTestDescriptor implements TestDescriptorInternal {
     String classDisplayName = "ClassName"
     boolean composite = false
     TestDescriptorInternal parent = null
-    Object ownerBuildOperationId = null
     Object getId() {
         "${parent?.id}$className$name" as String
     }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
@@ -25,7 +25,7 @@ class TestMainActionTest extends Specification {
     private final TestResultProcessor resultProcessor = Mock()
     private final Runnable detector = Mock()
     private final Clock timeProvider = Mock()
-    private final TestMainAction action = new TestMainAction(detector, processor, resultProcessor, timeProvider, "taskOperationId123", "rootTestSuiteId456", "Test Run")
+    private final TestMainAction action = new TestMainAction(detector, processor, resultProcessor, timeProvider, "rootTestSuiteId456", "Test Run")
 
     def 'fires start and end events around detector execution'() {
         when:

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -37,7 +37,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -57,7 +56,6 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
     private final ActorFactory actorFactory;
     private final ModuleRegistry moduleRegistry;
     private final WorkerLeaseRegistry workerLeaseRegistry;
-    private final BuildOperationExecutor buildOperationExecutor;
     private final int maxWorkerCount;
     private final Clock clock;
     private final DocumentationRegistry documentationRegistry;
@@ -65,13 +63,12 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
     private TestClassProcessor processor;
 
     public DefaultTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory, ModuleRegistry moduleRegistry,
-                               WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, int maxWorkerCount,
+                               WorkerLeaseRegistry workerLeaseRegistry, int maxWorkerCount,
                                Clock clock, DocumentationRegistry documentationRegistry, DefaultTestFilter testFilter) {
         this.workerFactory = workerFactory;
         this.actorFactory = actorFactory;
         this.moduleRegistry = moduleRegistry;
         this.workerLeaseRegistry = workerLeaseRegistry;
-        this.buildOperationExecutor = buildOperationExecutor;
         this.maxWorkerCount = maxWorkerCount;
         this.clock = clock;
         this.documentationRegistry = documentationRegistry;
@@ -116,9 +113,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
             detector = new DefaultTestClassScanner(testClassFiles, null, processor);
         }
 
-        final Object testTaskOperationId = buildOperationExecutor.getCurrentOperation().getParentId();
-
-        new TestMainAction(detector, processor, testResultProcessor, clock, testTaskOperationId, testExecutionSpec.getPath(), "Gradle Test Run " + testExecutionSpec.getIdentityPath()).run();
+        new TestMainAction(detector, processor, testResultProcessor, clock, testExecutionSpec.getPath(), "Gradle Test Run " + testExecutionSpec.getIdentityPath()).run();
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -70,7 +70,6 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
@@ -692,7 +691,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         if (testExecuter == null) {
             return new DefaultTestExecuter(getProcessBuilderFactory(), getActorFactory(), getModuleRegistry(),
                 getServices().get(WorkerLeaseRegistry.class),
-                getServices().get(BuildOperationExecutor.class),
                 getServices().get(StartParameter.class).getMaxWorkerCount(),
                 getServices().get(Clock.class),
                 getServices().get(DocumentationRegistry.class),

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
@@ -28,7 +28,6 @@ import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.io.LineBufferingOutputStream;
 import org.gradle.internal.io.TextStream;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.ExecResult;
@@ -63,11 +62,6 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
         throw new UnsupportedOperationException();
     }
 
-    @Inject
-    public BuildOperationExecutor getBuildOperationExcecutor() {
-        throw new UnsupportedOperationException();
-    }
-
     public IdGenerator<?> getIdGenerator() {
         return new LongIdGenerator();
     }
@@ -93,9 +87,7 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
 
         Runnable detector = new XCTestDetector(processor, testExecutionSpec.getTestSelection());
 
-        Object testTaskOperationId = getBuildOperationExcecutor().getCurrentOperation().getParentId();
-
-        new TestMainAction(detector, processor, testResultProcessor, getTimeProvider(), testTaskOperationId, rootTestSuiteId, "Gradle Test Run " + testExecutionSpec.getPath()).run();
+        new TestMainAction(detector, processor, testResultProcessor, getTimeProvider(), rootTestSuiteId, "Gradle Test Run " + testExecutionSpec.getPath()).run();
     }
 
     @Override

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildOperationParentTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildOperationParentTracker.java
@@ -34,7 +34,7 @@ class BuildOperationParentTracker implements BuildOperationListener {
     private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<>();
 
     @Nullable
-    OperationIdentifier findClosestMatchingAncestor(OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
+    OperationIdentifier findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate) {
         if (id == null || predicate.test(id)) {
             return id;
         }
@@ -42,7 +42,7 @@ class BuildOperationParentTracker implements BuildOperationListener {
     }
 
     @Nullable
-    <T> T findClosestExistingAncestor(OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
+    <T> T findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction) {
         if (id == null) {
             return null;
         }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -121,8 +121,10 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         return new DefaultTestDescriptor(id, name, displayName, testKind, null, className, methodName, parentId, taskPath);
     }
 
+    @Nullable
     private String getTaskPath(OperationIdentifier buildOperationId) {
-        return ancestryTracker.findClosestExistingAncestor(buildOperationId, runningTasks::get);
+        return ancestryTracker.findClosestExistingAncestor(buildOperationId, runningTasks::get)
+            .orElse(null);
     }
 
     private Object getParentId(OperationIdentifier buildOperationId, TestDescriptorInternal descriptor) {
@@ -132,7 +134,8 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         }
         // only set the TaskOperation as the parent if the Tooling API Consumer is listening to task progress events
         if (clientSubscriptions.isRequested(OperationType.TASK)) {
-            return ancestryTracker.findClosestMatchingAncestor(buildOperationId, runningTasks::containsKey);
+            return ancestryTracker.findClosestMatchingAncestor(buildOperationId, runningTasks::containsKey)
+                .orElse(null);
         }
         return null;
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -23,14 +23,6 @@ import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperatio
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
-import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationListener;
-import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationIdentifier;
-import org.gradle.internal.operations.OperationProgressEvent;
-import org.gradle.internal.operations.OperationStartEvent;
-import org.gradle.tooling.events.OperationType;
-import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
 import org.gradle.internal.build.event.types.AbstractTestResult;
 import org.gradle.internal.build.event.types.DefaultFailure;
 import org.gradle.internal.build.event.types.DefaultTestDescriptor;
@@ -39,7 +31,16 @@ import org.gradle.internal.build.event.types.DefaultTestFinishedProgressEvent;
 import org.gradle.internal.build.event.types.DefaultTestSkippedResult;
 import org.gradle.internal.build.event.types.DefaultTestStartedProgressEvent;
 import org.gradle.internal.build.event.types.DefaultTestSuccessResult;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.events.OperationType;
+import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +51,13 @@ import java.util.Map;
 class ClientForwardingTestOperationListener implements BuildOperationListener {
 
     private final ProgressEventConsumer eventConsumer;
+    private final BuildOperationParentTracker parentTracker;
     private final BuildEventSubscriptions clientSubscriptions;
     private final Map<Object, String> runningTasks = Maps.newConcurrentMap();
 
-    ClientForwardingTestOperationListener(ProgressEventConsumer eventConsumer, BuildEventSubscriptions clientSubscriptions) {
+    ClientForwardingTestOperationListener(ProgressEventConsumer eventConsumer, BuildOperationParentTracker parentTracker, BuildEventSubscriptions clientSubscriptions) {
         this.eventConsumer = eventConsumer;
+        this.parentTracker = parentTracker;
         this.clientSubscriptions = clientSubscriptions;
     }
 
@@ -70,12 +73,12 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         } else if (details instanceof ExecuteTestBuildOperationType.Details) {
             ExecuteTestBuildOperationType.Details testOperationDetails = (ExecuteTestBuildOperationType.Details) details;
             TestDescriptorInternal testDescriptor = (TestDescriptorInternal) testOperationDetails.getTestDescriptor();
-            eventConsumer.started(new DefaultTestStartedProgressEvent(testOperationDetails.getStartTime(), adapt(testDescriptor)));
+            eventConsumer.started(new DefaultTestStartedProgressEvent(testOperationDetails.getStartTime(), adapt(buildOperation.getId(), testDescriptor)));
         }
     }
 
     @Override
-    public void progress(OperationIdentifier buildOperationId, OperationProgressEvent progressEvent) {
+    public void progress(@Nullable OperationIdentifier buildOperationId, OperationProgressEvent progressEvent) {
     }
 
     @Override
@@ -85,56 +88,50 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         } else if (finishEvent.getResult() instanceof ExecuteTestBuildOperationType.Result) {
             TestResult testResult = ((ExecuteTestBuildOperationType.Result) finishEvent.getResult()).getResult();
             TestDescriptorInternal testDescriptor = (TestDescriptorInternal) ((ExecuteTestBuildOperationType.Details) buildOperation.getDetails()).getTestDescriptor();
-            eventConsumer.finished(new DefaultTestFinishedProgressEvent(testResult.getEndTime(), adapt(testDescriptor), adapt(testResult)));
+            eventConsumer.finished(new DefaultTestFinishedProgressEvent(testResult.getEndTime(), adapt(buildOperation.getId(), testDescriptor), adapt(testResult)));
         }
     }
 
-    private DefaultTestDescriptor adapt(TestDescriptorInternal testDescriptor) {
-        return testDescriptor.isComposite() ? toTestDescriptorForSuite(testDescriptor) : toTestDescriptorForTest(testDescriptor);
+    private DefaultTestDescriptor adapt(OperationIdentifier buildOperationId, TestDescriptorInternal testDescriptor) {
+        return testDescriptor.isComposite() ? toTestDescriptorForSuite(buildOperationId, testDescriptor) : toTestDescriptorForTest(buildOperationId, testDescriptor);
     }
 
-    private DefaultTestDescriptor toTestDescriptorForSuite(TestDescriptorInternal suite) {
+    private DefaultTestDescriptor toTestDescriptorForSuite(OperationIdentifier buildOperationId, TestDescriptorInternal suite) {
         Object id = suite.getId();
         String name = suite.getName();
         String displayName = suite.toString();
         String testKind = InternalJvmTestDescriptor.KIND_SUITE;
-        String suiteName = suite.getName();
         String className = suite.getClassName();
         String methodName = null;
-        Object parentId = getParentId(suite);
-        final String testTaskPath = getTaskPath(suite);
-        return new DefaultTestDescriptor(id, name, displayName, testKind, suiteName, className, methodName, parentId, testTaskPath);
+        Object parentId = getParentId(buildOperationId, suite);
+        String testTaskPath = getTaskPath(buildOperationId);
+        return new DefaultTestDescriptor(id, name, displayName, testKind, suite.getName(), className, methodName, parentId, testTaskPath);
     }
 
-    private DefaultTestDescriptor toTestDescriptorForTest(TestDescriptorInternal test) {
+    private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, TestDescriptorInternal test) {
         Object id = test.getId();
         String name = test.getName();
         String displayName = test.toString();
         String testKind = InternalJvmTestDescriptor.KIND_ATOMIC;
-        String suiteName = null;
         String className = test.getClassName();
         String methodName = test.getName();
-        Object parentId = getParentId(test);
-        final String taskPath = getTaskPath(test);
-        return new DefaultTestDescriptor(id, name, displayName, testKind, suiteName, className, methodName, parentId, taskPath);
+        Object parentId = getParentId(buildOperationId, test);
+        String taskPath = getTaskPath(buildOperationId);
+        return new DefaultTestDescriptor(id, name, displayName, testKind, null, className, methodName, parentId, taskPath);
     }
 
-    private String getTaskPath(TestDescriptorInternal givenDescriptor) {
-        TestDescriptorInternal descriptor = givenDescriptor;
-        while (descriptor.getOwnerBuildOperationId() == null && descriptor.getParent() != null) {
-            descriptor = descriptor.getParent();
-        }
-        return runningTasks.get(descriptor.getOwnerBuildOperationId());
+    private String getTaskPath(OperationIdentifier buildOperationId) {
+        return parentTracker.findClosestExistingAncestor(buildOperationId, runningTasks::get);
     }
 
-    private Object getParentId(TestDescriptorInternal descriptor) {
+    private Object getParentId(OperationIdentifier buildOperationId, TestDescriptorInternal descriptor) {
         TestDescriptorInternal parent = descriptor.getParent();
         if (parent != null) {
             return parent.getId();
         }
         // only set the TaskOperation as the parent if the Tooling API Consumer is listening to task progress events
         if (clientSubscriptions.isRequested(OperationType.TASK)) {
-            return descriptor.getOwnerBuildOperationId();
+            return parentTracker.findClosestMatchingAncestor(buildOperationId, runningTasks::containsKey);
         }
         return null;
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
@@ -22,6 +22,9 @@ import org.gradle.api.internal.ExecuteDomainObjectCollectionCallbackBuildOperati
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType;
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType;
 import org.gradle.configuration.internal.ExecuteListenerBuildOperationType;
+import org.gradle.internal.build.event.types.DefaultBinaryPluginIdentifier;
+import org.gradle.internal.build.event.types.DefaultScriptPluginIdentifier;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
@@ -31,8 +34,6 @@ import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier;
-import org.gradle.internal.build.event.types.DefaultBinaryPluginIdentifier;
-import org.gradle.internal.build.event.types.DefaultScriptPluginIdentifier;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -48,10 +49,10 @@ class PluginApplicationTracker implements BuildOperationListener {
 
     private final Map<OperationIdentifier, PluginApplication> runningPluginApplications = new ConcurrentHashMap<>();
     private final Map<Long, PluginApplication> pluginApplicationRegistry = new ConcurrentHashMap<>();
-    private final BuildOperationParentTracker parentTracker;
+    private final BuildOperationAncestryTracker ancestryTracker;
 
-    PluginApplicationTracker(BuildOperationParentTracker parentTracker) {
-        this.parentTracker = parentTracker;
+    PluginApplicationTracker(BuildOperationAncestryTracker ancestryTracker) {
+        this.ancestryTracker = ancestryTracker;
     }
 
     @Nullable
@@ -60,7 +61,7 @@ class PluginApplicationTracker implements BuildOperationListener {
     }
 
     public boolean hasRunningPluginApplication(OperationIdentifier id, Predicate<? super PluginApplication> predicate) {
-        return parentTracker.findClosestMatchingAncestor(id, parent -> {
+        return ancestryTracker.findClosestMatchingAncestor(id, parent -> {
             PluginApplication pluginApplication = runningPluginApplications.get(parent);
             return pluginApplication != null && predicate.test(pluginApplication);
         }) != null;
@@ -68,7 +69,7 @@ class PluginApplicationTracker implements BuildOperationListener {
 
     @Nullable
     public PluginApplication findRunningPluginApplication(OperationIdentifier id) {
-        return parentTracker.findClosestExistingAncestor(id, runningPluginApplications::get);
+        return ancestryTracker.findClosestExistingAncestor(id, runningPluginApplications::get);
     }
 
     @Override

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
@@ -64,12 +64,13 @@ class PluginApplicationTracker implements BuildOperationListener {
         return ancestryTracker.findClosestMatchingAncestor(id, parent -> {
             PluginApplication pluginApplication = runningPluginApplications.get(parent);
             return pluginApplication != null && predicate.test(pluginApplication);
-        }) != null;
+        }).isPresent();
     }
 
     @Nullable
     public PluginApplication findRunningPluginApplication(OperationIdentifier id) {
-        return ancestryTracker.findClosestExistingAncestor(id, runningPluginApplications::get);
+        return ancestryTracker.findClosestExistingAncestor(id, runningPluginApplications::get)
+            .orElse(null);
     }
 
     @Override

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
@@ -19,10 +19,12 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalProgressEvent;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -37,8 +39,10 @@ class ProgressEventConsumer {
         this.ancestryTracker = ancestryTracker;
     }
 
-    Object findStartedParentId(BuildOperationDescriptor operation) {
-        return ancestryTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains);
+    @Nullable
+    OperationIdentifier findStartedParentId(BuildOperationDescriptor operation) {
+        return ancestryTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains)
+            .orElse(null);
     }
 
     void started(InternalOperationStartedProgressEvent event) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildEventConsumer;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
@@ -29,15 +30,15 @@ class ProgressEventConsumer {
 
     private final Set<Object> startedIds = ConcurrentHashMap.newKeySet();
     private final BuildEventConsumer delegate;
-    private final BuildOperationParentTracker parentTracker;
+    private final BuildOperationAncestryTracker ancestryTracker;
 
-    ProgressEventConsumer(BuildEventConsumer delegate, BuildOperationParentTracker parentTracker) {
+    ProgressEventConsumer(BuildEventConsumer delegate, BuildOperationAncestryTracker ancestryTracker) {
         this.delegate = delegate;
-        this.parentTracker = parentTracker;
+        this.ancestryTracker = ancestryTracker;
     }
 
     Object findStartedParentId(BuildOperationDescriptor operation) {
-        return parentTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains);
+        return ancestryTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains);
     }
 
     void started(InternalOperationStartedProgressEvent event) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
@@ -21,6 +21,7 @@ import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionException;
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
@@ -28,9 +29,14 @@ import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
 import java.util.Collections;
 
 public class TestExecutionRequestActionRunner implements BuildActionRunner {
+    private final BuildOperationAncestryTracker ancestryTracker;
     private final BuildOperationListenerManager buildOperationListenerManager;
 
-    public TestExecutionRequestActionRunner(BuildOperationListenerManager buildOperationListenerManager) {
+    public TestExecutionRequestActionRunner(
+        BuildOperationAncestryTracker ancestryTracker,
+        BuildOperationListenerManager buildOperationListenerManager
+    ) {
+        this.ancestryTracker = ancestryTracker;
         this.buildOperationListenerManager = buildOperationListenerManager;
     }
 
@@ -42,7 +48,7 @@ public class TestExecutionRequestActionRunner implements BuildActionRunner {
 
         try {
             TestExecutionRequestAction testExecutionRequestAction = (TestExecutionRequestAction) action;
-            TestExecutionResultEvaluator testExecutionResultEvaluator = new TestExecutionResultEvaluator(testExecutionRequestAction);
+            TestExecutionResultEvaluator testExecutionResultEvaluator = new TestExecutionResultEvaluator(ancestryTracker, testExecutionRequestAction);
             buildOperationListenerManager.addListener(testExecutionResultEvaluator);
             try {
                 doRun(testExecutionRequestAction, buildController);

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
@@ -21,6 +21,7 @@ import org.gradle.internal.build.event.BuildEventListenerFactory;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
 import org.gradle.internal.build.event.OperationResultPostProcessor;
 import org.gradle.internal.build.event.OperationResultPostProcessorFactory;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.BuildOperationListener;
@@ -36,10 +37,12 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 
 public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFactory {
+    private final BuildOperationAncestryTracker ancestryTracker;
     private final BuildOperationIdFactory idFactory;
     private final List<OperationResultPostProcessorFactory> postProcessorFactories;
 
-    ToolingApiBuildEventListenerFactory(BuildOperationIdFactory idFactory, List<OperationResultPostProcessorFactory> postProcessorFactories) {
+    ToolingApiBuildEventListenerFactory(BuildOperationAncestryTracker ancestryTracker, BuildOperationIdFactory idFactory, List<OperationResultPostProcessorFactory> postProcessorFactories) {
+        this.ancestryTracker = ancestryTracker;
         this.idFactory = idFactory;
         this.postProcessorFactories = postProcessorFactories;
     }
@@ -49,12 +52,11 @@ public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFa
         if (!subscriptions.isAnyOperationTypeRequested()) {
             return emptyList();
         }
-        BuildOperationParentTracker parentTracker = new BuildOperationParentTracker();
-        ProgressEventConsumer progressEventConsumer = new ProgressEventConsumer(consumer, parentTracker);
+        ProgressEventConsumer progressEventConsumer = new ProgressEventConsumer(consumer, ancestryTracker);
         List<Object> listeners = new ArrayList<>();
-        listeners.add(parentTracker);
+        listeners.add(ancestryTracker);
         if (subscriptions.isRequested(OperationType.TEST)) {
-            BuildOperationListener buildListener = new ClientForwardingTestOperationListener(progressEventConsumer, parentTracker, subscriptions);
+            BuildOperationListener buildListener = new ClientForwardingTestOperationListener(progressEventConsumer, ancestryTracker, subscriptions);
             if (subscriptions.isRequested(OperationType.TEST_OUTPUT)) {
                 buildListener = new ClientForwardingTestOutputOperationListener(buildListener, progressEventConsumer, idFactory);
             }
@@ -74,7 +76,7 @@ public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFa
                 operationDependenciesResolver.addLookup(transformOperationListener);
                 buildListener = transformOperationListener;
             }
-            PluginApplicationTracker pluginApplicationTracker = new PluginApplicationTracker(parentTracker);
+            PluginApplicationTracker pluginApplicationTracker = new PluginApplicationTracker(ancestryTracker);
             if (subscriptions.isAnyRequested(OperationType.PROJECT_CONFIGURATION, OperationType.TASK)) {
                 listeners.add(pluginApplicationTracker);
             }
@@ -95,7 +97,7 @@ public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFa
                 operationDependenciesResolver.addLookup(taskOperationListener);
                 buildListener = taskOperationListener;
             }
-            listeners.add(new ClientForwardingProjectConfigurationOperationListener(progressEventConsumer, subscriptions, buildListener, parentTracker, pluginApplicationTracker));
+            listeners.add(new ClientForwardingProjectConfigurationOperationListener(progressEventConsumer, subscriptions, buildListener, ancestryTracker, pluginApplicationTracker));
         }
         return listeners;
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
@@ -54,7 +54,7 @@ public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFa
         List<Object> listeners = new ArrayList<>();
         listeners.add(parentTracker);
         if (subscriptions.isRequested(OperationType.TEST)) {
-            BuildOperationListener buildListener = new ClientForwardingTestOperationListener(progressEventConsumer, subscriptions);
+            BuildOperationListener buildListener = new ClientForwardingTestOperationListener(progressEventConsumer, parentTracker, subscriptions);
             if (subscriptions.isRequested(OperationType.TEST_OUTPUT)) {
                 buildListener = new ClientForwardingTestOutputOperationListener(buildListener, progressEventConsumer, idFactory);
             }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -33,11 +33,14 @@ public class ToolingBuilderServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.addProvider(new Object() {
-            BuildActionRunner createBuildActionRunner(final BuildOperationListenerManager buildOperationListenerManager) {
+            BuildActionRunner createBuildActionRunner(
+                BuildOperationAncestryTracker ancestryTracker,
+                BuildOperationListenerManager buildOperationListenerManager
+            ) {
                 return new ChainingBuildActionRunner(
                     Arrays.asList(
                         new BuildModelActionRunner(),
-                        new TestExecutionRequestActionRunner(buildOperationListenerManager),
+                        new TestExecutionRequestActionRunner(ancestryTracker, buildOperationListenerManager),
                         new ClientProvidedBuildActionRunner(),
                         new ClientProvidedPhasedActionRunner()));
             }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -19,6 +19,7 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.internal.build.event.BuildEventListenerFactory;
 import org.gradle.internal.build.event.OperationResultPostProcessorFactory;
 import org.gradle.internal.invocation.BuildActionRunner;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.service.ServiceRegistration;
@@ -41,8 +42,12 @@ public class ToolingBuilderServices extends AbstractPluginServiceRegistry {
                         new ClientProvidedPhasedActionRunner()));
             }
 
-            BuildEventListenerFactory createToolingApiSubscribableBuildActionRunnerRegistration(BuildOperationIdFactory buildOperationIdFactory, List<OperationResultPostProcessorFactory> postProcessorFactories) {
-                return new ToolingApiBuildEventListenerFactory(buildOperationIdFactory, postProcessorFactories);
+            BuildEventListenerFactory createToolingApiSubscribableBuildActionRunnerRegistration(
+                BuildOperationAncestryTracker ancestryTracker,
+                BuildOperationIdFactory buildOperationIdFactory,
+                List<OperationResultPostProcessorFactory> postProcessorFactories
+            ) {
+                return new ToolingApiBuildEventListenerFactory(ancestryTracker, buildOperationIdFactory, postProcessorFactories);
             }
         });
     }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.provider.runner
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.invocation.BuildController
+import org.gradle.internal.operations.BuildOperationAncestryTracker
 import org.gradle.internal.operations.BuildOperationListenerManager
 import spock.lang.Specification
 
@@ -24,8 +25,7 @@ class TestExecutionRequestActionRunnerTest extends Specification {
 
     def "does not handle non TestExecutionRequestAction"(){
         given:
-        BuildOperationListenerManager buildOperationService = Mock(BuildOperationListenerManager)
-        def runner = new TestExecutionRequestActionRunner(buildOperationService)
+        def runner = new TestExecutionRequestActionRunner(Mock(BuildOperationAncestryTracker), Mock(BuildOperationListenerManager))
         BuildAction buildAction = Mock(BuildAction)
         BuildController buildController= Mock(BuildController)
         when:

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
@@ -16,20 +16,21 @@
 
 package org.gradle.tooling.internal.provider.runner
 
-import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
 import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperationType
 import org.gradle.api.tasks.testing.TestExecutionException
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.execution.plan.LocalTaskNode
+import org.gradle.internal.build.event.types.DefaultTestDescriptor
+import org.gradle.internal.operations.BuildOperationAncestryTracker
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationStartEvent
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction
-import org.gradle.internal.build.event.types.DefaultTestDescriptor
 import spock.lang.Specification
 
 import static org.gradle.util.TextUtil.normaliseLineSeparators
@@ -38,8 +39,9 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
     def "evaluate throws exception if no results tracked"() {
         given:
+        def ancestryTracker = Mock(BuildOperationAncestryTracker)
         def testExecutionRequest = Mock(TestExecutionRequestAction)
-        TestExecutionResultEvaluator evaluator = new TestExecutionResultEvaluator(testExecutionRequest)
+        TestExecutionResultEvaluator evaluator = new TestExecutionResultEvaluator(ancestryTracker, testExecutionRequest)
 
         def testDescriptorInternal = Mock(TestDescriptorInternal)
         def defaultTestDescriptor = Mock(DefaultTestDescriptor)
@@ -92,8 +94,10 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
     def "evaluate throws exception if test failed"() {
         given:
+        def ancestryTracker = Mock(BuildOperationAncestryTracker)
+        1 * ancestryTracker.findClosestExistingAncestor(_, _) >> Optional.of(":someproject:someTestTask")
         def testExecutionRequest = Mock(TestExecutionRequestAction)
-        TestExecutionResultEvaluator evaluator = new TestExecutionResultEvaluator(testExecutionRequest)
+        TestExecutionResultEvaluator evaluator = new TestExecutionResultEvaluator(ancestryTracker, testExecutionRequest)
 
         def testDescriptorInternal = Mock(TestDescriptorInternal)
 

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
@@ -103,7 +103,6 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
         testDescriptorInternal.getName() >> "someTest"
         testDescriptorInternal.getClassName() >> "acme.SomeTestClass"
-        testDescriptorInternal.getOwnerBuildOperationId() >> new OperationIdentifier(1)
 
         def testResult = Mock(TestResult)
         1 * testResult.getTestCount() >> 1

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
     def "generates events for interleaved project configuration and dependency resolution"() {
         given:
         settingsFile << """
-            
+
             rootProject.name = 'multi'
             include 'a', 'b'
         """
@@ -114,7 +114,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
             repositories {
                maven { url '${mavenHttpRepo.uri}' }
             }
-            
+
             dependencies {
                 implementation project(':a')
                 implementation "group:projectB:1.0"
@@ -260,7 +260,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         and:
         def compileJavaActions = events.operations.findAll { it.descriptor.displayName.matches('Execute .*( action [0-9]+/[0-9]+)? for :compileJava') }
         compileJavaActions.size() > 0
-        compileJavaActions[0].parent.descriptor.displayName == 'Task :compileJava'
+        compileJavaActions[0].hasAncestor { it.descriptor.displayName == 'Task :compileJava' }
     }
 
     @TargetGradleVersion('>=3.5 <5.1')

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -35,6 +35,8 @@ import org.gradle.tooling.events.transform.TransformOperationDescriptor
 import org.gradle.tooling.events.work.WorkItemOperationDescriptor
 import org.gradle.util.GradleVersion
 
+import java.util.function.Predicate
+
 class ProgressEvents implements ProgressListener {
     private final List<ProgressEvent> events = []
     private boolean dirty
@@ -437,9 +439,13 @@ class ProgressEvents implements ProgressListener {
         }
 
         boolean hasAncestor(Operation ancestor) {
+            return hasAncestor({ it == ancestor })
+        }
+
+        boolean hasAncestor(Predicate<? super Operation> predicate) {
             return parent == null
                 ? false
-                : (parent == ancestor || parent.hasAncestor(ancestor))
+                : (predicate.test(parent) || parent.hasAncestor(predicate))
         }
     }
 


### PR DESCRIPTION
So we can track execution times for all work in Gradle Profiler.

This is a precursor of the stable operation we'll add in https://github.com/gradle/gradle/issues/9117.

![image](https://user-images.githubusercontent.com/495366/94925814-1f485c80-04c0-11eb-8262-3b7dcf2284a9.png)
