### PR TITLE
Suppress deprecation warnings in precompiled script plugin accessors

### DIFF
--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -62,6 +62,20 @@ import java.io.File
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest() {
 
+    @Test
+    @ToBeFixedForConfigurationCache
+    fun `generated type-safe accessors suppress deprecation warnings`() {
+        // `java-gradle-plugin` adds deprecated task `ValidateTaskProperties`
+        givenPrecompiledKotlinScript(
+            "java-project.gradle.kts",
+            """
+            plugins { `java-gradle-plugin` }
+            """
+        ).apply {
+            assertNotOutput("'ValidateTaskProperties' is deprecated.")
+        }
+    }
+
     @ToBeFixedForConfigurationCache
     @Test
     fun `can use type-safe accessors for plugin relying on gradleProperty provider`() {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/SourceFileHeader.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/SourceFileHeader.kt
@@ -34,7 +34,8 @@ fun fileHeaderFor(packageName: String) =
     "extension_shadowed_by_member",
     "redundant_projection",
     "RemoveRedundantBackticks",
-    "ObjectPropertyName"
+    "ObjectPropertyName",
+    "deprecation"
 )
 @file:org.gradle.api.Generated
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -66,7 +66,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
             ClassAndGroovyNamedArguments::class
         ) {
 
-            assertGeneratedJarHash("13a7ea47a1a16ebc7f420c9ad6d39c30")
+            assertGeneratedJarHash("b5b74390c5fd73a35a56879a8a667f62")
         }
     }
 

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -128,10 +128,10 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     }
 
     protected
-    fun givenPrecompiledKotlinScript(fileName: String, code: String) {
+    fun givenPrecompiledKotlinScript(fileName: String, code: String): ExecutionResult {
         withKotlinDslPlugin()
         withPrecompiledKotlinScript(fileName, code)
-        compileKotlin()
+        return compileKotlin()
     }
 
     protected


### PR DESCRIPTION
Fixes #11408
Fixes #13326
