### PR TITLE
Refine smoke test configurations

### DIFF
--- a/.teamcity/Gradle_Check/configurations/SmokeTests.kt
+++ b/.teamcity/Gradle_Check/configurations/SmokeTests.kt
@@ -25,6 +25,7 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
         model,
         this,
         ":smoke-test:$task",
+        timeout = 120,
         notQuick = true,
         extraParameters = buildScanTag("SmokeTests") + " -PtestJavaHome=%linux.${testJava.version.name}.${testJava.vendor.name}.64bit%"
     )

--- a/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -37,7 +37,7 @@ val allVersionsIntegMultiVersionTest = "allVersionsIntegMultiVersionTest"
 
 val soakTest = "soakTest"
 
-val smokeTest = "soakTest"
+val smokeTest = "smokeTest"
 
 
 setupTimeoutMonitorOnCI()

--- a/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -37,6 +37,8 @@ val allVersionsIntegMultiVersionTest = "allVersionsIntegMultiVersionTest"
 
 val soakTest = "soakTest"
 
+val smokeTest = "soakTest"
+
 
 setupTimeoutMonitorOnCI()
 setupGlobalState()
@@ -69,12 +71,11 @@ fun setupTimeoutMonitorOnCI() {
     }
 }
 
-fun determineTimeoutMillis() =
-    if (isRequestedTask(compileAllBuild) || isRequestedTask(sanityCheck) || isRequestedTask(quickTest)) {
-        Duration.ofMinutes(30).toMillis()
-    } else {
-        Duration.ofHours(2).plusMinutes(45).toMillis()
-    }
+fun determineTimeoutMillis() = when {
+    isRequestedTask(compileAllBuild) || isRequestedTask(sanityCheck) || isRequestedTask(quickTest) -> Duration.ofMinutes(30).toMillis()
+    isRequestedTask(smokeTest) -> Duration.ofHours(1).plusMinutes(30).toMillis()
+    else -> Duration.ofHours(2).plusMinutes(45).toMillis()
+}
 
 fun setupGlobalState() {
     if (needsToUseTestVersionsPartial()) {


### PR DESCRIPTION
Smoke tests seem to be slower than 90m recently, so we increase the timeout to 120m
and set the stacktrace timeout monitor to 90m.
