### PR TITLE
Add `@LeaksFileHandles` to cross version performance tests using the TAPI

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
@@ -110,7 +110,7 @@ abstract class AbstractCrossBuildPerformanceTestRunner<R extends CrossBuildPerfo
         assert builder.projectName
         assert builder.workingDirectory
         // Use a working directory based on the index of the spec
-        builder.invocation.workingDirectory = new File(builder.workingDirectory, specs.size().toString())
+        builder.invocation.workingDirectory = new File(builder.workingDirectory, String.format("%03d", specs.size()))
         if (builder instanceof GradleBuildExperimentSpec.GradleBuilder) {
             finalizeGradleSpec(builder)
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -94,7 +94,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
 
         GradleConnector connector = null;
         try {
-            GradleScenarioInvoker scenarioInvoker = createScenarioInvoker(new File(buildSpec.getWorkingDirectory(), GRADLE_USER_HOME_NAME));
+            GradleScenarioInvoker scenarioInvoker = createScenarioInvoker(invocationSettings.getGradleUserHome());
             Consumer<GradleBuildInvocationResult> scenarioReporter = getResultCollector().scenario(
                 scenarioDefinition,
                 scenarioInvoker.samplesFor(invocationSettings, scenarioDefinition)
@@ -158,7 +158,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             .setVersions(ImmutableList.of(invocationSpec.getGradleDistribution().getVersion().getVersion()))
             .setTargets(invocationSpec.getTasksToRun())
             .setSysProperties(emptyMap())
-            .setGradleUserHome(new File(invocationSpec.getWorkingDirectory(), GRADLE_USER_HOME_NAME))
+            .setGradleUserHome(determineGradleUserHome(invocationSpec))
             .setWarmupCount(warmupsForExperiment(experiment))
             .setIterations(invocationsForExperiment(experiment))
             .setMeasureConfigTime(false)
@@ -167,6 +167,12 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             .setCsvFormat(CsvGenerator.Format.LONG)
             .setBuildLog(invocationSpec.getBuildLog())
             .build();
+    }
+
+    private File determineGradleUserHome(GradleInvocationSpec invocationSpec) {
+        File projectDirectory = invocationSpec.getWorkingDirectory();
+        // do not add the Gradle user home in the project directory, so it is not watched
+        return new File(projectDirectory.getParent(), projectDirectory.getName() + "-" + GRADLE_USER_HOME_NAME);
     }
 
     private GradleScenarioDefinition createScenarioDefinition(GradleBuildExperimentSpec experimentSpec, InvocationSettings invocationSettings, GradleInvocationSpec invocationSpec) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -92,6 +92,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
         InvocationSettings invocationSettings = createInvocationSettings(buildSpec, gradleExperiment);
         GradleScenarioDefinition scenarioDefinition = createScenarioDefinition(gradleExperiment, invocationSettings, invocation);
 
+        GradleConnector connector = null;
         try {
             GradleScenarioInvoker scenarioInvoker = createScenarioInvoker(new File(buildSpec.getWorkingDirectory(), GRADLE_USER_HOME_NAME));
             Consumer<GradleBuildInvocationResult> scenarioReporter = getResultCollector().scenario(
@@ -101,7 +102,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             AtomicInteger iterationCount = new AtomicInteger(0);
             Logging.setupLogging(workingDirectory);
             if (gradleExperiment.getInvocation().isUseToolingApi()) {
-                GradleConnector connector = GradleConnector.newConnector();
+                connector = GradleConnector.newConnector();
                 connector.forProjectDirectory(buildSpec.getWorkingDirectory());
                 connector.useInstallation(scenarioDefinition.getBuildConfiguration().getGradleHome());
                 // First initialize the Gradle instance using the default user home dir
@@ -122,6 +123,9 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
                 Logging.resetLogging();
             } catch (IOException e) {
                 e.printStackTrace();
+            }
+            if (connector != null) {
+                connector.disconnect();
             }
             ConnectorServices.reset();
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
@@ -45,7 +45,7 @@ class PerformanceTestGradleDistribution implements GradleDistribution {
 
     TestFile getGradleHomeDir() {
         if (!gradleHome) {
-            gradleHome = new TestFile(testDir, "gradle-home")
+            gradleHome = new TestFile(testDir.parentFile, testDir.name + "-gradle-home")
             GFileUtils.copyDirectory(delegate.gradleHomeDir, gradleHome)
             gradleHome.file("bin/gradle").setExecutable(true, true)
         }

--- a/subprojects/performance/build.gradle.kts
+++ b/subprojects/performance/build.gradle.kts
@@ -24,3 +24,7 @@ dependencies {
         because("IDE tests use the Tooling API.")
     }
 }
+
+testFilesCleanup {
+    policy.set(gradlebuild.cleanup.WhenNotEmpty.REPORT)
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -21,7 +21,9 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.fixture.IncrementalAndroidTestProject
 import org.gradle.performance.fixture.IncrementalTestProject
 import org.gradle.performance.fixture.TestProjects
+import org.gradle.test.fixtures.file.LeaksFileHandles
 
+@LeaksFileHandles("The TAPI keeps handles to the distribution it starts open in the test JVM")
 class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceTest {
     private static final String AGP_TARGET_VERSION = "4.0"
 


### PR DESCRIPTION
When using the TAPI to invoke a Gradle build, the TAPI will create a classloader of all the libs in the Gradle home to load the client classes of the tooling API from the Gradle distribution to start. This classloader is not closed, so the file handles to the libraries are held open.

For the cross version performance tests we copy the Gradle distribution to a directory in the test directory, so that all the Gradle distributions under test have the same path length to the Gradle home. When running a performance test which uses the tooling API, we can't delete the Gradle homes on Windows, since the test JVM keeps handles to the jars in the Gradle homes open via the tooling API.

It would be great if `GradleConnector.disconnect()` or `ConnectorServices.reset()` could clean up this classloader as well.