### PR TITLE
Add evaluated init scripts to KotlinDslScriptsModel (#12640)

### DIFF
--- a/subprojects/kotlin-dsl-tooling-builders/build.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-builders/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(project(":platform-jvm"))
     implementation(project(":plugins"))
     implementation(project(":tooling-api"))
+    implementation(project(":logging"))
 
     testImplementation(testFixtures(project(":kotlin-dsl")))
     integTestImplementation(project(":internal-testing"))

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -40,6 +41,7 @@ import java.util.zip.ZipOutputStream
 import static org.gradle.kotlin.dsl.resolver.KotlinBuildScriptModelRequestKt.fetchKotlinBuildScriptModelFor
 
 import static org.hamcrest.CoreMatchers.allOf
+import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.not
@@ -348,5 +350,35 @@ abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpeci
 
     protected static String normalizedPathOf(File file) {
         return TextUtil.normaliseFileSeparators(file.path)
+    }
+
+    protected static class BuildSpec {
+        Map<String, TestFile> scripts
+        Map<String, TestFile> appliedScripts
+        Map<String, TestFile> jars
+    }
+
+    protected KotlinDslScriptsModel kotlinDslScriptsModelFor(boolean lenient = false, File... scripts) {
+        return kotlinDslScriptsModelFor(lenient, scripts.toList())
+    }
+
+    protected KotlinDslScriptsModel kotlinDslScriptsModelFor(boolean lenient = false, Iterable<File> scripts) {
+        return withConnection { connection ->
+            new KotlinDslScriptsModelClient().fetchKotlinDslScriptsModel(
+                connection,
+                new KotlinDslScriptsModelRequest(
+                    scripts.toList(),
+                    null, null, [], [], lenient
+                )
+            )
+        }
+    }
+
+    protected static List<File> canonicalClasspathOf(KotlinDslScriptsModel model, File script) {
+        return model.scriptModels[script].classPath.collect { it.canonicalFile }
+    }
+
+    protected static void assertHasExceptionMessage(KotlinDslScriptsModel model, TestFile script, String message) {
+        assertThat(model.scriptModels[script].exceptions, hasItem(containsString(message)))
     }
 }

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -18,8 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.kotlin.dsl.tooling.builders.KotlinDslScriptsModelClient
-import org.gradle.kotlin.dsl.tooling.builders.KotlinDslScriptsModelRequest
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
@@ -29,9 +27,6 @@ import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import java.lang.reflect.Proxy
 
 import static org.gradle.integtests.tooling.fixture.TextUtil.escapeString
-import static org.hamcrest.CoreMatchers.containsString
-import static org.hamcrest.CoreMatchers.hasItem
-import static org.hamcrest.MatcherAssert.assertThat
 
 
 @TargetGradleVersion(">=6.0")
@@ -190,32 +185,6 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
         buildFileKtsModel.exceptions.isEmpty()
     }
 
-    private KotlinDslScriptsModel kotlinDslScriptsModelFor(boolean lenient = false, File... scripts) {
-        return kotlinDslScriptsModelFor(lenient, scripts.toList())
-    }
-
-    private KotlinDslScriptsModel kotlinDslScriptsModelFor(boolean lenient = false, Iterable<File> scripts) {
-        return withConnection { connection ->
-            new KotlinDslScriptsModelClient().fetchKotlinDslScriptsModel(
-                connection,
-                new KotlinDslScriptsModelRequest(
-                    scripts.toList(),
-                    null, null, [], [], lenient
-                )
-            )
-        }
-    }
-
-    private static List<File> canonicalClasspathOf(KotlinDslScriptsModel model, File script) {
-        return model.scriptModels[script].classPath.collect { it.canonicalFile }
-    }
-
-    private static class BuildSpec {
-        Map<String, TestFile> scripts
-        Map<String, TestFile> appliedScripts
-        Map<String, TestFile> jars
-    }
-
     private BuildSpec withMultiProjectBuildWithBuildSrc() {
         withBuildSrc()
         def someJar = withEmptyJar("classes_some.jar")
@@ -339,9 +308,5 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
             assertIncludes(classPath, appliedJar)
             assertExcludes(classPath, *(spec.jars.values() - appliedJar) as TestFile[])
         }
-    }
-
-    private static void assertHasExceptionMessage(KotlinDslScriptsModel model, TestFile script, String message) {
-        assertThat(model.scriptModels[script].exceptions, hasItem(containsString(message)))
     }
 }

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.tooling.builders.r68
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
+import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+
+import static org.gradle.integtests.tooling.fixture.TextUtil.escapeString
+
+
+@TargetGradleVersion(">=6.8")
+@LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
+
+    def "can fetch model for the init scripts of a build"() {
+
+        given:
+        def spec = withBuildSrcAndInitScripts()
+
+        when:
+        def model = kotlinDslScriptsModelFor()
+
+        then:
+        model.scriptModels.keySet() == spec.scripts.values() as Set
+
+        and:
+        assertModelMatchesBuildSpec(model, spec)
+    }
+
+    def "can fetch model for the init scripts of a build in lenient mode"() {
+
+        given:
+        def spec = withBuildSrcAndInitScripts()
+
+        and:
+        spec.scripts.init << """
+            script_body_compilation_error
+        """
+
+        when:
+        def model = kotlinDslScriptsModelFor(true)
+
+        then:
+        model.scriptModels.keySet() == spec.scripts.values() as Set
+
+        and:
+        assertModelMatchesBuildSpec(model, spec)
+
+        and:
+        assertHasExceptionMessage(
+            model,
+            spec.scripts.init,
+            "Unresolved reference: script_body_compilation_error"
+        )
+    }
+
+    def "can fetch model for a given set of init scripts"() {
+
+        given:
+        def spec = withBuildSrcAndInitScripts()
+        def requestedScripts = spec.scripts.values()
+
+        when:
+        def model = kotlinDslScriptsModelFor(requestedScripts)
+
+        then:
+        model.scriptModels.keySet() == requestedScripts as Set
+
+        and:
+        assertModelMatchesBuildSpec(model, spec)
+    }
+
+    def "can fetch model for a given set of init scripts of a build in lenient mode"() {
+
+        given:
+        def spec = withBuildSrcAndInitScripts()
+        def requestedScripts = spec.scripts.values()
+
+        and:
+        spec.scripts.init << """
+            script_body_compilation_error
+        """
+
+        when:
+        def model = kotlinDslScriptsModelFor(true, requestedScripts)
+
+        then:
+        model.scriptModels.keySet() == requestedScripts as Set
+
+        and:
+        assertModelMatchesBuildSpec(model, spec)
+
+        and:
+        assertHasExceptionMessage(
+            model,
+            spec.scripts.init,
+            "Unresolved reference: script_body_compilation_error"
+        )
+    }
+
+    def "single request models for init scripts equal multi requests models"() {
+
+        given:
+        def spec = withBuildSrcAndInitScripts()
+
+        when:
+        Map<File, KotlinDslScriptModel> singleRequestModels = kotlinDslScriptsModelFor().scriptModels
+
+        and:
+        Map<File, KotlinBuildScriptModel> multiRequestsModels = spec.scripts.values().collectEntries {
+            [(it): kotlinBuildScriptModelFor(projectDir, it)]
+        }
+
+        then:
+        spec.scripts.values().each { script ->
+            assert singleRequestModels[script].classPath == multiRequestsModels[script].classPath
+            assert singleRequestModels[script].sourcePath == multiRequestsModels[script].sourcePath
+            assert singleRequestModels[script].implicitImports == multiRequestsModels[script].implicitImports
+        }
+    }
+
+    private BuildSpec withBuildSrcAndInitScripts() {
+        withBuildSrc()
+
+        def initJar = withEmptyJar("classes_init.jar")
+        def someInitJar = withEmptyJar("classes_some_init.jar")
+
+        toolingApi.requireIsolatedUserHome()
+        def gradleUserHomeDir = toolingApi.createExecuter().gradleUserHomeDir
+
+        def init = gradleUserHomeDir.file("init.gradle.kts").tap {
+            text = """
+                initscript {
+                    dependencies {
+                        classpath(files("${escapeString(initJar)}"))
+                    }
+                }
+            """.stripIndent()
+        }
+
+        def someInit = gradleUserHomeDir.file("init.d", "some.init.gradle.kts").tap {
+            text = """
+                initscript {
+                    dependencies {
+                        classpath(files("${escapeString(someInitJar)}"))
+                    }
+                }
+            """.stripIndent()
+        }
+
+        return new BuildSpec(
+            scripts: [
+                init: init,
+                someInit: someInit
+            ],
+            jars: [
+                init: initJar,
+                someInit: someInitJar
+            ]
+        )
+    }
+
+    private static void assertModelMatchesBuildSpec(KotlinDslScriptsModel model, BuildSpec spec) {
+
+        model.scriptModels.values().each { script ->
+            assertContainsGradleKotlinDslJars(script.classPath)
+        }
+
+        def initClassPath = canonicalClasspathOf(model, spec.scripts.init)
+        assertNotContainsBuildSrc(initClassPath)
+        assertContainsGradleKotlinDslJars(initClassPath)
+        assertIncludes(initClassPath, spec.jars.init)
+
+        def someInitClassPath = canonicalClasspathOf(model, spec.scripts.someInit)
+        assertNotContainsBuildSrc(someInitClassPath)
+        assertContainsGradleKotlinDslJars(someInitClassPath)
+        assertIncludes(someInitClassPath, spec.jars.someInit)
+    }
+}

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -200,6 +200,15 @@ fun Project.collectKotlinDslScripts(): List<File> = sequence<File> {
 
     val extension = ".gradle.kts"
 
+    // Init Scripts
+    project
+        .gradle
+        .startParameter
+        .allInitScripts
+        .filter(File::isFile)
+        .filter { it.name.endsWith(extension) }
+        .forEach { yield(it) }
+
     // Settings Script
     val settingsScriptFile = File((project as ProjectInternal).gradle.settings.settingsScript.fileName)
     if (settingsScriptFile.isFile && settingsScriptFile.name.endsWith(extension)) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptType.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptType.kt
@@ -46,6 +46,7 @@ data class KotlinScriptTypeMatch(
             listOf(
                 KotlinScriptTypeMatch(KotlinScriptType.SETTINGS, Match.Whole("settings.gradle.kts")),
                 KotlinScriptTypeMatch(KotlinScriptType.SETTINGS, Match.Suffix(".settings.gradle.kts")),
+                KotlinScriptTypeMatch(KotlinScriptType.INIT, Match.Whole("init.gradle.kts")),
                 KotlinScriptTypeMatch(KotlinScriptType.INIT, Match.Suffix(".init.gradle.kts")),
                 KotlinScriptTypeMatch(KotlinScriptType.PROJECT, Match.Suffix(".gradle.kts"))
             )


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Will partly solve #12640

With this change at least the typical init scripts can be properly edited using IntellliJ which currently is barely possible.

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes