### PR TITLE
Run Windows performance tests as part of Ready for Nightly

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestsPass.kt
@@ -16,6 +16,7 @@
 
 package Gradle_Check.configurations
 
+import Gradle_Check.model.PerformanceTestCoverage
 import common.Os
 import common.applyDefaultSettings
 import configurations.BaseGradleBuildType
@@ -99,4 +100,6 @@ subprojects/$performanceProjectName/build/performance-test-results.zip
             }
         }
     }
-})
+}) {
+    val performanceTestCoverage: PerformanceTestCoverage = performanceTestProject.performanceTestCoverage
+}

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -73,8 +73,8 @@ data class CIBuildModel(
                 TestCoverage(6, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION),
                 TestCoverage(28, TestType.watchFs, Os.LINUX, JvmCategory.MAX_VERSION)),
             performanceTests = listOf(
-                PerformanceTestCoverage(6, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5),
-                PerformanceTestCoverage(7, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5)
+                PerformanceTestCoverage(6, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5, failsStage = false),
+                PerformanceTestCoverage(7, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5, failsStage = false)
             )
         ),
         Stage(StageNames.READY_FOR_RELEASE,

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -73,6 +73,7 @@ data class CIBuildModel(
                 TestCoverage(6, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION),
                 TestCoverage(28, TestType.watchFs, Os.LINUX, JvmCategory.MAX_VERSION)),
             performanceTests = listOf(
+                PerformanceTestCoverage(6, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5),
                 PerformanceTestCoverage(7, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5)
             )
         ),
@@ -105,6 +106,7 @@ data class CIBuildModel(
                 PerformanceTestCoverage(3, PerformanceTestType.historical, Os.LINUX, numberOfBuckets = 60, oldUuid = "PerformanceTestHistoricalLinux"),
                 PerformanceTestCoverage(4, PerformanceTestType.flakinessDetection, Os.LINUX, numberOfBuckets = 60, oldUuid = "PerformanceTestFlakinessDetectionLinux"),
                 PerformanceTestCoverage(5, PerformanceTestType.experiment, Os.LINUX, numberOfBuckets = 20, oldUuid = "PerformanceTestExperimentLinux"),
+                PerformanceTestCoverage(8, PerformanceTestType.experiment, Os.WINDOWS, numberOfBuckets = 5),
                 PerformanceTestCoverage(9, PerformanceTestType.experiment, Os.MACOS, numberOfBuckets = 5)
             )),
         Stage(StageNames.EXPERIMENTAL,
@@ -155,8 +157,6 @@ data class CIBuildModel(
             trigger = Trigger.never,
             runsIndependent = true,
             performanceTests = listOf(
-                PerformanceTestCoverage(6, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5),
-                PerformanceTestCoverage(8, PerformanceTestType.experiment, Os.WINDOWS, numberOfBuckets = 5),
                 PerformanceTestCoverage(10, PerformanceTestType.test, Os.LINUX, numberOfBuckets = 40, withoutDependencies = true),
                 PerformanceTestCoverage(11, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5, withoutDependencies = true),
                 PerformanceTestCoverage(12, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5, withoutDependencies = true),

--- a/.teamcity/Gradle_Check/model/PerformanceTestCoverage.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestCoverage.kt
@@ -27,7 +27,8 @@ data class PerformanceTestCoverage(
     val os: Os,
     val numberOfBuckets: Int = 40,
     val oldUuid: String? = null,
-    val withoutDependencies: Boolean = false
+    val withoutDependencies: Boolean = false,
+    val failsStage: Boolean = true
 ) {
     fun asConfigurationId(model: CIBuildModel, bucket: String = "") =
         "${model.projectPrefix}${oldUuid ?: "PerformanceTest$uuid"}$bucket"


### PR DESCRIPTION
This reverts commit fde12d20

We currently won't fail Ready for Nightly if a Windows performance test fails.