### PR TITLE
Handle Kotlin multifile class metadata in buildscript compile avoidance

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
@@ -64,8 +64,15 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor, val inlineMethodWrit
             when (val kotlinMetadata = KotlinClassMetadata.read(parseKotlinClassHeader(it))) {
                 is KotlinClassMetadata.Class -> kotlinMetadata.toKmClass().extractFunctionMetadata()
                 is KotlinClassMetadata.FileFacade -> kotlinMetadata.toKmPackage().extractFunctionMetadata()
-                else -> {
-                    // KotlinClassMetadata.SyntheticClass || KotlinClassMetadata.MultiFileClassFacade || KotlinClassMetadata.MultiFileClassPart || KotlinClassMetadata.Unknown
+                is KotlinClassMetadata.MultiFileClassPart -> kotlinMetadata.toKmPackage().extractFunctionMetadata()
+                is KotlinClassMetadata.MultiFileClassFacade -> {
+                    // This metadata appears on a generated Java class resulting from @file:JvmName("ClassName") + @file:JvmMultiFileClass annotations in Kotlin scripts.
+                    // The resulting facade class contains references to classes generated from each script pointing to this class.
+                    // Each of those classes is visited separately and have KotlinClassMetadata.MultiFileClassPart on them
+                }
+                is KotlinClassMetadata.SyntheticClass -> {
+                }
+                is KotlinClassMetadata.Unknown -> {
                 }
             }
         }


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/9224

When Kotlin scripts are combined to a facade class using `@file:JvmName("ClassName")` + `@file:JvmMultiFileClass` annotations, the metadata of the individual classes for each script has `KotlinClassMetadata.MultiFileClassPart` metadata type and not `KotlinClassMetadata.Class` like for usual classes. This change handles the `KotlinClassMetadata.MultiFileClassPart` to correctly handle Kotlin-specific inline modifiers in compile avoidance context.
