### PR TITLE
Expand example for implementing tasks/plugins accepting a toolchain

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -149,12 +149,11 @@ org.gradle.java.installations.paths=/custom/path/jdk1.8,/shared/jre11
 [[sec:plugins]]
 == Toolchains for plugin authors
 
-For plugin authors, custom tasks that require a tool from the JDK should expose a `Property<T>` with the desired tool as generic type.
-By injecting the `JavaToolchainService` in the plugin, it is also possible to wire a convention in those properties by obtaining the `JavaToolchainSpec` from the `java` extension on the project.
+Custom tasks that require a tool from the JDK should expose a `Property<T>` with the desired tool as generic type.
+By injecting the `JavaToolchainService` in the plugin or task, it is also possible to wire a convention in those properties by obtaining the `JavaToolchainSpec` from the `java` extension on the project.
+The example below showcases how to use the default toolchain as convention while allowing users to individually configure the toolchain per task.
 
-```
-JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
-JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
-Provider<JavaCompiler> defaultCompiler = service.compilerFor(extension.getToolchain());
-myTask.getJavaCompiler().convention(defaultCompiler);
-```
+====
+include::sample[dir="snippets/java/toolchain-task/groovy/",files="build.gradle"]
+include::sample[dir="snippets/java/toolchain-task/kotlin/",files="build.gradle.kts"]
+====

--- a/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
@@ -1,0 +1,44 @@
+import javax.inject.Inject;
+
+class CustomTaskUsingToolchains extends DefaultTask {
+
+    @Input
+    final Property<JavaLauncher> launcher = project.objects.property(JavaLauncher.class);
+
+    @Inject
+    CustomTaskUsingToolchains(ObjectFactory factory) {
+        // Access the default toolchain
+        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).toolchain
+
+        // aquire a provider that returns the launcher for the toolchain
+        JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
+        Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain);
+
+        // use it as our default for the property
+        launcher.convention(defaultLauncher);
+    }
+
+    @TaskAction
+    def showConfiguredToolchain() {
+        println launcher.get().executablePath
+        println launcher.get().metadata.installationPath
+    }
+}
+
+plugins {
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
+task showDefaultToolchain(type: CustomTaskUsingToolchains)
+
+task showCustomToolchain(type: CustomTaskUsingToolchains) {
+    launcher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(14)
+    }
+}

--- a/subprojects/docs/src/snippets/java/toolchain-task/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-task/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "toolchain-task"

--- a/subprojects/docs/src/snippets/java/toolchain-task/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-task/kotlin/build.gradle.kts
@@ -1,0 +1,44 @@
+import javax.inject.Inject;
+
+open class CustomTaskUsingToolchains : DefaultTask {
+
+    @get:Input
+    val launcher: Property<JavaLauncher> = project.objects.property()
+
+    @Inject
+    constructor() {
+        // Access the default toolchain
+        val toolchain = project.extensions.getByType<JavaPluginExtension>().toolchain
+
+        // aquire a provider that returns the launcher for the toolchain
+        val service = project.extensions.getByType<JavaToolchainService>()
+        val defaultLauncher = service.launcherFor(toolchain)
+
+        // use it as our default for the property
+        launcher.convention(defaultLauncher);
+    }
+
+    @TaskAction
+    fun showConfiguredToolchain() {
+        println(launcher.get().executablePath)
+        println(launcher.get().metadata.installationPath)
+    }
+}
+
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
+tasks.register<CustomTaskUsingToolchains>("showDefaultToolchain")
+
+tasks.register<CustomTaskUsingToolchains>("showCustomToolchain") {
+    launcher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(14))
+    })
+}

--- a/subprojects/docs/src/snippets/java/toolchain-task/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-task/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "toolchain-task"

--- a/subprojects/docs/src/snippets/java/toolchain-task/tests/toolchainTask.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-task/tests/toolchainTask.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: build


### PR DESCRIPTION
Improve examples to make it easier for people to replicate that they need to do in order to support toolchains in their own tasks/plugins.