### PR TITLE
Wrap work execution in temporary build operation (backport to 6.7)

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventServices.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.build.event;
 
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
+import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.DefaultBuildOperationAncestryTracker;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
@@ -23,5 +26,12 @@ public class BuildEventServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.add(DefaultBuildEventsListenerRegistry.class);
+        registration.addProvider(new Object() {
+            BuildOperationAncestryTracker createBuildOperationAncestryTracker(BuildOperationListenerManager listenerManager) {
+                DefaultBuildOperationAncestryTracker tracker = new DefaultBuildOperationAncestryTracker();
+                listenerManager.addListener(tracker);
+                return tracker;
+            }
+        });
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.testing;
-
-import org.gradle.api.tasks.testing.TestDescriptor;
-import org.gradle.internal.scan.UsedByScanPlugin;
+package org.gradle.internal.operations;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
-@UsedByScanPlugin
-public interface TestDescriptorInternal extends TestDescriptor {
-    @Nullable
-    @Override
-    TestDescriptorInternal getParent();
+@SuppressWarnings("Since15")
+public interface BuildOperationAncestryTracker {
+    Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate);
 
-    Object getId();
-
-    /**
-     * The class name for display. It may be the same as or different from {@link #getClassName()}
-     * @return the class name for display.
-     */
-    String getClassDisplayName();
-
+    <T> Optional<T> findClosestExistingAncestor(@Nullable OperationIdentifier id, Function<? super OperationIdentifier, T> lookupFunction);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -169,7 +169,7 @@ public class ExecutionGradleServices {
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
             new CleanupOutputsStep<>(deleter, outputChangeListener,
-            new ExecuteStep<>(
+            new ExecuteStep<>(buildOperationExecutor
         )))))))))))))))))))));
         // @formatter:on
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -158,7 +158,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new CancelExecutionStep<>(cancellationToken,
         new ResolveInputChangesStep<>(
         new CleanupOutputsStep<>(deleter, outputChangeListener,
-        new ExecuteStep<>(
+        new ExecuteStep<>(buildOperationExecutor
     ))))))))))))))
     // @formatter:on
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -284,7 +284,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 new TimeoutStep<>(timeoutHandler,
                 new ResolveInputChangesStep<>(
                 new CleanupOutputsStep<>(deleter, outputChangeListener,
-                new ExecuteStep<>(
+                new ExecuteStep<>(buildOperationExecutor
             )))))))))))))));
             // @formatter:on
         }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -146,7 +146,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new CreateOutputsStep<>(
             new ResolveInputChangesStep<>(
             new CleanupOutputsStep<>(deleter, outputChangeListener,
-            new ExecuteStep<>(
+            new ExecuteStep<>(buildOperationExecutor
         )))))))))))))))
         // @formatter:on
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -22,12 +22,44 @@ import org.gradle.internal.execution.InputChangesContext;
 import org.gradle.internal.execution.Result;
 import org.gradle.internal.execution.Step;
 import org.gradle.internal.execution.UnitOfWork;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.operations.CallableBuildOperation;
+
+import javax.annotation.Nonnull;
 
 public class ExecuteStep<C extends InputChangesContext> implements Step<C, Result> {
+
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public ExecuteStep(BuildOperationExecutor buildOperationExecutor) {
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
 
     @Override
     public Result execute(C context) {
         UnitOfWork work = context.getWork();
+        return buildOperationExecutor.call(new CallableBuildOperation<Result>() {
+            @Override
+            public Result call(BuildOperationContext operationContext) {
+                Result result = executeOperation(work, context);
+                operationContext.setResult(Operation.Result.INSTANCE);
+                return result;
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor
+                    .displayName("Executing " + work.getDisplayName())
+                    .details(Operation.Details.INSTANCE);
+            }
+        });
+    }
+
+    @Nonnull
+    private Result executeOperation(UnitOfWork work, C context) {
         try {
             ExecutionOutcome outcome = context.getInputChanges()
                 .map(inputChanges -> determineOutcome(work.execute(inputChanges, context), inputChanges.isIncremental()))
@@ -48,6 +80,19 @@ public class ExecuteStep<C extends InputChangesContext> implements Step<C, Resul
                     : ExecutionOutcome.EXECUTED_NON_INCREMENTALLY;
             default:
                 throw new IllegalArgumentException("Unknown result: " + result);
+        }
+    }
+
+    /*
+     * This operation is only used here temporarily. Should be replaced with a more stable operation in the long term.
+     */
+    public interface Operation extends BuildOperationType<Operation.Details, Operation.Result> {
+        interface Details {
+            Operation.Details INSTANCE = new Operation.Details() {};
+        }
+
+        interface Result {
+            Operation.Result INSTANCE = new Operation.Result() {};
         }
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -20,10 +20,11 @@ import org.gradle.internal.execution.ExecutionOutcome
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.history.changes.InputChangesInternal
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Unroll
 
 class ExecuteStepTest extends StepSpec<InputChangesContext> {
-    def step = new ExecuteStep<>()
+    def step = new ExecuteStep<>(new TestBuildOperationExecutor())
     def inputChanges = Mock(InputChangesInternal)
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-import javax.annotation.Nullable;
-
 @UsedByScanPlugin("test-distribution")
 public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     private final Object id;
@@ -47,12 +45,6 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
 
     @Override
     public TestDescriptorInternal getParent() {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
         return null;
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import javax.annotation.Nullable;
-
 public class DecoratingTestDescriptor implements TestDescriptorInternal {
     private final TestDescriptorInternal descriptor;
     private final TestDescriptorInternal parent;
@@ -44,12 +42,6 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     @Override
     public Object getId() {
         return descriptor.getId();
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
-        return descriptor.getOwnerBuildOperationId();
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -19,35 +19,32 @@ package org.gradle.api.internal.tasks.testing.processors;
 import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor;
 import org.gradle.internal.time.Clock;
-
-import javax.annotation.Nullable;
 
 public class TestMainAction implements Runnable {
     private final Runnable detector;
     private final TestClassProcessor processor;
     private final TestResultProcessor resultProcessor;
     private final Clock clock;
-    private final Object testTaskOperationId;
     private final Object rootTestSuiteId;
     private final String displayName;
 
-    public TestMainAction(Runnable detector, TestClassProcessor processor, TestResultProcessor resultProcessor, Clock clock, Object testTaskOperationId, Object rootTestSuiteId, String displayName) {
+    public TestMainAction(Runnable detector, TestClassProcessor processor, TestResultProcessor resultProcessor, Clock clock, Object rootTestSuiteId, String displayName) {
         this.detector = detector;
         this.processor = processor;
         this.resultProcessor = new AttachParentTestResultProcessor(resultProcessor);
         this.clock = clock;
-        this.testTaskOperationId = testTaskOperationId;
         this.rootTestSuiteId = rootTestSuiteId;
         this.displayName = displayName;
     }
 
     @Override
     public void run() {
-        RootTestSuiteDescriptor suite = new RootTestSuiteDescriptor(rootTestSuiteId, displayName, testTaskOperationId);
+        TestDescriptorInternal suite = new RootTestSuiteDescriptor(rootTestSuiteId, displayName);
         resultProcessor.started(suite, new TestStartEvent(clock.getCurrentTime()));
         try {
             processor.startProcessing(resultProcessor);
@@ -61,18 +58,9 @@ public class TestMainAction implements Runnable {
         }
     }
 
-    public static final class RootTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
-        private final Object testTaskOperationId;
-
-        private RootTestSuiteDescriptor(Object id, String name, Object testTaskOperationId) {
+    private static final class RootTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
+        private RootTestSuiteDescriptor(Object id, String name) {
             super(id, name);
-            this.testTaskOperationId = testTaskOperationId;
-        }
-
-        @Nullable
-        @Override
-        public Object getOwnerBuildOperationId() {
-            return testTaskOperationId;
         }
 
         @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -17,8 +17,6 @@ package org.gradle.api.internal.tasks.testing.results;
 
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 
-import javax.annotation.Nullable;
-
 public class UnknownTestDescriptor implements TestDescriptorInternal {
 
     @Override
@@ -43,12 +41,6 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
 
     @Override
     public TestDescriptorInternal getParent() {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Object getOwnerBuildOperationId() {
         return null;
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -24,7 +24,6 @@ class SimpleTestDescriptor implements TestDescriptorInternal {
     String classDisplayName = "ClassName"
     boolean composite = false
     TestDescriptorInternal parent = null
-    Object ownerBuildOperationId = null
     Object getId() {
         "${parent?.id}$className$name" as String
     }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
@@ -25,7 +25,7 @@ class TestMainActionTest extends Specification {
     private final TestResultProcessor resultProcessor = Mock()
     private final Runnable detector = Mock()
     private final Clock timeProvider = Mock()
-    private final TestMainAction action = new TestMainAction(detector, processor, resultProcessor, timeProvider, "taskOperationId123", "rootTestSuiteId456", "Test Run")
+    private final TestMainAction action = new TestMainAction(detector, processor, resultProcessor, timeProvider, "rootTestSuiteId456", "Test Run")
 
     def 'fires start and end events around detector execution'() {
         when:

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -37,7 +37,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -57,7 +56,6 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
     private final ActorFactory actorFactory;
     private final ModuleRegistry moduleRegistry;
     private final WorkerLeaseRegistry workerLeaseRegistry;
-    private final BuildOperationExecutor buildOperationExecutor;
     private final int maxWorkerCount;
     private final Clock clock;
     private final DocumentationRegistry documentationRegistry;
@@ -65,13 +63,12 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
     private TestClassProcessor processor;
 
     public DefaultTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory, ModuleRegistry moduleRegistry,
-                               WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, int maxWorkerCount,
+                               WorkerLeaseRegistry workerLeaseRegistry, int maxWorkerCount,
                                Clock clock, DocumentationRegistry documentationRegistry, DefaultTestFilter testFilter) {
         this.workerFactory = workerFactory;
         this.actorFactory = actorFactory;
         this.moduleRegistry = moduleRegistry;
         this.workerLeaseRegistry = workerLeaseRegistry;
-        this.buildOperationExecutor = buildOperationExecutor;
         this.maxWorkerCount = maxWorkerCount;
         this.clock = clock;
         this.documentationRegistry = documentationRegistry;
@@ -116,9 +113,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
             detector = new DefaultTestClassScanner(testClassFiles, null, processor);
         }
 
-        final Object testTaskOperationId = buildOperationExecutor.getCurrentOperation().getParentId();
-
-        new TestMainAction(detector, processor, testResultProcessor, clock, testTaskOperationId, testExecutionSpec.getPath(), "Gradle Test Run " + testExecutionSpec.getIdentityPath()).run();
+        new TestMainAction(detector, processor, testResultProcessor, clock, testExecutionSpec.getPath(), "Gradle Test Run " + testExecutionSpec.getIdentityPath()).run();
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -70,7 +70,6 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
@@ -692,7 +691,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         if (testExecuter == null) {
             return new DefaultTestExecuter(getProcessBuilderFactory(), getActorFactory(), getModuleRegistry(),
                 getServices().get(WorkerLeaseRegistry.class),
-                getServices().get(BuildOperationExecutor.class),
                 getServices().get(StartParameter.class).getMaxWorkerCount(),
                 getServices().get(Clock.class),
                 getServices().get(DocumentationRegistry.class),

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
@@ -28,7 +28,6 @@ import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.io.LineBufferingOutputStream;
 import org.gradle.internal.io.TextStream;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.ExecResult;
@@ -63,11 +62,6 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
         throw new UnsupportedOperationException();
     }
 
-    @Inject
-    public BuildOperationExecutor getBuildOperationExcecutor() {
-        throw new UnsupportedOperationException();
-    }
-
     public IdGenerator<?> getIdGenerator() {
         return new LongIdGenerator();
     }
@@ -93,9 +87,7 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
 
         Runnable detector = new XCTestDetector(processor, testExecutionSpec.getTestSelection());
 
-        Object testTaskOperationId = getBuildOperationExcecutor().getCurrentOperation().getParentId();
-
-        new TestMainAction(detector, processor, testResultProcessor, getTimeProvider(), testTaskOperationId, rootTestSuiteId, "Gradle Test Run " + testExecutionSpec.getPath()).run();
+        new TestMainAction(detector, processor, testResultProcessor, getTimeProvider(), rootTestSuiteId, "Gradle Test Run " + testExecutionSpec.getPath()).run();
     }
 
     @Override

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
@@ -17,11 +17,14 @@
 package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildEventConsumer;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalProgressEvent;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -29,15 +32,17 @@ class ProgressEventConsumer {
 
     private final Set<Object> startedIds = ConcurrentHashMap.newKeySet();
     private final BuildEventConsumer delegate;
-    private final BuildOperationParentTracker parentTracker;
+    private final BuildOperationAncestryTracker ancestryTracker;
 
-    ProgressEventConsumer(BuildEventConsumer delegate, BuildOperationParentTracker parentTracker) {
+    ProgressEventConsumer(BuildEventConsumer delegate, BuildOperationAncestryTracker ancestryTracker) {
         this.delegate = delegate;
-        this.parentTracker = parentTracker;
+        this.ancestryTracker = ancestryTracker;
     }
 
-    Object findStartedParentId(BuildOperationDescriptor operation) {
-        return parentTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains);
+    @Nullable
+    OperationIdentifier findStartedParentId(BuildOperationDescriptor operation) {
+        return ancestryTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains)
+            .orElse(null);
     }
 
     void started(InternalOperationStartedProgressEvent event) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
@@ -21,6 +21,7 @@ import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionException;
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
@@ -28,9 +29,14 @@ import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
 import java.util.Collections;
 
 public class TestExecutionRequestActionRunner implements BuildActionRunner {
+    private final BuildOperationAncestryTracker ancestryTracker;
     private final BuildOperationListenerManager buildOperationListenerManager;
 
-    public TestExecutionRequestActionRunner(BuildOperationListenerManager buildOperationListenerManager) {
+    public TestExecutionRequestActionRunner(
+        BuildOperationAncestryTracker ancestryTracker,
+        BuildOperationListenerManager buildOperationListenerManager
+    ) {
+        this.ancestryTracker = ancestryTracker;
         this.buildOperationListenerManager = buildOperationListenerManager;
     }
 
@@ -42,7 +48,7 @@ public class TestExecutionRequestActionRunner implements BuildActionRunner {
 
         try {
             TestExecutionRequestAction testExecutionRequestAction = (TestExecutionRequestAction) action;
-            TestExecutionResultEvaluator testExecutionResultEvaluator = new TestExecutionResultEvaluator(testExecutionRequestAction);
+            TestExecutionResultEvaluator testExecutionResultEvaluator = new TestExecutionResultEvaluator(ancestryTracker, testExecutionRequestAction);
             buildOperationListenerManager.addListener(testExecutionResultEvaluator);
             try {
                 doRun(testExecutionRequestAction, buildController);

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -19,6 +19,7 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.internal.build.event.BuildEventListenerFactory;
 import org.gradle.internal.build.event.OperationResultPostProcessorFactory;
 import org.gradle.internal.invocation.BuildActionRunner;
+import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.service.ServiceRegistration;
@@ -32,17 +33,24 @@ public class ToolingBuilderServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.addProvider(new Object() {
-            BuildActionRunner createBuildActionRunner(final BuildOperationListenerManager buildOperationListenerManager) {
+            BuildActionRunner createBuildActionRunner(
+                BuildOperationAncestryTracker ancestryTracker,
+                BuildOperationListenerManager buildOperationListenerManager
+            ) {
                 return new ChainingBuildActionRunner(
                     Arrays.asList(
                         new BuildModelActionRunner(),
-                        new TestExecutionRequestActionRunner(buildOperationListenerManager),
+                        new TestExecutionRequestActionRunner(ancestryTracker, buildOperationListenerManager),
                         new ClientProvidedBuildActionRunner(),
                         new ClientProvidedPhasedActionRunner()));
             }
 
-            BuildEventListenerFactory createToolingApiSubscribableBuildActionRunnerRegistration(BuildOperationIdFactory buildOperationIdFactory, List<OperationResultPostProcessorFactory> postProcessorFactories) {
-                return new ToolingApiBuildEventListenerFactory(buildOperationIdFactory, postProcessorFactories);
+            BuildEventListenerFactory createToolingApiSubscribableBuildActionRunnerRegistration(
+                BuildOperationAncestryTracker ancestryTracker,
+                BuildOperationIdFactory buildOperationIdFactory,
+                List<OperationResultPostProcessorFactory> postProcessorFactories
+            ) {
+                return new ToolingApiBuildEventListenerFactory(ancestryTracker, buildOperationIdFactory, postProcessorFactories);
             }
         });
     }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.provider.runner
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.invocation.BuildController
+import org.gradle.internal.operations.BuildOperationAncestryTracker
 import org.gradle.internal.operations.BuildOperationListenerManager
 import spock.lang.Specification
 
@@ -24,8 +25,7 @@ class TestExecutionRequestActionRunnerTest extends Specification {
 
     def "does not handle non TestExecutionRequestAction"(){
         given:
-        BuildOperationListenerManager buildOperationService = Mock(BuildOperationListenerManager)
-        def runner = new TestExecutionRequestActionRunner(buildOperationService)
+        def runner = new TestExecutionRequestActionRunner(Mock(BuildOperationAncestryTracker), Mock(BuildOperationListenerManager))
         BuildAction buildAction = Mock(BuildAction)
         BuildController buildController= Mock(BuildController)
         when:

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
     def "generates events for interleaved project configuration and dependency resolution"() {
         given:
         settingsFile << """
-            
+
             rootProject.name = 'multi'
             include 'a', 'b'
         """
@@ -114,7 +114,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
             repositories {
                maven { url '${mavenHttpRepo.uri}' }
             }
-            
+
             dependencies {
                 implementation project(':a')
                 implementation "group:projectB:1.0"
@@ -260,7 +260,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         and:
         def compileJavaActions = events.operations.findAll { it.descriptor.displayName.matches('Execute .*( action [0-9]+/[0-9]+)? for :compileJava') }
         compileJavaActions.size() > 0
-        compileJavaActions[0].parent.descriptor.displayName == 'Task :compileJava'
+        compileJavaActions[0].hasAncestor { it.descriptor.displayName == 'Task :compileJava' }
     }
 
     @TargetGradleVersion('>=3.5 <5.1')

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -35,6 +35,8 @@ import org.gradle.tooling.events.transform.TransformOperationDescriptor
 import org.gradle.tooling.events.work.WorkItemOperationDescriptor
 import org.gradle.util.GradleVersion
 
+import java.util.function.Predicate
+
 class ProgressEvents implements ProgressListener {
     private final List<ProgressEvent> events = []
     private boolean dirty
@@ -437,9 +439,13 @@ class ProgressEvents implements ProgressListener {
         }
 
         boolean hasAncestor(Operation ancestor) {
+            return hasAncestor({ it == ancestor })
+        }
+
+        boolean hasAncestor(Predicate<? super Operation> predicate) {
             return parent == null
                 ? false
-                : (parent == ancestor || parent.hasAncestor(ancestor))
+                : (predicate.test(parent) || parent.hasAncestor(predicate))
         }
     }
 


### PR DESCRIPTION
This is a backport of https://github.com/gradle/gradle/pull/14736 to Gradle 6.7.

This is not something to necessarily release as part of 6.7, we just need the extra build operation to be able to measure performance against 6.7 using a snapshot release. We can also merge it if there's another RC.