### PR TITLE
Allow using async-profiler-alloc in performance tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
@@ -73,8 +73,8 @@ public abstract class AbstractBuildExperimentRunner implements BuildExperimentRu
     private Profiler createProfiler(String profilerName) {
         OptionParser optionParser = new OptionParser();
         optionParser.accepts("profiler");
+        ProfilerFactory.configureParser(optionParser);
         ProfilerFactory profilerFactory = ProfilerFactory.of(Collections.singletonList(profilerName));
-        profilerFactory.addOptions(optionParser);
         return profilerFactory.createFromOptions(optionParser.parse());
     }
 


### PR DESCRIPTION
We have been missing to configure the option factory for all profiler factories.