### PR TITLE
Support javax.inject.Inject as an implicit import

### DIFF
--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -373,7 +373,6 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
     def registeringPlugin() {
         buildFile << """
             import ${BuildEventsListenerRegistry.name}
-            import javax.inject.Inject
 
             abstract class LoggingPlugin implements Plugin<Project> {
                 @Inject

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ArchiveOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ArchiveOperationsIntegrationTest.groovy
@@ -28,8 +28,6 @@ class ArchiveOperationsIntegrationTest extends AbstractIntegrationSpec {
         given:
         file("inputs/file.txt") << "some text"
         buildFile << """
-            import javax.inject.Inject
-
             def createArchive = tasks.register("createArchive", ${archiveType.capitalize()}) {
                 destinationDirectory.set(layout.buildDirectory.dir("archives"))
                 archiveFileName.set("archive.$archiveType")
@@ -71,8 +69,6 @@ class ArchiveOperationsIntegrationTest extends AbstractIntegrationSpec {
         given:
         file("inputs/file.txt") << "some text"
         buildFile << """
-            import javax.inject.Inject
-
             def createArchive = tasks.register("createArchive", ${archiveType.capitalize()}) {
                 destinationDirectory.set(layout.buildDirectory.dir("archives"))
                 archiveFileName.set("archive.$archiveType")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -64,8 +64,6 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
     def "layout is available for injection"() {
         buildFile << """
-            import javax.inject.Inject
-
             class SomeTask extends DefaultTask {
                 @Inject
                 ProjectLayout getLayout() { null }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -24,8 +24,6 @@ class UpToDateIntegTest extends AbstractIntegrationSpec {
     def "empty output directories created automatically are part of up-to-date checking"() {
         given:
         buildFile << '''
-import javax.inject.Inject
-
 apply plugin: 'base'
 
 task checkCreated {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
@@ -38,8 +38,6 @@ class DefaultSourceDirectorySetFactoryTest extends AbstractIntegrationSpec {
             import org.gradle.api.Task;
             import org.gradle.api.internal.file.SourceDirectorySetFactory;
 
-            import javax.inject.Inject;
-
             public class TestPlugin implements Plugin<Project> {
 
                 private final SourceDirectorySetFactory sourceDirectorySetFactory;

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
@@ -38,6 +38,8 @@ class DefaultSourceDirectorySetFactoryTest extends AbstractIntegrationSpec {
             import org.gradle.api.Task;
             import org.gradle.api.internal.file.SourceDirectorySetFactory;
 
+            import javax.inject.Inject;
+
             public class TestPlugin implements Plugin<Project> {
 
                 private final SourceDirectorySetFactory sourceDirectorySetFactory;

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -56,7 +56,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
 
             @CacheableTask
             class Cacheable extends NotCacheable {}
-            
+
             class NoOutputs extends DefaultTask {
                 @TaskAction
                 void generate() {}
@@ -114,7 +114,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
                 @TaskAction
                 void generate() {}
             }
-            
+
             task noOutputs(type: CacheableNoOutputs) {}
         """
         when:
@@ -154,8 +154,6 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
     @Unroll
     def "cacheability for a task with @#annotation file tree outputs is NON_CACHEABLE_TREE_OUTPUT"() {
         buildFile << """
-            import javax.inject.Inject
-
             @CacheableTask
             abstract class PluralOutputs extends DefaultTask {
                 @$annotation
@@ -170,7 +168,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
                     layout.buildDirectory.file("some-dir/output.txt").get().asFile.text = "output"
                 }
             }
-            
+
             task pluralOutputs(type: PluralOutputs)
         """
         when:
@@ -240,7 +238,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
                 @SkipWhenEmpty
                 FileCollection empty = project.layout.files()
             }
-            
+
             task cacheable(type: NoSources)
         """
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -515,8 +515,6 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("input.txt") << "data"
 
         buildFile << """
-            import javax.inject.Inject
-
             @CacheableTask
             abstract class CustomTask extends DefaultTask {
                 @InputFile
@@ -921,7 +919,6 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         """
             import org.gradle.api.*
             import org.gradle.api.tasks.*
-            import javax.inject.Inject
 
             @CacheableTask
             abstract class ProducerTask extends DefaultTask {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -24,8 +24,6 @@ import spock.lang.Unroll
 
 class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
     private static final String CUSTOM_TASK_WITH_CONSTRUCTOR_ARGS = """
-        import javax.inject.Inject
-
         class CustomTask extends DefaultTask {
             @Internal
             final String message
@@ -738,7 +736,6 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 private final WorkerExecutor executor
@@ -768,7 +765,6 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 private final int number

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
@@ -56,8 +56,6 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
     def "incremental task after previous failure #description"() {
         file("src/input.txt") << "input"
         buildFile << """
-            import javax.inject.Inject
-
             abstract class IncrementalTask extends DefaultTask {
 
                 @Inject

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1287,8 +1287,6 @@ task generate(type: TransformerTask) {
     def "private inputs can be overridden in subclass"() {
         given:
         buildFile << '''
-            import javax.inject.Inject
-
             abstract class MyBaseTask extends DefaultTask {
 
                 @Inject
@@ -1354,8 +1352,6 @@ task generate(type: TransformerTask) {
     def "private inputs in superclass are respected"() {
         given:
         buildFile << '''
-            import javax.inject.Inject
-
             abstract class MyBaseTask extends DefaultTask {
 
                 @Inject

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -392,8 +392,6 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
     def "provides the file type"() {
         file("buildSrc").deleteDir()
         buildFile.text = """
-            import javax.inject.Inject
-
             abstract class MyCopy extends DefaultTask {
                 @Incremental
                 @PathSensitive(PathSensitivity.RELATIVE)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -23,8 +23,6 @@ import spock.lang.Unroll
 
 class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
     private static final String CUSTOM_TASK_WITH_CONSTRUCTOR_ARGS = """
-        import javax.inject.Inject
-
         class CustomTask extends DefaultTask {
             @Internal
             final String message
@@ -518,7 +516,6 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         file("build.gradle.kts") << """
             import org.gradle.api.*
             import org.gradle.api.tasks.*
-            import javax.inject.Inject
 
             open class CustomTask @Inject constructor(private val message: String, private val number: Int) : DefaultTask() {
                 @TaskAction fun run() = println("\$message \$number")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -23,8 +23,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.TestBuildCache
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.Actions
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -654,8 +654,6 @@ task someTask(type: SomeTask) {
     @ToBeFixedForConfigurationCache(because = "task references other task")
     def "input and output properties are not evaluated too often"() {
         buildFile << """
-            import javax.inject.Inject
-
             @CacheableTask
             abstract class CustomTask extends DefaultTask {
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
@@ -30,7 +30,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 private final WorkerExecutor executor
@@ -60,7 +59,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 private final int number
@@ -92,7 +90,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 @Inject
@@ -118,7 +115,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             class CustomTask extends DefaultTask {
                 CustomTask() {
@@ -173,7 +169,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
             import groovy.transform.PackageScope
 
             class CustomTask extends DefaultTask {
@@ -205,7 +200,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.api.*
             import org.gradle.api.tasks.*
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             open class CustomTask @Inject constructor(private val executor: WorkerExecutor) : DefaultTask() {
                 @TaskAction fun run() = println(if (executor != null) "got it" else "NOT IT")
@@ -228,7 +222,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.api.*
             import org.gradle.api.tasks.*
             import org.gradle.workers.WorkerExecutor
-            import javax.inject.Inject
 
             open class CustomTask @Inject constructor(private val number: Int, private val executor: WorkerExecutor) : DefaultTask() {
                 @TaskAction fun run() = println(if (executor != null) "got it \$number" else "\$number NOT IT")
@@ -248,8 +241,6 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
     def "service of type #serviceType is available for injection into task"() {
         given:
         buildFile << """
-            import javax.inject.Inject
-
             class CustomTask extends DefaultTask {
                 private final ${serviceType} service
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -170,7 +170,6 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             import java.util.concurrent.CountDownLatch;
             import java.util.concurrent.TimeUnit;
-            import javax.inject.Inject;
 
             task block(type: WorkerTask) {
                 timeout = Duration.ofMillis($TIMEOUT)

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -36,7 +36,6 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << 'include "a", "b"'
 
         buildFile << """
-            import javax.inject.Inject
             import org.gradle.workers.WorkerExecutor
             import org.gradle.workers.IsolationMode
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/ImplicitGroovyImportsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/ImplicitGroovyImportsIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ImplicitGroovyImportsIntegrationTest extends AbstractIntegrationSpec {
+
+    def "@Inject annotation can be imported by default"() {
+        buildFile << """
+            class Foo extends DefaultTask {
+                @Inject
+                Foo(ObjectFactory factory) {
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
@@ -28,7 +28,6 @@ class GradleBuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.internal.environment.GradleBuildEnvironment
-            import javax.inject.Inject
             class DaemonJudge extends DefaultTask {
                 @Internal
                 GradleBuildEnvironment buildEnvironment
@@ -37,12 +36,12 @@ class GradleBuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
                 DaemonJudge(GradleBuildEnvironment buildEnvironment) {
                     this.buildEnvironment = buildEnvironment
                 }
-                
+
                 @TaskAction
                 void run() {
                     assert buildEnvironment.isLongLivingProcess() == ${daemon}
-                } 
-            } 
+                }
+            }
 
             task judge(type: DaemonJudge)
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -115,8 +115,6 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
         file('outputFile') << ''
         blockCode()
         buildFile << """
-            import javax.inject.Inject
-
             apply plugin: 'java'
 
             @CacheableTask

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -61,6 +61,7 @@ import org.codehaus.groovy.syntax.Types;
 import org.codehaus.groovy.transform.trait.Traits;
 import org.objectweb.asm.Opcodes;
 
+import javax.inject.Inject;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Modifier;
@@ -576,7 +577,10 @@ public class GradleResolveVisitor extends ResolveVisitor {
                     return true;
                 }
             }
-            if (name.equals("BigInteger")) {
+            if (name.equals("Inject")) {
+                type.setRedirect(ClassHelper.makeCached(Inject.class));
+                return true;
+            } else if (name.equals("BigInteger")) {
                 type.setRedirect(ClassHelper.BigInteger_TYPE);
                 return true;
             } else if (name.equals("BigDecimal")) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -191,7 +191,6 @@ dependencies {
         }
         buildFile << """
 
-import javax.inject.Inject
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor
 
 @CacheableRule
@@ -259,8 +258,6 @@ dependencies {
         }
         buildFile << """
 
-import javax.inject.Inject
-
 @CacheableRule
 class AttributeCachedRule implements ComponentMetadataRule {
 
@@ -314,8 +311,6 @@ dependencies {
         def expectedStatus = useIvy() ? 'integration' : 'release'
 
         buildFile << """
-
-import javax.inject.Inject
 
 @CacheableRule
 class AttributeCachedRule implements ComponentMetadataRule {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1269,7 +1269,7 @@ group:projectB:2.2;release
         file << """import org.gradle.api.artifacts.ComponentMetadataSupplier
           import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
           import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor
-          import javax.inject.Inject;
+          import javax.inject.Inject
           import org.gradle.api.artifacts.CacheableRule
 
           ${cacheable ? '@CacheableRule' : ''}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1269,6 +1269,7 @@ group:projectB:2.2;release
         file << """import org.gradle.api.artifacts.ComponentMetadataSupplier
           import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
           import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor
+          import javax.inject.Inject;
           import org.gradle.api.artifacts.CacheableRule
 
           ${cacheable ? '@CacheableRule' : ''}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1269,7 +1269,6 @@ group:projectB:2.2;release
         file << """import org.gradle.api.artifacts.ComponentMetadataSupplier
           import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
           import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor
-          import javax.inject.Inject
           import org.gradle.api.artifacts.CacheableRule
 
           ${cacheable ? '@CacheableRule' : ''}
@@ -1345,8 +1344,6 @@ group:projectB:2.2;release
 
     void addDependenciesTo(TestFile buildFile) {
         buildFile << """
-          import javax.inject.Inject
-
           if (project.hasProperty('refreshDynamicVersions')) {
                 configurations.all {
                     resolutionStrategy.cacheDynamicVersionsFor 0, "seconds"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
@@ -27,6 +27,7 @@ class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyReso
 
         file("buildSrc/src/main/groovy/MakeGreen.groovy") << """
             import java.io.File
+            import javax.inject.Inject;
             import groovy.transform.CompileStatic
             import org.gradle.api.provider.*
             import org.gradle.api.file.*

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
@@ -27,7 +27,6 @@ class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyReso
 
         file("buildSrc/src/main/groovy/MakeGreen.groovy") << """
             import java.io.File
-            import javax.inject.Inject
             import groovy.transform.CompileStatic
             import org.gradle.api.provider.*
             import org.gradle.api.file.*
@@ -52,18 +51,18 @@ class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyReso
 
                 @Inject
                 abstract InputChanges getInputChanges()
-                
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInput()
-            
+
                 void transform(TransformOutputs outputs) {
                     println "Transforming " + input.get().asFile.name
                     println "incremental: " + inputChanges.incremental
                     assert parameters.incrementalExecution.get() == inputChanges.incremental
                     def changes = inputChanges.getFileChanges(input)
                     println "changes: \\n" + changes.join("\\n")
-                    assert changes.findAll { it.changeType == ChangeType.ADDED }*.file as Set == resolveFiles(parameters.addedFiles.get())                    
-                    assert changes.findAll { it.changeType == ChangeType.REMOVED }*.file as Set == resolveFiles(parameters.removedFiles.get())                    
+                    assert changes.findAll { it.changeType == ChangeType.ADDED }*.file as Set == resolveFiles(parameters.addedFiles.get())
+                    assert changes.findAll { it.changeType == ChangeType.REMOVED }*.file as Set == resolveFiles(parameters.removedFiles.get())
                     assert changes.findAll { it.changeType == ChangeType.MODIFIED }*.file as Set == resolveFiles(parameters.modifiedFiles.get())
                     def outputDirectory = outputs.dir("output")
                     changes.each { change ->

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -30,8 +30,6 @@ class ArtifactTransformIsolationIntegrationTest extends AbstractHttpDependencyRe
         """
 
         buildFile << """
-import javax.inject.Inject
-
 def artifactType = Attribute.of('artifactType', String)
 
 class Counter implements Serializable {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -97,8 +97,6 @@ project(':app') {
     }
 }
 
-import javax.inject.Inject
-
 abstract class TestTransform implements TransformAction<Parameters> {
     interface Parameters extends TransformParameters {
         @Input

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -85,6 +85,12 @@ In this release a number of core Gradle plugins got improved to support the conf
 
 See the [matrix of supported core plugins](userguide/configuration_cache.html#config_cache:plugins:core) in the user manual.
 
+## New features and usability improvements
+
+### Implicit imports
+
+This version of Gradle allows you to use the `@Inject` annotation without explicitly importing it into your build scripts the same way it works for other Gradle API classes.
+
 ## Security Improvements
 
 ### Outdated TLS versions are no longer enabled by default

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/build.gradle
@@ -1,6 +1,4 @@
 // tag::fixed[]
-import javax.inject.Inject
-
 abstract class MyCopyTask extends DefaultTask { // <1>
 
     @InputDirectory abstract DirectoryProperty getSource() // <2>

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/build.gradle.kts
@@ -1,6 +1,4 @@
 // tag::fixed[]
-import javax.inject.Inject
-
 abstract class MyCopyTask : DefaultTask() { // <1>
 
     @get:InputDirectory abstract val source: DirectoryProperty // <2>

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 abstract class MyCopyTask extends DefaultTask {
 
     @InputDirectory abstract DirectoryProperty getSource()

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 abstract class MyCopyTask : DefaultTask() {
 
     @get:InputDirectory abstract val source: DirectoryProperty

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/build.gradle
@@ -1,7 +1,5 @@
 // tag::task-type[]
 // tag::ad-hoc-task[]
-import javax.inject.Inject
-
 // end::ad-hoc-task[]
 abstract class SomeTask extends DefaultTask {
 

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/build.gradle.kts
@@ -1,8 +1,4 @@
 // tag::task-type[]
-// tag::ad-hoc-task[]
-import javax.inject.Inject
-
-// end::ad-hoc-task[]
 abstract class SomeTask : DefaultTask() {
 
     @get:Inject abstract val fs: FileSystemOperations // <1>

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -1,7 +1,3 @@
-import javax.inject.Inject
-
-import org.gradle.api.artifacts.transform.TransformParameters
-
 // tag::artifact-transform-countloc[]
 abstract class CountLoc implements TransformAction<TransformParameters.None> {
 

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -1,7 +1,10 @@
+import org.gradle.api.artifacts.transform.TransformParameters
+
 // tag::artifact-transform-countloc[]
 abstract class CountLoc implements TransformAction<TransformParameters.None> {
 
-    @Inject                                                             // <1>
+    @Inject
+    // <1>
     abstract InputChanges getInputChanges()
 
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -1,10 +1,9 @@
-import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.work.InputChanges
 
 // tag::artifact-transform-countloc[]
 abstract class CountLoc implements TransformAction<TransformParameters.None> {
 
-    @Inject
-    // <1>
+    @Inject // <1>
     abstract InputChanges getInputChanges()
 
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/groovy/build.gradle
@@ -1,9 +1,9 @@
-import org.gradle.work.InputChanges
+import org.gradle.api.artifacts.transform.TransformParameters
 
 // tag::artifact-transform-countloc[]
 abstract class CountLoc implements TransformAction<TransformParameters.None> {
 
-    @Inject // <1>
+    @Inject                                                             // <1>
     abstract InputChanges getInputChanges()
 
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/artifactTransforms-incremental/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 import org.gradle.api.artifacts.transform.TransformParameters
 
 // tag::artifact-transform-countloc[]

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 plugins {
     id 'java-library'
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 plugins {
     `java-library`
 }

--- a/subprojects/docs/src/snippets/providers/connectProperties/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/providers/connectProperties/groovy/build.gradle
@@ -3,7 +3,6 @@ class MessageExtension {
     // A configurable greeting
     final Property<String> greeting
 
-    @javax.inject.Inject
     MessageExtension(ObjectFactory objects) {
         greeting = objects.property(String)
     }

--- a/subprojects/docs/src/snippets/providers/fileAndDirectoryProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/providers/fileAndDirectoryProperty/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 // A task that generates a source file and writes the result to an output directory
-open class GenerateSource @javax.inject.Inject constructor(objects: ObjectFactory): DefaultTask() {
+open class GenerateSource @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     @InputFile
     val configFile: RegularFileProperty = objects.fileProperty()
 

--- a/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onProject/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onProject/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // tag::inject-task-constructor[]
 class CustomTask extends DefaultTask {
     final String message

--- a/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onProject/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onProject/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 open class CustomTask @Inject constructor(
     private val message: String,
     private val number: Int

--- a/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onTaskContainer/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onTaskContainer/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // tag::inject-task-constructor[]
 class CustomTask extends DefaultTask {
     final String message

--- a/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onTaskContainer/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/taskConstructorArgs-onTaskContainer/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // tag::inject-task-constructor[]
 open class CustomTask @Inject constructor(
     private val message: String,

--- a/subprojects/docs/src/snippets/workerApi/noIsolation/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/noIsolation/groovy/build.gradle
@@ -1,4 +1,3 @@
-import javax.inject.Inject
 // tag::unit-of-work[]
 // The parameters for a single unit of work
 interface ReverseParameters extends WorkParameters {

--- a/subprojects/docs/src/snippets/workerApi/noIsolation/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/noIsolation/kotlin/build.gradle.kts
@@ -1,7 +1,5 @@
 // tag::unit-of-work[]
 
-import javax.inject.Inject
-
 // The parameters for a single unit of work
 interface ReverseParameters : WorkParameters {
     val fileToReverse : RegularFileProperty

--- a/subprojects/docs/src/snippets/workerApi/waitForCompletion/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/waitForCompletion/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // The parameters for a single unit of work
 interface ReverseParameters extends WorkParameters {
     RegularFileProperty getFileToReverse()

--- a/subprojects/docs/src/snippets/workerApi/waitForCompletion/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/waitForCompletion/kotlin/build.gradle.kts
@@ -1,6 +1,4 @@
 
-import javax.inject.Inject
-
 // The parameters for a single unit of work
 interface ReverseParameters : WorkParameters {
     val fileToReverse : RegularFileProperty

--- a/subprojects/docs/src/snippets/workerApi/workerDaemon/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/workerDaemon/groovy/build.gradle
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // The parameters for a single unit of work
 interface ReverseParameters extends WorkParameters {
     RegularFileProperty getFileToReverse()

--- a/subprojects/docs/src/snippets/workerApi/workerDaemon/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/workerDaemon/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import javax.inject.Inject
-
 // The parameters for a single unit of work
 interface ReverseParameters : WorkParameters {
     val fileToReverse : RegularFileProperty

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -33,8 +33,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     def 'can execute java with #task'() {
         given:
         buildFile << """
-            import javax.inject.Inject
-
             apply plugin: 'java'
 
             task javaexecTask(type: JavaExec) {
@@ -92,7 +90,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.internal.jvm.Jvm
-            import javax.inject.Inject
 
             apply plugin: 'java'
 
@@ -273,7 +270,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import org.gradle.internal.jvm.Jvm
-            import javax.inject.Inject
             import static org.gradle.util.TextUtil.normaliseFileAndLineSeparators
 
             apply plugin: 'java'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -204,7 +204,6 @@ task("dumpKotlinBuildScriptModelClassPath") {
         buildFile << """
             import org.gradle.api.*
             import org.gradle.api.tasks.*
-            import javax.inject.Inject
 
             open class PrintInputToFile @Inject constructor(objects: ObjectFactory): DefaultTask() {
                 @get:Input

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -123,7 +123,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "two tasks can output in the same directory with --rerun-tasks"() {
         buildFile << """
             apply plugin: 'base'
-            
+
             task firstCopy {
                 inputs.file('first.file')
                 outputs.dir('build/destination')
@@ -131,7 +131,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                     file('build/destination/first.file').text = file('first.file').text
                 }
             }
-            
+
             task secondCopy {
                 inputs.file('second.file')
                 outputs.dir('build/destination')
@@ -139,7 +139,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                     file('build/destination/second.file').text = file('second.file').text
                 }
             }
-            
+
             secondCopy.dependsOn firstCopy
         """
         file("first.file").createFile()
@@ -156,14 +156,14 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             apply plugin: 'base'
-            
+
             task myTask {
                 outputs.dir "external/output"
                 outputs.file "customFile"
                 outputs.dir "build/dir"
                 doLast {}
             }
-            
+
             clean {
                 delete "customFile"
             }
@@ -363,7 +363,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         String taskName = 'test'
 
         String getBuildScript() {
-            """       
+            """
                 apply plugin: 'base'
 
                 task ${taskName} {
@@ -497,8 +497,6 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
     def "task with file tree output can be up-to-date"() {
         buildFile << """
-            import javax.inject.Inject
-
             plugins {
                 id 'base'
             }
@@ -517,14 +515,14 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                 FileCollection getOutputFileTree() {
                     objectFactory.fileTree().setDir(outputDir).include('**/myOutput.txt')
                 }
-                
+
                 @TaskAction
                 void generateOutputs() {
                     outputDir.mkdirs()
                     new File(outputDir, 'myOutput.txt').text = input
                 }
             }
-            
+
             task custom(type: TaskWithFileTreeOutput) {
                 outputDir = file('build/outputs')
                 input = 'input'
@@ -551,7 +549,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         String taskName = 'test'
 
         String getBuildScript() {
-            """       
+            """
                 apply plugin: 'base'
 
                 task ${taskName} {
@@ -677,8 +675,6 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
         String getBuildScript() {
             """
-            import javax.inject.Inject
-
             apply plugin: 'base'
 
             task ${taskName}(type: MyTask) {
@@ -706,10 +702,10 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                         from(inputDir) {
                             into 'subDir'
                         }
-                        from inputFile 
+                        from inputFile
                     }
                 }
-            }                        
+            }
 
             if (project.findProperty('assertRemoved')) {
                 ${taskName}.doFirst {
@@ -718,10 +714,10 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                     assert !file('${outputFilePath}').exists()
                 }
             }
-                
+
             task writeDirectlyToOutputDir {
                 outputs.dir('${buildDir}')
-                
+
                 doLast {
                     file("${getOverlappingOutputDir()}").mkdirs()
                     file("${getOverlappingOutputDir()}/new-output.txt").text = "new output"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -232,8 +232,6 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
     def "task stays up-to-date when filtered-out output is changed"() {
         file("build").mkdirs()
         buildFile << """
-            import javax.inject.Inject
-
             abstract class CustomTask extends DefaultTask {
                 @OutputFiles
                 FileTree outputFiles
@@ -314,8 +312,6 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
 
     def "can register multiple file trees within a single output property"() {
         buildFile << """
-            import javax.inject.Inject
-
             abstract class MyTask extends DefaultTask {
                 @OutputFiles
                 abstract ConfigurableFileCollection getOutputFiles()

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -37,6 +37,11 @@ class ImplicitImportsTest : AbstractKotlinIntegrationTest() {
             val c = File("some")
             val d = BigDecimal.ONE
             val e = BigInteger.ONE
+
+            open class Foo {
+                @Inject
+                constructor() {}
+            }
             """
         )
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -43,6 +43,7 @@ class ImplicitImports(private val importsReader: ImportsReader) {
             "java.util.concurrent.TimeUnit",
             "java.math.BigDecimal",
             "java.math.BigInteger",
-            "java.io.File"
+            "java.io.File",
+            "javax.inject.Inject"
         )
 }

--- a/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
+++ b/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
@@ -87,7 +87,6 @@ class JavaCompileTaskOperationResultCrossVersionTest extends ToolingApiSpecifica
     @TargetGradleVersion(">=6.7")
     def "reports annotation processor results for JavaCompile task even when build event listener is used"() {
         settingsFile << """
-            import javax.inject.Inject
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             import org.gradle.tooling.events.OperationCompletionListener

--- a/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
+++ b/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
@@ -87,7 +87,6 @@ class JavaCompileTaskOperationResultCrossVersionTest extends ToolingApiSpecifica
     @TargetGradleVersion(">=6.7")
     def "reports annotation processor results for JavaCompile task even when build event listener is used"() {
         settingsFile << """
-            import javax.inject.Inject;
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             import org.gradle.tooling.events.OperationCompletionListener

--- a/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
+++ b/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
@@ -87,6 +87,7 @@ class JavaCompileTaskOperationResultCrossVersionTest extends ToolingApiSpecifica
     @TargetGradleVersion(">=6.7")
     def "reports annotation processor results for JavaCompile task even when build event listener is used"() {
         settingsFile << """
+            import javax.inject.Inject;
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             import org.gradle.tooling.events.OperationCompletionListener

--- a/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
+++ b/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
@@ -87,6 +87,7 @@ class JavaCompileTaskOperationResultCrossVersionTest extends ToolingApiSpecifica
     @TargetGradleVersion(">=6.7")
     def "reports annotation processor results for JavaCompile task even when build event listener is used"() {
         settingsFile << """
+            import javax.inject.Inject
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             import org.gradle.tooling.events.OperationCompletionListener

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -52,8 +52,6 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
 
     def consumerBuildScript(String repoType) {
         return """
-            import javax.inject.Inject
-
             apply plugin: 'cpp-application'
 
             repositories {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
@@ -69,7 +69,6 @@ class ContinuousWorkerDaemonServiceIntegrationTest extends AbstractContinuousInt
 
     String getTaskTypeUsingWorkerDaemon() {
         return """
-            import javax.inject.Inject
             import org.gradle.api.file.ProjectLayout
             import org.gradle.workers.WorkerExecutor
             import org.gradle.workers.internal.WorkerDaemonFactory

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
@@ -74,6 +74,7 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
             import ${ProviderFactory.name};
             import ${TaskAction.name};
 
+            import javax.inject.Inject;
             import java.util.concurrent.Callable;
 
             public class MyTask extends DefaultTask {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderIntegrationTest.groovy
@@ -74,7 +74,6 @@ class ProviderIntegrationTest extends AbstractIntegrationSpec {
             import ${ProviderFactory.name};
             import ${TaskAction.name};
 
-            import javax.inject.Inject;
             import java.util.concurrent.Callable;
 
             public class MyTask extends DefaultTask {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/SharedJavaInstallationRegistryIntegrationTest.groovy
@@ -25,7 +25,6 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
     def "installation registry has no installations without environment setup or auto-detection"() {
         buildFile << """
             import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
-            import javax.inject.Inject
 
             abstract class ShowPlugin implements Plugin<Project> {
                 @Inject
@@ -58,7 +57,6 @@ class SharedJavaInstallationRegistryIntegrationTest extends AbstractIntegrationS
 
         buildFile << """
             import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
-            import javax.inject.Inject
 
             abstract class ShowPlugin implements Plugin<Project> {
                 @Inject

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
@@ -68,7 +68,6 @@ class SftpClientReuseIntegrationTest extends AbstractIntegrationSpec {
 
     String getSftpTask() {
         return """
-            import javax.inject.Inject
             import org.gradle.internal.resource.transport.sftp.SftpClientFactory
             import org.gradle.api.artifacts.repositories.PasswordCredentials
             import org.gradle.internal.credentials.DefaultPasswordCredentials

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -103,7 +103,6 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         """
 
         plugin.file('src/main/java/LegacyRunnable.java') << """
-            import javax.inject.Inject;
             import java.io.File;
             import org.gradle.test.FileHelper;
 
@@ -126,7 +125,6 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.Action;
             import org.gradle.api.tasks.*;
             import org.gradle.workers.*;
-            import javax.inject.Inject;
             import java.io.File;
 
             public class LegacyWorkerTask extends DefaultTask {
@@ -213,7 +211,6 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.file.RegularFileProperty;
             import org.gradle.api.tasks.*;
             import org.gradle.workers.*;
-            import javax.inject.Inject;
             import java.io.File;
 
             public class TypedWorkerTask extends DefaultTask {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -103,6 +103,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         """
 
         plugin.file('src/main/java/LegacyRunnable.java') << """
+            import javax.inject.Inject;
             import java.io.File;
             import org.gradle.test.FileHelper;
 
@@ -125,6 +126,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.Action;
             import org.gradle.api.tasks.*;
             import org.gradle.workers.*;
+            import javax.inject.Inject;
             import java.io.File;
 
             public class LegacyWorkerTask extends DefaultTask {
@@ -211,6 +213,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.file.RegularFileProperty;
             import org.gradle.api.tasks.*;
             import org.gradle.workers.*;
+            import javax.inject.Inject;
             import java.io.File;
 
             public class TypedWorkerTask extends DefaultTask {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -154,8 +154,6 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             include('project5')
         """
         buildFile << """
-            import javax.inject.Inject
-
             abstract class SubmitsAndWaits extends DefaultTask {
                 @Inject
                 abstract WorkerExecutor getWorkerExecutor()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -76,7 +76,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                 arrayOfThings = ["foo", "bar", "baz"]
                 listOfThings = ["foo", "bar", "baz"]
                 outputFile = file("${OUTPUT_FILE_NAME}")
-                
+
                 workerConfiguration = {
                     forkMode = ${forkMode}
                 }
@@ -84,7 +84,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                 doFirst {
                     daemonCount = services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size()
                 }
-                
+
                 doLast {
                     assert services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size() ${operator} daemonCount
                 }
@@ -169,7 +169,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                         }
                     }
                 }
-                
+
                 text = "foo"
                 arrayOfThings = ["foo", "bar", "baz"]
                 listOfThings = ["foo", "bar", "baz"]
@@ -232,7 +232,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             ${legacyWorkerTypeAndTask}
 
             ext.memoryHog = new byte[1024*1024*150] // ~150MB
-            
+
             tasks.withType(WorkerTask) { task ->
                 isolationMode = IsolationMode.PROCESS
                 displayName = "Test Work"
@@ -269,51 +269,49 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.api.tasks.TaskAction
             import org.gradle.workers.IsolationMode
             import org.gradle.workers.WorkerExecutor
-            
-            import javax.inject.Inject
-            
+
             task myTask(type: MyTask) {
                 description 'My Task'
                 outputFile = file("\${buildDir}/workOutput")
             }
-            
+
             class MyTask extends DefaultTask {
                 private final WorkerExecutor workerExecutor
-            
+
                 @OutputFile
                 File outputFile
-                
+
                 @Inject
                 MyTask(WorkerExecutor workerExecutor) {
                     this.workerExecutor = workerExecutor
                 }
-            
+
                 @TaskAction
                 def run() {
                     Properties myProps = new Properties()
                     myProps.setProperty('key1', 'value1')
                     myProps.setProperty('key2', 'value2')
                     myProps.setProperty('key3', 'value3')
-            
+
                     workerExecutor.submit(MyRunner.class) { config ->
                         config.isolationMode = IsolationMode.NONE
-            
+
                         config.params(myProps, outputFile)
                     }
-            
+
                     workerExecutor.await()
                 }
-            
+
                 private static class MyRunner implements Runnable {
                     Properties myProps
                     File outputFile
-            
+
                     @Inject
                     MyRunner(Properties myProps, File outputFile) {
                         this.myProps = myProps
                         this.outputFile = outputFile
                     }
-            
+
                     @Override
                     void run() {
                         Properties myProps = this.myProps;
@@ -341,14 +339,12 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
 
     String getLegacyWorkerTypeAndTask() {
         return """
-            import javax.inject.Inject
-
             class TestRunnable implements Runnable {
                 final String text
                 final String[] arrayOfThings
                 final ListProperty<String> listOfThings
                 final File outputFile
-                
+
                 @Inject
                 TestRunnable(String text, String[] arrayOfThings, ListProperty<String> listOfThings, File outputFile) {
                     this.text = text
@@ -356,7 +352,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                     this.listOfThings = listOfThings
                     this.outputFile = outputFile
                 }
-                
+
                 void run() {
                     outputFile.withWriter { writer ->
                         PrintWriter out = new PrintWriter(writer)
@@ -366,7 +362,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-            
+
             class WorkerTask extends DefaultTask {
                 private final WorkerExecutor workerExecutor
 
@@ -386,13 +382,13 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                 String displayName
                 @Internal
                 Closure workerConfiguration
-                
+
                 @Inject
                 WorkerTask(WorkerExecutor workerExecutor) {
                     this.workerExecutor = workerExecutor
                     this.listOfThings = project.objects.listProperty(String)
                 }
-                
+
                 @TaskAction
                 void doWork() {
                     workerExecutor.submit(runnableClass) { config ->
@@ -404,7 +400,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                             workerConfiguration(config)
                         }
                     }
-                }    
+                }
             }
         """
     }
@@ -413,7 +409,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
         return """
             public class RunnableWithDifferentConstructor implements Runnable {
                 @javax.inject.Inject
-                public RunnableWithDifferentConstructor(List<String> files, File outputDir) { 
+                public RunnableWithDifferentConstructor(List<String> files, File outputDir) {
                 }
                 public void run() {
                 }
@@ -427,7 +423,6 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             import java.util.List;
             import java.lang.management.ManagementFactory;
             import java.lang.management.RuntimeMXBean;
-            import javax.inject.Inject;
 
             public class OptionVerifyingRunnable extends TestRunnable {
                 @Inject

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -173,7 +173,6 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
 
     String getMultipleActionTaskType() {
         return """
-            import javax.inject.Inject
             import org.gradle.test.FileHelper
 
             class MultipleWorkItemTask extends DefaultTask {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -89,7 +89,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                     submitWorkItem("workItem0")
                     submitWorkItem("workItem1")
                     submitWorkItem("workItem2")
-                    
+
                     if (${waitForResults}) {
                         workerExecutor.await()
                     }
@@ -215,7 +215,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { 
+                doLast {
                     submitWorkItem("workItem1", ${parallelWorkAction.name}.class, IsolationMode.PROCESS)
                     submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode)
                     submitWorkItem("workItem3", ${parallelWorkAction.name}.class, IsolationMode.CLASSLOADER)
@@ -243,9 +243,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { 
-                    submitWorkItem("workItem1", ${failingWorkAction.name}.class, $isolationMode1) 
-                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode2) 
+                doLast {
+                    submitWorkItem("workItem1", ${failingWorkAction.name}.class, $isolationMode1)
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode2)
                 }
             }
         """
@@ -282,7 +282,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
-                doLast { 
+                doLast {
                     submitWorkItem("workItem1", ${failingWorkAction.name}.class)
                     throw new RuntimeException("Failure from task action")
                 }
@@ -318,7 +318,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
-                doLast { 
+                doLast {
                     submitWorkItem("workItem1", workActionClass)
 
                     submitWorkItem("workItem2", ${failingWorkAction.name}.class)
@@ -409,10 +409,10 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                     def threadGroup = Thread.currentThread().threadGroup
                     println "\\nWorker Executor threads:"
                     def threads = new Thread[threadGroup.activeCount()]
-                    threadGroup.enumerate(threads) 
-                    def executorThreads = threads.findAll { it?.name?.startsWith("${WorkerExecutionQueueFactory.QUEUE_DISPLAY_NAME}") } 
+                    threadGroup.enumerate(threads)
+                    def executorThreads = threads.findAll { it?.name?.startsWith("${WorkerExecutionQueueFactory.QUEUE_DISPLAY_NAME}") }
                     executorThreads.each { println it }
-                    
+
                     // Ensure that we don't leave any threads lying around
                     assert executorThreads.size() <= ${maxWorkers}
                 }
@@ -447,7 +447,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             import org.gradle.workers.internal.WorkerDaemonClientsManager
-            
+
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = IsolationMode.PROCESS
                 doLast {
@@ -499,7 +499,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             import org.gradle.workers.internal.WorkerDaemonClientsManager
-            
+
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = IsolationMode.PROCESS
                 doLast {
@@ -547,14 +547,14 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             task anotherParallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { 
-                    submitWorkItem("taskAction1")  
-                    submitWorkItem("taskAction2") 
+                doLast {
+                    submitWorkItem("taskAction1")
+                    submitWorkItem("taskAction2")
                 }
             }
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { submitWorkItem("taskAction3") }
-                
+
                 dependsOn anotherParallelWorkTask
             }
         """
@@ -573,22 +573,22 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         """
         buildFile << """
             task workTask(type: MultipleWorkItemTask) {
-                doLast { 
+                doLast {
                     submitWorkItem("workTask")
                 }
             }
-            
+
             task slowTask {
-                doLast { 
-                    ${blockingHttpServer.callFromBuild("slowTask1")} 
-                    ${blockingHttpServer.callFromBuild("slowTask2")} 
+                doLast {
+                    ${blockingHttpServer.callFromBuild("slowTask1")}
+                    ${blockingHttpServer.callFromBuild("slowTask2")}
                 }
             }
-            
+
             project(':childProject') {
                 task dependsOnWorkTask(type: MultipleWorkItemTask) {
                     doLast { submitWorkItem("dependsOnWorkTask") }
-                    
+
                     dependsOn project(':').workTask
                 }
             }
@@ -608,11 +608,11 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task firstTask(type: MultipleWorkItemTask) {
                 doLast { submitWorkItem("task1") }
             }
-            
+
             task secondTask(type: MultipleWorkItemTask) {
                 doLast { submitWorkItem("task2") }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, secondTask
             }
@@ -632,11 +632,11 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 doLast { submitWorkItem("task1-1") }
                 doLast { submitWorkItem("task1-2") }
             }
-            
+
             task secondTask(type: MultipleWorkItemTask) {
                 doLast { submitWorkItem("task2") }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, secondTask
             }
@@ -659,13 +659,13 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task firstTask(type: MultipleWorkItemTask) {
                 doLast { ${blockingHttpServer.callFromBuild("task1")} }
             }
-            
+
             project(':childProject') {
                 task secondTask(type: MultipleWorkItemTask) {
                     doLast { submitWorkItem("task2") }
                 }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, project(':childProject').secondTask
             }
@@ -688,13 +688,13 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task firstTask(type: MultipleWorkItemTask) {
                 doLast { submitWorkItem("task1") }
             }
-            
+
             project(':childProject') {
                 task secondTask(type: MultipleWorkItemTask) {
                     doLast { ${blockingHttpServer.callFromBuild("task2")} }
                 }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, project(':childProject').secondTask
             }
@@ -711,17 +711,17 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             task firstTask(type: MultipleWorkItemTask) {
-                doLast { 
-                    submitWorkItem("task1-1") 
+                doLast {
+                    submitWorkItem("task1-1")
                     workerExecutor.await()
                     ${blockingHttpServer.callFromBuild("task1-2")}
                 }
             }
-            
+
             task secondTask(type: MultipleWorkItemTask) {
                 doLast { ${blockingHttpServer.callFromBuild("task2")} }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, secondTask
             }
@@ -743,19 +743,19 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         """
         buildFile << """
             task firstTask(type: MultipleWorkItemTask) {
-                doLast { 
-                    submitWorkItem("task1-1") 
+                doLast {
+                    submitWorkItem("task1-1")
                     workerExecutor.await()
                     ${blockingHttpServer.callFromBuild("task1-2")}
                 }
             }
-            
+
             project(':childProject') {
                 task secondTask(type: MultipleWorkItemTask) {
                     doLast { ${blockingHttpServer.callFromBuild("task2")} }
                 }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, project(':childProject').secondTask
             }
@@ -777,19 +777,19 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         """
         buildFile << """
             task firstTask(type: MultipleWorkItemTask) {
-                doLast { 
-                    submitWorkItem("task1-1") 
+                doLast {
+                    submitWorkItem("task1-1")
                     workerExecutor.await()
                     ${blockingHttpServer.callFromBuild("task1-2")}
                 }
             }
-            
+
             project(':childProject') {
                 task secondTask(type: MultipleWorkItemTask) {
                     doLast { ${blockingHttpServer.callFromBuild("task2")} }
                 }
             }
-            
+
             task allTasks {
                 dependsOn firstTask, project(':childProject').secondTask
             }
@@ -820,37 +820,37 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             List<String> mutableList = ["foo"]
-            
+
             class VerifyingRunnableTask extends DefaultTask {
                 @Internal
                 String item
                 @Internal
                 List<String> testList
-                
+
                 @Inject
                 WorkerExecutor getWorkerExecutor() {
                     throw new UnsupportedOperationException()
                 }
-                
+
                 @TaskAction
                 void executeRunnable() {
-                    workerExecutor.noIsolation().submit(${verifyingWorkAction.name}.class) { 
+                    workerExecutor.noIsolation().submit(${verifyingWorkAction.name}.class) {
                         itemName = item.toString()
                         list = testList
                     }
                 }
             }
-            
+
             task firstTask(type: VerifyingRunnableTask) {
                 item = "task1"
                 testList = mutableList
             }
-            
+
             task secondTask(type: MultipleWorkItemTask) {
-                doLast { 
+                doLast {
                     mutableList.add "bar"
                     assert mutableList.size() == 2
-                    submitWorkItem("task2") 
+                    submitWorkItem("task2")
                 }
             }
         """
@@ -864,7 +864,6 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     String getMultipleActionTaskType() {
         return """
-            import javax.inject.Inject
             import org.gradle.workers.WorkerExecutor
 
             class MultipleWorkItemTask extends DefaultTask {
@@ -881,23 +880,23 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 WorkerExecutor getWorkerExecutor() {
                     throw new UnsupportedOperationException()
                 }
-                
+
                 def submitWorkItem(String item) {
-                    return submitWorkItem(item, workActionClass) 
+                    return submitWorkItem(item, workActionClass)
                 }
-                
+
                 def submitWorkItem(String item, Class<?> actionClass) {
                     return submitWorkItem(item, actionClass, isolationMode, {})
                 }
-                
+
                 def submitWorkItem(String item, Class<?> actionClass, IsolationMode isolationMode) {
                     return submitWorkItem(item, actionClass, isolationMode, {})
                 }
-                
+
                 def submitWorkItem(String item, Class<?> actionClass, Closure configClosure) {
                     return submitWorkItem(item, actionClass, isolationMode, configClosure)
                 }
-                
+
                 def submitWorkItem(String item, Class<?> actionClass, IsolationMode isolationMode, Closure configClosure) {
                     return workerExecutor."\${getWorkerMethod(isolationMode)}"({ config ->
                         if (config instanceof ProcessWorkerSpec) {
@@ -909,10 +908,10 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                         }
                         configClosure.call(config)
                     }).submit(actionClass) {
-                        itemName = item.toString() 
+                        itemName = item.toString()
                     }
                 }
-                
+
                 ${fixture.workerMethodTranslation}
             }
         """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.workers.internal
 
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.workers.IsolationMode
 import org.gradle.workers.fixtures.WorkerExecutorFixture
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -34,7 +33,6 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         buildFile << """
-            import javax.inject.Inject
             import org.gradle.workers.WorkerExecutor
 
             class ParameterTask extends DefaultTask {


### PR DESCRIPTION
This allows build authors to use @Inject in their build scripts without explicitly importing the annotation.

Fixes #13969
