### PR TITLE
Implement performance test checking non-abi change in buildSrc

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -148,6 +148,18 @@
     "linux" : 235000
   } ]
 }, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1002000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1558000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 235000
+  } ]
+}, {
   "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -1302,6 +1302,29 @@
             ]
         },
         {
+            "testId" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
+            "groups" : [
+                {
+                    "testProject" : "mediumMonolithicJavaProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProjectKotlinDsl",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
             "testId" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.first use",
             "groups" : [
                 {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -44,7 +44,7 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
 
         and:
         def changingClassFilePath = "buildSrc/src/main/groovy/ChangingClass.groovy"
-        runner.addBuildMutator(createChangingClassInBuildSrcBeforeScenario(changingClassFilePath))
+        runner.addBuildMutator { createChangingClass(it, changingClassFilePath) }
         runner.addBuildMutator { new ApplyAbiChangeToGroovySourceFileMutator(new File(it.projectDir, changingClassFilePath)) }
 
         when:
@@ -61,7 +61,7 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
 
         and:
         def changingClassFilePath = "buildSrc/src/main/groovy/ChangingClass.groovy"
-        runner.addBuildMutator(createChangingClassInBuildSrcBeforeScenario(changingClassFilePath))
+        runner.addBuildMutator { createChangingClass(changingClassFilePath) }
         runner.addBuildMutator { new ApplyNonAbiChangeToGroovySourceFileMutator(new File(it.projectDir, changingClassFilePath)) }
     }
 
@@ -78,24 +78,19 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
         }
     }
 
-    static Function<InvocationSettings, BuildMutator> createChangingClassInBuildSrcBeforeScenario(String filePath) {
-         new Function<InvocationSettings, BuildMutator>() {
+    static BuildMutator createChangingClass(InvocationSettings settings, String filePath) {
+         new BuildMutator() {
              @Override
-             BuildMutator apply(InvocationSettings settings) {
-                 new BuildMutator() {
-                     @Override
-                     void beforeScenario(ScenarioContext context) {
-                         new File(settings.projectDir, filePath).tap {
-                             parentFile.mkdirs()
-                             text = """
-                                 class ChangingClass {
-                                     void changingMethod() {
-                                         System.out.println("Do the thing");
-                                     }
-                                 }
-                             """
+             void beforeScenario(ScenarioContext context) {
+                 new File(settings.projectDir, filePath).tap {
+                     parentFile.mkdirs()
+                     text = """
+                         class ChangingClass {
+                             void changingMethod() {
+                                 System.out.println("Do the thing");
+                             }
                          }
-                     }
+                     """
                  }
              }
          }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -78,13 +78,6 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
         }
     }
 
-    private static void writeFile(File file, String content) {
-        file.tap {
-            parentFile.mkdirs()
-            text = content
-        }
-    }
-
     static Function<InvocationSettings, BuildMutator> createChangingClassInBuildSrcBeforeScenario(String filePath) {
          new Function<InvocationSettings, BuildMutator>() {
              @Override
@@ -92,13 +85,16 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
                  new BuildMutator() {
                      @Override
                      void beforeScenario(ScenarioContext context) {
-                         writeFile(new File(settings.projectDir, filePath), """
-                             class ChangingClass {
-                                 void changingMethod() {
-                                     System.out.println("Do the thing");
+                         new File(settings.projectDir, filePath).tap {
+                             parentFile.mkdirs()
+                             text = """
+                                 class ChangingClass {
+                                     void changingMethod() {
+                                         System.out.println("Do the thing");
+                                     }
                                  }
-                             }
-                        """)
+                             """
+                         }
                      }
                  }
              }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.performance.regression.inception
 
-
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.gradle.performance.mutator.ApplyAbiChangeToGroovySourceFileMutator
@@ -25,8 +24,6 @@ import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.ScenarioContext
 import org.gradle.util.GradleVersion
 import org.junit.experimental.categories.Category
-
-import java.util.function.Function
 
 @Category(SlowPerformanceRegressionTest)
 class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTest {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -72,7 +72,7 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
                 void beforeScenario(ScenarioContext context) {
                     writeFile(changingClassFilePath, """
                         class ChangingClass {
-                            void changingMethod${context.phase}${context.iteration}() {
+                            void changingMethod() {
                                 System.out.println("Do the thing");
                             }
                         }
@@ -83,7 +83,7 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
                 void beforeBuild(BuildContext context) {
                     writeFile(changingClassFilePath, """
                         class ChangingClass {
-                            void changingMethod${context.phase}${context.iteration}() {
+                            void changingMethod() {
                                 System.out.println("Do the other thing");
                             }
                         }


### PR DESCRIPTION
This PR adds performance test coverage for the use-case when the build sources change but the abi stays intact.