### PR TITLE
Remove now useless kotlin script compiler flag

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -343,7 +343,6 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     specificFeatures = mapOf(
         LanguageFeature.NewInference to LanguageFeature.State.ENABLED,
         LanguageFeature.SamConversionForKotlinFunctions to LanguageFeature.State.ENABLED,
-        LanguageFeature.SamConversionPerArgument to LanguageFeature.State.ENABLED,
         LanguageFeature.ReferencesToSyntheticJavaProperties to LanguageFeature.State.ENABLED
     ),
     analysisFlags = mapOf(


### PR DESCRIPTION
It was only useful during the 1.3/1.4 migration
