### PR TITLE
Add support for consistent resolution in the Java ecosystem

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.consistency
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        buildFile << """
+            apply plugin: 'java-library' // not using plugins { ... } because of the injected test fixture
+
+            repositories {
+                maven {
+                    url "${mavenHttpRepo.uri}"
+                }
+            }
+        """
+    }
+
+    def "can configure the runtime classpath to be consistent with the compile classpath"() {
+        withCompileClasspathAsReference()
+        def foo = mavenHttpRepo.module('org', 'foo', '1.0')
+            .dependsOn("org", "transitive", "1.0")
+            .publish()
+        def bar = mavenHttpRepo.module('org', 'bar', '1.0')
+            .dependsOn("org", "transitive", "1.1")
+            .publish()
+        def baz = mavenHttpRepo.module('org', 'baz', '1.0')
+            .dependsOn("org", "transitive", "1.2")
+            .publish()
+        def transitive10 = mavenHttpRepo.module('org', 'transitive', '1.0').publish()
+        def transitive11 = mavenHttpRepo.module('org', 'transitive', '1.1').publish()
+        buildFile << """
+            dependencies {
+                implementation 'org:foo:1.0'
+                runtimeOnly 'org:bar:1.0'
+                testImplementation 'org:baz:1.0'
+            }
+        """
+        def resolve = resolveClasspath 'runtime'
+
+        when:
+        foo.pom.expectGet()
+        foo.artifact.expectGet()
+        bar.pom.expectGet()
+        bar.artifact.expectGet()
+        transitive10.pom.expectGet()
+        transitive10.artifact.expectGet()
+
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0') {
+                    module("org:transitive:1.0")
+                }
+                module('org:bar:1.0') {
+                    edge("org:transitive:1.1", "org:transitive:1.0") {
+                        byConsistentResolution('compileClasspath')
+                    }
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+                constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
+            }
+        }
+
+        when:
+        resolve = resolveClasspath 'testRuntime'
+        baz.pom.expectGet()
+        baz.artifact.expectGet()
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0') {
+                    module("org:transitive:1.0")
+                }
+                module('org:bar:1.0') {
+                    edge("org:transitive:1.1", "org:transitive:1.0") {
+                        byConsistentResolution('testCompileClasspath')
+                    }
+                }
+                module('org:baz:1.0') {
+                    edge("org:transitive:1.2", "org:transitive:1.0") {
+                        byConsistentResolution('testCompileClasspath')
+                    }
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+                constraint("org:baz:{strictly 1.0}", "org:baz:1.0")
+                constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
+            }
+        }
+
+    }
+
+    def "can configure the compile classpath to be consistent with the runtime classpath"() {
+        withRuntimeClasspathAsReference()
+        def foo = mavenHttpRepo.module('org', 'foo', '1.0')
+            .dependsOn("org", "transitive", "1.0")
+            .publish()
+        def bar = mavenHttpRepo.module('org', 'bar', '1.0')
+            .dependsOn("org", "transitive", "1.1")
+            .publish()
+        def transitive10 = mavenHttpRepo.module('org', 'transitive', '1.0').publish()
+        def transitive11 = mavenHttpRepo.module('org', 'transitive', '1.1').publish()
+        buildFile << """
+            dependencies {
+                implementation 'org:foo:1.0'
+                runtimeOnly 'org:bar:1.0'
+            }
+        """
+        def resolve = resolveClasspath 'compile'
+
+        when:
+        foo.pom.expectGet()
+        foo.artifact.expectGet()
+        bar.pom.expectGet()
+        transitive10.pom.expectGet()
+        transitive11.pom.expectGet()
+        transitive11.artifact.expectGet()
+
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0') {
+                    edge("org:transitive:1.0", "org:transitive:1.1") {
+                        byConsistentResolution('runtimeClasspath')
+                    }
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+                constraint("org:transitive:{strictly 1.1}", "org:transitive:1.1")
+            }
+        }
+    }
+
+    def "custom source sets also benefit from configured consistent resolution"() {
+        withCompileClasspathAsReference()
+        def foo = mavenHttpRepo.module('org', 'foo', '1.0')
+            .dependsOn("org", "transitive", "1.0")
+            .publish()
+        def bar = mavenHttpRepo.module('org', 'bar', '1.0')
+            .dependsOn("org", "transitive", "1.1")
+            .publish()
+        def transitive10 = mavenHttpRepo.module('org', 'transitive', '1.0').publish()
+        def transitive11 = mavenHttpRepo.module('org', 'transitive', '1.1').publish()
+        buildFile << """
+            sourceSets {
+                custom
+            }
+            dependencies {
+                customImplementation 'org:foo:1.0'
+                customRuntimeOnly 'org:bar:1.0'
+            }
+        """
+        def resolve = resolveClasspath 'customRuntime'
+
+        when:
+        foo.pom.expectGet()
+        foo.artifact.expectGet()
+        bar.pom.expectGet()
+        bar.artifact.expectGet()
+        transitive10.pom.expectGet()
+        transitive10.artifact.expectGet()
+
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0') {
+                    module("org:transitive:1.0")
+                }
+                module('org:bar:1.0') {
+                    edge("org:transitive:1.1", "org:transitive:1.0") {
+                        byConsistentResolution('customCompileClasspath')
+                    }
+                }
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
+                constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
+            }
+        }
+    }
+
+    ResolveTestFixture resolveClasspath(String name) {
+        def resolve = new ResolveTestFixture(buildFile, "${name}Classpath")
+        resolve.expectDefaultConfiguration((name =~ "[rR]untime") ? "runtime" : "compile")
+        resolve.prepare()
+        resolve
+    }
+
+    private void configureConsistentResolution(String whatFirst) {
+        buildFile << """
+            java {
+                consistentResolution {
+                    use${whatFirst.capitalize()}ClasspathVersions()
+                }
+            }
+        """
+    }
+
+    private void withCompileClasspathAsReference() {
+        configureConsistentResolution 'compile'
+    }
+
+    private void withRuntimeClasspathAsReference() {
+        configureConsistentResolution 'runtime'
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -146,4 +146,14 @@ public interface JavaPluginExtension {
     @Incubating
     JavaToolchainSpec toolchain(Action<? super JavaToolchainSpec> action);
 
+    /**
+     * Configure the dependency resolution consistency for this Java project.
+     *
+     * @param action the configuration action
+     *
+     * @since 6.8
+     */
+    @Incubating
+    void consistentResolution(Action<? super JavaResolutionConsistency> action);
+
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaResolutionConsistency.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaResolutionConsistency.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Dependency resolution consistency configuration for
+ * the Java derived plugins.
+ *
+ * @since 6.8
+ */
+@Incubating
+public interface JavaResolutionConsistency {
+    /**
+     * Configures the runtime classpath of every source set to be consistent
+     * with the compile classpath. For dependencies which are common between
+     * the compile classpath and the runtime classpath, the version from the
+     * compile classpath is going to be used.
+     * <p>
+     * Unless you have a good reason to, this option should be preferred to
+     * {@link #useRuntimeClasspathVersions()} for different reasons:
+     * <p>
+     * <ul>
+     *     <li>when working with code, what you care about first is what
+     *     dependencies you use for compile. It is expected that the versions
+     *     at runtime would be the same.
+     *     </li>
+     *     <li>it's more performant, as in most situations you always start
+     *     with compiling code, then run it. This means that the runtime
+     *     classpath wouldn't have to be resolved, for example, if you have
+     *     a compile error.
+     *     </li>
+     * </ul>
+     *
+     * In addition, the test compile classpath is going to be configured to
+     * be consistent with the main compile classpath.
+     */
+    void useCompileClasspathVersions();
+
+    /**
+     * Configures the compile classpath of every source set to be consistent
+     * with the runtime classpath. For dependencies which are common between
+     * the compile classpath and the runtime classpath, the version from the
+     * runtime classpath is going to be used.
+     * <p>
+     * In addition, the test runtime classpath is going to be configured to
+     * be consistent with the main runtime classpath.
+     * <p>
+     * Prefer {@link #useCompileClasspathVersions()} unless you have special
+     * requirements at runtime.
+     */
+    void useRuntimeClasspathVersions();
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaResolutionConsistency.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaResolutionConsistency.java
@@ -35,14 +35,10 @@ public interface JavaResolutionConsistency {
      * {@link #useRuntimeClasspathVersions()} for different reasons:
      * <p>
      * <ul>
-     *     <li>when working with code, what you care about first is what
-     *     dependencies you use for compile. It is expected that the versions
-     *     at runtime would be the same.
+     *     <li>As code is compiled first against the given dependencies,
+     *     it is expected that the versions at runtime would be the same.
      *     </li>
-     *     <li>it's more performant, as in most situations you always start
-     *     with compiling code, then run it. This means that the runtime
-     *     classpath wouldn't have to be resolved, for example, if you have
-     *     a compile error.
+     *     <li>It avoids resolving the runtime classpath in case of a compile error.
      *     </li>
      * </ul>
      *

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponentContainer;
@@ -29,13 +30,16 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.JavaResolutionConsistency;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
+import javax.inject.Inject;
 import java.util.regex.Pattern;
 
 import static org.gradle.api.attributes.DocsType.JAVADOC;
@@ -137,10 +141,67 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         return toolchain;
     }
 
+    @Override
+    public void consistentResolution(Action<? super JavaResolutionConsistency> action) {
+        final ConfigurationContainer configurations = project.getConfigurations();;
+        final SourceSetContainer sourceSets = convention.getSourceSets();
+
+        action.execute(project.getObjects().newInstance(DefaultJavaResolutionConsistency.class, sourceSets, configurations));
+    }
+
     private static String validateFeatureName(String name) {
         if (!VALID_FEATURE_NAME.matcher(name).matches()) {
             throw new InvalidUserDataException("Invalid feature name '" + name + "'. Must match " + VALID_FEATURE_NAME.pattern());
         }
         return name;
+    }
+
+    public static class DefaultJavaResolutionConsistency implements JavaResolutionConsistency {
+        private final Configuration mainCompileClasspath;
+        private final Configuration mainRuntimeClasspath;
+        private final Configuration testCompileClasspath;
+        private final Configuration testRuntimeClasspath;
+        private final SourceSetContainer sourceSets;
+        private final ConfigurationContainer configurations;
+
+        @Inject
+        public DefaultJavaResolutionConsistency(SourceSetContainer sourceSets, ConfigurationContainer configurations) {
+            this.sourceSets = sourceSets;
+            this.configurations = configurations;
+            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+            SourceSet testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
+            mainCompileClasspath = findConfiguration(mainSourceSet.getCompileClasspathConfigurationName());
+            mainRuntimeClasspath = findConfiguration(mainSourceSet.getRuntimeClasspathConfigurationName());
+            testCompileClasspath = findConfiguration(testSourceSet.getCompileClasspathConfigurationName());
+            testRuntimeClasspath = findConfiguration(testSourceSet.getRuntimeClasspathConfigurationName());
+        }
+
+        @Override
+        public void useCompileClasspathVersions() {
+            sourceSets.configureEach(this::applyCompileClasspathConsistency);
+            testCompileClasspath.shouldResolveConsistentlyWith(mainCompileClasspath);
+        }
+
+        @Override
+        public void useRuntimeClasspathVersions() {
+            sourceSets.configureEach(this::applyRuntimeClasspathConsistency);
+            testRuntimeClasspath.shouldResolveConsistentlyWith(mainRuntimeClasspath);
+        }
+
+        private void applyCompileClasspathConsistency(SourceSet sourceSet) {
+            Configuration compileClasspath = findConfiguration(sourceSet.getCompileClasspathConfigurationName());
+            Configuration runtimeClasspath = findConfiguration(sourceSet.getRuntimeClasspathConfigurationName());
+            runtimeClasspath.shouldResolveConsistentlyWith(compileClasspath);
+        }
+
+        private void applyRuntimeClasspathConsistency(SourceSet sourceSet) {
+            Configuration compileClasspath = findConfiguration(sourceSet.getCompileClasspathConfigurationName());
+            Configuration runtimeClasspath = findConfiguration(sourceSet.getRuntimeClasspathConfigurationName());
+            compileClasspath.shouldResolveConsistentlyWith(runtimeClasspath);
+        }
+
+        private Configuration findConfiguration(String configName) {
+            return configurations.getByName(configName);
+        }
     }
 }


### PR DESCRIPTION
A new configuration block on the Java plugin extension lets the
user decide what configuration should be used as the reference.
There are a couple options: compile or runtime classpath as the
reference, but the docs explain why using compile is probably
best.

