### PR TITLE
Detect new JDK vendors 

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -243,6 +243,8 @@ public class JavaInstallationProbe {
                 return result == InstallType.IS_JDK ? "OpenJDK" : "OpenJDK JRE";
             }
             return "Oracle " + basename;
+        } else if (vendor.contains("amazon")) {
+            return "Amazon Corretto " + basename;
         } else if (vendor.contains("ibm")) {
             return "IBM " + basename;
         } else if (vendor.contains("sap se")) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -245,6 +245,8 @@ public class JavaInstallationProbe {
             return "Oracle " + basename;
         } else if (vendor.contains("ibm")) {
             return "IBM " + basename;
+        } else if (vendor.contains("sap se")) {
+            return "SAP SapMachine " + basename;
         } else if (vendor.contains("azul systems")) {
             return "Zulu " + basename;
         } else if (vendor.contains("hewlett-packard")) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -245,6 +245,8 @@ public class JavaInstallationProbe {
             return "Oracle " + basename;
         } else if (vendor.contains("amazon")) {
             return "Amazon Corretto " + basename;
+        } else if (vendor.contains("bellsoft")) {
+            return "BellSoft Liberica " + basename;
         } else if (vendor.contains("ibm")) {
             return "IBM " + basename;
         } else if (vendor.contains("sap se")) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
@@ -121,6 +121,8 @@ class JavaInstallationProbeTest extends Specification {
         'hpuxJdk7'                            | hpuxJvm('7')     | JavaVersion.VERSION_1_7 | 'HP-UX JDK 7'  | true | false | IS_JDK
         'sapjdk13'                            | sapJvm('13')      | JavaVersion.VERSION_13 | 'SAP SapMachine JDK 13'  | true | false | IS_JDK
         'sapjre13'                            | sapJvm('13')      | JavaVersion.VERSION_13 | 'SAP SapMachine JRE 13'  | true | true | IS_JRE
+        'correttojdk11'                            | correttoJvm('11')      | JavaVersion.VERSION_11 | 'Amazon Corretto JDK 11'  | true | false | IS_JDK
+        'correttojre11'                            | correttoJvm('11')      | JavaVersion.VERSION_11 | 'Amazon Corretto JRE 11'  | true | true | IS_JRE
         'whitespaces'                         | whitespaces('11.0.3')  | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11' | true   | true  | IS_JRE
         'binary that has invalid output'      | invalidOutput()  | null                    | null           | true | false | INVALID_JDK
         'binary that returns unknown version' | invalidVersion() | null                    | null           | true | false | INVALID_JDK
@@ -251,6 +253,17 @@ class JavaInstallationProbeTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "13.0.2+8-sapmachine",
+         'java.runtime.name': "OpenJDK Runtime Environment"
+        ]
+    }
+
+    private static Map<String, String> correttoJvm(String version) {
+        ['java.home': "java-home",
+         'java.version': "${version}.0.8",
+         'java.vendor': "Amazon.com Inc.",
+         'os.arch': "x86_64",
+         'java.vm.name': "OpenJDK 64-Bit Server VM",
+         'java.vm.version': "11.0.8+10-LTS",
          'java.runtime.name': "OpenJDK Runtime Environment"
         ]
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
@@ -123,6 +123,8 @@ class JavaInstallationProbeTest extends Specification {
         'sapjre13'                            | sapJvm('13')      | JavaVersion.VERSION_13 | 'SAP SapMachine JRE 13'  | true | true | IS_JRE
         'correttojdk11'                            | correttoJvm('11')      | JavaVersion.VERSION_11 | 'Amazon Corretto JDK 11'  | true | false | IS_JDK
         'correttojre11'                            | correttoJvm('11')      | JavaVersion.VERSION_11 | 'Amazon Corretto JRE 11'  | true | true | IS_JRE
+        'bellsoftjdk11'                            | bellsoftJvm('15')      | JavaVersion.VERSION_15 | 'BellSoft Liberica JDK 15'  | true | false | IS_JDK
+        'bellsoftjre11'                            | bellsoftJvm('15')      | JavaVersion.VERSION_15 | 'BellSoft Liberica JRE 15'  | true | true | IS_JRE
         'whitespaces'                         | whitespaces('11.0.3')  | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11' | true   | true  | IS_JRE
         'binary that has invalid output'      | invalidOutput()  | null                    | null           | true | false | INVALID_JDK
         'binary that returns unknown version' | invalidVersion() | null                    | null           | true | false | INVALID_JDK
@@ -264,6 +266,17 @@ class JavaInstallationProbeTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "11.0.8+10-LTS",
+         'java.runtime.name': "OpenJDK Runtime Environment"
+        ]
+    }
+
+    private static Map<String, String> bellsoftJvm(String version) {
+        ['java.home': "java-home",
+         'java.version': "${version}",
+         'java.vendor': "BellSoft.",
+         'os.arch': "x86_64",
+         'java.vm.name': "OpenJDK 64-Bit Server VM",
+         'java.vm.version': "${version}+36",
          'java.runtime.name': "OpenJDK Runtime Environment"
         ]
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
@@ -119,6 +119,8 @@ class JavaInstallationProbeTest extends Specification {
         'zuluJdk8'                            | zuluJvm('8')     | JavaVersion.VERSION_1_8 | 'Zulu JDK 8'   | true | false | IS_JDK
         'hpuxJre6'                            | hpuxJvm('6')     | JavaVersion.VERSION_1_6 | 'HP-UX JRE 6'  | true | true  | IS_JRE
         'hpuxJdk7'                            | hpuxJvm('7')     | JavaVersion.VERSION_1_7 | 'HP-UX JDK 7'  | true | false | IS_JDK
+        'sapjdk13'                            | sapJvm('13')      | JavaVersion.VERSION_13 | 'SAP SapMachine JDK 13'  | true | false | IS_JDK
+        'sapjre13'                            | sapJvm('13')      | JavaVersion.VERSION_13 | 'SAP SapMachine JRE 13'  | true | true | IS_JRE
         'whitespaces'                         | whitespaces('11.0.3')  | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11' | true   | true  | IS_JRE
         'binary that has invalid output'      | invalidOutput()  | null                    | null           | true | false | INVALID_JDK
         'binary that returns unknown version' | invalidVersion() | null                    | null           | true | false | INVALID_JDK
@@ -239,6 +241,17 @@ class JavaInstallationProbeTest extends Specification {
          'java.vm.name': "Java HotSpot(TM) 64-Bit Server VM",
          'java.vm.version': "25.66-b17",
          'java.runtime.name': "Java(TM) SE Runtime Environment"
+        ]
+    }
+
+    private static Map<String, String> sapJvm(String version) {
+        ['java.home': "java-home",
+         'java.version': "${version}.0.2",
+         'java.vendor': "SAP SE",
+         'os.arch': "x86_64",
+         'java.vm.name': "OpenJDK 64-Bit Server VM",
+         'java.vm.version': "13.0.2+8-sapmachine",
+         'java.runtime.name': "OpenJDK Runtime Environment"
         ]
     }
 


### PR DESCRIPTION
These are more recent JDK vendors that our probe service just detects as "JDK". Given this is now exposed in toolchain reports (and will be used by vendor matching), ensure we support more vendors.