### PR TITLE
Remove Gradle 3.4 version check from performance test templates

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -52,7 +52,6 @@ abstract class FileContentGenerator {
         return """
         import org.gradle.util.GradleVersion
 
-        ${missingJavaLibrarySupportFlag()}
         ${noJavaLibraryPluginFlag()}
 
         ${config.plugins.collect { decideOnJavaPlugin(it, dependencyTree.hasParentProject(subProjectNumber)) }.join("\n        ")}
@@ -405,7 +404,7 @@ abstract class FileContentGenerator {
         if (plugin.contains('java')) {
             if (projectHasParents) {
                 return """
-                    if (missingJavaLibrarySupport || noJavaLibraryPlugin) {
+                    if (noJavaLibraryPlugin) {
                         ${imperativelyApplyPlugin("java")}
                     } else {
                         ${imperativelyApplyPlugin("java-library")}
@@ -462,8 +461,6 @@ abstract class FileContentGenerator {
                     <scope>$scope</scope>
                 </dependency>"""
     }
-
-    protected abstract String missingJavaLibrarySupportFlag()
 
     protected abstract String noJavaLibraryPluginFlag()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -435,7 +435,7 @@ abstract class FileContentGenerator {
                     $subProjectDependencies
         """
         return """
-            ${configurationsIfMissingJavaLibrarySupport(hasParent)}
+            ${addJavaLibraryConfigurationsIfNecessary(hasParent)}
             if (hasProperty("compileConfiguration")) {
                 dependencies {
                     ${block.replace(api, 'compile').replace(implementation, 'compile').replace(testImplementation, 'testCompile')}
@@ -470,7 +470,7 @@ abstract class FileContentGenerator {
 
     protected abstract String createTaskThatDependsOnAllIncludedBuildsTaskWithSameName(String taskName)
 
-    protected abstract String configurationsIfMissingJavaLibrarySupport(boolean hasParent)
+    protected abstract String addJavaLibraryConfigurationsIfNecessary(boolean hasParent)
 
     protected abstract String directDependencyDeclaration(String configuration, String notation)
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
@@ -99,7 +99,7 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
-    protected String configurationsIfMissingJavaLibrarySupport(boolean hasParent) {
+    protected String addJavaLibraryConfigurationsIfNecessary(boolean hasParent) {
         """
         if (noJavaLibraryPlugin) {
             configurations {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
@@ -37,11 +37,6 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
-    protected String missingJavaLibrarySupportFlag() {
-        "def missingJavaLibrarySupport = GradleVersion.current() < GradleVersion.version('3.4')"
-    }
-
-    @Override
     protected String noJavaLibraryPluginFlag() {
         "def noJavaLibraryPlugin = hasProperty('noJavaLibraryPlugin')"
     }
@@ -68,14 +63,14 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
             groovyOptions.forkOptions.memoryMaximumSize = compilerMemory
             groovyOptions.forkOptions.jvmArgs.addAll(javaCompileJvmArgs)
         }
-        
+
         tasks.withType(Test) {
             ${config.useTestNG ? 'useTestNG()' : ''}
             minHeapSize = testRunnerMemory
             maxHeapSize = testRunnerMemory
             maxParallelForks = ${config.maxParallelForks}
             forkEvery = testForkEvery
-            
+
             if (!JavaVersion.current().java8Compatible) {
                 jvmArgs '-XX:MaxPermSize=512m'
             }
@@ -106,16 +101,7 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
     @Override
     protected String configurationsIfMissingJavaLibrarySupport(boolean hasParent) {
         """
-        if (missingJavaLibrarySupport) {
-            configurations {
-                ${hasParent ? 'api' : ''}
-                implementation
-                testImplementation
-                ${hasParent ? 'compile.extendsFrom api' : ''}
-                compile.extendsFrom implementation
-                testCompile.extendsFrom testImplementation
-            }
-        } else if (noJavaLibraryPlugin) {
+        if (noJavaLibraryPlugin) {
             configurations {
                 ${hasParent ? 'api' : ''}
                 ${hasParent ? 'compile.extendsFrom api' : ''}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
@@ -86,7 +86,7 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
-    protected String configurationsIfMissingJavaLibrarySupport(boolean hasParent) {
+    protected String addJavaLibraryConfigurationsIfNecessary(boolean hasParent) {
         """
         if (noJavaLibraryPlugin) {
             configurations {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
@@ -27,11 +27,6 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
-    protected String missingJavaLibrarySupportFlag() {
-        'val missingJavaLibrarySupport = GradleVersion.current() < GradleVersion.version("3.4")'
-    }
-
-    @Override
     protected String noJavaLibraryPluginFlag() {
         'val noJavaLibraryPlugin = hasProperty("noJavaLibraryPlugin")'
     }
@@ -55,14 +50,14 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
             options.forkOptions.memoryInitialSize = compilerMemory
             options.forkOptions.memoryMaximumSize = compilerMemory
         }
-        
+
         tasks.withType<Test> {
             ${config.useTestNG ? 'useTestNG()' : ''}
             minHeapSize = testRunnerMemory
             maxHeapSize = testRunnerMemory
             maxParallelForks = ${config.maxParallelForks}
             setForkEvery(testForkEvery.toLong())
-            
+
             if (!JavaVersion.current().isJava8Compatible) {
                 jvmArgs("-XX:MaxPermSize=512m")
             }
@@ -93,16 +88,7 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
     @Override
     protected String configurationsIfMissingJavaLibrarySupport(boolean hasParent) {
         """
-        if (missingJavaLibrarySupport) {
-            configurations {
-                ${hasParent ? '"api"()' : ''}
-                "implementation"()
-                "testImplementation"()
-                ${hasParent ? '"compile" { extendsFrom(configurations["api"]) }' : ''}
-                "compile" { extendsFrom(configurations["implementation"]) }
-                "testCompile" { extendsFrom(configurations["testImplementation"]) }
-            }
-        } else if (noJavaLibraryPlugin) {
+        if (noJavaLibraryPlugin) {
             configurations {
                 ${hasParent ? '"api"()' : ''}
                 ${hasParent ? '"compile" { extendsFrom(configurations["api"]) }' : ''}


### PR DESCRIPTION
We no longer run historical performance tests against Gradle 3.4
