### PR TITLE
Re-use Scala compiler between runs

### DIFF
--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaCompilerContinuousIntegrationTest.groovy
@@ -68,4 +68,15 @@ class ScalaCompilerContinuousIntegrationTest extends AbstractCompilerContinuousI
             }
         """
     }
+
+    @Override
+    String getVerifyDaemonsTask() {
+        """
+            task verifyDaemons {
+                doLast {
+                    assert services.get(WorkerDaemonClientsManager).allClients.size() == 1
+                }
+            }
+"""
+    }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -99,7 +99,7 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)
             .withClassLoaderStructure(classLoaderStructure)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(KeepAliveMode.DAEMON)
             .build();
     }
 


### PR DESCRIPTION
Relates to #13274

### Context

Tested by changing a single Scala source file.

Before:
```
Compiling with Zinc Scala compiler.
Prepared Zinc Scala inputs: 0.443 secs
Compiling 1 Scala source to /home/alpar/work/elastic/cloud/scala-services/util/build/classes/scala/main ...
Done compiling.
Completed Scala compilation: 5.929 secs
```

After:
```
Prepared Zinc Scala inputs: 0.075 secs
Compiling 1 Scala source to /home/alpar/work/elastic/cloud/scala-services/util/build/classes/scala/main ...
Done compiling.
Completed Scala compilation: 0.694 secs
```

I also used a build with this change to run build for a while without any
side-effects.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
