### PR TITLE
Let Kotlin DSL script compilation disable compatibility mode for kotlin new inference engine

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -342,6 +342,7 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     apiVersion = ApiVersion.KOTLIN_1_3,
     specificFeatures = mapOf(
         LanguageFeature.NewInference to LanguageFeature.State.ENABLED,
+        LanguageFeature.DisableCompatibilityModeForNewInference to LanguageFeature.State.ENABLED,
         LanguageFeature.SamConversionForKotlinFunctions to LanguageFeature.State.ENABLED,
         LanguageFeature.SamConversionPerArgument to LanguageFeature.State.ENABLED,
         LanguageFeature.ReferencesToSyntheticJavaProperties to LanguageFeature.State.ENABLED


### PR DESCRIPTION
`DisableCompatibilityModeForNewInference` is a special flag to preserve compatibility with the old type inference. It only appeared in 1.4 and is turned off by default.

What it does is artificially lower the priority to resolve in some corner cases (for example, some cases with SAM conversions, as in our case). In the old inference, such calls were not prioritized properly. Now this flag was introduced to smooth migration.

A funny fact is that when the `-XXLanguage: +NewInference` flag is passed from the command line, Gradle or IDE, the `DisableCompatibilityModeForNewInference` flag is turned on automatically, but not in the case of embedded Kotlin in Gradle, since the language version settings are manually configured there, bypassing this logic.
