### PR TITLE
Let configuration cache key include `--include-build` and `--settings-file`

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheKey.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheKey.kt
@@ -52,6 +52,12 @@ class ConfigurationCacheKey(
             } ?: ""
         )
 
+        putAll(
+            startParameter.includedBuilds.map {
+                relativePathOf(it, startParameter.rootDirectory)
+            }
+        )
+
         val requestedTaskNames = startParameter.requestedTaskNames
         putAll(requestedTaskNames)
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -18,9 +18,9 @@ package org.gradle.configurationcache.initialization
 
 import org.gradle.StartParameter
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.configurationcache.extensions.unsafeLazy
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
-import org.gradle.configurationcache.extensions.unsafeLazy
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
 import java.io.File
@@ -89,4 +89,7 @@ class ConfigurationCacheStartParameter(
 
     val gradleUserHomeDir: File
         get() = startParameter.gradleUserHomeDir
+
+    val includedBuilds: List<File>
+        get() = startParameter.includedBuilds
 }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.internal.StartParameterInternal
+import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
+import org.gradle.initialization.layout.BuildLayout
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+
+class ConfigurationCacheKeyTest {
+
+    @JvmField
+    @Rule
+    val testDirectoryProvider = TestNameTestDirectoryProvider(javaClass)
+
+    @Test
+    fun `cache key honours --include-build`() {
+        assertThat(
+            cacheKeyStringFromStartParameter {
+                includeBuild(file("included"))
+            },
+            equalTo(
+                cacheKeyStringFromStartParameter {
+                    includeBuild(file("included"))
+                }
+            )
+        )
+        assertThat(
+            cacheKeyStringFromStartParameter {
+                includeBuild(file("included"))
+            },
+            not(equalTo(cacheKeyStringFromStartParameter { }))
+        )
+    }
+
+    @Test
+    fun `cache key honours --settings-file`() {
+        assertThat(
+            cacheKeyStringFromStartParameter {
+                settingsFile = file("settings.gradle")
+            },
+            equalTo(
+                cacheKeyStringFromStartParameter {
+                    settingsFile = file("settings.gradle")
+                }
+            )
+        )
+        assertThat(
+            cacheKeyStringFromStartParameter {
+                settingsFile = file("settings.gradle")
+            },
+            not(
+                equalTo(
+                    cacheKeyStringFromStartParameter {
+                        settingsFile = file("custom-settings.gradle")
+                    }
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `sanity check`() {
+        assertThat(
+            cacheKeyStringFromStartParameter {},
+            equalTo(cacheKeyStringFromStartParameter {})
+        )
+    }
+
+    private
+    fun cacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String =
+        ConfigurationCacheKey(
+            ConfigurationCacheStartParameter(
+                BuildLayout(
+                    file("root"),
+                    file("settings"),
+                    null
+                ),
+                StartParameterInternal().apply(configure)
+            )
+        ).string
+
+    private
+    fun file(path: String) =
+        testDirectoryProvider.file(path)
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
