### PR TITLE
Remove deployment ChangeBehavior.BLOCK_AND_REBUILD

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/deployment/internal/DeploymentRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/deployment/internal/DeploymentRegistry.java
@@ -52,13 +52,6 @@ public interface DeploymentRegistry {
      */
     enum ChangeBehavior {
         /**
-         * When changes are detected, wait for a deployment request before rebuilding.
-         *
-         * The deployment needs to call {@link Deployment#status()} to trigger a rebuild wait for changes.
-         */
-        BLOCK_AND_REBUILD,
-
-        /**
          * When changes are detected, block the deployment until all changes are incorporated.
          *
          * The deployment needs to call {@link Deployment#status()} to wait for changes.


### PR DESCRIPTION
This was broken since 2017 (commit 998d8f639f6b77ee57b8d66ae38ad80162f06b91)
and is not used by the only user of deployments (play application plugin).

### Context
The `RegisteredDeployment.create` function has a switch-case without this value. As an alternative to deleting this option, we could also restore the implementation there (but as it's dead code right now anyway, I decided to propose to delete it instead). 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
