### PR TITLE
Let the Gradle build accept a property defining the Kotlin version to use for building

### DIFF
--- a/buildSrc/subprojects/build-platform/build.gradle.kts
+++ b/buildSrc/subprojects/build-platform/build.gradle.kts
@@ -22,6 +22,10 @@ plugins {
 val javaParserVersion = "3.6.11"
 val asmVersion = "7.1"
 
+val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
+    .forUseAtConfigurationTime()
+    .getOrElse(embeddedKotlinVersion)
+
 dependencies {
     constraints {
         // Gradle Plugins
@@ -33,6 +37,7 @@ dependencies {
         api("me.champeau.gradle:jmh-gradle-plugin:0.5.2")
         api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
         api("org.gradle:test-retry-gradle-plugin:1.1.7")
+        api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.6.0")
 
         // Java Libraries

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ org.gradle.vfs.verbose=true
 
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
+
+kotlin.stdlib.default.dependency=false

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -366,13 +366,13 @@ fun <T : Any, U : NamedDomainObjectCollection<T>> U.getting(configuration: T.() 
 /**
  * Enables typed access to container elements via delegated properties.
  */
-class NamedDomainObjectCollectionDelegateProvider<T>
+class NamedDomainObjectCollectionDelegateProvider<T : Any>
 private constructor(
     internal val collection: NamedDomainObjectCollection<T>,
     internal val configuration: (T.() -> Unit)?
 ) {
     companion object {
-        fun <T> of(
+        fun <T : Any> of(
             collection: NamedDomainObjectCollection<T>,
             configuration: (T.() -> Unit)? = null
         ) =

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -218,7 +218,7 @@ inline fun <reified T> Project.container(): NamedDomainObjectContainer<T> =
  *
  * @see [Project.container]
  */
-inline fun <reified T> Project.container(noinline factory: (String) -> T): NamedDomainObjectContainer<T> =
+inline fun <reified T : Any> Project.container(noinline factory: (String) -> T): NamedDomainObjectContainer<T> =
     container(T::class.java, factory)
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -157,7 +157,7 @@ class GenerateProjectAccessors(
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
 
-    override fun <T : Any?> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
+    override fun <T : Any> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
         workspaceProvider.withWorkspace("$accessorsWorkspacePrefix/$identity") { workspace, _ ->
             action.executeInWorkspace(workspace)
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -157,7 +157,7 @@ class GeneratePluginAccessors(
 
     override fun getHistory(): Optional<ExecutionHistoryStore> = Optional.of(executionHistoryStore)
 
-    override fun <T : Any?> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
+    override fun <T : Any> withWorkspace(identity: String, action: UnitOfWork.WorkspaceAction<T>): T =
         workspaceProvider.withWorkspace("$accessorsWorkspacePrefix/$identity") { workspace, _ ->
             action.executeInWorkspace(workspace)
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
@@ -38,7 +38,7 @@ import java.util.SortedSet
  *
  * See [GradleDelegate] for why this is currently necessary.
  */
-abstract class NamedDomainObjectContainerDelegate<T> : NamedDomainObjectContainer<T> {
+abstract class NamedDomainObjectContainerDelegate<T : Any> : NamedDomainObjectContainer<T> {
 
     internal
     abstract val delegate: NamedDomainObjectContainer<T>

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
@@ -60,7 +60,7 @@ class ComponentSelectionRulesTest {
     }
 
     private
-    fun <E> InvocationOnMock.executeActionOn(element: E): Any? {
+    fun <E : Any> InvocationOnMock.executeActionOn(element: E): Any? {
         getArgument<Action<E>>(0).execute(element)
         return mock
     }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -570,7 +570,7 @@ class NamedDomainObjectCollectionExtensionsTest {
 
 
 internal
-fun <T> KStubbing<NamedDomainObjectContainer<T>>.onCreateWithAction(name: String, domainObject: T) {
+fun <T : Any> KStubbing<NamedDomainObjectContainer<T>>.onCreateWithAction(name: String, domainObject: T) {
     on { create(eq(name), any<Action<T>>()) } doAnswer {
         it.getArgument<Action<T>>(1).execute(domainObject)
         domainObject
@@ -579,7 +579,7 @@ fun <T> KStubbing<NamedDomainObjectContainer<T>>.onCreateWithAction(name: String
 
 
 internal
-fun <T> KStubbing<NamedDomainObjectContainer<T>>.onRegisterWithAction(name: String, provider: NamedDomainObjectProvider<T>) {
+fun <T : Any> KStubbing<NamedDomainObjectContainer<T>>.onRegisterWithAction(name: String, provider: NamedDomainObjectProvider<T>) {
     on { register(eq(name), any<Action<T>>()) } doAnswer {
         it.getArgument<Action<T>>(1).execute(provider.get())
         provider

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -39,6 +39,8 @@ class NamedDomainObjectContainerExtensionsTest {
             on { maybeCreate("john") } doReturn john
             on { named("marty") } doReturn marty
             on { register("doc") } doReturn doc
+            on { getByName(eq("alice"), any<Action<DomainObject>>()) } doReturn alice
+            on { create(eq("bob"), any<Action<DomainObject>>()) } doReturn bob
         }
 
         // regular syntax
@@ -83,6 +85,7 @@ class NamedDomainObjectContainerExtensionsTest {
             on { getByName("alice") } doReturn alice
             on { maybeCreate("alice", DomainObjectBase.Foo::class.java) } doReturn alice
             on { create(eq("bob"), eq(DomainObjectBase.Bar::class.java), any<Action<DomainObjectBase.Bar>>()) } doReturn bob
+            on { create("john") } doReturn default
             on { create("john", DomainObjectBase.Default::class.java) } doReturn default
             onNamedWithAction("marty", DomainObjectBase.Foo::class, martyProvider)
             on { register(eq("doc"), eq(DomainObjectBase.Bar::class.java)) } doReturn docProviderAsBarProvider

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
@@ -93,7 +93,7 @@ class RepositoryHandlerExtensionsTest {
     }
 
     private
-    fun <T> InvocationOnMock.configureWithAction(repository: T): T = repository.also {
+    fun <T : Any> InvocationOnMock.configureWithAction(repository: T): T = repository.also {
         getArgument<Action<T>>(0).execute(it)
     }
 }


### PR DESCRIPTION
This PR adds a Gradle property to the build of Gradle in order to allow defining the Kotlin version to use for building.
This allows us to try EAP and development versions of Kotlin against the build of Gradle.

Other commits fix compilation warnings emitted by Kotlin 1.4.20.