### PR TITLE
Reorganize some things around execution engine

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -293,7 +293,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
 
             List<InputChangesAwareTaskAction> taskActions = task.getTaskActions();
             for (InputChangesAwareTaskAction taskAction : taskActions) {
-                visitor.visitAdditionalImplementation(taskAction.getActionImplementation(classLoaderHierarchyHasher));
+                visitor.visitImplementation(taskAction.getActionImplementation(classLoaderHierarchyHasher));
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -330,17 +330,9 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                     visitor.visitOutputProperty(property.getPropertyName(), property.getOutputType(), outputFile, property.getPropertyFiles());
                 }
             }
-        }
-
-        @Override
-        public void visitLocalState(LocalStateVisitor visitor) {
             for (File localStateRoot : context.getTaskProperties().getLocalStateFiles()) {
                 visitor.visitLocalStateRoot(localStateRoot);
             }
-        }
-
-        @Override
-        public void visitDestroyableRoots(DestroyableVisitor visitor) {
             for (File destroyableRoot : context.getTaskProperties().getDestroyableFiles()) {
                 visitor.visitDestroyableRoot(destroyableRoot);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -300,14 +300,10 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         @Override
         public void visitInputProperties(InputPropertyVisitor visitor) {
             ImmutableSortedSet<InputPropertySpec> inputProperties = context.getTaskProperties().getInputProperties();
+            ImmutableSortedSet<InputFilePropertySpec> inputFileProperties = context.getTaskProperties().getInputFileProperties();
             for (InputPropertySpec inputProperty : inputProperties) {
                 visitor.visitInputProperty(inputProperty.getPropertyName(), NON_IDENTITY, () -> InputParameterUtils.prepareInputParameterValue(inputProperty, task));
             }
-        }
-
-        @Override
-        public void visitInputFileProperties(InputFilePropertyVisitor visitor) {
-            ImmutableSortedSet<InputFilePropertySpec> inputFileProperties = context.getTaskProperties().getInputFileProperties();
             for (InputFilePropertySpec inputFileProperty : inputFileProperties) {
                 Object value = inputFileProperty.getValue();
                 // SkipWhenEmpty implies incremental.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -298,7 +298,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public void visitInputProperties(InputPropertyVisitor visitor) {
+        public void visitInputs(InputVisitor visitor) {
             ImmutableSortedSet<InputPropertySpec> inputProperties = context.getTaskProperties().getInputProperties();
             ImmutableSortedSet<InputFilePropertySpec> inputFileProperties = context.getTaskProperties().getInputFileProperties();
             for (InputPropertySpec inputProperty : inputProperties) {
@@ -323,7 +323,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public void visitOutputProperties(File workspace, OutputPropertyVisitor visitor) {
+        public void visitOutputs(File workspace, OutputVisitor visitor) {
             for (OutputFilePropertySpec property : context.getTaskProperties().getOutputFileProperties()) {
                 File outputFile = property.getOutputFile();
                 if (outputFile != null) {
@@ -331,10 +331,10 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                 }
             }
             for (File localStateRoot : context.getTaskProperties().getLocalStateFiles()) {
-                visitor.visitLocalStateRoot(localStateRoot);
+                visitor.visitLocalState(localStateRoot);
             }
             for (File destroyableRoot : context.getTaskProperties().getDestroyableFiles()) {
-                visitor.visitDestroyableRoot(destroyableRoot);
+                visitor.visitDestroyable(destroyableRoot);
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultOutputSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultOutputSnapshotter.java
@@ -42,12 +42,6 @@ public class DefaultOutputSnapshotter implements OutputSnapshotter {
                 List<FileSystemSnapshot> results = fileCollectionSnapshotter.snapshot(contents);
                 builder.put(propertyName, CompositeFileSystemSnapshot.of(results));
             }
-
-            @Override
-            public void visitLocalStateRoot(File localStateRoot) {}
-
-            @Override
-            public void visitDestroyableRoot(File destroyableRoot) {}
         });
         return builder.build();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultOutputSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultOutputSnapshotter.java
@@ -36,7 +36,7 @@ public class DefaultOutputSnapshotter implements OutputSnapshotter {
     @Override
     public ImmutableSortedMap<String, FileSystemSnapshot> snapshotOutputs(UnitOfWork work, File workspace) {
         ImmutableSortedMap.Builder<String, FileSystemSnapshot> builder = ImmutableSortedMap.naturalOrder();
-        work.visitOutputProperties(workspace, new UnitOfWork.OutputPropertyVisitor() {
+        work.visitOutputs(workspace, new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 List<FileSystemSnapshot> results = fileCollectionSnapshotter.snapshot(contents);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -47,7 +47,7 @@ import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
 import org.gradle.internal.execution.steps.BuildCacheStep;
 import org.gradle.internal.execution.steps.CancelExecutionStep;
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep;
-import org.gradle.internal.execution.steps.CleanupOutputsStep;
+import org.gradle.internal.execution.steps.RemovePreviousOutputsStep;
 import org.gradle.internal.execution.steps.CreateOutputsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
 import org.gradle.internal.execution.steps.IdentifyStep;
@@ -174,7 +174,7 @@ public class ExecutionGradleServices {
             new TimeoutStep<>(timeoutHandler,
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(deleter, outputChangeListener,
+            new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(buildOperationExecutor
         ))))))))))))))))))))))));
         // @formatter:on

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -49,7 +49,7 @@ import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CancelExecutionStep
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
-import org.gradle.internal.execution.steps.CleanupOutputsStep
+import org.gradle.internal.execution.steps.RemovePreviousOutputsStep
 import org.gradle.internal.execution.steps.ExecuteStep
 import org.gradle.internal.execution.steps.IdentifyStep
 import org.gradle.internal.execution.steps.IdentityCacheStep
@@ -162,7 +162,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new SnapshotOutputsStep<>(buildOperationExecutor, buildId, outputSnapshotter,
         new CancelExecutionStep<>(cancellationToken,
         new ResolveInputChangesStep<>(
-        new CleanupOutputsStep<>(deleter, outputChangeListener,
+        new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
         new ExecuteStep<>(buildOperationExecutor
     )))))))))))))))))
     // @formatter:on

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -147,12 +147,12 @@ import org.gradle.internal.execution.impl.DefaultExecutionEngine;
 import org.gradle.internal.execution.steps.AssignWorkspaceStep;
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep;
-import org.gradle.internal.execution.steps.CleanupOutputsStep;
 import org.gradle.internal.execution.steps.CreateOutputsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
 import org.gradle.internal.execution.steps.IdentifyStep;
 import org.gradle.internal.execution.steps.IdentityCacheStep;
 import org.gradle.internal.execution.steps.LoadExecutionStateStep;
+import org.gradle.internal.execution.steps.RemovePreviousOutputsStep;
 import org.gradle.internal.execution.steps.ResolveChangesStep;
 import org.gradle.internal.execution.steps.ResolveInputChangesStep;
 import org.gradle.internal.execution.steps.SkipUpToDateStep;
@@ -295,7 +295,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 new CreateOutputsStep<>(
                 new TimeoutStep<>(timeoutHandler,
                 new ResolveInputChangesStep<>(
-                new CleanupOutputsStep<>(deleter, outputChangeListener,
+                new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
                 new ExecuteStep<>(buildOperationExecutor
             ))))))))))))))))));
             // @formatter:on

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -374,7 +374,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         }
 
         @Override
-        public void visitInputProperties(InputPropertyVisitor visitor) {
+        public void visitInputs(InputVisitor visitor) {
             // Emulate secondary inputs as a single property for now
             visitor.visitInputProperty(SECONDARY_INPUTS_HASH_PROPERTY_NAME, NON_IDENTITY,
                 () -> transformer.getSecondaryInputHash().toString());
@@ -387,7 +387,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         }
 
         @Override
-        public void visitOutputProperties(File workspace, OutputPropertyVisitor visitor) {
+        public void visitOutputs(File workspace, OutputVisitor visitor) {
             File outputDir = getOutputDir(workspace);
             File resultsFile = getResultsFile(workspace);
             visitor.visitOutputProperty(OUTPUT_DIRECTORY_PROPERTY_NAME, DIRECTORY,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -378,10 +378,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             // Emulate secondary inputs as a single property for now
             visitor.visitInputProperty(SECONDARY_INPUTS_HASH_PROPERTY_NAME, NON_IDENTITY,
                 () -> transformer.getSecondaryInputHash().toString());
-        }
-
-        @Override
-        public void visitInputFileProperties(InputFilePropertyVisitor visitor) {
             visitor.visitInputFileProperty(INPUT_ARTIFACT_PROPERTY_NAME, PRIMARY, NON_IDENTITY,
                 inputArtifactProvider,
                 () -> inputArtifactFingerprinter.fingerprint(ImmutableList.of(inputArtifactSnapshot)));

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -837,10 +837,6 @@ class IncrementalExecutionIntegrationTest extends Specification {
                     inputProperties.each { propertyName, value ->
                         visitor.visitInputProperty(propertyName, NON_IDENTITY, { -> value } as UnitOfWork.ValueSupplier)
                     }
-                }
-
-                @Override
-                void visitInputFileProperties(UnitOfWork.InputFilePropertyVisitor visitor) {
                     for (entry in inputs.entrySet()) {
                         visitor.visitInputFileProperty(
                             entry.key,

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -34,13 +34,13 @@ import org.gradle.internal.execution.impl.DefaultExecutionEngine
 import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
-import org.gradle.internal.execution.steps.RemovePreviousOutputsStep
 import org.gradle.internal.execution.steps.CreateOutputsStep
 import org.gradle.internal.execution.steps.ExecuteStep
 import org.gradle.internal.execution.steps.IdentifyStep
 import org.gradle.internal.execution.steps.IdentityCacheStep
 import org.gradle.internal.execution.steps.LoadExecutionStateStep
 import org.gradle.internal.execution.steps.RecordOutputsStep
+import org.gradle.internal.execution.steps.RemovePreviousOutputsStep
 import org.gradle.internal.execution.steps.ResolveCachingStateStep
 import org.gradle.internal.execution.steps.ResolveChangesStep
 import org.gradle.internal.execution.steps.ResolveInputChangesStep
@@ -833,7 +833,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
                 }
 
                 @Override
-                void visitInputProperties(UnitOfWork.InputPropertyVisitor visitor) {
+                void visitInputs(UnitOfWork.InputVisitor visitor) {
                     inputProperties.each { propertyName, value ->
                         visitor.visitInputProperty(propertyName, NON_IDENTITY, { -> value } as UnitOfWork.ValueSupplier)
                     }
@@ -849,7 +849,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
                 }
 
                 @Override
-                void visitOutputProperties(File workspace, UnitOfWork.OutputPropertyVisitor visitor) {
+                void visitOutputs(File workspace, UnitOfWork.OutputVisitor visitor) {
                     outputs.forEach { name, spec ->
                         visitor.visitOutputProperty(name, spec.treeType, spec.root, TestFiles.fixed(spec.root))
                     }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.internal.execution.impl.DefaultExecutionEngine
 import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
-import org.gradle.internal.execution.steps.CleanupOutputsStep
+import org.gradle.internal.execution.steps.RemovePreviousOutputsStep
 import org.gradle.internal.execution.steps.CreateOutputsStep
 import org.gradle.internal.execution.steps.ExecuteStep
 import org.gradle.internal.execution.steps.IdentifyStep
@@ -151,7 +151,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new SnapshotOutputsStep<>(buildOperationExecutor, buildInvocationScopeId.getId(), outputSnapshotter,
             new CreateOutputsStep<>(
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(deleter, outputChangeListener,
+            new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(buildOperationExecutor
         ))))))))))))))))))
         // @formatter:on

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -114,9 +114,19 @@ public interface UnitOfWork extends Describable {
     void visitInputProperties(InputPropertyVisitor visitor);
 
     interface InputPropertyVisitor {
-        void visitInputProperty(String propertyName, IdentityKind identity, ValueSupplier value);
+        default void visitInputProperty(
+            String propertyName,
+            IdentityKind identity,
+            ValueSupplier value
+        ) {}
 
-        void visitInputFileProperty(String propertyName, InputPropertyType type, IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter);
+        default void visitInputFileProperty(
+            String propertyName,
+            InputPropertyType type,
+            IdentityKind identity,
+            @Nullable Object value,
+            Supplier<CurrentFileCollectionFingerprint> fingerprinter
+        ) {}
     }
 
     interface ValueSupplier {
@@ -165,9 +175,16 @@ public interface UnitOfWork extends Describable {
     void visitOutputProperties(File workspace, OutputPropertyVisitor visitor);
 
     interface OutputPropertyVisitor {
-        void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents);
-        void visitLocalStateRoot(File localStateRoot);
-        void visitDestroyableRoot(File destroyableRoot);
+        default void visitOutputProperty(
+            String propertyName,
+            TreeType type,
+            File root,
+            FileCollection contents
+        ) {}
+
+        default void visitLocalStateRoot(File localStateRoot) {}
+
+        default void visitDestroyableRoot(File destroyableRoot) {}
     }
 
     default long markExecutionTime() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -99,7 +99,7 @@ public interface UnitOfWork extends Describable {
      * Capture the classloader of the work's implementation type.
      * There can be more than one type reported by the work; additional types are considered in visitation order.
      *
-     * TODO Move this to {@link #visitInputProperties(InputPropertyVisitor)}
+     * TODO Move this to {@link #visitInputs(InputVisitor)}
      */
     void visitImplementations(ImplementationVisitor visitor);
 
@@ -111,9 +111,9 @@ public interface UnitOfWork extends Describable {
     /**
      * Visit all inputs of the work.
      */
-    void visitInputProperties(InputPropertyVisitor visitor);
+    void visitInputs(InputVisitor visitor);
 
-    interface InputPropertyVisitor {
+    interface InputVisitor {
         default void visitInputProperty(
             String propertyName,
             IdentityKind identity,
@@ -172,9 +172,9 @@ public interface UnitOfWork extends Describable {
         NON_IDENTITY, IDENTITY
     }
 
-    void visitOutputProperties(File workspace, OutputPropertyVisitor visitor);
+    void visitOutputs(File workspace, OutputVisitor visitor);
 
-    interface OutputPropertyVisitor {
+    interface OutputVisitor {
         default void visitOutputProperty(
             String propertyName,
             TreeType type,
@@ -182,9 +182,9 @@ public interface UnitOfWork extends Describable {
             FileCollection contents
         ) {}
 
-        default void visitLocalStateRoot(File localStateRoot) {}
+        default void visitLocalState(File localStateRoot) {}
 
-        default void visitDestroyableRoot(File destroyableRoot) {}
+        default void visitDestroyable(File destroyableRoot) {}
     }
 
     default long markExecutionTime() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -107,17 +107,13 @@ public interface UnitOfWork extends Describable {
 
     interface InputPropertyVisitor {
         void visitInputProperty(String propertyName, IdentityKind identity, ValueSupplier value);
+
+        void visitInputFileProperty(String propertyName, InputPropertyType type, IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter);
     }
 
     interface ValueSupplier {
         @Nullable
         Object getValue();
-    }
-
-    void visitInputFileProperties(InputFilePropertyVisitor visitor);
-
-    interface InputFilePropertyVisitor {
-        void visitInputFileProperty(String propertyName, InputPropertyType type, IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter);
     }
 
     enum InputPropertyType {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -158,17 +158,7 @@ public interface UnitOfWork extends Describable {
 
     interface OutputPropertyVisitor {
         void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents);
-    }
-
-    default void visitLocalState(LocalStateVisitor visitor) {}
-
-    interface LocalStateVisitor {
         void visitLocalStateRoot(File localStateRoot);
-    }
-
-    default void visitDestroyableRoots(DestroyableVisitor visitor) {}
-
-    interface DestroyableVisitor {
         void visitDestroyableRoot(File destroyableRoot);
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -95,14 +95,22 @@ public interface UnitOfWork extends Describable {
         return InputChangeTrackingStrategy.NONE;
     }
 
+    /**
+     * Capture the classloader of the work's implementation type.
+     * There can be more than one type reported by the work; additional types are considered in visitation order.
+     *
+     * TODO Move this to {@link #visitInputProperties(InputPropertyVisitor)}
+     */
     void visitImplementations(ImplementationVisitor visitor);
 
     interface ImplementationVisitor {
         void visitImplementation(Class<?> implementation);
         void visitImplementation(ImplementationSnapshot implementation);
-        void visitAdditionalImplementation(ImplementationSnapshot implementation);
     }
 
+    /**
+     * Visit all inputs of the work.
+     */
     void visitInputProperties(InputPropertyVisitor visitor);
 
     interface InputPropertyVisitor {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
@@ -42,7 +42,7 @@ public class InputFingerprintUtil {
     ) {
         valueSnapshotsBuilder.putAll(knownValueSnapshots);
         fingerprintsBuilder.putAll(knownFingerprints);
-        work.visitInputProperties(new UnitOfWork.InputPropertyVisitor() {
+        work.visitInputs(new UnitOfWork.InputVisitor() {
             @Override
             public void visitInputProperty(String propertyName, UnitOfWork.IdentityKind identity, UnitOfWork.ValueSupplier value) {
                 if (knownValueSnapshots.containsKey(propertyName)) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/InputFingerprintUtil.java
@@ -23,6 +23,8 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 
+import static org.gradle.internal.execution.UnitOfWork.InputPropertyType.NON_INCREMENTAL;
+
 public class InputFingerprintUtil {
 
     public static ImmutableSortedMap<String, ValueSnapshot> fingerprintInputProperties(
@@ -38,7 +40,7 @@ public class InputFingerprintUtil {
             if (alreadyKnownSnapshots.containsKey(propertyName)) {
                 return;
             }
-            if (!filter.include(propertyName, identity)) {
+            if (!filter.include(propertyName, NON_INCREMENTAL, identity)) {
                 return;
             }
             Object actualValue = value.getValue();
@@ -57,14 +59,10 @@ public class InputFingerprintUtil {
         return builder.build();
     }
 
-    public interface InputPropertyPredicate {
-        boolean include(String propertyName, UnitOfWork.IdentityKind identity);
-    }
-
     public static ImmutableSortedMap<String, CurrentFileCollectionFingerprint> fingerprintInputFiles(
         UnitOfWork work,
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> alreadyKnownFingerprints,
-        InputFilePropertyPredicate filter
+        InputPropertyPredicate filter
     ) {
         ImmutableSortedMap.Builder<String, CurrentFileCollectionFingerprint> builder = ImmutableSortedMap.naturalOrder();
         builder.putAll(alreadyKnownFingerprints);
@@ -80,7 +78,7 @@ public class InputFingerprintUtil {
         return builder.build();
     }
 
-    public interface InputFilePropertyPredicate {
+    public interface InputPropertyPredicate {
         boolean include(String propertyName, UnitOfWork.InputPropertyType type, UnitOfWork.IdentityKind identity);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BroadcastChangingOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BroadcastChangingOutputsStep.java
@@ -44,19 +44,19 @@ public class BroadcastChangingOutputsStep<C extends WorkspaceContext, R extends 
     public R execute(C context) {
         UnitOfWork work = context.getWork();
         ImmutableList.Builder<String> builder = ImmutableList.builder();
-        work.visitOutputProperties(context.getWorkspace(), new UnitOfWork.OutputPropertyVisitor() {
+        work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 builder.add(root.getAbsolutePath());
             }
 
             @Override
-            public void visitLocalStateRoot(File localStateRoot) {
+            public void visitLocalState(File localStateRoot) {
                 builder.add(localStateRoot.getAbsolutePath());
             }
 
             @Override
-            public void visitDestroyableRoot(File destroyableRoot) {
+            public void visitDestroyable(File destroyableRoot) {
                 builder.add(destroyableRoot.getAbsolutePath());
             }
         });

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
@@ -136,9 +136,9 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, CurrentSn
     }
 
     private void cleanLocalState(File workspace, UnitOfWork work) {
-        work.visitOutputProperties(workspace, new UnitOfWork.OutputPropertyVisitor() {
+        work.visitOutputs(workspace, new UnitOfWork.OutputVisitor() {
             @Override
-            public void visitLocalStateRoot(File localStateRoot) {
+            public void visitLocalState(File localStateRoot) {
                 try {
                     outputChangeListener.beforeOutputChange(ImmutableList.of(localStateRoot.getAbsolutePath()));
                     deleter.deleteRecursively(localStateRoot);
@@ -205,7 +205,7 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, CurrentSn
 
         @Override
         public void visitOutputTrees(CacheableTreeVisitor visitor) {
-            work.visitOutputProperties(workspace, new UnitOfWork.OutputPropertyVisitor() {
+            work.visitOutputs(workspace, new UnitOfWork.OutputVisitor() {
                 @Override
                 public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                     visitor.visitOutputTree(propertyName, type, root);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
@@ -138,9 +138,6 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, CurrentSn
     private void cleanLocalState(File workspace, UnitOfWork work) {
         work.visitOutputProperties(workspace, new UnitOfWork.OutputPropertyVisitor() {
             @Override
-            public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {}
-
-            @Override
             public void visitLocalStateRoot(File localStateRoot) {
                 try {
                     outputChangeListener.beforeOutputChange(ImmutableList.of(localStateRoot.getAbsolutePath()));
@@ -149,9 +146,6 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, CurrentSn
                     throw new UncheckedIOException(String.format("Failed to clean up local state files for %s: %s", work.getDisplayName(), localStateRoot), ex);
                 }
             }
-
-            @Override
-            public void visitDestroyableRoot(File destroyableRoot) {}
         });
     }
 
@@ -215,14 +209,6 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, CurrentSn
                 @Override
                 public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                     visitor.visitOutputTree(propertyName, type, root);
-                }
-
-                @Override
-                public void visitLocalStateRoot(File localStateRoot) {
-                }
-
-                @Override
-                public void visitDestroyableRoot(File destroyableRoot) {
                 }
             });
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
@@ -249,15 +249,11 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPre
 
         @Override
         public void visitImplementation(ImplementationSnapshot implementation) {
-            if (this.implementation != null) {
-                throw new IllegalStateException("Implementation already set");
+            if (this.implementation == null) {
+                this.implementation = implementation;
+            } else {
+                this.additionalImplementations.add(implementation);
             }
-            this.implementation = implementation;
-        }
-
-        @Override
-        public void visitAdditionalImplementation(ImplementationSnapshot implementation) {
-            additionalImplementations.add(implementation);
         }
 
         public ImplementationSnapshot getImplementation() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
@@ -183,7 +183,7 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPre
             previousInputProperties,
             valueSnapshotter,
             context.getInputProperties(),
-            (propertyName, identity) -> identity == NON_IDENTITY);
+            (propertyName, type, identity) -> identity == NON_IDENTITY);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints = fingerprintInputFiles(
             work,
             context.getInputFileProperties(),

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.execution.steps;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.internal.execution.Result;
 import org.gradle.internal.execution.Step;
+import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkspaceContext;
 import org.gradle.internal.file.TreeType;
 import org.slf4j.Logger;
@@ -38,7 +40,20 @@ public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> imp
 
     @Override
     public R execute(C context) {
-        context.getWork().visitOutputProperties(context.getWorkspace(), (name, type, root, contents) -> ensureOutput(name, root, type));
+        context.getWork().visitOutputProperties(context.getWorkspace(), new UnitOfWork.OutputPropertyVisitor() {
+            @Override
+            public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
+                ensureOutput(propertyName, root, type);
+            }
+
+            @Override
+            public void visitLocalStateRoot(File localStateRoot) {
+                ensureOutput("local state", localStateRoot, TreeType.FILE);
+            }
+
+            @Override
+            public void visitDestroyableRoot(File destroyableRoot) {}
+        });
         return delegate.execute(context);
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
@@ -40,14 +40,14 @@ public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> imp
 
     @Override
     public R execute(C context) {
-        context.getWork().visitOutputProperties(context.getWorkspace(), new UnitOfWork.OutputPropertyVisitor() {
+        context.getWork().visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 ensureOutput(propertyName, root, type);
             }
 
             @Override
-            public void visitLocalStateRoot(File localStateRoot) {
+            public void visitLocalState(File localStateRoot) {
                 ensureOutput("local state", localStateRoot, TreeType.FILE);
             }
         });

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
@@ -50,9 +50,6 @@ public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> imp
             public void visitLocalStateRoot(File localStateRoot) {
                 ensureOutput("local state", localStateRoot, TreeType.FILE);
             }
-
-            @Override
-            public void visitDestroyableRoot(File destroyableRoot) {}
         });
         return delegate.execute(context);
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -34,7 +34,6 @@ import javax.annotation.Nonnull;
 import java.util.Optional;
 
 import static org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY;
-import static org.gradle.internal.execution.impl.InputFingerprintUtil.fingerprintInputFiles;
 import static org.gradle.internal.execution.impl.InputFingerprintUtil.fingerprintInputProperties;
 
 public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> implements DeferredExecutionAwareStep<C, R> {
@@ -61,16 +60,19 @@ public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> i
 
     @Nonnull
     private IdentityContext createIdentityContext(C context) {
-        ImmutableSortedMap<String, ValueSnapshot> identityInputProperties = fingerprintInputProperties(
+        ImmutableSortedMap.Builder<String, ValueSnapshot> identityInputPropertiesBuilder = ImmutableSortedMap.naturalOrder();
+        ImmutableSortedMap.Builder<String, CurrentFileCollectionFingerprint> identityInputFilePropertiesBuilder = ImmutableSortedMap.naturalOrder();
+        fingerprintInputProperties(
             context.getWork(),
             ImmutableSortedMap.of(),
             valueSnapshotter,
             ImmutableSortedMap.of(),
-            (propertyName, type, identity) -> identity == IDENTITY);
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = fingerprintInputFiles(
-            context.getWork(),
+            identityInputPropertiesBuilder,
             ImmutableSortedMap.of(),
+            identityInputFilePropertiesBuilder,
             (propertyName, type, identity) -> identity == IDENTITY);
+        ImmutableSortedMap<String, ValueSnapshot> identityInputProperties = identityInputPropertiesBuilder.build();
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = identityInputFilePropertiesBuilder.build();
         Identity identity = context.getWork().identify(identityInputProperties, identityInputFileProperties);
         return new IdentityContext() {
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -66,7 +66,7 @@ public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> i
             ImmutableSortedMap.of(),
             valueSnapshotter,
             ImmutableSortedMap.of(),
-            (propertyName, identity) -> identity == IDENTITY);
+            (propertyName, type, identity) -> identity == IDENTITY);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = fingerprintInputFiles(
             context.getWork(),
             ImmutableSortedMap.of(),

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -33,13 +33,16 @@ import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CleanupOutputsStep<C extends InputChangesContext, R extends Result> implements Step<C, R> {
+/**
+ * When executed non-incrementally remove previous outputs owned by the work unit.
+ */
+public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends Result> implements Step<C, R> {
 
     private final Deleter deleter;
     private final OutputChangeListener outputChangeListener;
     private final Step<? super C, ? extends R> delegate;
 
-    public CleanupOutputsStep(
+    public RemovePreviousOutputsStep(
         Deleter deleter,
         OutputChangeListener outputChangeListener,
         Step<? super C, ? extends R> delegate
@@ -60,7 +63,7 @@ public class CleanupOutputsStep<C extends InputChangesContext, R extends Result>
                 if (hasOverlappingOutputs) {
                     cleanupOverlappingOutputs(context, work);
                 } else {
-                    cleanupExclusiveOutputs(context, work);
+                    cleanupExclusivelyOwnedOutputs(context, work);
                 }
             }
         }
@@ -102,7 +105,7 @@ public class CleanupOutputsStep<C extends InputChangesContext, R extends Result>
         });
     }
 
-    private void cleanupExclusiveOutputs(BeforeExecutionContext context, UnitOfWork work) {
+    private void cleanupExclusivelyOwnedOutputs(BeforeExecutionContext context, UnitOfWork work) {
         work.visitOutputProperties(context.getWorkspace(), (name, type, root, contents) -> {
             if (root.exists()) {
                 try {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -92,12 +92,6 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
                             throw new AssertionError();
                     }
                 }
-
-                @Override
-                public void visitLocalStateRoot(File localStateRoot) {}
-
-                @Override
-                public void visitDestroyableRoot(File destroyableRoot) {}
             });
             OutputsCleaner cleaner = new OutputsCleaner(
                 deleter,
@@ -137,12 +131,6 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
                     }
                 }
             }
-
-            @Override
-            public void visitLocalStateRoot(File localStateRoot) {}
-
-            @Override
-            public void visitDestroyableRoot(File destroyableRoot) {}
         });
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -75,7 +75,7 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
     private void cleanupOverlappingOutputs(BeforeExecutionContext context, UnitOfWork work) {
         context.getAfterPreviousExecutionState().ifPresent(previousOutputs -> {
             Set<File> outputDirectoriesToPreserve = new HashSet<>();
-            work.visitOutputProperties(context.getWorkspace(), new UnitOfWork.OutputPropertyVisitor() {
+            work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
                 @Override
                 public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                     switch (type) {
@@ -111,7 +111,7 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
     }
 
     private void cleanupExclusivelyOwnedOutputs(BeforeExecutionContext context, UnitOfWork work) {
-        work.visitOutputProperties(context.getWorkspace(), new UnitOfWork.OutputPropertyVisitor() {
+        work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 if (root.exists()) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -146,10 +146,6 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                 ImmutableBiMap.Builder<String, Object> builder = ImmutableBiMap.builder();
                 work.visitInputProperties(new UnitOfWork.InputPropertyVisitor() {
                     @Override
-                    public void visitInputProperty(String propertyName, UnitOfWork.IdentityKind identity, UnitOfWork.ValueSupplier value) {
-                    }
-
-                    @Override
                     public void visitInputFileProperty(String propertyName, UnitOfWork.InputPropertyType type, UnitOfWork.IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter) {
                         if (type.isIncremental()) {
                             if (value == null) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -144,7 +144,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                 return IncrementalInputProperties.ALL;
             case INCREMENTAL_PARAMETERS:
                 ImmutableBiMap.Builder<String, Object> builder = ImmutableBiMap.builder();
-                work.visitInputProperties(new UnitOfWork.InputPropertyVisitor() {
+                work.visitInputs(new UnitOfWork.InputVisitor() {
                     @Override
                     public void visitInputFileProperty(String propertyName, UnitOfWork.InputPropertyType type, UnitOfWork.IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter) {
                         if (type.isIncremental()) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -35,8 +35,10 @@ import org.gradle.internal.execution.history.changes.RebuildExecutionStateChange
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class ResolveChangesStep<R extends Result> implements Step<CachingContext, R> {
     private static final String NO_HISTORY = "No history is available.";
@@ -142,12 +144,19 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                 return IncrementalInputProperties.ALL;
             case INCREMENTAL_PARAMETERS:
                 ImmutableBiMap.Builder<String, Object> builder = ImmutableBiMap.builder();
-                work.visitInputFileProperties((propertyName, type, identity, value, fingerprinter) -> {
-                    if (type.isIncremental()) {
-                        if (value == null) {
-                            throw new InvalidUserDataException("Must specify a value for incremental input property '" + propertyName + "'.");
+                work.visitInputProperties(new UnitOfWork.InputPropertyVisitor() {
+                    @Override
+                    public void visitInputProperty(String propertyName, UnitOfWork.IdentityKind identity, UnitOfWork.ValueSupplier value) {
+                    }
+
+                    @Override
+                    public void visitInputFileProperty(String propertyName, UnitOfWork.InputPropertyType type, UnitOfWork.IdentityKind identity, @Nullable Object value, Supplier<CurrentFileCollectionFingerprint> fingerprinter) {
+                        if (type.isIncremental()) {
+                            if (value == null) {
+                                throw new InvalidUserDataException("Must specify a value for incremental input property '" + propertyName + "'.");
+                            }
+                            builder.put(propertyName, value);
                         }
-                        builder.put(propertyName, value);
                     }
                 });
                 return new DefaultIncrementalInputProperties(builder.build());

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
@@ -44,10 +44,10 @@ class BroadcastChangingOutputsStepTest extends StepSpec<WorkspaceContext> {
         then:
         result == delegateResult
 
-        _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor) >> { File workspace, UnitOfWork.OutputPropertyVisitor visitor ->
+        _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
             visitor.visitOutputProperty("output", TreeType.DIRECTORY, outputDir, Mock(FileCollection))
-            visitor.visitDestroyableRoot(destroyableDir)
-            visitor.visitLocalStateRoot(localStateDir)
+            visitor.visitDestroyable(destroyableDir)
+            visitor.visitLocalState(localStateDir)
         }
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
@@ -46,11 +46,7 @@ class BroadcastChangingOutputsStepTest extends StepSpec<WorkspaceContext> {
 
         _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor) >> { File workspace, UnitOfWork.OutputPropertyVisitor visitor ->
             visitor.visitOutputProperty("output", TreeType.DIRECTORY, outputDir, Mock(FileCollection))
-        }
-        _ * work.visitDestroyableRoots(_ as UnitOfWork.DestroyableVisitor) >> { UnitOfWork.DestroyableVisitor visitor ->
             visitor.visitDestroyableRoot(destroyableDir)
-        }
-        _ * work.visitLocalState(_ as UnitOfWork.LocalStateVisitor) >> { UnitOfWork.LocalStateVisitor visitor ->
             visitor.visitLocalStateRoot(localStateDir)
         }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -77,7 +77,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         1 * buildCacheController.load(loadCommand) >> Optional.of(loadMetadata)
 
         then:
-        _ * work.visitLocalState(_) >> { UnitOfWork.LocalStateVisitor visitor ->
+        _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor) >> { File workspace, UnitOfWork.OutputPropertyVisitor visitor ->
             visitor.visitLocalStateRoot(localStateFile)
         }
         1 * outputChangeListener.beforeOutputChange([localStateFile.getAbsolutePath()])

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -77,8 +77,8 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         1 * buildCacheController.load(loadCommand) >> Optional.of(loadMetadata)
 
         then:
-        _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor) >> { File workspace, UnitOfWork.OutputPropertyVisitor visitor ->
-            visitor.visitLocalStateRoot(localStateFile)
+        _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
+            visitor.visitLocalState(localStateFile)
         }
         1 * outputChangeListener.beforeOutputChange([localStateFile.getAbsolutePath()])
         1 * deleter.deleteRecursively(_) >> { File root ->

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -111,7 +111,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         when:
         step.execute(context)
         then:
-        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+        _ * work.visitInputs(_) >> { UnitOfWork.InputVisitor visitor ->
             visitor.visitInputProperty("inputString", NON_IDENTITY) { inputPropertyValue }
         }
         1 * valueSnapshotter.snapshot(inputPropertyValue) >> valueSnapshot
@@ -137,7 +137,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
         1 * afterPreviousExecutionState.inputProperties >> ImmutableSortedMap.<String, ValueSnapshot>of("inputString", valueSnapshot)
         1 * afterPreviousExecutionState.outputFileProperties >> ImmutableSortedMap.<String, FileCollectionFingerprint>of()
-        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+        _ * work.visitInputs(_) >> { UnitOfWork.InputVisitor visitor ->
             visitor.visitInputProperty("inputString", NON_IDENTITY) { inputPropertyValue }
         }
         1 * valueSnapshotter.snapshot(inputPropertyValue, valueSnapshot) >> valueSnapshot
@@ -159,7 +159,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         step.execute(context)
 
         then:
-        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+        _ * work.visitInputs(_) >> { UnitOfWork.InputVisitor visitor ->
             visitor.visitInputFileProperty("inputFile", NON_INCREMENTAL, NON_IDENTITY, "ignored", { -> fingerprint })
         }
         interaction { fingerprintInputs() }
@@ -287,7 +287,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         _ * work.visitImplementations(_ as UnitOfWork.ImplementationVisitor) >> { UnitOfWork.ImplementationVisitor visitor ->
             visitor.visitImplementation(implementationSnapshot)
         }
-        _ * work.visitInputProperties(_ as UnitOfWork.InputPropertyVisitor)
+        _ * work.visitInputs(_ as UnitOfWork.InputVisitor)
         _ * work.overlappingOutputHandling >> IGNORE_OVERLAPS
         _ * outputSnapshotter.snapshotOutputs(work, _) >> ImmutableSortedMap.of()
         _ * context.history >> Optional.of(executionHistoryStore)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -159,7 +159,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         step.execute(context)
 
         then:
-        _ * work.visitInputFileProperties(_) >> { UnitOfWork.InputFilePropertyVisitor visitor ->
+        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
             visitor.visitInputFileProperty("inputFile", NON_INCREMENTAL, NON_IDENTITY, "ignored", { -> fingerprint })
         }
         interaction { fingerprintInputs() }
@@ -288,7 +288,6 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
             visitor.visitImplementation(implementationSnapshot)
         }
         _ * work.visitInputProperties(_ as UnitOfWork.InputPropertyVisitor)
-        _ * work.visitInputFileProperties(_ as UnitOfWork.InputFilePropertyVisitor)
         _ * work.overlappingOutputHandling >> IGNORE_OVERLAPS
         _ * outputSnapshotter.snapshotOutputs(work, _) >> ImmutableSortedMap.of()
         _ * context.history >> Optional.of(executionHistoryStore)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -89,7 +89,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<AfterPreviousExecutio
         _ * work.visitImplementations(_) >> { UnitOfWork.ImplementationVisitor visitor ->
             visitor.visitImplementation(implementationSnapshot)
             additionalImplementations.each {
-                visitor.visitAdditionalImplementation(it)
+                visitor.visitImplementation(it)
             }
         }
         interaction { fingerprintInputs() }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
@@ -41,11 +41,11 @@ class CreateOutputsStepTest extends StepSpec<WorkspaceContext> {
         step.execute(context)
 
         then:
-        _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor) >> { File workspace, UnitOfWork.OutputPropertyVisitor visitor ->
+        _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
             visitor.visitOutputProperty("dir", TreeType.DIRECTORY, outputDir, TestFiles.fixed(outputDir))
             visitor.visitOutputProperty("file", TreeType.FILE, outputFile, TestFiles.fixed(outputFile))
-            visitor.visitLocalStateRoot(localStateFile)
-            visitor.visitDestroyableRoot(destroyableFile)
+            visitor.visitLocalState(localStateFile)
+            visitor.visitDestroyable(destroyableFile)
         }
 
         then:
@@ -67,7 +67,7 @@ class CreateOutputsStepTest extends StepSpec<WorkspaceContext> {
         then:
         result == expected
 
-        _ * work.visitOutputProperties(_ as File, _ as UnitOfWork.OutputPropertyVisitor)
+        _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor)
         1 * delegate.execute(context) >> expected
         0 * _
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -46,7 +46,7 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
         then:
         result == delegateResult
 
-        _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
+        _ * work.visitInputs(_) >> { UnitOfWork.InputVisitor visitor ->
             visitor.visitInputProperty("non-identity", NON_IDENTITY) { Mock(Object) }
             visitor.visitInputProperty("identity", UnitOfWork.IdentityKind.IDENTITY) { 123 }
             visitor.visitInputFileProperty(

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -49,8 +49,6 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
         _ * work.visitInputProperties(_) >> { UnitOfWork.InputPropertyVisitor visitor ->
             visitor.visitInputProperty("non-identity", NON_IDENTITY) { Mock(Object) }
             visitor.visitInputProperty("identity", UnitOfWork.IdentityKind.IDENTITY) { 123 }
-        }
-        _ * work.visitInputFileProperties(_) >> { UnitOfWork.InputFilePropertyVisitor visitor ->
             visitor.visitInputFileProperty(
                 "non-identity-file",
                 UnitOfWork.InputPropertyType.NON_INCREMENTAL,

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.Result
-import org.gradle.internal.execution.UnitOfWork.OutputPropertyVisitor
+import org.gradle.internal.execution.UnitOfWork.OutputVisitor
 import org.gradle.internal.execution.history.AfterPreviousExecutionState
 import org.gradle.internal.execution.history.BeforeExecutionState
 import org.gradle.internal.file.TreeType
@@ -184,7 +184,7 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         _ * work.shouldCleanupOutputsOnNonIncrementalExecution() >> true
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         1 * beforeExecutionState.detectedOverlappingOutputs >> Optional.of(new OverlappingOutputs("test", "/absolute/path"))
-        _ * work.visitOutputProperties(_, _) >> { File workspace, OutputPropertyVisitor visitor ->
+        _ * work.visitOutputs(_, _) >> { File workspace, OutputVisitor visitor ->
             visitor.visitOutputProperty("dir", TreeType.DIRECTORY, outputs.dir, TestFiles.fixed(outputs.dir))
             visitor.visitOutputProperty("file", TreeType.FILE, outputs.file, TestFiles.fixed(outputs.file))
         }
@@ -199,7 +199,7 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         _ * work.shouldCleanupOutputsOnNonIncrementalExecution() >> true
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         1 * beforeExecutionState.detectedOverlappingOutputs >> Optional.empty()
-        _ * work.visitOutputProperties(_, _) >> { File workspace, OutputPropertyVisitor visitor ->
+        _ * work.visitOutputs(_, _) >> { File workspace, OutputVisitor visitor ->
             visitor.visitOutputProperty("dir", TreeType.DIRECTORY, outputs.dir, TestFiles.fixed(outputs.dir))
             visitor.visitOutputProperty("file", TreeType.FILE, outputs.file, TestFiles.fixed(outputs.file))
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.internal.fingerprint.overlap.OverlappingOutputs
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 
-class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements FingerprinterFixture {
+class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implements FingerprinterFixture {
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def afterPreviousExecution = Mock(AfterPreviousExecutionState)
@@ -39,7 +39,7 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
     def outputChangeListener = Mock(OutputChangeListener)
     def deleter = TestFiles.deleter()
 
-    def step = new CleanupOutputsStep<>(deleter, outputChangeListener, delegate)
+    def step = new RemovePreviousOutputsStep<>(deleter, outputChangeListener, delegate)
 
     @Override
     protected InputChangesContext createContext() {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -165,14 +165,14 @@ class GenerateProjectAccessors(
         visitor.visitImplementation(GenerateProjectAccessors::class.java)
     }
 
-    override fun visitInputProperties(visitor: UnitOfWork.InputPropertyVisitor) {
+    override fun visitInputs(visitor: UnitOfWork.InputVisitor) {
         visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY, IDENTITY) { hashCodeFor(projectSchema) }
         visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, NON_INCREMENTAL, IDENTITY, classPath) {
             classpathFingerprinter.fingerprint(fileCollectionFactory.fixed(classPath.asFiles))
         }
     }
 
-    override fun visitOutputProperties(workspace: File, visitor: UnitOfWork.OutputPropertyVisitor) {
+    override fun visitOutputs(workspace: File, visitor: UnitOfWork.OutputVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
         visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -167,9 +167,6 @@ class GenerateProjectAccessors(
 
     override fun visitInputProperties(visitor: UnitOfWork.InputPropertyVisitor) {
         visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY, IDENTITY) { hashCodeFor(projectSchema) }
-    }
-
-    override fun visitInputFileProperties(visitor: UnitOfWork.InputFilePropertyVisitor) {
         visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, NON_INCREMENTAL, IDENTITY, classPath) {
             classpathFingerprinter.fingerprint(fileCollectionFactory.fixed(classPath.asFiles))
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -170,8 +170,6 @@ class GeneratePluginAccessors(
         visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY, IDENTITY) { classLoaderHash }
     }
 
-    override fun visitInputFileProperties(visitor: UnitOfWork.InputFilePropertyVisitor) = Unit
-
     override fun visitOutputProperties(workspace: File, visitor: UnitOfWork.OutputPropertyVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -166,11 +166,11 @@ class GeneratePluginAccessors(
         visitor.visitImplementation(GeneratePluginAccessors::class.java)
     }
 
-    override fun visitInputProperties(visitor: UnitOfWork.InputPropertyVisitor) {
+    override fun visitInputs(visitor: UnitOfWork.InputVisitor) {
         visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY, IDENTITY) { classLoaderHash }
     }
 
-    override fun visitOutputProperties(workspace: File, visitor: UnitOfWork.OutputPropertyVisitor) {
+    override fun visitOutputs(workspace: File, visitor: UnitOfWork.OutputVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
         visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir))


### PR DESCRIPTION
- Rename `CleanupOutputsStep` to `RemovePreviousOutputsStep`, because that's what we are doing
- Simplify visiting implementation(s)
- Simplify input property visiting by merging `UnitOfWork.visitInputProperites()` and `visitInputFileProperites()`.
- Simplify output property visiting by merging `UnitOfWork.visitOutputProperites()`, `visitLocalState()` and `visitDestroyables()`.