### PR TITLE
Follow up on allocating workspace in execution engine

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.FilePropertyContainer;
@@ -163,13 +162,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         Map<String, Object> result = new HashMap<>();
         for (InputPropertySpec inputProperty : visitor.getProperties()) {
-            String propertyName = inputProperty.getPropertyName();
-            try {
-                Object value = InputParameterUtils.prepareInputParameterValue(inputProperty.getValue());
-                result.put(propertyName, value);
-            } catch (Exception ex) {
-                throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", propertyName, task), ex);
-            }
+            result.put(inputProperty.getPropertyName(), InputParameterUtils.prepareInputParameterValue(inputProperty, task));
         }
         return Collections.unmodifiableMap(result);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.file.FileCollection;
@@ -305,12 +304,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             }
             ImmutableSortedSet<InputPropertySpec> inputProperties = context.getTaskProperties().getInputProperties();
             for (InputPropertySpec inputProperty : inputProperties) {
-                Object value;
-                try {
-                    value = InputParameterUtils.prepareInputParameterValue(inputProperty.getValue());
-                } catch (Exception ex) {
-                    throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", inputProperty.getPropertyName(), task), ex);
-                }
+                Object value = InputParameterUtils.prepareInputParameterValue(inputProperty, task);
                 visitor.visitInputProperty(inputProperty.getPropertyName(), value);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -298,22 +298,15 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public void visitInputProperties(Set<IdentityKind> filter, InputPropertyVisitor visitor) {
-            if (!filter.contains(NON_IDENTITY)) {
-                return;
-            }
+        public void visitInputProperties(InputPropertyVisitor visitor) {
             ImmutableSortedSet<InputPropertySpec> inputProperties = context.getTaskProperties().getInputProperties();
             for (InputPropertySpec inputProperty : inputProperties) {
-                Object value = InputParameterUtils.prepareInputParameterValue(inputProperty, task);
-                visitor.visitInputProperty(inputProperty.getPropertyName(), () -> value);
+                visitor.visitInputProperty(inputProperty.getPropertyName(), NON_IDENTITY, () -> InputParameterUtils.prepareInputParameterValue(inputProperty, task));
             }
         }
 
         @Override
-        public void visitInputFileProperties(Set<IdentityKind> filter, InputFilePropertyVisitor visitor) {
-            if (!filter.contains(NON_IDENTITY)) {
-                return;
-            }
+        public void visitInputFileProperties(InputFilePropertyVisitor visitor) {
             ImmutableSortedSet<InputFilePropertySpec> inputFileProperties = context.getTaskProperties().getInputFileProperties();
             for (InputFilePropertySpec inputFileProperty : inputFileProperties) {
                 Object value = inputFileProperty.getValue();
@@ -326,7 +319,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                         ? InputPropertyType.INCREMENTAL
                         : InputPropertyType.NON_INCREMENTAL;
                 String propertyName = inputFileProperty.getPropertyName();
-                visitor.visitInputFileProperty(propertyName, value, type, () -> {
+                visitor.visitInputFileProperty(propertyName, type, NON_IDENTITY, value, () -> {
                     FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(inputFileProperty.getNormalizer());
                     return fingerprinter.fingerprint(inputFileProperty.getPropertyFiles());
                 });

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -305,7 +305,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             ImmutableSortedSet<InputPropertySpec> inputProperties = context.getTaskProperties().getInputProperties();
             for (InputPropertySpec inputProperty : inputProperties) {
                 Object value = InputParameterUtils.prepareInputParameterValue(inputProperty, task);
-                visitor.visitInputProperty(inputProperty.getPropertyName(), value);
+                visitor.visitInputProperty(inputProperty.getPropertyName(), () -> value);
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
@@ -17,12 +17,24 @@
 package org.gradle.api.internal.tasks.properties;
 
 import groovy.lang.GString;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.util.DeferredUtil;
 
 import javax.annotation.Nullable;
 
 public class InputParameterUtils {
+    @Nullable
+    public static Object prepareInputParameterValue(InputPropertySpec inputProperty, Task task) {
+        String propertyName = inputProperty.getPropertyName();
+        try {
+            return prepareInputParameterValue(inputProperty.getValue());
+        } catch (Exception ex) {
+            throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", propertyName, task), ex);
+        }
+    }
+
     @Nullable
     public static Object prepareInputParameterValue(@Nullable Object value) {
         Object unpacked = DeferredUtil.unpack(value);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -379,7 +379,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
                 return;
             }
             // Emulate secondary inputs as a single property for now
-            visitor.visitInputProperty(SECONDARY_INPUTS_HASH_PROPERTY_NAME, transformer.getSecondaryInputHash().toString());
+            visitor.visitInputProperty(SECONDARY_INPUTS_HASH_PROPERTY_NAME, () -> transformer.getSecondaryInputHash().toString());
         }
 
         @Override

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -797,25 +797,20 @@ class IncrementalExecutionIntegrationTest extends Specification {
                 }
 
                 @Override
-                void visitInputProperties(Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputPropertyVisitor visitor) {
-                    if (!filter.contains(NON_IDENTITY)) {
-                        return
-                    }
+                void visitInputProperties(UnitOfWork.InputPropertyVisitor visitor) {
                     inputProperties.each { propertyName, value ->
-                        visitor.visitInputProperty(propertyName, { -> value } as UnitOfWork.ValueSupplier)
+                        visitor.visitInputProperty(propertyName, NON_IDENTITY, { -> value } as UnitOfWork.ValueSupplier)
                     }
                 }
 
                 @Override
-                void visitInputFileProperties(Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputFilePropertyVisitor visitor) {
-                    if (!filter.contains(NON_IDENTITY)) {
-                        return
-                    }
+                void visitInputFileProperties(UnitOfWork.InputFilePropertyVisitor visitor) {
                     for (entry in inputs.entrySet()) {
                         visitor.visitInputFileProperty(
                             entry.key,
-                            entry.value,
                             NON_INCREMENTAL,
+                            NON_IDENTITY,
+                            entry.value,
                             { -> fingerprinter.fingerprint(TestFiles.fixed(entry.value)) }
                         )
                     }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -802,7 +802,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
                         return
                     }
                     inputProperties.each { propertyName, value ->
-                        visitor.visitInputProperty(propertyName, value)
+                        visitor.visitInputProperty(propertyName, { -> value } as UnitOfWork.ValueSupplier)
                     }
                 }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -111,7 +111,7 @@ public interface UnitOfWork extends Describable {
 
     interface ValueSupplier {
         @Nullable
-        Object resolveValue();
+        Object getValue();
     }
 
     void visitInputFileProperties(InputFilePropertyVisitor visitor);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 
 public interface UnitOfWork extends Describable {
@@ -104,10 +103,10 @@ public interface UnitOfWork extends Describable {
         void visitAdditionalImplementation(ImplementationSnapshot implementation);
     }
 
-    void visitInputProperties(Set<IdentityKind> filter, InputPropertyVisitor visitor);
+    void visitInputProperties(InputPropertyVisitor visitor);
 
     interface InputPropertyVisitor {
-        void visitInputProperty(String propertyName, ValueSupplier value);
+        void visitInputProperty(String propertyName, IdentityKind identity, ValueSupplier value);
     }
 
     interface ValueSupplier {
@@ -115,10 +114,10 @@ public interface UnitOfWork extends Describable {
         Object resolveValue();
     }
 
-    void visitInputFileProperties(Set<IdentityKind> filter, InputFilePropertyVisitor visitor);
+    void visitInputFileProperties(InputFilePropertyVisitor visitor);
 
     interface InputFilePropertyVisitor {
-        void visitInputFileProperty(String propertyName, @Nullable Object value, InputPropertyType type, Supplier<CurrentFileCollectionFingerprint> fingerprinter);
+        void visitInputFileProperty(String propertyName, InputPropertyType type, IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter);
     }
 
     enum InputPropertyType {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -107,7 +107,12 @@ public interface UnitOfWork extends Describable {
     void visitInputProperties(Set<IdentityKind> filter, InputPropertyVisitor visitor);
 
     interface InputPropertyVisitor {
-        void visitInputProperty(String propertyName, @Nullable Object value);
+        void visitInputProperty(String propertyName, ValueSupplier value);
+    }
+
+    interface ValueSupplier {
+        @Nullable
+        Object resolveValue();
     }
 
     void visitInputFileProperties(Set<IdentityKind> filter, InputFilePropertyVisitor visitor);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
@@ -41,17 +41,17 @@ public class InputFingerprintUtil {
             if (!filter.include(propertyName, identity)) {
                 return;
             }
+            Object actualValue = value.getValue();
             try {
                 ValueSnapshot previousSnapshot = previousSnapshots.get(propertyName);
-                Object resolvedValue = value.resolveValue();
                 if (previousSnapshot == null) {
-                    builder.put(propertyName, valueSnapshotter.snapshot(resolvedValue));
+                    builder.put(propertyName, valueSnapshotter.snapshot(actualValue));
                 } else {
-                    builder.put(propertyName, valueSnapshotter.snapshot(resolvedValue, previousSnapshot));
+                    builder.put(propertyName, valueSnapshotter.snapshot(actualValue, previousSnapshot));
                 }
             } catch (Exception e) {
                 throw new UncheckedIOException(String.format("Unable to store input properties for %s. Property '%s' with value '%s' cannot be serialized.",
-                    work.getDisplayName(), propertyName, value), e);
+                    work.getDisplayName(), propertyName, value.getValue()), e);
             }
         });
         return builder.build();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
@@ -42,10 +42,11 @@ public class InputFingerprintUtil {
             }
             try {
                 ValueSnapshot previousSnapshot = previousSnapshots.get(propertyName);
+                Object resolvedValue = value.resolveValue();
                 if (previousSnapshot == null) {
-                    builder.put(propertyName, valueSnapshotter.snapshot(value));
+                    builder.put(propertyName, valueSnapshotter.snapshot(resolvedValue));
                 } else {
-                    builder.put(propertyName, valueSnapshotter.snapshot(value, previousSnapshot));
+                    builder.put(propertyName, valueSnapshotter.snapshot(resolvedValue, previousSnapshot));
                 }
             } catch (Exception e) {
                 throw new UncheckedIOException(String.format("Unable to store input properties for %s. Property '%s' with value '%s' cannot be serialized.",

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
@@ -17,10 +17,8 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.gradle.internal.execution.AfterPreviousExecutionContext;
 import org.gradle.internal.execution.BeforeExecutionContext;
 import org.gradle.internal.execution.CachingResult;
@@ -59,7 +57,6 @@ import static org.gradle.internal.execution.impl.InputFingerprintUtil.fingerprin
 
 public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPreviousExecutionContext, CachingResult> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CaptureStateBeforeExecutionStep.class);
-    private static final ImmutableSet<UnitOfWork.IdentityKind> NON_IDENTITY_FILTER = Sets.immutableEnumSet(NON_IDENTITY);
 
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final OutputSnapshotter outputSnapshotter;
@@ -186,11 +183,11 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPre
             previousInputProperties,
             valueSnapshotter,
             context.getInputProperties(),
-            NON_IDENTITY_FILTER);
+            (propertyName, identity) -> identity == NON_IDENTITY);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints = fingerprintInputFiles(
             work,
             context.getInputFileProperties(),
-            NON_IDENTITY_FILTER);
+            (propertyName, type, identity) -> identity == NON_IDENTITY);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFileFingerprints = fingerprintOutputFiles(
             outputSnapshotsAfterPreviousExecution,
             outputFileSnapshots,

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -17,9 +17,7 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.cache.Cache;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Sets;
 import org.gradle.internal.Try;
 import org.gradle.internal.execution.DeferredExecutionAwareStep;
 import org.gradle.internal.execution.DeferredResultProcessor;
@@ -40,8 +38,6 @@ import static org.gradle.internal.execution.impl.InputFingerprintUtil.fingerprin
 import static org.gradle.internal.execution.impl.InputFingerprintUtil.fingerprintInputProperties;
 
 public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> implements DeferredExecutionAwareStep<C, R> {
-    public static final ImmutableSet<UnitOfWork.IdentityKind> IDENTITY_FILTER = Sets.immutableEnumSet(IDENTITY);
-
     private final DeferredExecutionAwareStep<? super IdentityContext, R> delegate;
     private final ValueSnapshotter valueSnapshotter;
 
@@ -70,11 +66,11 @@ public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> i
             ImmutableSortedMap.of(),
             valueSnapshotter,
             ImmutableSortedMap.of(),
-            IDENTITY_FILTER);
+            (propertyName, identity) -> identity == IDENTITY);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = fingerprintInputFiles(
             context.getWork(),
             ImmutableSortedMap.of(),
-            IDENTITY_FILTER);
+            (propertyName, type, identity) -> identity == IDENTITY);
         Identity identity = context.getWork().identify(identityInputProperties, identityInputFileProperties);
         return new IdentityContext() {
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -17,9 +17,7 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Sets;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.internal.execution.CachingContext;
 import org.gradle.internal.execution.IncrementalChangesContext;
@@ -38,12 +36,10 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
 import java.io.File;
-import java.util.EnumSet;
 import java.util.Optional;
 
 public class ResolveChangesStep<R extends Result> implements Step<CachingContext, R> {
     private static final String NO_HISTORY = "No history is available.";
-    private static final ImmutableSet<UnitOfWork.IdentityKind> ALL_PROPERTIES_FILTER = Sets.immutableEnumSet(EnumSet.allOf(UnitOfWork.IdentityKind.class));
 
     private final ExecutionStateChangeDetector changeDetector;
 
@@ -146,7 +142,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                 return IncrementalInputProperties.ALL;
             case INCREMENTAL_PARAMETERS:
                 ImmutableBiMap.Builder<String, Object> builder = ImmutableBiMap.builder();
-                work.visitInputFileProperties(ALL_PROPERTIES_FILTER, (propertyName, value, type, fingerprinter) -> {
+                work.visitInputFileProperties((propertyName, type, identity, value, fingerprinter) -> {
                     if (type.isIncremental()) {
                         if (value == null) {
                             throw new InvalidUserDataException("Must specify a value for incremental input property '" + propertyName + "'.");

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -111,9 +111,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         when:
         step.execute(context)
         then:
-        _ * work.visitInputProperties(_, _) >> { Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputPropertyVisitor visitor ->
-            assert filter == [NON_IDENTITY] as Set
-            visitor.visitInputProperty("inputString", inputPropertyValue)
+        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+            visitor.visitInputProperty("inputString", NON_IDENTITY) { inputPropertyValue }
         }
         1 * valueSnapshotter.snapshot(inputPropertyValue) >> valueSnapshot
         interaction { fingerprintInputs() }
@@ -138,9 +137,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
         1 * afterPreviousExecutionState.inputProperties >> ImmutableSortedMap.<String, ValueSnapshot>of("inputString", valueSnapshot)
         1 * afterPreviousExecutionState.outputFileProperties >> ImmutableSortedMap.<String, FileCollectionFingerprint>of()
-        _ * work.visitInputProperties(_, _) >> { Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputPropertyVisitor visitor ->
-            assert filter == [NON_IDENTITY] as Set
-            visitor.visitInputProperty("inputString", inputPropertyValue)
+        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+            visitor.visitInputProperty("inputString", NON_IDENTITY) { inputPropertyValue }
         }
         1 * valueSnapshotter.snapshot(inputPropertyValue, valueSnapshot) >> valueSnapshot
         interaction { fingerprintInputs() }
@@ -161,9 +159,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         step.execute(context)
 
         then:
-        _ * work.visitInputFileProperties(_, _) >> { Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputFilePropertyVisitor visitor ->
-            assert filter == [NON_IDENTITY] as Set
-            visitor.visitInputFileProperty("inputFile", "ignored", NON_INCREMENTAL, { -> fingerprint })
+        _ * work.visitInputFileProperties(_) >> { UnitOfWork.InputFilePropertyVisitor visitor ->
+            visitor.visitInputFileProperty("inputFile", NON_INCREMENTAL, NON_IDENTITY, "ignored", { -> fingerprint })
         }
         interaction { fingerprintInputs() }
         1 * delegate.execute(_) >> { BeforeExecutionContext beforeExecution ->
@@ -290,12 +287,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         _ * work.visitImplementations(_ as UnitOfWork.ImplementationVisitor) >> { UnitOfWork.ImplementationVisitor visitor ->
             visitor.visitImplementation(implementationSnapshot)
         }
-        _ * work.visitInputProperties(_, _) >> { Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputPropertyVisitor visitor ->
-            assert filter == [NON_IDENTITY] as Set
-        }
-        _ * work.visitInputFileProperties(_, _) >> { Set<UnitOfWork.IdentityKind> filter, UnitOfWork.InputFilePropertyVisitor visitor ->
-            assert filter == [NON_IDENTITY] as Set
-        }
+        _ * work.visitInputProperties(_ as UnitOfWork.InputPropertyVisitor)
+        _ * work.visitInputFileProperties(_ as UnitOfWork.InputFilePropertyVisitor)
         _ * work.overlappingOutputHandling >> IGNORE_OVERLAPS
         _ * outputSnapshotter.snapshotOutputs(work, _) >> ImmutableSortedMap.of()
         _ * context.history >> Optional.of(executionHistoryStore)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -156,7 +156,7 @@ class GenerateProjectAccessors(
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
 
-    override fun <T : Any?> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
+    override fun <T : Any> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
         workspaceProvider.withWorkspace("$accessorsWorkspacePrefix/$identity") { workspace, _ ->
             action.executeInWorkspace(workspace)
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -26,10 +26,11 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
+import org.gradle.internal.execution.UnitOfWork.InputPropertyType.NON_INCREMENTAL
 import org.gradle.internal.execution.WorkExecutor
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.changes.InputChangesInternal
-import org.gradle.internal.file.TreeType
+import org.gradle.internal.file.TreeType.DIRECTORY
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter
 import org.gradle.internal.hash.HashCode
@@ -150,9 +151,7 @@ class GenerateProjectAccessors(
         requireNotNull(identityInputs[PROJECT_SCHEMA_INPUT_PROPERTY]).appendToHasher(hasher)
         hasher.putHash(requireNotNull(identityFileInputs[CLASSPATH_INPUT_PROPERTY]).hash)
         val identityHash = hasher.hash().toString()
-        return object : UnitOfWork.Identity {
-            override fun getUniqueId() = identityHash
-        }
+        return UnitOfWork.Identity { identityHash }
     }
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
@@ -170,25 +169,21 @@ class GenerateProjectAccessors(
         visitor.visitImplementation(GenerateProjectAccessors::class.java)
     }
 
-    override fun visitInputProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputPropertyVisitor) {
-        if (filter.contains(IDENTITY)) {
-            visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY) { -> hashCodeFor(projectSchema) }
-        }
+    override fun visitInputProperties(visitor: UnitOfWork.InputPropertyVisitor) {
+        visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY, IDENTITY) { hashCodeFor(projectSchema) }
     }
 
-    override fun visitInputFileProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputFilePropertyVisitor) {
-        if (filter.contains(IDENTITY)) {
-            visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, classPath, UnitOfWork.InputPropertyType.NON_INCREMENTAL) {
-                classpathFingerprinter.fingerprint(fileCollectionFactory.fixed(classPath.asFiles))
-            }
+    override fun visitInputFileProperties(visitor: UnitOfWork.InputFilePropertyVisitor) {
+        visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, NON_INCREMENTAL, IDENTITY, classPath) {
+            classpathFingerprinter.fingerprint(fileCollectionFactory.fixed(classPath.asFiles))
         }
     }
 
     override fun visitOutputProperties(workspace: File, visitor: UnitOfWork.OutputPropertyVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
-        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, TreeType.DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))
-        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, TreeType.DIRECTORY, classesOutputDir, fileCollectionFactory.fixed(classesOutputDir))
+        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))
+        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, classesOutputDir, fileCollectionFactory.fixed(classesOutputDir))
     }
 }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -172,7 +172,7 @@ class GenerateProjectAccessors(
 
     override fun visitInputProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputPropertyVisitor) {
         if (filter.contains(IDENTITY)) {
-            visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY, hashCodeFor(projectSchema))
+            visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY) { -> hashCodeFor(projectSchema) }
         }
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -155,7 +155,7 @@ class GeneratePluginAccessors(
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
 
-    override fun <T : Any?> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
+    override fun <T : Any> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
         workspaceProvider.withWorkspace("$accessorsWorkspacePrefix/$identity") { workspace, _ ->
             action.executeInWorkspace(workspace)
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -172,7 +172,7 @@ class GeneratePluginAccessors(
 
     override fun visitInputProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputPropertyVisitor) {
         if (filter.contains(IDENTITY)) {
-            visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY, classLoaderHash)
+            visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY) { -> classLoaderHash }
         }
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -32,7 +32,7 @@ import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
 import org.gradle.internal.execution.WorkExecutor
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.changes.InputChangesInternal
-import org.gradle.internal.file.TreeType
+import org.gradle.internal.file.TreeType.DIRECTORY
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
@@ -151,9 +151,7 @@ class GeneratePluginAccessors(
         DefaultClassPath.of(getSourcesOutputDir(workspace))
     )
 
-    override fun identify(identityInputs: MutableMap<String, ValueSnapshot>, identityFileInputs: MutableMap<String, CurrentFileCollectionFingerprint>) = object : UnitOfWork.Identity {
-        override fun getUniqueId() = classLoaderHash.toString()
-    }
+    override fun identify(identityInputs: MutableMap<String, ValueSnapshot>, identityFileInputs: MutableMap<String, CurrentFileCollectionFingerprint>) = UnitOfWork.Identity { classLoaderHash.toString() }
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
 
@@ -170,19 +168,17 @@ class GeneratePluginAccessors(
         visitor.visitImplementation(GeneratePluginAccessors::class.java)
     }
 
-    override fun visitInputProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputPropertyVisitor) {
-        if (filter.contains(IDENTITY)) {
-            visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY) { -> classLoaderHash }
-        }
+    override fun visitInputProperties(visitor: UnitOfWork.InputPropertyVisitor) {
+        visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY, IDENTITY) { classLoaderHash }
     }
 
-    override fun visitInputFileProperties(filter: Set<UnitOfWork.IdentityKind>, visitor: UnitOfWork.InputFilePropertyVisitor) = Unit
+    override fun visitInputFileProperties(visitor: UnitOfWork.InputFilePropertyVisitor) = Unit
 
     override fun visitOutputProperties(workspace: File, visitor: UnitOfWork.OutputPropertyVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
-        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, TreeType.DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))
-        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, TreeType.DIRECTORY, classesOutputDir, fileCollectionFactory.fixed(classesOutputDir))
+        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))
+        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, classesOutputDir, fileCollectionFactory.fixed(classesOutputDir))
     }
 }
 


### PR DESCRIPTION
Following up on https://github.com/gradle/gradle/pull/14691:

- [x] Revert ec776737efe90ba1e5954d52f718753c0dc9e46a as it leads to too eager resolution of input properties
- [x] Replace `EnumSet` parameter in `UnitOfWork.visitInput*Properites()` with separate methods
- [x] Add integration test for identity cache in `:execution`
