### PR TITLE
Make `ScopeIdsFixture` compatible with Gradle 4.0+

### DIFF
--- a/subprojects/core/src/crossVersionTest/groovy/org/gradle/internal/scopeids/CrossVersionScopeIdsIntegrationTest.groovy
+++ b/subprojects/core/src/crossVersionTest/groovy/org/gradle/internal/scopeids/CrossVersionScopeIdsIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.ScopeIdsFixture
 import org.gradle.integtests.fixtures.TargetVersions
 import org.junit.Rule
 
-@TargetVersions("4.10+")
+@TargetVersions("4.0+")
 class CrossVersionScopeIdsIntegrationTest extends CrossVersionIntegrationSpec {
 
     def currentExecuter = version(current)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScopeIdsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScopeIdsFixture.groovy
@@ -120,7 +120,7 @@ class ScopeIdsFixture extends UserInitScriptExecuterFixture {
                 task collectScopeIds(type: CollectScopeIds) {
                     outputJsonFile = new File("${normaliseFileSeparators(idsFile.absolutePath)}")
                 }
-                tasks.withType(DefaultTask).configureEach {
+                tasks.withType(DefaultTask) {
                     if (name != "collectScopeIds") {
                         dependsOn collectScopeIds
                     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScopeIdsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ScopeIdsFixture.groovy
@@ -117,12 +117,12 @@ class ScopeIdsFixture extends UserInitScriptExecuterFixture {
             }
 
             rootProject {
-                def collector = tasks.register("collectScopeIds", CollectScopeIds) {
+                task collectScopeIds(type: CollectScopeIds) {
                     outputJsonFile = new File("${normaliseFileSeparators(idsFile.absolutePath)}")
                 }
                 tasks.withType(DefaultTask).configureEach {
                     if (name != "collectScopeIds") {
-                        dependsOn collector
+                        dependsOn collectScopeIds
                     }
                 }
             }


### PR DESCRIPTION
By using the legacy task declaration syntax.