### PR TITLE
Introduce API to declare consistency between configurations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
@@ -539,4 +540,19 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      */
     boolean isCanBeResolved();
 
+    /**
+     * Tells that this configuration, when resolved, should resolve versions consistently
+     * from the resolution result of another resolvable configuration. For example, it's
+     * expected that the versions of the runtime classpath are the same as the versions
+     * from the compile classpath.
+     *
+     * Setting to null would disable any previously configured consistency source.
+     *
+     * @param versionsSource another resolvable configuration to use as reference for versions
+     * @return this configuration
+     *
+     * @since 6.8
+     */
+    @Incubating
+    Configuration resolveConsistentlyWith(@Nullable Configuration versionsSource);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -546,13 +546,19 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * expected that the versions of the runtime classpath are the same as the versions
      * from the compile classpath.
      *
-     * Setting to null would disable any previously configured consistency source.
-     *
      * @param versionsSource another resolvable configuration to use as reference for versions
      * @return this configuration
      *
      * @since 6.8
      */
     @Incubating
-    Configuration resolveConsistentlyWith(@Nullable Configuration versionsSource);
+    Configuration shouldResolveConsistentlyWith(Configuration versionsSource);
+
+    /**
+     * Disables consistent resolution for this configuration
+     *
+     * @since 6.8
+     */
+    @Incubating
+    Configuration disableConsistentResolution();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
@@ -48,6 +48,14 @@ class DefaultDependencyConstraintTest extends Specification {
         return new DefaultDependencyConstraint(group, name, version)
     }
 
+    def "creates a strict version"() {
+        when:
+        def constraint = DefaultDependencyConstraint.strictly("org", "foo", "1.0")
+
+        then:
+        constraint.versionConstraint.strictVersion == '1.0'
+    }
+
     def "creates deep copy"() {
         when:
         def copy = dependencyConstraint.copy() as DependencyConstraint

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.consistency
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
@@ -62,6 +63,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         }
     }
 
+    @ToBeFixedForConfigurationCache(because = "dependency resolution errors are not supported by the CC")
     def "fails if there's a conflict between a first level dependency version and a strict version from consistency"() {
         repository {
             'org:foo:1.0'()
@@ -222,6 +224,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         }
     }
 
+    @ToBeFixedForConfigurationCache(because = "dependency resolution errors are not supported by the CC")
     def "detects cycles in consistency"() {
         repository {
             'org:foo:1.0'()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.consistency
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+// Limit the combinations of tests since we're only interested in the consistency
+// behavior, not actual metadata
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends AbstractModuleDependencyResolveTest {
+    def "can declare consistency between two configurations"() {
+        repository {
+            'org:foo:1.1'()
+        }
+
+        buildFile << """
+            configurations {
+                other
+                conf.resolveConsistentlyWith(other)
+            }
+
+            dependencies {
+                conf 'org:foo:1.0'
+                other 'org:foo:1.1'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.1' {
+                expectResolve()
+            }
+        }
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:foo:1.0', 'org:foo:1.1') {
+                    byConstraint("version resolved in configuration ':other' by consistent resolution")
+                }
+                constraint("org:foo:{strictly 1.1}", "org:foo:1.1")
+            }
+        }
+    }
+
+    def "fails if there's a conflict between a first level dependency version and a strict version from consistency"() {
+        repository {
+            'org:foo:1.0'()
+            'org:foo:1.1'()
+        }
+
+        buildFile << """
+            configurations {
+                other
+                conf.resolveConsistentlyWith(other)
+            }
+
+            dependencies {
+                conf 'org:foo:1.1'
+                other 'org:foo:1.0'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+            'org:foo:1.1' {
+                expectGetMetadata()
+            }
+        }
+        fails 'checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
+   Dependency path ':test:unspecified' --> 'org:foo:1.1'
+   Constraint path ':test:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: version resolved in configuration ':other' by consistent resolution"""
+    }
+
+    def "first level dependency can be downgraded only if it's a preferred version"() {
+        repository {
+            'org:foo:1.0'()
+            'org:foo:1.1'()
+        }
+
+        buildFile << """
+            configurations {
+                other
+                conf.resolveConsistentlyWith(other)
+            }
+
+            dependencies {
+                conf('org:foo') {
+                    version {
+                        prefer '1.1'
+                    }
+                }
+                other 'org:foo:1.0'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+            }
+        }
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:foo:{prefer 1.1}', 'org:foo:1.0') {
+                    byConstraint("version resolved in configuration ':other' by consistent resolution")
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+            }
+        }
+    }
+
+    def "a transitive dependency may be downgraded by consistent resolution"() {
+        repository {
+            'org:foo:1.0' {
+                dependsOn 'org:fooA:1.0'
+            }
+            'org:bar:1.0' {
+                dependsOn 'org:barA:1.0'
+            }
+            'org:fooA:1.0' {
+                dependsOn 'org:transitive:1.0'
+            }
+            'org:barA:1.0' {
+                dependsOn 'org:transitive:2.0'
+            }
+            'org:transitive:1.0'()
+            'org:transitive:2.0'()
+        }
+
+        buildFile << """
+            configurations {
+                implementation
+                runtimeOnly.extendsFrom(implementation)
+                compileClasspath.extendsFrom(implementation)
+                runtimeClasspath.extendsFrom(implementation, runtimeOnly)
+                runtimeClasspath {
+                   resolveConsistentlyWith(compileClasspath)
+                }
+            }
+
+            dependencies {
+                implementation 'org:foo:1.0'
+                runtimeOnly 'org:bar:1.0'
+            }
+        """
+        def resolve = new ResolveTestFixture(buildFile, "runtimeClasspath")
+        resolve.expectDefaultConfiguration("runtime")
+        resolve.prepare()
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+            }
+            'org:bar:1.0' {
+                expectResolve()
+            }
+            'org:fooA:1.0' {
+                expectResolve()
+            }
+            'org:barA:1.0' {
+                expectResolve()
+            }
+            'org:transitive:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0') {
+                    byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                    module('org:fooA:1.0') {
+                        byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                        module("org:transitive:1.0") {
+                            byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                        }
+                    }
+                }
+                module('org:bar:1.0') {
+                    module('org:barA:1.0') {
+                        edge("org:transitive:2.0", "org:transitive:1.0") {
+                            byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                        }
+                    }
+                }
+                // The following constraints come from the compile classpath configuration resolution result
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+                constraint("org:fooA:{strictly 1.0}", "org:fooA:1.0")
+                constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
+            }
+        }
+    }
+
+    def "detects cycles in consistency"() {
+        repository {
+            'org:foo:1.0'()
+            'org:foo:1.1'()
+        }
+        buildFile << """
+            configurations {
+                other.resolveConsistentlyWith(another)
+                another.resolveConsistentlyWith(conf)
+                conf.resolveConsistentlyWith(other)
+            }
+
+            dependencies {
+                conf 'org:foo:1.0'
+                other 'org:foo:1.1'
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause 'Cycle detected in consistent resolution sources: conf -> other -> another -> conf'
+    }
+
+    def "resolution rules have higher priority than consistency"() {
+        repository {
+            'org:foo:1.0'()
+            'org:foo:1.1'()
+            'org:foo:1.2'()
+        }
+
+        buildFile << """
+            configurations {
+                other
+                conf.resolveConsistentlyWith(other)
+
+                conf.resolutionStrategy.eachDependency { details ->
+                    if (details.requested.name == 'foo') {
+                        details.useVersion '1.2'
+                    }
+                }
+            }
+
+            dependencies {
+                conf 'org:foo:1.1'
+                other 'org:foo:1.0'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+            'org:foo:1.2' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:foo:1.1', 'org:foo:1.2') {
+                    selectedByRule()
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.2")
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         buildFile << """
             configurations {
                 other
-                conf.resolveConsistentlyWith(other)
+                conf.shouldResolveConsistentlyWith(other)
             }
 
             dependencies {
@@ -56,7 +56,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         resolve.expectGraph {
             root(':', ':test:') {
                 edge('org:foo:1.0', 'org:foo:1.1') {
-                    byConstraint("version resolved in configuration ':other' by consistent resolution")
+                    byConsistentResolution('other')
                 }
                 constraint("org:foo:{strictly 1.1}", "org:foo:1.1")
             }
@@ -73,7 +73,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         buildFile << """
             configurations {
                 other
-                conf.resolveConsistentlyWith(other)
+                conf.shouldResolveConsistentlyWith(other)
             }
 
             dependencies {
@@ -108,7 +108,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         buildFile << """
             configurations {
                 other
-                conf.resolveConsistentlyWith(other)
+                conf.shouldResolveConsistentlyWith(other)
             }
 
             dependencies {
@@ -133,7 +133,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         resolve.expectGraph {
             root(':', ':test:') {
                 edge('org:foo:{prefer 1.1}', 'org:foo:1.0') {
-                    byConstraint("version resolved in configuration ':other' by consistent resolution")
+                    byConsistentResolution('other')
                 }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
             }
@@ -165,7 +165,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
                 compileClasspath.extendsFrom(implementation)
                 runtimeClasspath.extendsFrom(implementation, runtimeOnly)
                 runtimeClasspath {
-                   resolveConsistentlyWith(compileClasspath)
+                   shouldResolveConsistentlyWith(compileClasspath)
                 }
             }
 
@@ -201,18 +201,18 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:foo:1.0') {
-                    byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                    byConsistentResolution('compileClasspath')
                     module('org:fooA:1.0') {
-                        byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                        byConsistentResolution('compileClasspath')
                         module("org:transitive:1.0") {
-                            byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                            byConsistentResolution('compileClasspath')
                         }
                     }
                 }
                 module('org:bar:1.0') {
                     module('org:barA:1.0') {
                         edge("org:transitive:2.0", "org:transitive:1.0") {
-                            byConstraint("version resolved in configuration ':compileClasspath' by consistent resolution")
+                            byConsistentResolution('compileClasspath')
                         }
                     }
                 }
@@ -232,9 +232,9 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         }
         buildFile << """
             configurations {
-                other.resolveConsistentlyWith(another)
-                another.resolveConsistentlyWith(conf)
-                conf.resolveConsistentlyWith(other)
+                other.shouldResolveConsistentlyWith(another)
+                another.shouldResolveConsistentlyWith(conf)
+                conf.shouldResolveConsistentlyWith(other)
             }
 
             dependencies {
@@ -260,7 +260,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         buildFile << """
             configurations {
                 other
-                conf.resolveConsistentlyWith(other)
+                conf.shouldResolveConsistentlyWith(other)
 
                 conf.resolutionStrategy.eachDependency { details ->
                     if (details.requested.name == 'foo') {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
@@ -43,9 +43,14 @@ public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<De
     }
 
     @Override
-    public boolean add(final DependencyConstraint dependencyConstraints) {
+    public boolean add(final DependencyConstraint dependencyConstraint) {
         warnIfConfigurationIsDeprecated();
-        return super.add(dependencyConstraints);
+        return addInternalDependencyConstraint(dependencyConstraint);
+    }
+
+    // For internal use only, allows adding a dependency constraint without issuing a deprecation warning
+    public boolean addInternalDependencyConstraint(DependencyConstraint dependencyConstraint) {
+        return super.add(dependencyConstraint);
     }
 
     private void warnIfConfigurationIsDeprecated() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -27,6 +27,7 @@ import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
 
@@ -85,6 +86,9 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     Set<ExcludeRule> getAllExcludeRules();
 
     ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver();
+
+    @Nullable
+    ConfigurationInternal getConsistentResolutionSource();
 
     interface VariantVisitor {
         // The artifacts to use when this configuration is used as a configuration

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -712,10 +712,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private void registerConsistentResolutionConstraint(ResolvedComponentResult result) {
         if (result.getId() instanceof ModuleComponentIdentifier) {
             ModuleVersionIdentifier moduleVersion = result.getModuleVersion();
-            DefaultDependencyConstraint constraint = DefaultDependencyConstraint.of(
+            DefaultDependencyConstraint constraint = DefaultDependencyConstraint.strictly(
                 moduleVersion.getGroup(),
                 moduleVersion.getName(),
-                vc -> vc.strictly(moduleVersion.getVersion()));
+                moduleVersion.getVersion());
             constraint.because(consistentResolutionReason);
             this.dependencyConstraints.addInternalDependencyConstraint(constraint);
         }
@@ -1427,9 +1427,16 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public Configuration resolveConsistentlyWith(Configuration versionsSource) {
+    public Configuration shouldResolveConsistentlyWith(Configuration versionsSource) {
         this.consistentResolutionSource = (ConfigurationInternal) versionsSource;
         this.consistentResolutionReason = "version resolved in " + versionsSource + " by consistent resolution";
+        return this;
+    }
+
+    @Override
+    public Configuration disableConsistentResolution() {
+        this.consistentResolutionSource = null;
+        this.consistentResolutionReason = null;
         return this;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -24,6 +24,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
@@ -36,6 +37,7 @@ import org.gradle.api.artifacts.DependencyConstraintSet;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.artifacts.ResolutionStrategy;
@@ -43,6 +45,7 @@ import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
@@ -128,6 +131,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED;
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED;
@@ -219,6 +223,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private List<String> resolutionAlternatives;
 
     private final CalculatedModelValue<ResolveState> currentResolveState;
+
+    private ConfigurationInternal consistentResolutionSource;
+    private String consistentResolutionReason;
 
     public DefaultConfiguration(DomainObjectContext domainObjectContext,
                                 String name,
@@ -611,6 +618,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
                 ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) getIncoming();
                 performPreResolveActions(incoming);
+                maybeConfigureConsistentResolution();
                 DefaultResolverResults results = new DefaultResolverResults();
                 resolver.resolveGraph(DefaultConfiguration.this, results);
                 dependenciesModified = false;
@@ -668,6 +676,49 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                     ));
             }
         });
+    }
+
+    @Override
+    public ConfigurationInternal getConsistentResolutionSource() {
+        return consistentResolutionSource;
+    }
+
+    private void maybeConfigureConsistentResolution() {
+        if (consistentResolutionSource != null) {
+            assertThatConsistentResolutionIsPropertyConfigured();
+            consistentResolutionSource.getIncoming().getResolutionResult().allComponents(this::registerConsistentResolutionConstraint);
+        }
+    }
+
+    private void assertThatConsistentResolutionIsPropertyConfigured() {
+        if (!consistentResolutionSource.isCanBeResolved()) {
+            throw new InvalidUserCodeException("You can't use " + consistentResolutionSource + " as a consistent resolution source for " + this + " because it isn't a resolvable configuration.");
+        }
+        assertNoDependencyResolutionConsistencyCycle();
+    }
+
+    private void assertNoDependencyResolutionConsistencyCycle() {
+        Set<ConfigurationInternal> sources = Sets.newLinkedHashSet();
+        ConfigurationInternal src = this;
+        while (src != null) {
+            if (!sources.add(src)) {
+                String cycle = sources.stream().map(Configuration::getName).collect(Collectors.joining(" -> ")) + " -> " + getName();
+                throw new InvalidUserDataException("Cycle detected in consistent resolution sources: " + cycle);
+            }
+            src = src.getConsistentResolutionSource();
+        }
+    }
+
+    private void registerConsistentResolutionConstraint(ResolvedComponentResult result) {
+        if (result.getId() instanceof ModuleComponentIdentifier) {
+            ModuleVersionIdentifier moduleVersion = result.getModuleVersion();
+            DefaultDependencyConstraint constraint = DefaultDependencyConstraint.of(
+                moduleVersion.getGroup(),
+                moduleVersion.getName(),
+                vc -> vc.strictly(moduleVersion.getVersion()));
+            constraint.because(consistentResolutionReason);
+            this.dependencyConstraints.addInternalDependencyConstraint(constraint);
+        }
     }
 
     private void performPreResolveActions(ResolvableDependencies incoming) {
@@ -986,16 +1037,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private DefaultConfiguration createCopy(Set<Dependency> dependencies, Set<DependencyConstraint> dependencyConstraints) {
-        DetachedConfigurationsProvider configurationsProvider = new DetachedConfigurationsProvider();
-        RootComponentMetadataBuilder rootComponentMetadataBuilder = this.rootComponentMetadataBuilder.withConfigurationsProvider(configurationsProvider);
-
-        String newName = getNameWithCopySuffix();
-
-        Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
-        DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName,
-            configurationsProvider, resolver, listenerManager, metaDataProvider, childResolutionStrategy, projectAccessListener, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory,
-            rootComponentMetadataBuilder, documentationRegistry, userCodeApplicationContext, owner, projectStateRegistry, domainObjectCollectionFactory);
-        configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
+        DefaultConfiguration copiedConfiguration = newConfiguration();
         // state, cachedResolvedConfiguration, and extendsFrom intentionally not copied - must re-resolve copy
         // copying extendsFrom could mess up dependencies when copy was re-resolved
 
@@ -1034,6 +1076,20 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         for (DependencyConstraint dependencyConstraint : dependencyConstraints) {
             copiedDependencyConstraints.add(((DefaultDependencyConstraint) dependencyConstraint).copy());
         }
+        return copiedConfiguration;
+    }
+
+    private DefaultConfiguration newConfiguration() {
+        DetachedConfigurationsProvider configurationsProvider = new DetachedConfigurationsProvider();
+        RootComponentMetadataBuilder rootComponentMetadataBuilder = this.rootComponentMetadataBuilder.withConfigurationsProvider(configurationsProvider);
+
+        String newName = getNameWithCopySuffix();
+
+        Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
+        DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName,
+            configurationsProvider, resolver, listenerManager, metaDataProvider, childResolutionStrategy, projectAccessListener, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory,
+            rootComponentMetadataBuilder, documentationRegistry, userCodeApplicationContext, owner, projectStateRegistry, domainObjectCollectionFactory);
+        configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
         return copiedConfiguration;
     }
 
@@ -1367,6 +1423,13 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public DeprecatableConfiguration deprecateForResolution(String... alternativesForResolving) {
         this.resolutionAlternatives = ImmutableList.copyOf(alternativesForResolving);
+        return this;
+    }
+
+    @Override
+    public Configuration resolveConsistentlyWith(Configuration versionsSource) {
+        this.consistentResolutionSource = (ConfigurationInternal) versionsSource;
+        this.consistentResolutionReason = "version resolved in " + versionsSource + " by consistent resolution";
         return this;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -52,6 +52,12 @@ public class DefaultDependencyConstraint implements DependencyConstraintInternal
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
     }
 
+    public static DefaultDependencyConstraint of(String group, String name, Action<? super MutableVersionConstraint> versionSpec) {
+        DefaultMutableVersionConstraint versionConstraint = new DefaultMutableVersionConstraint((String) null);
+        versionSpec.execute(versionConstraint);
+        return new DefaultDependencyConstraint(DefaultModuleIdentifier.newId(group, name), versionConstraint);
+    }
+
     private DefaultDependencyConstraint(ModuleIdentifier module, MutableVersionConstraint versionConstraint) {
         this.moduleIdentifier = module;
         this.versionConstraint = versionConstraint;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -52,9 +52,9 @@ public class DefaultDependencyConstraint implements DependencyConstraintInternal
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
     }
 
-    public static DefaultDependencyConstraint of(String group, String name, Action<? super MutableVersionConstraint> versionSpec) {
+    public static DefaultDependencyConstraint strictly(String group, String name, String strictVersion) {
         DefaultMutableVersionConstraint versionConstraint = new DefaultMutableVersionConstraint((String) null);
-        versionSpec.execute(versionConstraint);
+        versionConstraint.strictly(strictVersion);
         return new DefaultDependencyConstraint(DefaultModuleIdentifier.newId(group, name), versionConstraint);
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -805,6 +805,10 @@ allprojects {
             byReason(ComponentSelectionCause.BY_ANCESTOR.defaultReason)
         }
 
+        NodeBuilder byConsistentResolution(String source) {
+            byConstraint("version resolved in configuration ':$source' by consistent resolution")
+        }
+
         /**
          * Marks that this node was selected by the given reason
          */


### PR DESCRIPTION
## Project local dependency resolution consistency

This commit introduces a new method on the `Configuration` interface,
which lets the user declare that it should resolve consistenly with
another configuration.

The relationship between two configurations is directed. In other words,
"A must resolve consistenly with B" means that the reference is B.
When A is going to be resolved, we start with resolving B, then inject
strict dependencies on the resolved versions of B into A.

For example, `runtimeClasspath.resolveConsistentlyWith(compileClasspath)`
means that the compile classpath is the reference. That is to say, you
expect that the versions of dependencies you use at compile time will
be the ones found at runtime.

There's only one "source" of consistency for a configuration. It is
expected that the consistency source is also resolvable, but it doesn't
have to use the same attributes for resolution. In the example above,
we resolve the "compile classpath" which would typically resolve using
the usage=JAVA_API attribute, collect the resolved dependency versions,
then inject the result to the runtime classpath configuration as
constraints, but runtime classpath would use usage=JAVA_RUNTIME.

Because we use strict dependencies under the hood, it means that:

- a conflict on first level dependencies would trigger a build failure
- a transitive dependency can be downgraded if the reference version
is lower

In any case, we're using regular constraints, which means that all
selectors are used during resolution, and that an incompatible selector
would trigger an error that the user would have to fix.
