### PR TITLE
build-init should generate projects with "--split-project" option set to false without requiring user input

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -108,6 +108,11 @@ class MultiProjectJvmApplicationInitIntegrationTest extends AbstractIntegrationS
         [jvmLanguage, scriptDsl] << [[JAVA, GROOVY, KOTLIN, SCALA], ScriptDslFixture.SCRIPT_DSLS].combinations()
     }
 
+    def "can explicitly configure application not to split projects"() {
+        expect:
+        succeeds('init', '--type', "java-application", '--dsl', 'groovy')
+    }
+
     void assertTestPassed(String subprojectName, String className, String name) {
         def result = new DefaultTestExecutionResult(targetDir.file(subprojectName))
         result.assertTestClassesExecuted(className)

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -178,6 +178,8 @@ public class InitBuild extends DefaultTask {
             modularizationOption = splitProject.get() ? ModularizationOption.WITH_LIBRARY_PROJECTS : ModularizationOption.SINGLE_PROJECT;
         } else if (initDescriptor.getModularizationOptions().size() == 1) {
             modularizationOption = initDescriptor.getModularizationOptions().iterator().next();
+        } else if (!isNullOrEmpty(type)) {
+            modularizationOption = ModularizationOption.SINGLE_PROJECT;
         } else {
             modularizationOption = inputHandler.selectOption("Split functionality across multiple subprojects?",
                 initDescriptor.getModularizationOptions(), ModularizationOption.SINGLE_PROJECT);


### PR DESCRIPTION
The build-init plugin uses a boolean property in conjunction with `@Option` to specify whether the generated project should be split into separate subprojects. If the --split-project argument is not specified then the input prompt appears. This means it's not possible to generate a non-split project without expecting user input.

To resolve that, the boolean property is replaced with a string property. Users can either specify --split-project false or --split-project true on the command line. If the property is not specified then the input prompt appears.

