### PR TITLE
Document memory setting of performance tests

### DIFF
--- a/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -370,6 +370,8 @@ class PerformanceTestExtension(
 
             maxParallelForks = 1
             useJUnitPlatform()
+            // We need 5G of heap to parse large JFR recordings when generating flamegraphs.
+            // If we drop JFR as profiler and switch to something else, we can reduce the memory.
             jvmArgs("-Xmx5g", "-XX:+HeapDumpOnOutOfMemoryError")
             if (project.hasProperty(PropertyNames.performanceTestVerbose)) {
                 testLogging.showStandardStreams = true


### PR DESCRIPTION
We use 5G of memory for the performance test JVMs. We do this because we want to be able to parse huge JFR recordings to generate flamegraphs.