### PR TITLE
Added 2 new ant.importBuild methods to allow specifying the basedir

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
@@ -45,6 +45,17 @@ public abstract class AntBuilder extends groovy.util.AntBuilder {
     public abstract void importBuild(Object antBuildFile);
 
     /**
+     * Imports an Ant build into the associated Gradle project, specifying the base directory for Gradle tasks that correspond to Ant targets.
+     * <p>
+     * By default the base directory is the Ant build file parent directory. The relative paths are relative to {@link Project#getProjectDir()}.
+     *
+     * @param antBuildFile The build file. This is resolved as per {@link Project#file(Object)}.
+     * @param baseDirectory The base directory. This is resolved as per {@link Project#file(Object)}.
+     */
+    @Incubating
+    public abstract void importBuild(Object antBuildFile, String baseDirectory);
+
+    /**
      * Imports an Ant build into the associated Gradle project, potentially providing alternative names for Gradle tasks that correspond to Ant targets.
      * <p>
      * For each Ant target that is to be converted to a Gradle task, the given {@code taskNamer} receives the Ant target name as input
@@ -52,13 +63,34 @@ public abstract class AntBuilder extends groovy.util.AntBuilder {
      * The transformer may be called multiple times with the same input.
      * Implementations should ensure uniqueness of the return value for a distinct input.
      * That is, no two inputs should yield the same return value.
-     *  @param antBuildFile The build file. This is resolved as per {@link org.gradle.api.Project#file(Object)}.
+     *
+     * @param antBuildFile The build file. This is resolved as per {@link org.gradle.api.Project#file(Object)}.
      * @param taskNamer A transformer that calculates the name of the Gradle task for a corresponding Ant target.
      */
     public abstract void importBuild(Object antBuildFile, Transformer<? extends String, ? super String> taskNamer);
 
     /**
+     * Imports an Ant build into the associated Gradle project, specifying the base directory and potentially providing alternative names
+     * for Gradle tasks that correspond to Ant targets.
+     * <p>
+     * By default the base directory is the Ant build file parent directory. The relative paths are relative to {@link Project#getProjectDir()}.
+     * <p>
+     * For each Ant target that is to be converted to a Gradle task, the given {@code taskNamer} receives the Ant target name as input
+     * and is expected to return the desired name for the corresponding Gradle task.
+     * The transformer may be called multiple times with the same input.
+     * Implementations should ensure uniqueness of the return value for a distinct input.
+     * That is, no two inputs should yield the same return value.
+     *
+     * @param antBuildFile The build file. This is resolved as per {@link Project#file(Object)}.
+     * @param baseDirectory The base directory. This is resolved as per {@link Project#file(Object)}.
+     * @param taskNamer A transformer that calculates the name of the Gradle task for a corresponding Ant target.
+     */
+    @Incubating
+    public abstract void importBuild(Object antBuildFile, String baseDirectory, Transformer<? extends String, ? super String> taskNamer);
+
+    /**
      * Returns this AntBuilder. Useful when you need to pass this builder to methods from within closures.
+     *
      * @return this
      */
     public AntBuilder getAnt() {
@@ -100,7 +132,7 @@ public abstract class AntBuilder extends groovy.util.AntBuilder {
         DEBUG, VERBOSE, INFO, WARN, ERROR;
 
         public static AntMessagePriority from(int messagePriority) {
-            switch(messagePriority) {
+            switch (messagePriority) {
                 case org.apache.tools.ant.Project.MSG_ERR:
                     return ERROR;
                 case org.apache.tools.ant.Project.MSG_WARN:

--- a/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
@@ -51,6 +51,8 @@ public abstract class AntBuilder extends groovy.util.AntBuilder {
      *
      * @param antBuildFile The build file. This is resolved as per {@link Project#file(Object)}.
      * @param baseDirectory The base directory. This is resolved as per {@link Project#file(Object)}.
+     *
+     * @since 6.9
      */
     @Incubating
     public abstract void importBuild(Object antBuildFile, String baseDirectory);
@@ -84,6 +86,8 @@ public abstract class AntBuilder extends groovy.util.AntBuilder {
      * @param antBuildFile The build file. This is resolved as per {@link Project#file(Object)}.
      * @param baseDirectory The base directory. This is resolved as per {@link Project#file(Object)}.
      * @param taskNamer A transformer that calculates the name of the Gradle task for a corresponding Ant target.
+     *
+     * @since 6.9
      */
     @Incubating
     public abstract void importBuild(Object antBuildFile, String baseDirectory, Transformer<? extends String, ? super String> taskNamer);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
@@ -18,37 +18,14 @@ package org.gradle.api.internal.project.ant
 
 import groovy.xml.MarkupBuilder
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Issue
 
 class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final String EXECUTER_SYS_PROP = "org.gradle.integtest.executer"
-    private static final String EXECUTER_CONFIG_CACHE = "configCache"
-    private static final String EXECUTER_FORKING = "forking"
-
-    private static String initialExecuterType
+    private static final String CONFIGURATION_CACHE_FAIL_REASON = "serialization issues with org.gradle.api.tasks.ant.AntTarget"
 
     File antBuildFile
-
-    /**
-     * Ensure that {@link org.gradle.integtests.fixtures.executer.ConfigurationCacheGradleExecuter}
-     * will not be created, because of serialization issues with {@link org.gradle.api.tasks.ant.AntTarget}.
-     */
-    def setupSpec() {
-        initialExecuterType = System.getProperty(EXECUTER_SYS_PROP)
-        if (initialExecuterType == EXECUTER_CONFIG_CACHE) {
-            System.setProperty(EXECUTER_SYS_PROP, EXECUTER_FORKING)
-        }
-    }
-
-    /**
-     * Restore initial property value.
-     */
-    def cleanupSpec() {
-        if (initialExecuterType != null) {
-            System.setProperty(EXECUTER_SYS_PROP, initialExecuterType)
-        }
-    }
 
     def setup() {
         antBuildFile = new File(testDirectory, 'build.xml')
@@ -71,6 +48,8 @@ class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
         outputContains("[ant:echo] Basedir is: " + expectedBasedir.getAbsolutePath())
     }
 
+
+    @ToBeFixedForConfigurationCache(because = CONFIGURATION_CACHE_FAIL_REASON)
     def "by default basedir is same as Ant file location"() {
         expect:
         "test basedir"("""
@@ -79,6 +58,7 @@ class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("gradle/gradle#1698")
+    @ToBeFixedForConfigurationCache(because = CONFIGURATION_CACHE_FAIL_REASON)
     def "user can set different basedir for imported Ant file"() {
         expect:
         "test basedir"("""
@@ -86,6 +66,7 @@ class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
         """, testDirectory.getParentFile(), "test-build")
     }
 
+    @ToBeFixedForConfigurationCache(because = CONFIGURATION_CACHE_FAIL_REASON)
     def "user can specify transformer without specifying basedir"() {
         expect:
         "test basedir"("""
@@ -96,6 +77,7 @@ class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("gradle/gradle#1698")
+    @ToBeFixedForConfigurationCache(because = CONFIGURATION_CACHE_FAIL_REASON)
     def "user can specify both basedir and transformer"() {
         expect:
         "test basedir"("""

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.ant
+
+import groovy.xml.MarkupBuilder
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
+
+    File antBuildFile
+
+    def setup() {
+        antBuildFile = new File(testDirectory, 'build.xml')
+        antBuildFile.withWriter { Writer writer ->
+            def xml = new MarkupBuilder(writer)
+            xml.project {
+                target(name: 'test-build') {
+                    echo(message: 'Basedir is: ${basedir}')
+                }
+            }
+        }
+    }
+
+    private void "test basedir" (String buildFileContents, File expectedBasedir, String taskName) {
+        // given
+        buildFile << buildFileContents
+        // when
+        succeeds(taskName)
+        // then
+        outputContains("[ant:echo] Basedir is: " + expectedBasedir.getAbsolutePath())
+    }
+
+    def "by default basedir is same as Ant file location" () {
+        expect:
+        "test basedir"("""
+            ant.importBuild 'build.xml'
+        """, testDirectory, "test-build")
+    }
+
+    @Issue("gradle/gradle#1698")
+    def "user can set different basedir for imported Ant file" () {
+        expect:
+        "test basedir"("""
+            ant.importBuild('build.xml', '..')
+        """, testDirectory.getParentFile(), "test-build")
+    }
+
+    def "user can specify transformer without specifying basedir" () {
+        expect:
+        "test basedir"("""
+            ant.importBuild('build.xml') { antTaskName ->
+                'ant-' + antTaskName
+            }
+        """, testDirectory, "ant-test-build")
+    }
+
+    @Issue("gradle/gradle#1698")
+    def "user can specify both basedir and transformer" () {
+        expect:
+        "test basedir"("""
+            ant.importBuild('build.xml', '..') { antTaskName ->
+                'ant-' + antTaskName
+            }
+        """, testDirectory.getParentFile(), "ant-test-build")
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ant/AntImportBuildIntegrationTest.groovy
@@ -18,11 +18,17 @@ package org.gradle.api.internal.project.ant
 
 import groovy.xml.MarkupBuilder
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import spock.lang.Issue
 
 class AntImportBuildIntegrationTest extends AbstractIntegrationSpec {
 
     File antBuildFile
+
+    GradleExecuter createExecuter() {
+        new NoDaemonGradleExecuter(distribution, temporaryFolder)
+    }
 
     def setup() {
         antBuildFile = new File(testDirectory, 'build.xml')

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilder.java
@@ -99,9 +99,21 @@ public class DefaultAntBuilder extends BasicAntBuilder implements GroovyObject {
     }
 
     @Override
+    public void importBuild(Object antBuildFile, String baseDirectory) {
+        importBuild(antBuildFile, baseDirectory, Transformers.<String>noOpTransformer());
+    }
+
+    @Override
     public void importBuild(Object antBuildFile, Transformer<? extends String, ? super String> taskNamer) {
+        importBuild(antBuildFile, null, taskNamer);
+    }
+
+    @Override
+    public void importBuild(Object antBuildFile, String baseDirectory, Transformer<? extends String, ? super String> taskNamer) {
         File file = gradleProject.file(antBuildFile);
-        final File baseDir = file.getParentFile();
+
+        Optional<Object> baseDirectoryOptional = Optional.ofNullable(baseDirectory);
+        final File baseDir = gradleProject.file(baseDirectoryOptional.orElse(file.getParentFile().getAbsolutePath()));
 
         Set<String> existingAntTargets = new HashSet<String>(getAntProject().getTargets().keySet());
         File oldBaseDir = getAntProject().getBaseDir();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
@@ -68,7 +68,17 @@ public class BasicAntBuilder extends org.gradle.api.AntBuilder implements Closea
     }
 
     @Override
+    public void importBuild(Object antBuildFile, String baseDirectory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void importBuild(Object antBuildFile, Transformer<? extends String, ? super String> taskNamer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void importBuild(Object antBuildFile, String baseDirectory, Transformer<? extends String, ? super String> taskNamer) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Fixes #1698

### Context
Added 2 new ant.importBuild methods to allow specifying the basedir, keeping the backwards compatibility with existing Ant API.

Extended the `org.gradle.api.AntBuilder` with 2 new abstract methods, which overload the existing `importBuild()` methods, allowing to explicitly specify the `baseDirectory` for the imported Ant tasks. This change also required to add new implementations in `org.gradle.api.internal.project.ant.BasicAntBuilder` and `org.gradle.api.internal.project.DefaultAntBuilder`.

Below examples of how to make use of the changes above in `gradle.build`.

    // Example 1. Define only build file and base directory.
    ant.importBuild('build/build.xml', '.')
    
    // Example 2. Define build file, base directory and task name transformer.
    ant.importBuild('build/build.xml', '..') { taskName ->
        'a-' + taskName
    }

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] NA ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
__`./gradlew :doc:doc` is failing, was failing also on clean checkout__
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`
__my tests do, but some other don't - they were also failing on clean checkout__

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
