### PR TITLE
Fix the Windows file system watching performance test

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -33,6 +33,7 @@ class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceT
         runner.targetVersions = ["6.8-20201007220043+0000"]
         runner.useToolingApi = true
         if (OperatingSystem.current().windows) {
+            // Reduce the number of iterations on Windows, since the test takes 3 times as long (10s vs 3s).
             runner.warmUpRuns = 5
             runner.runs = 20
         } else {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -29,7 +29,7 @@ class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceT
 
     def setup() {
         runner.minimumBaseVersion = "6.7"
-        runner.targetVersions = ["6.8-20201002220441+0000"]
+        runner.targetVersions = ["6.8-20201007220043+0000"]
         runner.useToolingApi = true
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.performance.regression.corefeature
 
 import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.fixture.IncrementalAndroidTestProject
 import org.gradle.performance.fixture.IncrementalTestProject
@@ -31,6 +32,13 @@ class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceT
         runner.minimumBaseVersion = "6.7"
         runner.targetVersions = ["6.8-20201007220043+0000"]
         runner.useToolingApi = true
+        if (OperatingSystem.current().windows) {
+            runner.warmUpRuns = 5
+            runner.runs = 20
+        } else {
+            runner.warmUpRuns = 10
+            runner.runs = 40
+        }
     }
 
     def "assemble for non-abi change with file system watching"() {


### PR DESCRIPTION
The performance test has been failing on Windows. Rebaselining seems to fix it. I also reduced the number of iterations on Windows, since it seems to take three times as long to run the test there (10s vs 3s).