### PR TITLE
Do not run promotion builds on EC2 agents

### DIFF
--- a/.teamcity/Gradle_Promotion/buildTypes/BasePromotionBuildType.kt
+++ b/.teamcity/Gradle_Promotion/buildTypes/BasePromotionBuildType.kt
@@ -17,6 +17,7 @@
 package Gradle_Promotion.buildTypes
 
 import common.Os
+import common.requiresNoEc2Agent
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
@@ -34,6 +35,7 @@ abstract class BasePromotionBuildType(vcsRoot: GitVcsRoot, cleanCheckout: Boolea
 
         requirements {
             requiresOs(Os.LINUX)
+            requiresNoEc2Agent()
         }
 
         params {

--- a/.teamcity/Gradle_Promotion/buildTypes/PublishGradleDistribution.kt
+++ b/.teamcity/Gradle_Promotion/buildTypes/PublishGradleDistribution.kt
@@ -19,7 +19,6 @@ package Gradle_Promotion.buildTypes
 import common.Os
 import common.builtInRemoteBuildCacheNode
 import common.gradleWrapper
-import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 
@@ -56,10 +55,6 @@ abstract class PublishGradleDistribution(
                 cleanDestination = true
                 artifactRules = "build-receipt.properties => incoming-build-receipt/"
             }
-        }
-
-        requirements {
-            requiresOs(Os.LINUX)
         }
     }
 }

--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -57,6 +57,12 @@ fun Requirements.requiresOs(os: Os) {
     contains("teamcity.agent.jvm.os.name", os.agentRequirement)
 }
 
+fun Requirements.requiresNoEc2Agent() {
+    doesNotContain("teamcity.agent.name", "ec2")
+    // US region agents have name "EC2-XXX"
+    doesNotContain("teamcity.agent.name", "EC2")
+}
+
 fun VcsSettings.filterDefaultBranch() {
     branchFilter = allBranchesFilter
 }

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -29,9 +29,7 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
     """.trimIndent()
     detectHangingBuilds = false
     requirements {
-        doesNotContain("teamcity.agent.name", "ec2")
-        // US region agents have name "EC2-XXX"
-        doesNotContain("teamcity.agent.name", "EC2")
+        requiresNoEc2Agent()
     }
     params {
         param("env.GRADLE_OPTS", "-Xmx1536m -XX:MaxPermSize=384m")


### PR DESCRIPTION
Sometimes EC2 agents are shutdown in the middle of a build. That is particularly bad for promotion builds. Let's only run them on the Hetzner boxes.