### PR TITLE
Write transformed jars with UTF-8

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -83,6 +83,7 @@ public class ClasspathBuilder {
         public void put(String name, byte[] content) throws IOException {
             maybeAddParent(name);
             ZipEntry zipEntry = newZipEntryWithFixedTime(name);
+            outputStream.setEncoding("UTF-8");
             outputStream.putNextEntry(zipEntry);
             outputStream.write(content);
             outputStream.closeEntry();


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/14155

The old transformation code used defaut encoding when writing ZipOutputStream,
which caused "bad entry name" issue on Windows JDKs with special locales.

@adammurdoch @big-guy I think this worths `6.7` release. I was intended to create a PR for `release` but accidentally direct-pushed to `release` branch, so if you think it should be in `6.8`, I can revert that commit: https://github.com/gradle/gradle/commit/ed3dab682368179381dffeb86773d25a43bb29df