### PR TITLE
Refine KotlinDslPluginGradlePluginCrossVersionSmokeTest

### DIFF
--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -43,9 +43,9 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
         @Parameterized.Parameters(name = "{0}")
         @JvmStatic
         fun testedKotlinVersions() = listOf(
-            "1.4.10",
-            "1.4.0",
             embeddedKotlinVersion,
+            "1.4.0",
+            "1.3.72",
             "1.3.60",
             "1.3.40",
             "1.3.30"
@@ -88,7 +88,7 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
         )
         withFile(
             "buildSrc/src/main/kotlin/my-plugin.gradle.kts",
-            "apply<org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin>()"
+            "apply(plugin = \"kotlin\")"
         )
 
         withBuildScript(


### PR DESCRIPTION
by testing 1.3.72 now that embedded is 1.4.10
by applying the kotlin plugin by id to remove deprecation warnings
