### PR TITLE
Apply `sam-with-receiver` plugin to `kotlin-dsl`

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/build.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
 
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions")
     implementation(kotlin("gradle-plugin"))
+    implementation(kotlin("sam-with-receiver"))
     implementation("org.ow2.asm:asm")
 
     testImplementation("junit:junit")

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-sam-with-receiver.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-sam-with-receiver.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("kotlin-sam-with-receiver")
+}
+
+samWithReceiver {
+    annotation("org.gradle.api.HasImplicitReceiver")
+}

--- a/buildSrc/subprojects/uber-plugins/build.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/build.gradle.kts
@@ -10,5 +10,4 @@ dependencies {
 
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions")
     implementation(kotlin("gradle-plugin"))
-    implementation(kotlin("sam-with-receiver"))
 }

--- a/buildSrc/subprojects/uber-plugins/build.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions")
     implementation(kotlin("gradle-plugin"))
+    implementation(kotlin("sam-with-receiver"))
 }

--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("gradlebuild.distribution.implementation-kotlin")
+    id("gradlebuild.kotlin-dsl-sam-with-receiver")
 }
 
 tasks {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ListenerBroadcastCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ListenerBroadcastCodec.kt
@@ -33,7 +33,7 @@ class ListenerBroadcastCodec(private val listenerManager: ListenerManager) : Cod
         writeClass(value.type)
         val listeners = mutableListOf<Any>()
         broadcast.visitListeners {
-            listeners.add(it)
+            listeners.add(this)
         }
         writeCollection(listeners) {
             write(it)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/Transforms.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/Transforms.kt
@@ -75,7 +75,7 @@ class TransformationSpec(val transformation: Transformation, val dependencies: L
 fun unpackTransformation(transformation: Transformation, dependenciesResolver: ExecutionGraphDependenciesResolver): TransformationSpec {
     val dependencies = mutableListOf<TransformDependencies>()
     transformation.visitTransformationSteps {
-        dependencies.add(transformDependencies(it.transformer, dependenciesResolver))
+        dependencies.add(transformDependencies(transformer, dependenciesResolver))
     }
     return TransformationSpec(transformation, dependencies)
 }

--- a/subprojects/kotlin-dsl/build.gradle.kts
+++ b/subprojects/kotlin-dsl/build.gradle.kts
@@ -18,7 +18,7 @@ import gradlebuild.cleanup.WhenNotEmpty
 plugins {
     id("gradlebuild.distribution.api-kotlin")
     id("gradlebuild.kotlin-dsl-dependencies-embedded")
-    id("kotlin-sam-with-receiver")
+    id("gradlebuild.kotlin-dsl-sam-with-receiver")
 }
 
 description = "Kotlin DSL Provider"
@@ -132,8 +132,4 @@ classycle {
 
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
-}
-
-samWithReceiver {
-    annotation("org.gradle.api.HasImplicitReceiver")
 }

--- a/subprojects/kotlin-dsl/build.gradle.kts
+++ b/subprojects/kotlin-dsl/build.gradle.kts
@@ -18,6 +18,7 @@ import gradlebuild.cleanup.WhenNotEmpty
 plugins {
     id("gradlebuild.distribution.api-kotlin")
     id("gradlebuild.kotlin-dsl-dependencies-embedded")
+    id("kotlin-sam-with-receiver")
 }
 
 description = "Kotlin DSL Provider"
@@ -131,4 +132,8 @@ classycle {
 
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
+}
+
+samWithReceiver {
+    annotation("org.gradle.api.HasImplicitReceiver")
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -57,7 +57,7 @@ private constructor(
      * @since 6.3
      */
     fun constraints(configureAction: DependencyConstraintHandlerScope.() -> Unit) {
-        super.constraints { t -> configureAction(DependencyConstraintHandlerScope.of(t)) }
+        super.constraints { configureAction(DependencyConstraintHandlerScope.of(this)) }
     }
 
     /**

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensions.kt
@@ -30,10 +30,10 @@ import org.gradle.api.plugins.PluginAware
  */
 fun PluginAware.apply(from: Any? = null, plugin: String? = null, to: Any? = null) {
     require(from != null || plugin != null) { "At least one of 'from' or 'plugin' must be given." }
-    apply { action ->
-        if (plugin != null) action.plugin(plugin)
-        if (from != null) action.from(from)
-        if (to != null) action.to(to)
+    apply {
+        if (plugin != null) this.plugin(plugin)
+        if (from != null) this.from(from)
+        if (to != null) this.to(to)
     }
 }
 
@@ -48,7 +48,7 @@ fun PluginAware.apply(from: Any? = null, plugin: String? = null, to: Any? = null
  */
 inline fun <reified T : Plugin<*>> PluginAware.apply() {
     apply {
-        it.plugin(T::class.java)
+        plugin(T::class.java)
     }
 }
 
@@ -64,7 +64,7 @@ inline fun <reified T : Plugin<*>> PluginAware.apply() {
  */
 inline fun <reified T : Plugin<*>> PluginAware.applyTo(vararg targets: Any) {
     apply {
-        it.plugin(T::class.java)
-        it.to(*targets)
+        plugin(T::class.java)
+        to(*targets)
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensions.kt
@@ -33,7 +33,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
  * @see [MavenArtifactRepository.setUrl]
  */
 fun RepositoryHandler.maven(url: Any) =
-    maven { it.setUrl(url) }
+    maven { setUrl(url) }
 
 
 /**
@@ -51,8 +51,8 @@ fun RepositoryHandler.maven(url: Any) =
  */
 fun RepositoryHandler.maven(url: Any, action: MavenArtifactRepository.() -> Unit) =
     maven {
-        it.setUrl(url)
-        it.action()
+        setUrl(url)
+        action()
     }
 
 
@@ -69,7 +69,7 @@ fun RepositoryHandler.maven(url: Any, action: MavenArtifactRepository.() -> Unit
  * @see [RepositoryHandler.ivy]
  */
 fun RepositoryHandler.ivy(url: Any) =
-    ivy { it.setUrl(url) }
+    ivy { setUrl(url) }
 
 
 /**
@@ -87,6 +87,6 @@ fun RepositoryHandler.ivy(url: Any) =
  */
 fun RepositoryHandler.ivy(url: Any, action: IvyArtifactRepository.() -> Unit) =
     ivy {
-        it.setUrl(url)
-        it.action()
+        setUrl(url)
+        action()
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -106,4 +106,4 @@ fun externalModuleDependencyFor(
 
 
 fun functionToAction(f: (Any?) -> Unit): Action<Any?> =
-    Action { f(it) }
+    Action { f(this) }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -58,7 +58,7 @@ class ScriptCache(
             .withProperties(cacheProperties)
             .withInitializer {
                 initializeCacheDir(
-                    cacheDirOf(it.baseDir).apply { mkdir() },
+                    cacheDirOf(baseDir).apply { mkdir() },
                     cacheKey,
                     scriptTarget,
                     displayName,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.resolver
 
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.repositories.ArtifactRepository
@@ -105,14 +106,14 @@ class SourceDistributionResolver(val project: Project) : SourceDistributionProvi
         val repoName = repositoryNameFor(gradleVersion)
         name = "Gradle $repoName"
         setUrl("https://services.gradle.org/$repoName")
-        metadataSources { sources ->
-            sources.artifact()
+        metadataSources {
+            artifact()
         }
-        patternLayout { layout ->
+        patternLayout {
             if (isSnapshot(gradleVersion)) {
-                layout.ivy("/dummy") // avoids a lookup that interferes with version listing
+                ivy("/dummy") // avoids a lookup that interferes with version listing
             }
-            layout.artifact("[module]-[revision](-[classifier])(.[ext])")
+            artifact("[module]-[revision](-[classifier])(.[ext])")
         }
     }.also {
         // push the repository first in the list, for performance
@@ -143,12 +144,12 @@ class SourceDistributionResolver(val project: Project) : SourceDistributionProvi
     }
 
     private
-    inline fun <reified T : TransformAction<TransformParameters.None>> registerTransform(crossinline configure: TransformSpec<TransformParameters.None>.() -> Unit) =
-        dependencies.registerTransform(T::class.java) { configure(it) }
+    inline fun <reified T : TransformAction<TransformParameters.None>> registerTransform(configure: Action<TransformSpec<TransformParameters.None>>) =
+        dependencies.registerTransform(T::class.java, configure)
 
     private
-    fun ivy(configure: IvyArtifactRepository.() -> Unit) =
-        repositories.ivy { configure(it) }
+    fun ivy(configure: Action<IvyArtifactRepository>) =
+        repositories.ivy(configure)
 
     private
     fun minimumGradleVersion(): String? {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -41,7 +41,7 @@ class EmbeddedKotlinProvider {
     ) {
         embeddedKotlinVersions.forEach { (module, version) ->
             dependencies.constraints.add(configuration, module).apply {
-                version { it.strictly(version) }
+                version { strictly(version) }
                 because("Pinned to the embedded Kotlin")
             }
         }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
@@ -47,10 +47,10 @@ class ComponentSelectionRulesTest {
 
         configurations {
             create("conf") {
-                it.resolutionStrategy {
-                    it.componentSelection {
-                        it.all { selection ->
-                            selection.reject("all")
+                resolutionStrategy {
+                    componentSelection {
+                        all {
+                            reject("all")
                         }
                     }
                 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -281,7 +281,7 @@ class DependencyHandlerExtensionsTest {
             constraints {
                 add("api", "some:thing:1.0")
                 add("api", "other:thing") {
-                    it.version { it.strictly("1.0") }
+                    version { strictly("1.0") }
                 }
             }
         }
@@ -297,7 +297,7 @@ class DependencyHandlerExtensionsTest {
             constraints {
                 api("some:thing:1.0")
                 api("other:thing") {
-                    version { it.strictly("1.0") }
+                    version { strictly("1.0") }
                 }
             }
         }
@@ -307,7 +307,7 @@ class DependencyHandlerExtensionsTest {
             (constraints) {
                 "api"("some:thing:1.0")
                 "api"("other:thing") {
-                    version { it.strictly("1.0") }
+                    version { strictly("1.0") }
                 }
             }
         }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedContainersDslTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedContainersDslTest.kt
@@ -177,11 +177,11 @@ class NamedContainersDslTest : AbstractDslTest() {
             configurations {
                 val bazar by creating
                 create("cathedral") {
-                    it.extendsFrom(bazar)
+                    extendsFrom(bazar)
                 }
                 val valley by registering
                 register("hill") {
-                    it.extendsFrom(valley.get())
+                    extendsFrom(valley.get())
                 }
             }
             apply(plugin = "java")

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -184,14 +184,14 @@ class NamedDomainObjectCollectionExtensionsTest {
         }
 
         container.named<DomainObject>("foo").configure {
-            it.foo = "reified access"
+            foo = "reified access"
         }
         container.named<DomainObject>("foo") {
             bar = "reified configuration"
         }
 
         container.named("bar", DomainObject::class).configure {
-            it.foo = "typed access"
+            foo = "typed access"
         }
         container.named("bar", DomainObject::class) {
             bar = "typed configuration"

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -45,10 +45,10 @@ class NamedDomainObjectContainerExtensionsTest {
 
         // regular syntax
         container.getByName("alice") {
-            it.foo = "alice-foo"
+            foo = "alice-foo"
         }
         container.create("bob") {
-            it.foo = "bob-foo"
+            foo = "bob-foo"
         }
         container.maybeCreate("john")
 
@@ -58,10 +58,10 @@ class NamedDomainObjectContainerExtensionsTest {
         // invoke syntax
         container {
             getByName("alice") {
-                it.foo = "alice-foo"
+                foo = "alice-foo"
             }
             create("bob") {
-                it.foo = "bob-foo"
+                foo = "bob-foo"
             }
             maybeCreate("john")
 


### PR DESCRIPTION
1. To make the Gradle API available to unit tests and the implementation more
similar to the one available to scripts.

2. To ease the migration from Kotlin
function types with receiver to Gradle `Action`.