### PR TITLE
Clean buildSrc before and after build on subst drive

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -71,7 +71,8 @@ class PerformanceTest(
             steps {
                 preBuildSteps()
                 killGradleProcessesStep(os)
-                substDirOnWindows(os)
+                substDirOnWindows(os, model.parentBuildCache)
+
                 gradleWrapper {
                     name = "GRADLE_RUNNER"
                     tasks = ""
@@ -88,7 +89,7 @@ class PerformanceTest(
                             model.parentBuildCache.gradleParameters(os)
                         ).joinToString(separator = " ")
                 }
-                removeSubstDirOnWindows(os)
+                removeSubstDirOnWindows(os, model.parentBuildCache)
                 checkCleanM2(os)
             }
         }

--- a/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/AdHocPerformanceScenario.kt
@@ -68,7 +68,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
 
     steps {
         killGradleProcessesStep(os)
-        substDirOnWindows(os)
+        substDirOnWindows(os, builtInRemoteBuildCacheNode)
         gradleWrapper {
             name = "GRADLE_RUNNER"
             workingDir = os.perfTestWorkingDir
@@ -83,7 +83,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
                     builtInRemoteBuildCacheNode.gradleParameters(os)
                 ).joinToString(separator = " ")
         }
-        removeSubstDirOnWindows(os)
+        removeSubstDirOnWindows(os, builtInRemoteBuildCacheNode)
         checkCleanM2(os)
     }
 })


### PR DESCRIPTION
Working on a substituted drive causes problems when there are changes in buildSrc between the build running on P: and the build running in the actual working directory. Gradle detects overlapping outputs and does not clean up old files.

See for example https://ge.gradle.org/s/nm7bkbc2mzkyk/timeline?cacheableFilter=overlapping_outputs&details=6qiisbnr3kyx6

Cleaning buildSrc should get rid of the overlapping files.