### PR TITLE
Add default implementation for UnitOfWork.markExecutionTime()

### DIFF
--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -870,11 +870,6 @@ class IncrementalExecutionIntegrationTest extends Specification {
                 }
 
                 @Override
-                long markExecutionTime() {
-                    0
-                }
-
-                @Override
                 Optional<CachingDisabledReason> shouldDisableCaching(@Nullable OverlappingOutputs detectedOverlappingOutputs) {
                     throw new UnsupportedOperationException()
                 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -176,7 +176,9 @@ public interface UnitOfWork extends Describable {
         void visitDestroyableRoot(File destroyableRoot);
     }
 
-    long markExecutionTime();
+    default long markExecutionTime() {
+        return 0;
+    }
 
     /**
      * Validate the work definition and configuration.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -161,8 +161,6 @@ class GenerateProjectAccessors(
 
     override fun getDisplayName(): String = "Kotlin DSL accessors for $project"
 
-    override fun markExecutionTime(): Long = 0
-
     override fun visitImplementations(visitor: UnitOfWork.ImplementationVisitor) {
         visitor.visitImplementation(GenerateProjectAccessors::class.java)
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -162,8 +162,6 @@ class GeneratePluginAccessors(
 
     override fun getDisplayName(): String = "Kotlin DSL plugin accessors for classpath '$classLoaderHash'"
 
-    override fun markExecutionTime(): Long = 0
-
     override fun visitImplementations(visitor: UnitOfWork.ImplementationVisitor) {
         visitor.visitImplementation(GeneratePluginAccessors::class.java)
     }


### PR DESCRIPTION
This is only used in task execution, no need for other work units to care about it.
