### PR TITLE
Fix configuration cache serialization of file dependencies with artifact transforms applied

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
@@ -48,6 +48,7 @@ class ConfigurationCacheTestkitIntegrationTest extends AbstractConfigurationCach
         runner.withArguments("--configuration-cache")
         runner.forwardOutput()
         runner.withProjectDir(testDirectory)
+        runner.withPluginClasspath([new File("some-dir")])
         def result = runner.buildAndFail()
         def output = result.output
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -154,6 +154,7 @@ class ConfigurationCacheIO internal constructor(
         Codecs(
             directoryFileTreeFactory = service(),
             fileCollectionFactory = service(),
+            artifactSetConverter = service(),
             fileLookup = service(),
             propertyFactory = service(),
             filePropertyFactory = service(),

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -28,11 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult
-import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformDependencies
-import org.gradle.api.internal.artifacts.transform.ExecutionGraphDependenciesResolver
-import org.gradle.api.internal.artifacts.transform.Transformation
 import org.gradle.api.internal.artifacts.transform.TransformationNode
-import org.gradle.api.internal.artifacts.transform.TransformationSubject
 import org.gradle.api.internal.artifacts.transform.TransformedExternalArtifactSet
 import org.gradle.api.internal.artifacts.transform.TransformedProjectArtifactSet
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -43,12 +39,10 @@ import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
-import org.gradle.configurationcache.serialization.codecs.transform.FixedDependenciesResolver
 import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
-import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import java.io.File
 import java.util.concurrent.Callable
 
@@ -58,9 +52,6 @@ class ArtifactCollectionCodec(
     private val fileCollectionFactory: FileCollectionFactory,
     private val artifactSetConverter: ArtifactSetToFileCollectionFactory
 ) : Codec<ArtifactCollectionInternal> {
-
-    private
-    val noDependencies = FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty()))
 
     override suspend fun WriteContext.encode(value: ArtifactCollectionInternal) {
         val visitor = CollectingArtifactVisitor()
@@ -80,17 +71,14 @@ class ArtifactCollectionCodec(
                     is TransformedProjectVariantSpec -> Callable {
                         element.nodes.flatMap { it.transformedSubject.get().files }
                     }
-                    is TransformedLocalArtifactSpec -> Callable {
-                        element.transformation.isolateParameters()
-                        element.transformation.createInvocation(TransformationSubject.initial(element.origin), FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty())), null).invoke().get().files
-                    }
+                    is LocalFileDependencyBackedArtifactSet -> artifactSetConverter.asFileCollection(element)
                     is TransformedExternalArtifactSet -> artifactSetConverter.asFileCollection(element)
                     else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
                 }
             }
         )
         val failures = readList().uncheckedCast<List<Throwable>>()
-        return FixedArtifactCollection(files, elements, failures, artifactSetConverter, noDependencies)
+        return FixedArtifactCollection(files, elements, failures, artifactSetConverter)
     }
 }
 
@@ -113,21 +101,12 @@ class TransformedProjectVariantSpec(
 
 
 private
-class TransformedLocalArtifactSpec(
-    val ownerId: ComponentIdentifier,
-    val origin: File,
-    val transformation: Transformation,
-    val variantAttributes: ImmutableAttributes
-)
-
-
-private
 class CollectingArtifactVisitor : ArtifactVisitor {
     val elements = mutableListOf<Any>()
     val failures = mutableListOf<Throwable>()
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
-        return if (source is TransformedProjectArtifactSet || source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet || source is TransformedExternalArtifactSet) {
+        return if (source is TransformedProjectArtifactSet || source is LocalFileDependencyBackedArtifactSet || source is TransformedExternalArtifactSet) {
             // Represents artifact transform outputs. Visit the source rather than the files
             // Transforms may have inputs or parameters that are task outputs or other changing files
             // When this is not the case, we should run the transform now and write the result.
@@ -154,8 +133,8 @@ class CollectingArtifactVisitor : ArtifactVisitor {
     override fun endVisitCollection(source: FileCollectionInternal.Source) {
         if (source is TransformedProjectArtifactSet) {
             elements.add(TransformedProjectVariantSpec(source.ownerId, source.targetVariantAttributes, source.scheduledNodes))
-        } else if (source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet) {
-            elements.add(TransformedLocalArtifactSpec(source.ownerId, source.file, source.transformation, source.targetVariantAttributes))
+        } else if (source is LocalFileDependencyBackedArtifactSet) {
+            elements.add(source)
         } else if (source is TransformedExternalArtifactSet) {
             elements.add(source)
         }
@@ -168,8 +147,7 @@ class FixedArtifactCollection(
     private val artifactFiles: FileCollection,
     private val elements: List<Any>,
     private val failures: List<Throwable>,
-    private val artifactSetConverter: ArtifactSetToFileCollectionFactory,
-    private val noDependencies: ExecutionGraphDependenciesResolver
+    private val artifactSetConverter: ArtifactSetToFileCollectionFactory
 ) : ArtifactCollectionInternal {
 
     private
@@ -226,21 +204,8 @@ class FixedArtifactCollection(
                 is TransformedExternalArtifactSet -> {
                     result.addAll(artifactSetConverter.asResolvedArtifactSupplier(element).get())
                 }
-                is TransformedLocalArtifactSpec -> {
-                    element.transformation.isolateParameters()
-                    val displayName = Describables.of(element.ownerId, element.variantAttributes)
-                    for (output in element.transformation.createInvocation(TransformationSubject.initial(element.origin), noDependencies, null).invoke().get().files) {
-                        val artifactId = ComponentFileArtifactIdentifier(element.ownerId, output.name)
-                        result.add(
-                            DefaultResolvedArtifactResult(
-                                artifactId,
-                                element.variantAttributes,
-                                displayName,
-                                Artifact::class.java,
-                                output
-                            )
-                        )
-                    }
+                is LocalFileDependencyBackedArtifactSet -> {
+                    result.addAll(artifactSetConverter.asResolvedArtifactSupplier(element).get())
                 }
                 else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache.serialization.codecs
 
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetToFileCollectionFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.BuildIdentifierSerializer
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
@@ -78,6 +79,7 @@ import java.io.Externalizable
 class Codecs(
     directoryFileTreeFactory: DirectoryFileTreeFactory,
     fileCollectionFactory: FileCollectionFactory,
+    artifactSetConverter: ArtifactSetToFileCollectionFactory,
     fileLookup: FileLookup,
     propertyFactory: PropertyFactory,
     filePropertyFactory: FilePropertyFactory,
@@ -118,7 +120,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileFactory, patternSetFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, artifactSetConverter, fileOperations, fileFactory, patternSetFactory)
 
         bind(ApiTextResourceAdapterCodec)
 
@@ -126,7 +128,7 @@ class Codecs(
         bind(GroovyMetaClassCodec)
 
         // Dependency management types
-        bind(ArtifactCollectionCodec(fileCollectionFactory))
+        bind(ArtifactCollectionCodec(fileCollectionFactory, artifactSetConverter))
         bind(ImmutableAttributesCodec(attributesFactory, managedFactoryRegistry))
         bind(AttributeContainerCodec(attributesFactory, managedFactoryRegistry))
         bind(TransformationNodeReferenceCodec)
@@ -177,7 +179,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(propertyFactory, filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, fileOperations, fileFactory, patternSetFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, artifactSetConverter, fileOperations, fileFactory, patternSetFactory)
 
         bind(BuildIdentifierSerializer())
         bind(TaskNodeCodec(userTypesCodec, taskNodeFactory))
@@ -207,12 +209,12 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, fileOperations: FileOperations, fileFactory: FileFactory, patternSetFactory: Factory<PatternSet>) {
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, artifactSetConverter: ArtifactSetToFileCollectionFactory, fileOperations: FileOperations, fileFactory: FileFactory, patternSetFactory: Factory<PatternSet>) {
         bind(DirectoryCodec(fileFactory))
         bind(RegularFileCodec(fileFactory))
         bind(ConfigurableFileTreeCodec(fileCollectionFactory))
         bind(FileTreeCodec(fileCollectionFactory, directoryFileTreeFactory, fileOperations))
-        val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory)
+        val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory, artifactSetConverter)
         bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
         bind(fileCollectionCodec)
         bind(IntersectPatternSetCodec)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -140,6 +140,7 @@ class Codecs(
         bind(TransformDependenciesCodec)
         bind(PublishArtifactLocalArtifactMetadataCodec)
         bind(TransformedExternalArtifactSetCodec(transformationNodeRegistry))
+        bind(LocalFileDependencyBackedArtifactSetCodec(instantiator, attributesFactory, fileCollectionFactory))
 
         bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
@@ -20,10 +20,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetToFileCollectionFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
-import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformDependencies
-import org.gradle.api.internal.artifacts.transform.Transformation
 import org.gradle.api.internal.artifacts.transform.TransformationNode
-import org.gradle.api.internal.artifacts.transform.TransformationSubject
 import org.gradle.api.internal.artifacts.transform.TransformedExternalArtifactSet
 import org.gradle.api.internal.artifacts.transform.TransformedProjectArtifactSet
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -42,7 +39,6 @@ import org.gradle.api.tasks.util.PatternSet
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
-import org.gradle.configurationcache.serialization.codecs.transform.FixedDependenciesResolver
 import org.gradle.configurationcache.serialization.decodePreservingIdentity
 import org.gradle.configurationcache.serialization.encodePreservingIdentityOf
 import org.gradle.configurationcache.serialization.logPropertyProblem
@@ -55,9 +51,6 @@ class FileCollectionCodec(
     private val fileCollectionFactory: FileCollectionFactory,
     private val artifactSetConverter: ArtifactSetToFileCollectionFactory
 ) : Codec<FileCollectionInternal> {
-
-    private
-    val noDependencies = FixedDependenciesResolver(DefaultArtifactTransformDependencies(fileCollectionFactory.empty()))
 
     override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         encodePreservingIdentityOf(value) {
@@ -95,10 +88,7 @@ class FileCollectionCodec(
                             is ProviderBackedFileCollectionSpec -> element.provider
                             is FileTree -> element
                             is TransformedExternalArtifactSet -> artifactSetConverter.asFileCollection(element)
-                            is TransformedLocalFileSpec -> Callable {
-                                element.transformation.isolateParameters()
-                                element.transformation.createInvocation(TransformationSubject.initial(element.origin), noDependencies, null).invoke().get().files
-                            }
+                            is LocalFileDependencyBackedArtifactSet -> artifactSetConverter.asFileCollection(element)
                             else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
                         }
                     }
@@ -119,10 +109,6 @@ class SubtractingFileCollectionSpec(val left: FileCollection, val right: FileCol
 
 private
 class FilteredFileCollectionSpec(val collection: FileCollection, val filter: Spec<in File>)
-
-
-private
-class TransformedLocalFileSpec(val origin: File, val transformation: Transformation)
 
 
 private
@@ -161,7 +147,7 @@ class CollectingVisitor : FileCollectionStructureVisitor {
         }
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType =
-        if (source is TransformedProjectArtifactSet || source is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet || source is TransformedExternalArtifactSet) {
+        if (source is TransformedProjectArtifactSet || source is LocalFileDependencyBackedArtifactSet || source is TransformedExternalArtifactSet) {
             // Represents artifact transform outputs. Visit the source rather than the files
             // Transforms may have inputs or parameters that are task outputs or other changing files
             // When this is not the case, we should run the transform now and write the result.
@@ -177,8 +163,8 @@ class CollectingVisitor : FileCollectionStructureVisitor {
             is TransformedProjectArtifactSet -> {
                 elements.addAll(source.scheduledNodes)
             }
-            is LocalFileDependencyBackedArtifactSet.TransformedLocalFileArtifactSet -> {
-                elements.add(TransformedLocalFileSpec(source.file, source.transformation))
+            is LocalFileDependencyBackedArtifactSet -> {
+                elements.add(source)
             }
             is TransformedExternalArtifactSet -> {
                 elements.add(source)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("DEPRECATION")
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.FileCollectionDependency
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.artifacts.transform.VariantTransform
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.internal.artifacts.ArtifactTransformRegistration
+import org.gradle.api.internal.artifacts.VariantTransformRegistry
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformDependencies
+import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformDependencies
+import org.gradle.api.internal.artifacts.transform.ExecutionGraphDependenciesResolver
+import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory
+import org.gradle.api.internal.artifacts.transform.Transformation
+import org.gradle.api.internal.artifacts.transform.TransformationStep
+import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory
+import org.gradle.api.internal.artifacts.transform.Transformer
+import org.gradle.api.internal.artifacts.transform.VariantSelector
+import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry
+import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.AttributesSchemaInternal
+import org.gradle.api.internal.attributes.EmptySchema
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory
+import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.tasks.TaskDependencyContainer
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.specs.Spec
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.decodePreservingSharedIdentity
+import org.gradle.configurationcache.serialization.encodePreservingSharedIdentityOf
+import org.gradle.configurationcache.serialization.readCollection
+import org.gradle.configurationcache.serialization.readNonNull
+import org.gradle.configurationcache.serialization.writeCollection
+import org.gradle.internal.Describables
+import org.gradle.internal.DisplayName
+import org.gradle.internal.Try
+import org.gradle.internal.component.local.model.LocalFileDependencyMetadata
+import org.gradle.internal.component.model.VariantResolveMetadata
+import org.gradle.internal.operations.BuildOperationQueue
+import org.gradle.internal.operations.RunnableBuildOperation
+import org.gradle.internal.reflect.Instantiator
+import java.io.File
+
+
+class LocalFileDependencyBackedArtifactSetCodec(
+    private val instantiator: Instantiator,
+    private val attributesFactory: ImmutableAttributesFactory,
+    private val fileCollectionFactory: FileCollectionFactory
+) : Codec<LocalFileDependencyBackedArtifactSet> {
+    override suspend fun WriteContext.encode(value: LocalFileDependencyBackedArtifactSet) {
+        // TODO - When the set of files is fixed (eg `gradleApi()` or some hard-coded list of files):
+        //   - calculate the attributes for each of the files eagerly rather than writing the mappings
+        //   - when the selector would not apply a transform, then write only the files and nothing else
+        //   - otherwise, write only the transform and attributes for each file rather than writing the transform registry
+        write(value.dependencyMetadata.componentId)
+        write(value.dependencyMetadata.files)
+        write(value.componentFilter)
+
+        // Write the file extension -> attributes mappings
+        // TODO - move this to an encoder
+        encodePreservingSharedIdentityOf(value.artifactTypeRegistry) {
+            val mappings = value.artifactTypeRegistry.create()!!
+            writeCollection(mappings) {
+                writeString(it.name)
+                write(it.attributes)
+            }
+        }
+
+        // Write the file extension -> transformation mappings
+        // This currently uses a dummy file and dummy set of variants to calculate the mappings.
+        // TODO - simplify extracting the mappings
+        // TODO - deduplicate this data, as the mapping is project scoped and almost always the same across all projects of a given type
+        val mappings = mutableMapOf<ImmutableAttributes, MappingSpec>()
+        value.artifactTypeRegistry.visitArtifactTypes { type ->
+            val sourceAttributes = value.artifactTypeRegistry.mapAttributesFor(File("thing.$type"))
+            val recordingSet = RecordingVariantSet(value.dependencyMetadata.files, sourceAttributes)
+            val selected = value.selector.select(recordingSet, recordingSet)
+            if (selected == ResolvedArtifactSet.EMPTY) {
+                mappings.put(sourceAttributes, EmptyMapping)
+            } else if (recordingSet.targetAttributes != null) {
+                mappings.put(sourceAttributes, TransformMapping(recordingSet.targetAttributes!!, recordingSet.transformation!!))
+            } else {
+                mappings.put(sourceAttributes, IdentityMapping)
+            }
+        }
+        write(mappings)
+    }
+
+    override suspend fun ReadContext.decode(): LocalFileDependencyBackedArtifactSet {
+        val componentId = read() as ComponentIdentifier?
+        val files = readNonNull<FileCollectionInternal>()
+        val filter = readNonNull<Spec<ComponentIdentifier>>()
+
+        // TODO - use an immutable registry implementation
+        val artifactTypeRegistry = decodePreservingSharedIdentity {
+            val registry = DefaultArtifactTypeRegistry(instantiator, attributesFactory, CollectionCallbackActionDecorator.NOOP, EmptyVariantTransformRegistry)
+            val mappings = registry.create()!!
+            readCollection {
+                val name = readString()
+                val attributes = readNonNull<AttributeContainer>()
+                val mapping = mappings.create(name).attributes
+                @Suppress("UNCHECKED_CAST")
+                for (attribute in attributes.keySet() as Set<Attribute<Any>>) {
+                    mapping.attribute(attribute, attributes.getAttribute(attribute) as Any)
+                }
+            }
+            registry
+        }
+
+        val transforms = readNonNull<Map<ImmutableAttributes, MappingSpec>>()
+        val selector = FixedVariantSelector(transforms, fileCollectionFactory, NoOpTransformedVariantFactory)
+        return LocalFileDependencyBackedArtifactSet(FixedFileMetadata(componentId, files), filter, selector, artifactTypeRegistry)
+    }
+}
+
+
+private
+class RecordingVariantSet(
+    private val source: FileCollectionInternal,
+    private val attributes: ImmutableAttributes
+) : ResolvedVariantSet, ResolvedVariant, VariantSelector.Factory, ResolvedArtifactSet {
+    var targetAttributes: ImmutableAttributes? = null
+    var transformation: Transformation? = null
+
+    override fun asDescribable(): DisplayName {
+        return Describables.of(source)
+    }
+
+    override fun getSchema(): AttributesSchemaInternal {
+        return EmptySchema.INSTANCE
+    }
+
+    override fun getVariants(): Set<ResolvedVariant> {
+        return setOf(this)
+    }
+
+    override fun getOverriddenAttributes(): ImmutableAttributes {
+        return ImmutableAttributes.EMPTY
+    }
+
+    override fun getIdentifier(): VariantResolveMetadata.Identifier? {
+        return null
+    }
+
+    override fun getAttributes(): AttributeContainerInternal {
+        return attributes
+    }
+
+    override fun visitDependencies(context: TaskDependencyResolveContext) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun startVisit(actions: BuildOperationQueue<RunnableBuildOperation>, listener: ResolvedArtifactSet.AsyncArtifactListener): ResolvedArtifactSet.Completion {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun visitLocalArtifacts(visitor: ResolvedArtifactSet.LocalArtifactVisitor) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun visitExternalArtifacts(visitor: Action<ResolvableArtifact>) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun getArtifacts(): ResolvedArtifactSet {
+        return this
+    }
+
+    override fun asTransformed(sourceVariant: ResolvedVariant, targetAttributes: ImmutableAttributes, transformation: Transformation, dependenciesResolver: ExtraExecutionGraphDependenciesResolverFactory, transformedVariantFactory: TransformedVariantFactory): ResolvedArtifactSet {
+        this.transformation = transformation
+        this.targetAttributes = targetAttributes
+        return sourceVariant.artifacts
+    }
+}
+
+
+private
+sealed class MappingSpec
+
+
+private
+class TransformMapping(val targetAttributes: ImmutableAttributes, val transformation: Transformation) : MappingSpec()
+
+
+private
+object EmptyMapping : MappingSpec()
+
+
+private
+object IdentityMapping : MappingSpec()
+
+
+private
+class FixedVariantSelector(
+    private val transforms: Map<ImmutableAttributes, MappingSpec>,
+    private val fileCollectionFactory: FileCollectionFactory,
+    private val transformedVariantFactory: TransformedVariantFactory
+) : VariantSelector {
+    override fun select(candidates: ResolvedVariantSet, factory: VariantSelector.Factory): ResolvedArtifactSet {
+        require(candidates.variants.size == 1)
+        val variant = candidates.variants.first()
+        val spec = transforms.get(variant.attributes.asImmutable())
+        return when (spec) {
+            null -> variant.artifacts // was no mapping for extension
+            is EmptyMapping -> ResolvedArtifactSet.EMPTY
+            is IdentityMapping -> variant.artifacts
+            is TransformMapping -> factory.asTransformed(variant, spec.targetAttributes, spec.transformation, EmptyDependenciesResolverFactory(fileCollectionFactory), transformedVariantFactory)
+        }
+    }
+}
+
+
+private
+class FixedFileMetadata(
+    private val compId: ComponentIdentifier?,
+    private val source: FileCollectionInternal
+) : LocalFileDependencyMetadata {
+    override fun getComponentId(): ComponentIdentifier? {
+        return compId
+    }
+
+    override fun getFiles(): FileCollectionInternal {
+        return source
+    }
+
+    override fun getSource(): FileCollectionDependency {
+        throw UnsupportedOperationException("Should not be called")
+    }
+}
+
+
+private
+class EmptyDependenciesResolverFactory(private val fileCollectionFactory: FileCollectionFactory) : ExtraExecutionGraphDependenciesResolverFactory {
+    override fun create(componentIdentifier: ComponentIdentifier): ExecutionGraphDependenciesResolver {
+        return object : ExecutionGraphDependenciesResolver {
+            override fun computeDependencyNodes(transformationStep: TransformationStep): TaskDependencyContainer {
+                throw UnsupportedOperationException("Should not be called")
+            }
+
+            override fun selectedArtifacts(transformer: Transformer): FileCollection {
+                throw UnsupportedOperationException("Should not be called")
+            }
+
+            override fun computeArtifacts(transformer: Transformer): Try<ArtifactTransformDependencies> {
+                return Try.successful(DefaultArtifactTransformDependencies(fileCollectionFactory.empty()))
+            }
+        }
+    }
+}
+
+
+private
+object NoOpTransformedVariantFactory : TransformedVariantFactory {
+    override fun transformedExternalArtifacts(componentIdentifier: ComponentIdentifier, sourceVariant: ResolvedVariant, target: ImmutableAttributes, transformation: Transformation, dependenciesResolverFactory: ExtraExecutionGraphDependenciesResolverFactory): ResolvedArtifactSet {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun transformedProjectArtifacts(componentIdentifier: ComponentIdentifier, sourceVariant: ResolvedVariant, target: ImmutableAttributes, transformation: Transformation, dependenciesResolverFactory: ExtraExecutionGraphDependenciesResolverFactory): ResolvedArtifactSet {
+        throw UnsupportedOperationException("Should not be called")
+    }
+}
+
+
+private
+object EmptyVariantTransformRegistry : VariantTransformRegistry {
+    override fun registerTransform(registrationAction: Action<in VariantTransform>) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun <T : TransformParameters?> registerTransform(actionType: Class<out TransformAction<T>>, registrationAction: Action<in org.gradle.api.artifacts.transform.TransformSpec<T>>) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    override fun getTransforms(): MutableList<ArtifactTransformRegistration> {
+        throw UnsupportedOperationException("Should not be called")
+    }
+}

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -152,6 +152,7 @@ abstract class AbstractUserTypeCodecTest {
     fun codecs() = Codecs(
         directoryFileTreeFactory = mock(),
         fileCollectionFactory = mock(),
+        artifactSetConverter = mock(),
         fileLookup = mock(),
         propertyFactory = mock(),
         filePropertyFactory = mock(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -569,8 +569,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return null;
         }
 
-        ArtifactTypeRegistry createArtifactTypeRegistry(Instantiator instantiator, ImmutableAttributesFactory immutableAttributesFactory, CollectionCallbackActionDecorator decorator) {
-            return new DefaultArtifactTypeRegistry(instantiator, immutableAttributesFactory, decorator);
+        ArtifactTypeRegistry createArtifactTypeRegistry(Instantiator instantiator, ImmutableAttributesFactory immutableAttributesFactory, CollectionCallbackActionDecorator decorator, VariantTransformRegistry transformRegistry) {
+            return new DefaultArtifactTypeRegistry(instantiator, immutableAttributesFactory, decorator, transformRegistry);
         }
 
         DependencyHandler createDependencyHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetToFileCollectionFactory;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformationNodeRegistry;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeDependencyResolver;
@@ -39,6 +40,11 @@ public class DependencyServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerBuildServices(ServiceRegistration registration) {
         registration.addProvider(new DependencyManagementBuildScopeServices());
+    }
+
+    @Override
+    public void registerBuildSessionServices(ServiceRegistration registration) {
+        registration.add(ArtifactSetToFileCollectionFactory.class);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -71,7 +71,6 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstrain
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedFileCollectionVisitor;
-import org.gradle.api.internal.artifacts.ivyservice.ResolvedFilesCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
@@ -1305,14 +1304,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         protected void visitContents(FileCollectionStructureVisitor visitor) {
-            visitArtifacts(new ResolvedFileCollectionVisitor(visitor));
-        }
-
-        private void visitArtifacts(ResolvedFilesCollectingVisitor visitor) {
-            getSelectedArtifacts().visitArtifacts(visitor, lenient);
-
+            ResolvedFileCollectionVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
+            getSelectedArtifacts().visitArtifacts(collectingVisitor, lenient);
             if (!lenient) {
-                rethrowFailure("files", visitor.getFailures());
+                rethrowFailure("files", collectingVisitor.getFailures());
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.ResolvedFileCollectionVisitor;
+import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+@ServiceScope(Scopes.BuildSession.class)
+public class ArtifactSetToFileCollectionFactory {
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public ArtifactSetToFileCollectionFactory(BuildOperationExecutor buildOperationExecutor) {
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    /**
+     * Presents the contents of the given artifacts as a partial {@link FileCollectionInternal} implementation.
+     *
+     * <p>This produces only a minimal implementation to use for artifact sets loaded from the configuration cache
+     * Over time, this should be merged with the FileCollection implementation in DefaultConfiguration
+     */
+    public FileCollectionInternal asFileCollection(ResolvedArtifactSet artifacts) {
+        return new AbstractFileCollection() {
+            @Override
+            public String getDisplayName() {
+                return "files";
+            }
+
+            @Override
+            protected void visitContents(FileCollectionStructureVisitor visitor) {
+                ResolvedFileCollectionVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
+                ParallelResolveArtifactSet.wrap(artifacts, buildOperationExecutor).visit(collectingVisitor);
+                if (!collectingVisitor.getFailures().isEmpty()) {
+                    throw UncheckedException.throwAsUncheckedException(collectingVisitor.getFailures().iterator().next());
+                }
+            }
+        };
+    }
+
+    /**
+     * Presents the contents of the given artifacts as a supplier of {@link ResolvedArtifactResult} instances.
+     *
+     * <p>Over time, this should be merged with the ArtifactCollection implementation in DefaultConfiguration
+     */
+    public Supplier<Set<ResolvedArtifactResult>> asResolvedArtifactSupplier(ResolvedArtifactSet artifacts) {
+        return () -> {
+            ResolvedArtifactCollectingVisitor collectingVisitor = new ResolvedArtifactCollectingVisitor();
+            ParallelResolveArtifactSet.wrap(artifacts, buildOperationExecutor).visit(collectingVisitor);
+            if (!collectingVisitor.getFailures().isEmpty()) {
+                throw UncheckedException.throwAsUncheckedException(collectingVisitor.getFailures().iterator().next());
+            }
+            return collectingVisitor.getArtifacts();
+        };
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -69,7 +69,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
         FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(this);
         if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
-            return EMPTY_RESULT;
+            return visitor -> visitor.endVisitCollection(this);
         }
 
         ComponentIdentifier componentIdentifier = dependencyMetadata.getComponentId();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -65,6 +65,22 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         this.artifactTypeRegistry = artifactTypeRegistry;
     }
 
+    public LocalFileDependencyMetadata getDependencyMetadata() {
+        return dependencyMetadata;
+    }
+
+    public ArtifactTypeRegistry getArtifactTypeRegistry() {
+        return artifactTypeRegistry;
+    }
+
+    public Spec<? super ComponentIdentifier> getComponentFilter() {
+        return componentFilter;
+    }
+
+    public VariantSelector getSelector() {
+        return selector;
+    }
+
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
         FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(this);
@@ -222,7 +238,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     /**
      * An artifact set that contains a single transformed local file.
      */
-    public static class TransformedLocalFileArtifactSet extends AbstractTransformedArtifactSet implements FileCollectionInternal.Source {
+    private static class TransformedLocalFileArtifactSet extends AbstractTransformedArtifactSet implements FileCollectionInternal.Source {
         private final SingletonFileResolvedVariant delegate;
         private final Transformation transformation;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
@@ -23,10 +23,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * An artifact set containing transformed external artifacts.
  */
@@ -54,18 +50,6 @@ public class TransformedExternalArtifactSet extends AbstractTransformedArtifactS
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         getTransformation().visitTransformationSteps(step -> context.add(getDependenciesResolver().computeDependencyNodes(step)));
-    }
-
-    public List<File> calculateResult() {
-        getTransformation().isolateParameters();
-
-        List<File> files = new ArrayList<>();
-        delegate.visitExternalArtifacts(artifact -> {
-            TransformationSubject subject = TransformationSubject.initial(artifact.getId(), artifact.getFile());
-            TransformationSubject transformed = getTransformation().createInvocation(subject, getDependenciesResolver(), null).invoke().get();
-            files.addAll(transformed.getFiles());
-        });
-        return files;
     }
 
     public void visitArtifacts(Action<ResolvableArtifact> visitor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
@@ -22,9 +22,12 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 
 import java.io.File;
+import java.util.function.Consumer;
 
 public interface ArtifactTypeRegistry extends Factory<ArtifactTypeContainer> {
     ImmutableAttributes mapAttributesFor(ImmutableAttributes attributes, Iterable<? extends ComponentArtifactMetadata> artifacts);
 
     ImmutableAttributes mapAttributesFor(File file);
+
+    void visitArtifactTypes(Consumer<String> action);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
+import org.gradle.api.internal.artifacts.ArtifactTransformRegistration;
+import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -28,6 +30,9 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
 
@@ -35,12 +40,32 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
     private final Instantiator instantiator;
     private final ImmutableAttributesFactory attributesFactory;
     private final CollectionCallbackActionDecorator callbackActionDecorator;
+    private final VariantTransformRegistry transformRegistry;
     private ArtifactTypeContainer artifactTypeDefinitions;
 
-    public DefaultArtifactTypeRegistry(Instantiator instantiator, ImmutableAttributesFactory attributesFactory, CollectionCallbackActionDecorator callbackActionDecorator) {
+    public DefaultArtifactTypeRegistry(Instantiator instantiator, ImmutableAttributesFactory attributesFactory, CollectionCallbackActionDecorator callbackActionDecorator, VariantTransformRegistry transformRegistry) {
         this.instantiator = instantiator;
         this.attributesFactory = attributesFactory;
         this.callbackActionDecorator = callbackActionDecorator;
+        this.transformRegistry = transformRegistry;
+    }
+
+    @Override
+    public void visitArtifactTypes(Consumer<String> action) {
+        Set<String> seen = new HashSet<>();
+        if (artifactTypeDefinitions != null) {
+            for (ArtifactTypeDefinition artifactTypeDefinition : artifactTypeDefinitions) {
+                seen.add(artifactTypeDefinition.getName());
+                action.accept(artifactTypeDefinition.getName());
+            }
+        }
+        for (ArtifactTransformRegistration transform : transformRegistry.getTransforms()) {
+            String format = transform.getFrom().getAttribute(ARTIFACT_FORMAT);
+            // Not a directory and some format that is not already registered
+            if (format != null && !format.equals(ArtifactTypeDefinition.DIRECTORY_TYPE) && seen.add(format)) {
+                action.accept(format);
+            }
+        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -68,6 +68,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         1 * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.NoContents
+        1 * visitor.endVisitCollection(_)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ArtifactAttributes
+import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.IvyArtifactName
@@ -30,7 +31,7 @@ import spock.lang.Specification
 
 class DefaultArtifactTypeRegistryTest extends Specification {
     def attributesFactory = AttributeTestUtil.attributesFactory()
-    def registry = new DefaultArtifactTypeRegistry(TestUtil.instantiatorFactory().decorateLenient(), attributesFactory, CollectionCallbackActionDecorator.NOOP)
+    def registry = new DefaultArtifactTypeRegistry(TestUtil.instantiatorFactory().decorateLenient(), attributesFactory, CollectionCallbackActionDecorator.NOOP, Stub(VariantTransformRegistry))
 
     def "creates as required and reuses"() {
         expect:

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.transform
 
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
@@ -75,14 +76,11 @@ allprojects {
     artifacts {
         implementation producer.output
     }
-    task resolve {
+    task resolve (type: ShowFileCollection) {
         def view = configurations.implementation.incoming.artifactView {
             attributes.attribute(color, 'green')
         }.files
-        inputs.files view
-        doLast {
-            println "result = \${view.files.name}"
-        }
+        files.from(view)
     }
     task resolveArtifacts(type: ShowArtifactCollection) {
         collection = configurations.implementation.incoming.artifactView {
@@ -93,6 +91,16 @@ allprojects {
 
 import ${JarOutputStream.name}
 import ${ZipEntry.name}
+
+class ShowFileCollection extends DefaultTask {
+    @InputFiles
+    final ConfigurableFileCollection files = project.objects.fileCollection()
+
+    @TaskAction
+    def go() {
+        println "result = \${files.files.name}"
+    }
+}
 
 class JarProducer extends DefaultTask {
     @OutputFile

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class DependencyResolvingClasspath extends AbstractOpaqueFileCollection {
     private final GlobalDependencyResolutionRules globalRules = GlobalDependencyResolutionRules.NO_OP;
@@ -151,6 +152,11 @@ public class DependencyResolvingClasspath extends AbstractOpaqueFileCollection {
             @Override
             public ImmutableAttributes mapAttributesFor(ImmutableAttributes attributes, Iterable<? extends ComponentArtifactMetadata> artifacts) {
                 return attributes;
+            }
+
+            @Override
+            public void visitArtifactTypes(Consumer<String> action) {
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
@@ -50,8 +50,9 @@ import org.gradle.plugin.use.internal.PluginDependencyResolutionServices;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
 import org.gradle.plugin.use.internal.PluginResolverFactory;
 import org.gradle.plugin.use.resolve.internal.PluginResolverContributor;
+import org.gradle.plugin.use.resolve.service.internal.DefaultInjectedClasspathPluginResolver;
 import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathInstrumentationStrategy;
-import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathPluginResolver;
+import org.gradle.plugin.use.resolve.service.internal.ClientInjectedClasspathPluginResolver;
 
 import java.util.List;
 
@@ -86,7 +87,7 @@ public class PluginUsePluginServiceRegistry extends AbstractPluginServiceRegistr
 
         PluginResolverFactory createPluginResolverFactory(PluginRegistry pluginRegistry,
                                                           DocumentationRegistry documentationRegistry,
-                                                          InjectedClasspathPluginResolver injectedClasspathPluginResolver,
+                                                          ClientInjectedClasspathPluginResolver injectedClasspathPluginResolver,
                                                           PluginDependencyResolutionServices dependencyResolutionServices,
                                                           List<PluginResolverContributor> pluginResolverContributors,
                                                           VersionSelectorScheme versionSelectorScheme) {
@@ -101,10 +102,13 @@ public class PluginUsePluginServiceRegistry extends AbstractPluginServiceRegistr
                 internalPluginResolutionStrategy, pluginInspector, cachedClasspathTransformer);
         }
 
-        InjectedClasspathPluginResolver createInjectedClassPathPluginResolver(ClassLoaderScopeRegistry classLoaderScopeRegistry, PluginInspector pluginInspector,
-                                                                              InjectedPluginClasspath injectedPluginClasspath, CachedClasspathTransformer classpathTransformer,
-                                                                              InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
-            return new InjectedClasspathPluginResolver(classLoaderScopeRegistry.getCoreAndPluginsScope(), classpathTransformer, pluginInspector, injectedPluginClasspath.getClasspath(), instrumentationStrategy);
+        ClientInjectedClasspathPluginResolver createInjectedClassPathPluginResolver(ClassLoaderScopeRegistry classLoaderScopeRegistry, PluginInspector pluginInspector,
+                                                                                    InjectedPluginClasspath injectedPluginClasspath, CachedClasspathTransformer classpathTransformer,
+                                                                                    InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
+            if (injectedPluginClasspath.getClasspath().isEmpty()) {
+                return ClientInjectedClasspathPluginResolver.EMPTY;
+            }
+            return new DefaultInjectedClasspathPluginResolver(classLoaderScopeRegistry.getCoreAndPluginsScope(), classpathTransformer, pluginInspector, injectedPluginClasspath.getClasspath(), instrumentationStrategy);
         }
 
         PluginResolutionStrategyInternal createPluginResolutionStrategy(Instantiator instantiator, ListenerManager listenerManager) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginResolverFactory.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginResolverFactory.java
@@ -27,7 +27,8 @@ import org.gradle.plugin.use.resolve.internal.CorePluginResolver;
 import org.gradle.plugin.use.resolve.internal.NoopPluginResolver;
 import org.gradle.plugin.use.resolve.internal.PluginResolver;
 import org.gradle.plugin.use.resolve.internal.PluginResolverContributor;
-import org.gradle.plugin.use.resolve.service.internal.InjectedClasspathPluginResolver;
+import org.gradle.plugin.use.resolve.service.internal.DefaultInjectedClasspathPluginResolver;
+import org.gradle.plugin.use.resolve.service.internal.ClientInjectedClasspathPluginResolver;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -36,18 +37,18 @@ public class PluginResolverFactory implements Factory<PluginResolver> {
 
     private final PluginRegistry pluginRegistry;
     private final DocumentationRegistry documentationRegistry;
-    private final InjectedClasspathPluginResolver injectedClasspathPluginResolver;
+    private final ClientInjectedClasspathPluginResolver injectedClasspathPluginResolver;
     private final DependencyResolutionServices dependencyResolutionServices;
     private final List<PluginResolverContributor> pluginResolverContributors;
     private final VersionSelectorScheme versionSelectorScheme;
 
     public PluginResolverFactory(
-            PluginRegistry pluginRegistry,
-            DocumentationRegistry documentationRegistry,
-            InjectedClasspathPluginResolver injectedClasspathPluginResolver,
-            DependencyResolutionServices dependencyResolutionServices,
-            List<PluginResolverContributor> pluginResolverContributors,
-            VersionSelectorScheme versionSelectorScheme) {
+        PluginRegistry pluginRegistry,
+        DocumentationRegistry documentationRegistry,
+        ClientInjectedClasspathPluginResolver injectedClasspathPluginResolver,
+        DependencyResolutionServices dependencyResolutionServices,
+        List<PluginResolverContributor> pluginResolverContributors,
+        VersionSelectorScheme versionSelectorScheme) {
         this.pluginRegistry = pluginRegistry;
         this.documentationRegistry = documentationRegistry;
         this.injectedClasspathPluginResolver = injectedClasspathPluginResolver;
@@ -76,7 +77,7 @@ public class PluginResolverFactory implements Factory<PluginResolver> {
      * <ol>
      *     <li>{@link NoopPluginResolver} - Only used in tests.</li>
      *     <li>{@link CorePluginResolver} - distributed with Gradle</li>
-     *     <li>{@link InjectedClasspathPluginResolver} - from a TestKit test's ClassPath</li>
+     *     <li>{@link DefaultInjectedClasspathPluginResolver} - from a TestKit test's ClassPath</li>
      *     <li>Resolvers contributed by this distribution.</li>
      *     <li>Resolvers based on the entries of the `pluginRepositories` block</li>
      *     <li>{@link org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver} - from Gradle Plugin Portal if no `pluginRepositories` were defined</li>
@@ -89,9 +90,7 @@ public class PluginResolverFactory implements Factory<PluginResolver> {
         resolvers.add(new NoopPluginResolver(pluginRegistry));
         resolvers.add(new CorePluginResolver(documentationRegistry, pluginRegistry));
 
-        if (!injectedClasspathPluginResolver.isClasspathEmpty()) {
-            resolvers.add(injectedClasspathPluginResolver);
-        }
+        injectedClasspathPluginResolver.collectResolversInto(resolvers);
 
         for (PluginResolverContributor contributor : pluginResolverContributors) {
             contributor.collectResolversInto(resolvers);

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/ClientInjectedClasspathPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/ClientInjectedClasspathPluginResolver.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.use.resolve.service.internal;
+
+import org.gradle.plugin.use.resolve.internal.PluginResolver;
+
+import java.util.Collection;
+
+public interface ClientInjectedClasspathPluginResolver {
+    ClientInjectedClasspathPluginResolver EMPTY = dest -> { };
+
+    void collectResolversInto(Collection<? super PluginResolver> dest);
+}

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
@@ -35,13 +35,14 @@ import org.gradle.plugin.use.resolve.internal.PluginResolveContext;
 import org.gradle.plugin.use.resolve.internal.PluginResolver;
 
 import java.io.File;
+import java.util.Collection;
 
-public class InjectedClasspathPluginResolver implements PluginResolver {
+public class DefaultInjectedClasspathPluginResolver implements ClientInjectedClasspathPluginResolver, PluginResolver {
 
     private final ClassPath injectedClasspath;
     private final PluginRegistry pluginRegistry;
 
-    public InjectedClasspathPluginResolver(ClassLoaderScope parentScope, CachedClasspathTransformer classpathTransformer, PluginInspector pluginInspector, ClassPath injectedClasspath, InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
+    public DefaultInjectedClasspathPluginResolver(ClassLoaderScope parentScope, CachedClasspathTransformer classpathTransformer, PluginInspector pluginInspector, ClassPath injectedClasspath, InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
         this.injectedClasspath = injectedClasspath;
         ClassPath cachedClassPath = classpathTransformer.transform(injectedClasspath, instrumentationStrategy.getTransform());
         this.pluginRegistry = new DefaultPluginRegistry(pluginInspector,
@@ -49,6 +50,11 @@ public class InjectedClasspathPluginResolver implements PluginResolver {
                 .local(cachedClassPath)
                 .lock()
         );
+    }
+
+    @Override
+    public void collectResolversInto(Collection<? super PluginResolver> dest) {
+        dest.add(this);
     }
 
     @Override

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -229,12 +229,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
                     @Override
                     public void execute(ArtifactView.ViewConfiguration viewConfiguration) {
                         viewConfiguration.lenient(true);
-                        viewConfiguration.componentFilter(new Spec<ComponentIdentifier>() {
-                            @Override
-                            public boolean isSatisfiedBy(ComponentIdentifier element) {
-                                return element instanceof ProjectComponentIdentifier;
-                            }
-                        });
+                        viewConfiguration.componentFilter(new IsProjectComponent());
                     }
                 }).getFiles());
 
@@ -329,6 +324,13 @@ public class ScalaBasePlugin implements Plugin<Project> {
                     details.closestMatch(javaRuntime);
                 }
             }
+        }
+    }
+
+    private static class IsProjectComponent implements Spec<ComponentIdentifier> {
+        @Override
+        public boolean isSatisfiedBy(ComponentIdentifier element) {
+            return element instanceof ProjectComponentIdentifier;
         }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #14513 

### Context

This PR fixes the issue but introduces some complexity in one of the codecs and also serializes some duplicate state to the configuration cache. This can be addressed in a later PR.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
