### PR TITLE
Rename WorkExecutor to ExecutionEngine

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.execution.WorkExecutor
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
 import spock.lang.Unroll
 
@@ -165,7 +165,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
             ObjectFactory,
             ProjectLayout,
             ProviderFactory,
-            WorkExecutor,
+            ExecutionEngine,
             FileSystemOperations,
             ExecOperations,
         ].collect { it.name }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionServiceInjectionIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.execution.WorkExecutor
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
 import spock.lang.Unroll
 
@@ -148,7 +148,7 @@ class ObjectExtensionServiceInjectionIntegrationTest extends AbstractIntegration
             ObjectFactory,
             ProjectLayout,
             ProviderFactory,
-            WorkExecutor,
+            ExecutionEngine,
             FileSystemOperations,
             ExecOperations,
         ].collect { it.name }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.execution.WorkExecutor
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
 import spock.lang.Unroll
 
@@ -182,7 +182,7 @@ class PluginServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
             ObjectFactory,
             ProjectLayout,
             ProviderFactory,
-            WorkExecutor,
+            ExecutionEngine,
             FileSystemOperations,
             ExecOperations,
         ].collect { it.name }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -56,10 +56,10 @@ import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.exceptions.MultiCauseException;
 import org.gradle.internal.execution.CachingResult;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.ExecutionOutcome;
 import org.gradle.internal.execution.InputChangesContext;
 import org.gradle.internal.execution.UnitOfWork;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingState;
@@ -122,7 +122,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     private final TaskCacheabilityResolver taskCacheabilityResolver;
     private final FileCollectionFingerprinterRegistry fingerprinterRegistry;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
-    private final WorkExecutor workExecutor;
+    private final ExecutionEngine executionEngine;
     private final ListenerManager listenerManager;
     private final ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry;
     private final EmptySourceTaskSkipper emptySourceTaskSkipper;
@@ -140,7 +140,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         TaskCacheabilityResolver taskCacheabilityResolver,
         FileCollectionFingerprinterRegistry fingerprinterRegistry,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-        WorkExecutor workExecutor,
+        ExecutionEngine executionEngine,
         ListenerManager listenerManager,
         ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
         EmptySourceTaskSkipper emptySourceTaskSkipper,
@@ -157,7 +157,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         this.taskCacheabilityResolver = taskCacheabilityResolver;
         this.fingerprinterRegistry = fingerprinterRegistry;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
-        this.workExecutor = workExecutor;
+        this.executionEngine = executionEngine;
         this.listenerManager = listenerManager;
         this.reservedFileSystemLocationRegistry = reservedFileSystemLocationRegistry;
         this.emptySourceTaskSkipper = emptySourceTaskSkipper;
@@ -177,7 +177,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     }
 
     private TaskExecuterResult executeIfValid(TaskInternal task, TaskStateInternal state, TaskExecutionContext context, TaskExecution work) {
-        CachingResult result = workExecutor.execute(work, context.getTaskExecutionMode().getRebuildReason().orElse(null));
+        CachingResult result = executionEngine.execute(work, context.getTaskExecutionMode().getRebuildReason().orElse(null));
         result.getExecutionResult().ifSuccessfulOrElse(
             executionResult -> state.setOutcome(TaskExecutionOutcome.valueOf(executionResult.getOutcome())),
             failure -> state.setOutcome(new TaskExecutionException(task, failure))

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -47,8 +47,8 @@ import org.gradle.execution.taskgraph.TaskListenerInternal;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.OutputChangeListener;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OutputFilesRepository;
 import org.gradle.internal.file.DefaultReservedFileSystemLocationRegistry;
@@ -126,7 +126,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         TaskExecutionListener taskExecutionListener,
         TaskExecutionModeResolver repository,
         TaskListenerInternal taskListenerInternal,
-        WorkExecutor workExecutor
+        ExecutionEngine executionEngine
     ) {
         TaskExecuter executer = new ExecuteActionsTaskExecuter(
             buildCacheController.isEnabled()
@@ -142,7 +142,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             taskCacheabilityResolver,
             fingerprinterRegistry,
             classLoaderHierarchyHasher,
-            workExecutor,
+            executionEngine,
             listenerManager,
             reservedFileSystemLocationRegistry,
             emptySourceTaskSkipper,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -32,16 +32,16 @@ import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.execution.OutputSnapshotter;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OutputFilesRepository;
 import org.gradle.internal.execution.history.changes.ExecutionStateChangeDetector;
 import org.gradle.internal.execution.history.impl.DefaultExecutionHistoryStore;
 import org.gradle.internal.execution.history.impl.DefaultOutputFilesRepository;
-import org.gradle.internal.execution.impl.DefaultWorkExecutor;
+import org.gradle.internal.execution.impl.DefaultExecutionEngine;
 import org.gradle.internal.execution.steps.AssignWorkspaceStep;
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
 import org.gradle.internal.execution.steps.BuildCacheStep;
@@ -133,7 +133,7 @@ public class ExecutionGradleServices {
         return listenerManager.getBroadcaster(OutputChangeListener.class);
     }
 
-    public WorkExecutor createWorkExecutor(
+    public ExecutionEngine createExecutionEngine(
         BuildCacheCommandFactory buildCacheCommandFactory,
         BuildCacheController buildCacheController,
         BuildCancellationToken cancellationToken,
@@ -152,7 +152,7 @@ public class ExecutionGradleServices {
         ValueSnapshotter valueSnapshotter
     ) {
         // @formatter:off
-        return new DefaultWorkExecutor(
+        return new DefaultExecutionEngine(
             new IdentifyStep<>(valueSnapshotter,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -44,7 +44,7 @@ import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.history.AfterPreviousExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
-import org.gradle.internal.execution.impl.DefaultWorkExecutor
+import org.gradle.internal.execution.impl.DefaultExecutionEngine
 import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CancelExecutionStep
@@ -147,7 +147,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def validationWarningReporter = Stub(ValidateStep.ValidationWarningReporter)
 
     // @formatter:off
-    def workExecutor = new DefaultWorkExecutor(
+    def executionEngine = new DefaultExecutionEngine(
         new IdentifyStep<>(valueSnapshotter,
         new IdentityCacheStep<>(
         new AssignWorkspaceStep<>(
@@ -177,7 +177,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         taskCacheabilityResolver,
         fingerprinterRegistry,
         classloaderHierarchyHasher,
-        workExecutor,
+        executionEngine,
         listenerManager,
         reservedFileSystemLocationRegistry,
         emptySourceTaskSkipper,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -132,18 +132,18 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.BeforeExecutionContext;
 import org.gradle.internal.execution.CachingContext;
 import org.gradle.internal.execution.CachingResult;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.execution.OutputSnapshotter;
 import org.gradle.internal.execution.Step;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.UpToDateResult;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.changes.ExecutionStateChangeDetector;
-import org.gradle.internal.execution.impl.DefaultWorkExecutor;
+import org.gradle.internal.execution.impl.DefaultExecutionEngine;
 import org.gradle.internal.execution.steps.AssignWorkspaceStep;
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep;
@@ -259,11 +259,11 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         /**
-         * Work executer for usage above Gradle scope
+         * Execution engine for usage above Gradle scope
          *
          * Currently used for running artifact transformations in buildscript blocks.
          */
-        WorkExecutor createWorkExecutor(
+        ExecutionEngine createExecutionEngine(
                 BuildOperationExecutor buildOperationExecutor,
                 ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
                 Deleter deleter,
@@ -279,7 +279,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             // TODO: Figure out how to get rid of origin scope id in snapshot outputs step
             UniqueId fixedUniqueId = UniqueId.from("dhwwyv4tqrd43cbxmdsf24wquu");
             // @formatter:off
-            return new DefaultWorkExecutor(
+            return new DefaultExecutionEngine(
                 new IdentifyStep<>(valueSnapshotter,
                 new IdentityCacheStep<>(
                 new AssignWorkspaceStep<>(
@@ -409,7 +409,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         TransformerInvocationFactory createTransformerInvocationFactory(
-                WorkExecutor workExecutor,
+                ExecutionEngine executionEngine,
                 FileSystemAccess fileSystemAccess,
                 ImmutableTransformationWorkspaceProvider transformationWorkspaceProvider,
                 ArtifactTransformListener artifactTransformListener,
@@ -418,7 +418,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 BuildOperationExecutor buildOperationExecutor
         ) {
             return new DefaultTransformerInvocationFactory(
-                workExecutor,
+                executionEngine,
                 fileSystemAccess,
                 artifactTransformListener,
                 transformationWorkspaceProvider,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -30,9 +30,9 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.Try;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.execution.DeferredResultProcessor;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputChangesContext;
 import org.gradle.internal.execution.UnitOfWork;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
@@ -86,7 +86,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
     private static final String OUTPUT_FILE_PATH_PREFIX = "o/";
 
     private final FileSystemAccess fileSystemAccess;
-    private final WorkExecutor workExecutor;
+    private final ExecutionEngine executionEngine;
     private final ArtifactTransformListener artifactTransformListener;
     private final TransformationWorkspaceProvider immutableWorkspaceProvider;
     private final FileCollectionFactory fileCollectionFactory;
@@ -94,7 +94,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
     private final BuildOperationExecutor buildOperationExecutor;
 
     public DefaultTransformerInvocationFactory(
-        WorkExecutor workExecutor,
+        ExecutionEngine executionEngine,
         FileSystemAccess fileSystemAccess,
         ArtifactTransformListener artifactTransformListener,
         TransformationWorkspaceProvider immutableWorkspaceProvider,
@@ -102,7 +102,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         ProjectStateRegistry projectStateRegistry,
         BuildOperationExecutor buildOperationExecutor
     ) {
-        this.workExecutor = workExecutor;
+        this.executionEngine = executionEngine;
         this.fileSystemAccess = fileSystemAccess;
         this.artifactTransformListener = artifactTransformListener;
         this.immutableWorkspaceProvider = immutableWorkspaceProvider;
@@ -140,7 +140,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             workspaceProvider
         );
 
-        return workExecutor.executeDeferred(execution, null, workspaceProvider.getIdentityCache(), new DeferredResultProcessor<ImmutableList<File>, CacheableInvocation<ImmutableList<File>>>() {
+        return executionEngine.executeDeferred(execution, null, workspaceProvider.getIdentityCache(), new DeferredResultProcessor<ImmutableList<File>, CacheableInvocation<ImmutableList<File>>>() {
             @Override
             public CacheableInvocation<ImmutableList<File>> processCachedOutput(Try<ImmutableList<File>> cachedOutput) {
                 return CacheableInvocation.cached(mapResult(cachedOutput));

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -119,7 +119,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     }
     def outputSnapshotter = new DefaultOutputSnapshotter(fileCollectionSnapshotter)
     def deleter = TestFiles.deleter()
-    def workExecutor = new ExecutionGradleServices().createWorkExecutor(
+    def executionEngine = new ExecutionGradleServices().createExecutionEngine(
         buildCacheCommandFactory,
         buildCacheController,
         cancellationToken,
@@ -143,7 +143,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     )
 
     def invoker = new DefaultTransformerInvocationFactory(
-        workExecutor,
+        executionEngine,
         fileSystemAccess,
         artifactTransformListener,
         transformationWorkspaceProvider,

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OutputFilesRepository
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
 import org.gradle.internal.execution.history.changes.InputChangesInternal
-import org.gradle.internal.execution.impl.DefaultWorkExecutor
+import org.gradle.internal.execution.impl.DefaultExecutionEngine
 import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
@@ -133,9 +133,9 @@ class IncrementalExecutionIntegrationTest extends Specification {
     def overlappingOutputDetector = new DefaultOverlappingOutputDetector()
     def deleter = TestFiles.deleter()
 
-    WorkExecutor getExecutor() {
+    ExecutionEngine getExecutor() {
         // @formatter:off
-        new DefaultWorkExecutor(
+        new DefaultExecutionEngine(
             new IdentifyStep<>(valueSnapshotter,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -22,7 +22,7 @@ import org.gradle.internal.execution.UnitOfWork.Identity;
 
 import javax.annotation.Nullable;
 
-public interface WorkExecutor {
+public interface ExecutionEngine {
     CachingResult execute(UnitOfWork work, @Nullable String rebuildReason);
 
     <T, O> T executeDeferred(UnitOfWork work, @Nullable String rebuildReason, Cache<Identity, Try<O>> cache, DeferredResultProcessor<O, T> processor);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
@@ -21,18 +21,18 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.CachingResult;
 import org.gradle.internal.execution.DeferredExecutionAwareStep;
 import org.gradle.internal.execution.DeferredResultProcessor;
+import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.ExecutionRequestContext;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.UnitOfWork.Identity;
-import org.gradle.internal.execution.WorkExecutor;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-public class DefaultWorkExecutor implements WorkExecutor {
+public class DefaultExecutionEngine implements ExecutionEngine {
     private final DeferredExecutionAwareStep<? super ExecutionRequestContext, CachingResult> executeStep;
 
-    public DefaultWorkExecutor(DeferredExecutionAwareStep<? super ExecutionRequestContext, CachingResult> executeStep) {
+    public DefaultExecutionEngine(DeferredExecutionAwareStep<? super ExecutionRequestContext, CachingResult> executeStep) {
         this.executeStep = executeStep;
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -23,11 +23,11 @@ import org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
 import org.gradle.internal.classanalysis.AsmConstants.ASM_LEVEL
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
 import org.gradle.internal.execution.UnitOfWork.InputPropertyType.NON_INCREMENTAL
-import org.gradle.internal.execution.WorkExecutor
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.changes.InputChangesInternal
 import org.gradle.internal.file.TreeType.DIRECTORY
@@ -66,7 +66,7 @@ class ProjectAccessorsClassPathGenerator @Inject constructor(
     private val classpathFingerprinter: ClasspathFingerprinter,
     private val fileCollectionFactory: FileCollectionFactory,
     private val projectSchemaProvider: ProjectSchemaProvider,
-    private val workExecutor: WorkExecutor,
+    private val executionEngine: ExecutionEngine,
     private val workspaceProvider: KotlinDslWorkspaceProvider
 ) {
 
@@ -89,7 +89,7 @@ class ProjectAccessorsClassPathGenerator @Inject constructor(
                 fileCollectionFactory,
                 workspaceProvider
             )
-            val result = workExecutor.execute(work, null)
+            val result = executionEngine.execute(work, null)
             result.executionResult.get().output as AccessorsClassPath
         }
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GradleScopeServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GradleScopeServices.kt
@@ -17,7 +17,7 @@
 package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.api.internal.file.FileCollectionFactory
-import org.gradle.internal.execution.WorkExecutor
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
@@ -30,12 +30,12 @@ object GradleScopeServices {
     fun createPluginAccessorClassPathGenerator(
         classLoaderHierarchyHasher: ClassLoaderHierarchyHasher,
         fileCollectionFactory: FileCollectionFactory,
-        workExecutor: WorkExecutor,
+        executionEngine: ExecutionEngine,
         workspaceProvider: KotlinDslWorkspaceProvider
     ) = PluginAccessorClassPathGenerator(
         classLoaderHierarchyHasher,
         fileCollectionFactory,
-        workExecutor,
+        executionEngine,
         workspaceProvider
     )
 
@@ -44,13 +44,13 @@ object GradleScopeServices {
         classpathFingerprinter: ClasspathFingerprinter,
         fileCollectionFactory: FileCollectionFactory,
         projectSchemaProvider: ProjectSchemaProvider,
-        workExecutor: WorkExecutor,
+        executionEngine: ExecutionEngine,
         workspaceProvider: KotlinDslWorkspaceProvider
     ) = ProjectAccessorsClassPathGenerator(
         classpathFingerprinter,
         fileCollectionFactory,
         projectSchemaProvider,
-        workExecutor,
+        executionEngine,
         workspaceProvider
     )
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -26,10 +26,10 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
-import org.gradle.internal.execution.WorkExecutor
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.changes.InputChangesInternal
 import org.gradle.internal.file.TreeType.DIRECTORY
@@ -91,7 +91,7 @@ import javax.inject.Inject
 class PluginAccessorClassPathGenerator @Inject constructor(
     private val classLoaderHierarchyHasher: ClassLoaderHierarchyHasher,
     private val fileCollectionFactory: FileCollectionFactory,
-    private val workExecutor: WorkExecutor,
+    private val executionEngine: ExecutionEngine,
     private val workspaceProvider: KotlinDslWorkspaceProvider
 ) {
     fun pluginSpecBuildersClassPath(project: Project): AccessorsClassPath = project.rootProject.let { rootProject ->
@@ -107,7 +107,7 @@ class PluginAccessorClassPathGenerator @Inject constructor(
                 fileCollectionFactory,
                 workspaceProvider
             )
-            val result = workExecutor.execute(work, null)
+            val result = executionEngine.execute(work, null)
             result.executionResult.get().output as AccessorsClassPath
         }
     }


### PR DESCRIPTION
A better name and it disambiguates `BuildWorkExecutor`.