### PR TITLE
Moved the antlr convention to the conventions section

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
@@ -91,15 +91,15 @@ If no dependency is declared, `antlr:antlr:2.7.7` will be used as the default. T
 [[sec:antlr_convention_properties]]
 == Convention properties
 
-The ANTLR plugin does not add any convention properties.
+The ANTLR plugin adds one convention property.
+
+`antlr` — link:{groovyDslPath}/org.gradle.api.file.SourceDirectorySet.html[SourceDirectorySet]::
+The ANTLR grammar files of this source set. Contains all `.g` or `.g4` files found in the ANTLR source directories, and excludes all other types of files. _Default value is non-null._
 
 [[sec:antlr_source_set_properties]]
 == Source set properties
 
 The ANTLR plugin adds the following properties to each source set in the project.
-
-`antlr` — link:{groovyDslPath}/org.gradle.api.file.SourceDirectorySet.html[SourceDirectorySet]::
-The ANTLR grammar files of this source set. Contains all `.g` or `.g4` files found in the ANTLR source directories, and excludes all other types of files. _Default value is non-null._
 
 `antlr.srcDirs` — `Set&lt;File&gt;`::
 The source directories containing the ANTLR grammar files of this source set.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #13017

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This fixes an issue in the Antlr plugin doc, which mistakenly mentioned that the plugin didn't add any conventions.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
