### PR TITLE
Fall back to hashing the whole jar on unknown Kotlin metadata when extracting Kotlin's ABI

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -581,7 +581,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
         )
         withBuildScript("println(\"foo\")")
         configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
-        configureProject().assertBuildScriptCompilationAvoided().assertOutputContains("foo")
+        configureProject().assertBuildScriptCompilationAvoided()
     }
 
     private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
@@ -21,6 +21,7 @@ import kotlinx.metadata.KmDeclarationContainer
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
 import kotlinx.metadata.jvm.signature
+import org.gradle.api.GradleException
 import org.gradle.internal.normalization.java.ApiClassExtractor
 import org.gradle.internal.normalization.java.impl.AnnotationMember
 import org.gradle.internal.normalization.java.impl.ApiMemberWriter
@@ -73,6 +74,7 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor, val inlineMethodWrit
                 is KotlinClassMetadata.SyntheticClass -> {
                 }
                 is KotlinClassMetadata.Unknown -> {
+                    throw GradleException("Unknown Kotlin metadata with kind: ${kotlinMetadata.header.kind} on class ${classMember.name} - don't know how to extract its API class")
                 }
             }
         }


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/9224

If the metadata type of compiled Kotlin classes on buildscript's classpath can not be determined, fall back to using the content hash for that jar, turning off compile avoidance for it.
This can happen when the class on the script's classpath was compiled with some future version of Kotlin which has added new metadata types that this version of Gradle is not able to parse and thus does not know how or if it contributes to the ABI.