### PR TITLE
 Use G1 GC when running BuildSrcApiChangePerformanceTest on Java 8

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -136,6 +136,30 @@
     "linux" : 477000
   } ]
 }, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1002000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1558000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 235000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1002000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1558000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 235000
+  } ]
+}, {
   "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -1279,6 +1279,52 @@
             ]
         },
         {
+            "testId" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
+            "groups" : [
+                {
+                    "testProject" : "mediumMonolithicJavaProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProjectKotlinDsl",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
+            "testId" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
+            "groups" : [
+                {
+                    "testProject" : "mediumMonolithicJavaProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProject",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                },
+                {
+                    "testProject" : "largeJavaMultiProjectKotlinDsl",
+                    "coverage" : {
+                        "slow":  ["linux"]
+                    }
+                }
+            ]
+        },
+        {
             "testId" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.first use",
             "groups" : [
                 {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -22,9 +22,7 @@ import org.gradle.performance.mutator.ApplyNonAbiChangeToGroovySourceFileMutator
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 import org.junit.experimental.categories.Category
-import spock.lang.Ignore
 
-@Ignore // TODO (donat) there's a memory leak probably. Will investigate later.
 @Category(SlowPerformanceRegressionTest)
 class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -15,8 +15,10 @@
  */
 package org.gradle.performance.regression.inception
 
+import org.gradle.api.JavaVersion
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.categories.SlowPerformanceRegressionTest
+import org.gradle.performance.fixture.CrossVersionPerformanceTestRunner
 import org.gradle.performance.mutator.ApplyAbiChangeToGroovySourceFileMutator
 import org.gradle.performance.mutator.ApplyNonAbiChangeToGroovySourceFileMutator
 import org.gradle.profiler.BuildMutator
@@ -31,13 +33,14 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.targetVersions = [targetVersion]
         runner.minimumBaseVersion = "6.8"
         runner.warmUpRuns = 3
+        runner.gradleOpts = runner.projectMemoryOptions
+        useG1GarbageCollectorOnJava8(runner)
     }
 
     def "buildSrc abi change"() {
         given:
         runner.tasksToRun = ['help']
         runner.runs = determineNumberOfRuns(runner.testProject)
-        runner.gradleOpts = runner.projectMemoryOptions
 
         and:
         def changingClassFilePath = "buildSrc/src/main/groovy/ChangingClass.groovy"
@@ -55,7 +58,6 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
         given:
         runner.tasksToRun = ['help']
         runner.runs = determineNumberOfRuns(runner.testProject)
-        runner.gradleOpts = runner.projectMemoryOptions
 
         and:
         def changingClassFilePath = "buildSrc/src/main/groovy/ChangingClass.groovy"
@@ -78,6 +80,12 @@ class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTe
                 return 10
             default:
                 20
+        }
+    }
+
+    private static void useG1GarbageCollectorOnJava8(CrossVersionPerformanceTestRunner runner) {
+        if (!JavaVersion.current().isJava9Compatible()) {
+            runner.gradleOpts.addAll(['-XX:+UnlockExperimentalVMOptions', '-XX:+UseG1GC'])
         }
     }
 


### PR DESCRIPTION
The default Parallel GC cannot keep up with the performance test which causes build flakiness.