### PR TITLE
Synchronize access to provisioning within daemon

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
@@ -54,10 +54,10 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
     }
 
     public Optional<File> tryInstall(JavaToolchainSpec spec) {
+        if (!isAutoDownloadEnabled()) {
+            return Optional.empty();
+        }
         synchronized (provisioningProcessLock) {
-            if (!isAutoDownloadEnabled()) {
-                return Optional.empty();
-            }
             String destinationFilename = openJdkBinary.toFilename(spec);
             File destinationFile = cacheDirProvider.getDownloadLocation(destinationFilename);
             final FileLock fileLock = cacheDirProvider.acquireWriteLock(destinationFile, "Downloading toolchain");


### PR DESCRIPTION
In case that we try to provision a toolchain in parallel
(e.g. multiple projects at execution time ask for a toolchain tool).
