### PR TITLE
Update performance test durations and improve `writePerformanceTimes`

### DIFF
--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -120,7 +120,7 @@ fun splitBucketsByScenarios(scenarios: List<PerformanceScenario>, testProjectToS
         .groupBy({ it.testProject }, { scenario ->
             listOf(testProjectToScenarioDurations, testProjectScenarioDurationsFallback)
                 .mapNotNull { it.getOrDefault(scenario.testProject, emptyList()).firstOrNull { duration -> duration.scenario == scenario.scenario } }
-                .first()
+                .firstOrNull() ?: throw IllegalArgumentException("No durations found for $scenario")
         })
         .entries
         .map { TestProjectDuration(it.key, it.value) }

--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -1,697 +1,32 @@
 [ {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftCleanBuildPerformanceTest.clean assemble (swift)",
-  "durations" : [ {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 1063000
-  }, {
-    "testProject" : "bigSwiftApp",
-    "linux" : 730000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for non-abi change with file system watching",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 485000,
-    "windows" : 1481000,
-    "macOs" : 900000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 500000,
-    "windows" : 980000,
-    "macOs" : 809000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
-  "durations" : [ {
-    "testProject" : "bigCppApp",
-    "linux" : 142000
-  }, {
-    "testProject" : "bigCppMulti",
-    "linux" : 273000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
-  "durations" : [ {
-    "testProject" : "smallNativeMonolithic",
-    "linux" : 616000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 306000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 661000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
-  "durations" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 462000
-  }, {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 173000
-  }, {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 698000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest.create many deprecation warnings",
-  "durations" : [ {
-    "testProject" : "generateLotsOfDeprecationWarnings",
-    "linux" : 105000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.assemble for non-abi change (Gradle vs Maven)",
-  "durations" : [ {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 295000
-  }, {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 682000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty remote http cache",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 958000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1171000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
-  "durations" : [ {
-    "testProject" : "bigCppMulti",
-    "linux" : 280000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 108000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativeParallelPerformanceTest.clean assemble with parallel workers",
-  "durations" : [ {
-    "testProject" : "smallNative",
-    "linux" : 114000
-  }, {
-    "testProject" : "mediumNative",
-    "linux" : 186000
-  }, {
-      "testProject" : "multiNative",
-      "linux" : 186000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 670000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaABIChangePerformanceTest.assemble for abi change",
-  "durations" : [ {
-    "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1714000,
-    "windows" : 2340000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 518000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1038000
-  }, {
-    "testProject" : "largeGroovyMultiProject",
-    "linux" : 716000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
-  "durations" : [ {
-    "testProject" : "bigCppMulti",
-    "linux" : 491000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 233000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 231000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 477000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1002000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1558000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 235000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1002000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1558000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 235000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1333000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1419000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:buildDependentsLibA0",
-  "durations" : [ {
-    "testProject" : "nativeDependents",
-    "linux" : 542000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
-  "durations" : [ {
-    "testProject" : "bigCppMulti",
-    "linux" : 278000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 235000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
-  "durations" : [ {
-    "testProject" : "createLotsOfTasks",
-    "linux" : 133000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 760000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
-  "durations" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 1256000
-  }, {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 227000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster abi change (build comparison)",
-  "durations" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 799000
-  }, {
-    "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 406000
-  } ]
-}, {
-    "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.file system watching baseline non-abi change (build comparison)",
-    "durations" : [ {
-        "testProject" : "santaTrackerAndroidBuild",
-        "linux" : 413000
-    } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 792000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 531000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativePreCompiledHeaderPerformanceTest.clean assemble with precompiled headers",
-  "durations" : [ {
-    "testProject" : "mediumPCHNative",
-    "linux" : 302000
-  }, {
-    "testProject" : "bigPCHNative",
-    "linux" : 1079000
-  }, {
-    "testProject" : "smallPCHNative",
-    "linux" : 123000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 142000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 281000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean assemble (Gradle vs Maven)",
-  "durations" : [ {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 416000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 193000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 810000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 721000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 185000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = true)",
-  "durations" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 241000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native)",
-  "durations" : [ {
-    "testProject" : "mediumCppMultiWithMacroIncludes",
-    "linux" : 482000
-  }, {
-    "testProject" : "mediumCppMulti",
-    "linux" : 483000
-  }, {
-    "testProject" : "bigNative",
-    "linux" : 751000
-  }, {
-    "testProject" : "mediumCppApp",
-    "linux" : 225000
-  }, {
-    "testProject" : "multiNative",
-    "linux" : 1824000
-  }, {
-    "testProject" : "mediumCppAppWithMacroIncludes",
-    "linux" : 232000
-  }, {
-    "testProject" : "smallNative",
-    "linux" : 305000
-  }, {
-    "testProject" : "bigCppApp",
-    "linux" : 503000
-  }, {
-    "testProject" : "smallCppMulti",
-    "linux" : 316000
-  }, {
-    "testProject" : "smallCppApp",
-    "linux" : 296000
-  }, {
-    "testProject" : "bigCppMulti",
-    "linux" : 1471000
-  }, {
-    "testProject" : "mediumNative",
-    "linux" : 267000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 492000
-  }, {
-    "testProject" : "mediumJavaCompositeBuild",
-    "linux" : 294000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 530000
-  }, {
-    "testProject" : "mediumJavaPredefinedCompositeBuild",
-    "linux" : 297000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with hot daemon",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 387000
-  }, {
-    "testProject" : "smallJavaMultiProject",
-    "linux" : 186000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
-  "durations" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 393000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean test (Gradle vs Maven)",
-  "durations" : [ {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 1221000
-  }, {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 535000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
-  "durations" : [ {
-    "testProject" : "bigSwiftApp",
-    "linux" : 318000
-  }, {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 520000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean assembleDebug with clean transforms cache",
-  "durations" : [ {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 3615000
-  }, {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 2416000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
-  "durations" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 291000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 464000,
-    "windows" : 1365000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:dependentComponents",
-  "durations" : [ {
-    "testProject" : "nativeDependents",
-    "linux" : 537000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 148000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 396000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 146000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 360000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for abi change with file system watching",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 515000,
-    "windows" : 1461000,
-    "macOs" : 945000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 767000,
-    "windows" : 1613000,
-    "macOs" : 1283000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster non-abi change (build comparison)",
-  "durations" : [ {
-    "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 377000
-  }, {
-    "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 413000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.test for non-abi change (Gradle vs Maven)",
-  "durations" : [ {
-    "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 880000
-  }, {
-    "testProject" : "mediumJavaMultiProject",
-    "linux" : 1880000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.clean checkout",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 1025000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 413000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1113000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
-  "durations" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 226000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1446000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 579000
-  }, {
-    "testProject" : "mediumJavaMultiProjectWithTestNG",
-    "linux" : 288000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
-  "durations" : [ {
-    "testProject" : "mediumNativeMonolithic",
-    "linux" : 268000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 120000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 468000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
-  "durations" : [ {
-    "testProject" : "smallJavaMultiProject",
-    "linux" : 186000
-  }, {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 390000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.cold daemon",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1098000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 374000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 982000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
-  "durations" : [ {
-    "testProject" : "withVerboseJUnit",
-    "linux" : 65000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
-  "durations" : [ {
-    "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 970000
-  }, {
-    "testProject" : "nativeMonolithic",
-    "linux" : 965000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationPerformanceTest.configure",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 375000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 141000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 267000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
-  "durations" : [ {
-    "testProject" : "springBootApp",
-    "linux" : 336000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.first use",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 423000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 781000
-  }, {
-    "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 965000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
-  "durations" : [ {
-    "testProject" : "withVerboseTestNG",
-    "linux" : 173000
-  }, {
-    "testProject" : "withVerboseJUnit",
-    "linux" : 192000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
-  "durations" : [ {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 172000
-  }, {
-    "testProject" : "bigSwiftApp",
-    "linux" : 113000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 146000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 290000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 473000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 116000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run clean phthalic:assembleDebug",
-  "durations" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 617000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 81000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 148000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
-  "durations" : [ {
-    "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 766000
-  }, {
-    "testProject" : "nativeMonolithic",
-    "linux" : 767000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote https cache",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 784000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 534000
-  } ]
-}, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.abi change",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 800000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 139000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 329000
+    "linux" : 758000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.non-abi change",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 462000
+    "linux" : 453000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
   "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 947000
+    "testProject" : "k9AndroidBuild",
+    "linux" : 174000
   }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 1142000
+    "testProject" : "largeAndroidBuild",
+    "linux" : 695000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 461000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.experiment.java.ParallelBuildPerformanceTest.clean assemble with 4 parallel workers",
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run clean phthalic:assembleDebug",
   "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 351000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 488000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository (parallel)",
-  "durations" : [ {
-    "testProject" : "springBootApp",
-    "linux" : 267000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
-  "durations" : [ {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 289000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 678000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
-  "durations" : [ {
-    "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1694000,
-    "windows" : 2345000
-  }, {
-    "testProject" : "largeGroovyMultiProject",
-    "linux" : 616000
-  }, {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 492000
-  }, {
-    "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1024000
+    "testProject" : "largeAndroidBuild",
+    "linux" : 614000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
@@ -700,70 +35,607 @@
     "linux" : 130000
   }, {
     "testProject" : "largeAndroidBuild",
-    "linux" : 221000
+    "linux" : 229000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.experiment.java.JavaLibraryPluginPerformanceTest.java-library vs java",
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean assembleDebug with clean transforms cache",
   "durations" : [ {
-    "testProject" : "largeJavaMultiProject",
-    "linux" : 347000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
-  "durations" : [ {
-    "testProject" : "excludeRuleMergingBuild",
-    "linux" : 280000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 664000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.incremental compile",
-  "durations" : [ {
-    "testProject" : "mediumSwiftMulti",
-    "linux" : 529000
+    "testProject" : "largeAndroidBuild",
+    "linux" : 2406000
   }, {
-    "testProject" : "bigSwiftApp",
-    "linux" : 184000
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 3659000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean phthalic:assembleDebug with clean transforms cache",
+  "durations" : [ {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 1775000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
+  "durations" : [ {
+    "testProject" : "k9AndroidBuild",
+    "linux" : 208000
+  }, {
+    "testProject" : "largeAndroidBuild",
+    "linux" : 1295000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for abi change with local cache",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 788000
+    "linux" : 812000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 808000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1141000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 972000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty remote http cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1161000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 989000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 786000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 838000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 804000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 532000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote https cache",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 820000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 532000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
+  "durations" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 237000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 504000
+  }, {
+    "testProject" : "bigNative",
+    "linux" : 231000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
+  "durations" : [ {
+    "testProject" : "bigSwiftApp",
+    "linux" : 311000
+  }, {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 516000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
+  "durations" : [ {
+    "testProject" : "archivePerformanceProject",
+    "linux" : 166000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
   "durations" : [ {
     "testProject" : "archivePerformanceProject",
-    "linux" : 163000
+    "linux" : 160000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
   "durations" : [ {
     "testProject" : "archivePerformanceProject",
-    "linux" : 229000
+    "linux" : 226000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
+  "scenario" : "org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest.create many deprecation warnings",
+  "durations" : [ {
+    "testProject" : "generateLotsOfDeprecationWarnings",
+    "linux" : 107000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 206000
-  } ]
-}, {
-  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
-  "durations" : [ {
-    "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 661000
+    "linux" : 294000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules (parallel)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 239000
+    "linux" : 244000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for abi change with file system watching",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 450000,
+    "windows" : 949000,
+    "macOs" : 893000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 668000,
+    "windows" : 920000,
+    "macOs" : 1185000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for non-abi change with file system watching",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 430000,
+    "windows" : 934000,
+    "macOs" : 819000
+  }, {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 355000,
+    "windows" : 562000,
+    "macOs" : 602000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 413000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 153000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 373000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 155000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
+  "durations" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 281000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = true)",
+  "durations" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 245000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
+  "durations" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 237000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
+  "durations" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 214000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
+  "durations" : [ {
+    "testProject" : "excludeRuleMergingBuild",
+    "linux" : 413000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
+  "durations" : [ {
+    "testProject" : "springBootApp",
+    "linux" : 332000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository (parallel)",
+  "durations" : [ {
+    "testProject" : "springBootApp",
+    "linux" : 268000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
+  "durations" : [ {
+    "testProject" : "bigNative",
+    "linux" : 186000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 741000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 809000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
+  "durations" : [ {
+    "testProject" : "withVerboseJUnit",
+    "linux" : 65000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
+  "durations" : [ {
+    "testProject" : "createLotsOfTasks",
+    "linux" : 135000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
+  "durations" : [ {
+    "testProject" : "withVerboseJUnit",
+    "linux" : 191000
+  }, {
+    "testProject" : "withVerboseTestNG",
+    "linux" : 175000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 690000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1124000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 221000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc non-abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 703000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 741000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 212000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaABIChangePerformanceTest.assemble for abi change",
+  "durations" : [ {
+    "testProject" : "largeGroovyMultiProject",
+    "linux" : 722000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 529000
+  }, {
+    "testProject" : "largeMonolithicGroovyProject",
+    "linux" : 1703000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1030000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 519000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 527000
+  }, {
+    "testProject" : "mediumJavaCompositeBuild",
+    "linux" : 334000
+  }, {
+    "testProject" : "mediumJavaPredefinedCompositeBuild",
+    "linux" : 340000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 673000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with hot daemon",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 393000
+  }, {
+    "testProject" : "smallJavaMultiProject",
+    "linux" : 188000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 667000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProjectNoBuildSrc",
+    "linux" : 400000
+  }, {
+    "testProject" : "smallJavaMultiProject",
+    "linux" : 188000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaConfigurationPerformanceTest.configure",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 268000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 375000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 146000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 292000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 141000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.clean checkout",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1124000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 1105000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 435000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.cold daemon",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 1089000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 998000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 378000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.first use",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 761000
+  }, {
+    "testProject" : "largeJavaMultiProjectKotlinDsl",
+    "linux" : 946000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 426000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 490000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 114000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 482000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 118000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
+  "durations" : [ {
+    "testProject" : "largeGroovyMultiProject",
+    "linux" : 628000
+  }, {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 513000
+  }, {
+    "testProject" : "largeMonolithicGroovyProject",
+    "linux" : 1666000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1033000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 300000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 144000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 336000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 144000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 591000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 1480000
+  }, {
+    "testProject" : "mediumJavaMultiProjectWithTestNG",
+    "linux" : 297000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 675000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 290000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 478000,
+    "windows" : 1434000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 687000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 301000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 483000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:buildDependentsLibA0",
+  "durations" : [ {
+    "testProject" : "nativeDependents",
+    "linux" : 550000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:dependentComponents",
+  "durations" : [ {
+    "testProject" : "nativeDependents",
+    "linux" : 540000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
+  "durations" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 236000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 285000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
+  "durations" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 145000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 281000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
+  "durations" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 109000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 279000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native, parallel)",
+  "durations" : [ {
+    "testProject" : "manyProjectsNative",
+    "linux" : 702000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native)",
+  "durations" : [ {
+    "testProject" : "bigCppApp",
+    "linux" : 532000
+  }, {
+    "testProject" : "bigCppMulti",
+    "linux" : 1483000
+  }, {
+    "testProject" : "bigNative",
+    "linux" : 757000
+  }, {
+    "testProject" : "mediumCppApp",
+    "linux" : 231000
+  }, {
+    "testProject" : "mediumCppAppWithMacroIncludes",
+    "linux" : 228000
+  }, {
+    "testProject" : "mediumCppMulti",
+    "linux" : 490000
+  }, {
+    "testProject" : "mediumCppMultiWithMacroIncludes",
+    "linux" : 494000
+  }, {
+    "testProject" : "mediumNative",
+    "linux" : 272000
+  }, {
+    "testProject" : "multiNative",
+    "linux" : 1840000
+  }, {
+    "testProject" : "smallCppApp",
+    "linux" : 299000
+  }, {
+    "testProject" : "smallCppMulti",
+    "linux" : 322000
+  }, {
+    "testProject" : "smallNative",
+    "linux" : 310000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
+  "durations" : [ {
+    "testProject" : "nativeMonolithic",
+    "linux" : 1050000
+  }, {
+    "testProject" : "nativeMonolithicOverlapping",
+    "linux" : 970000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
+  "durations" : [ {
+    "testProject" : "nativeMonolithic",
+    "linux" : 773000
+  }, {
+    "testProject" : "nativeMonolithicOverlapping",
+    "linux" : 775000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
+  "durations" : [ {
+    "testProject" : "smallNativeMonolithic",
+    "linux" : 616000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",
@@ -772,30 +644,158 @@
     "linux" : 268000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
+  "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
+  "durations" : [ {
+    "testProject" : "mediumNativeMonolithic",
+    "linux" : 267000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.incremental compile",
+  "durations" : [ {
+    "testProject" : "bigSwiftApp",
+    "linux" : 184000
+  }, {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 534000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
+  "durations" : [ {
+    "testProject" : "bigSwiftApp",
+    "linux" : 116000
+  }, {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 179000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftCleanBuildPerformanceTest.clean assemble (swift)",
+  "durations" : [ {
+    "testProject" : "bigSwiftApp",
+    "linux" : 728000
+  }, {
+    "testProject" : "mediumSwiftMulti",
+    "linux" : 1082000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 709000
+    "linux" : 1393000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 854000
+    "linux" : 1429000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 421000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildSlowPerformanceTest.clean phthalic:assembleDebug with clean transforms cache",
+  "scenario" : "org.gradle.performance.experiment.java.JavaLibraryPluginPerformanceTest.java-library vs java",
   "durations" : [ {
-    "testProject" : "largeAndroidBuild",
-    "linux" : 1768000
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 338000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
+  "scenario" : "org.gradle.performance.experiment.java.ParallelBuildPerformanceTest.clean assemble with 4 parallel workers",
   "durations" : [ {
-    "testProject" : "archivePerformanceProject",
-    "linux" : 167000
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 494000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 357000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native, parallel)",
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.assemble for non-abi change (Gradle vs Maven)",
   "durations" : [ {
-    "testProject" : "manyProjectsNative",
-    "linux" : 681000
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 672000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 286000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean assemble (Gradle vs Maven)",
+  "durations" : [ {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 413000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 189000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean test (Gradle vs Maven)",
+  "durations" : [ {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 1200000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 531000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.test for non-abi change (Gradle vs Maven)",
+  "durations" : [ {
+    "testProject" : "mediumJavaMultiProject",
+    "linux" : 1841000
+  }, {
+    "testProject" : "mediumMonolithicJavaProject",
+    "linux" : 889000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativeParallelPerformanceTest.clean assemble with parallel workers",
+  "durations" : [ {
+    "testProject" : "bigNative",
+    "linux" : 671000
+  }, {
+    "testProject" : "mediumNative",
+    "linux" : 187000
+  }, {
+    "testProject" : "smallNative",
+    "linux" : 116000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.experiment.nativeplatform.NativePreCompiledHeaderPerformanceTest.clean assemble with precompiled headers",
+  "durations" : [ {
+    "testProject" : "bigPCHNative",
+    "linux" : 1084000
+  }, {
+    "testProject" : "mediumPCHNative",
+    "linux" : 301000
+  }, {
+    "testProject" : "smallPCHNative",
+    "linux" : 124000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster abi change (build comparison)",
+  "durations" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 839000
+  }, {
+    "testProject" : "santaTrackerAndroidJavaBuild",
+    "linux" : 425000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster non-abi change (build comparison)",
+  "durations" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 434000
+  }, {
+    "testProject" : "santaTrackerAndroidJavaBuild",
+    "linux" : 403000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.file system watching baseline non-abi change (build comparison)",
+  "durations" : [ {
+    "testProject" : "santaTrackerAndroidBuild",
+    "linux" : 1104000,
+    "windows" : 2186000,
+    "macOs" : 1802000
+  } ]
+}, {
+  "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
+  "durations" : [ {
+    "testProject" : "largeJavaMultiProject",
+    "linux" : 151000
+  }, {
+    "testProject" : "largeMonolithicJavaProject",
+    "linux" : 80000
   } ]
 } ]

--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -2,37 +2,37 @@
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.abi change",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 758000
+    "linux" : 796000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.non-abi change",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 453000
+    "linux" : 527000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
   "durations" : [ {
     "testProject" : "k9AndroidBuild",
-    "linux" : 174000
+    "linux" : 184000
   }, {
     "testProject" : "largeAndroidBuild",
-    "linux" : 695000
+    "linux" : 702000
   }, {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 461000
+    "linux" : 595000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run clean phthalic:assembleDebug",
   "durations" : [ {
     "testProject" : "largeAndroidBuild",
-    "linux" : 614000
+    "linux" : 618000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
   "durations" : [ {
     "testProject" : "k9AndroidBuild",
-    "linux" : 130000
+    "linux" : 133000
   }, {
     "testProject" : "largeAndroidBuild",
     "linux" : 229000
@@ -56,22 +56,22 @@
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
   "durations" : [ {
     "testProject" : "k9AndroidBuild",
-    "linux" : 208000
+    "linux" : 222000
   }, {
     "testProject" : "largeAndroidBuild",
-    "linux" : 1295000
+    "linux" : 1310000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for abi change with local cache",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 812000
+    "linux" : 774000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble for non-abi change with local cache",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 808000
+    "linux" : 753000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with empty local cache",
@@ -95,10 +95,10 @@
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with local cache",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 786000
+    "linux" : 732000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 838000
+    "linux" : 844000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingJavaPerformanceTest.clean assemble with remote http cache",
@@ -122,132 +122,132 @@
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingNativePerformanceTest.clean assemble with local cache (native project)",
   "durations" : [ {
     "testProject" : "bigCppApp",
-    "linux" : 237000
+    "linux" : 239000
   }, {
     "testProject" : "bigCppMulti",
-    "linux" : 504000
+    "linux" : 502000
   }, {
     "testProject" : "bigNative",
-    "linux" : 231000
+    "linux" : 238000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.buildcache.TaskOutputCachingSwiftPerformanceTest.clean assemble with local cache (swift)",
   "durations" : [ {
     "testProject" : "bigSwiftApp",
-    "linux" : 311000
+    "linux" : 312000
   }, {
     "testProject" : "mediumSwiftMulti",
-    "linux" : 516000
+    "linux" : 525000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting gzip tar trees",
   "durations" : [ {
     "testProject" : "archivePerformanceProject",
-    "linux" : 166000
+    "linux" : 164000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
   "durations" : [ {
     "testProject" : "archivePerformanceProject",
-    "linux" : 160000
+    "linux" : 161000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
   "durations" : [ {
     "testProject" : "archivePerformanceProject",
-    "linux" : 226000
+    "linux" : 229000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.DeprecationCreationPerformanceTest.create many deprecation warnings",
   "durations" : [ {
     "testProject" : "generateLotsOfDeprecationWarnings",
-    "linux" : 107000
+    "linux" : 113000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 294000
+    "linux" : 302000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ExcludeRuleMergingPerformanceTest.merge exclude rules (parallel)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 244000
+    "linux" : 237000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for abi change with file system watching",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 450000,
-    "windows" : 949000,
-    "macOs" : 893000
+    "linux" : 455000,
+    "windows" : 954000,
+    "macOs" : 887000
   }, {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 668000,
-    "windows" : 920000,
-    "macOs" : 1185000
+    "linux" : 757000,
+    "windows" : 1002000,
+    "macOs" : 1269000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.FileSystemWatchingPerformanceTest.assemble for non-abi change with file system watching",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 430000,
-    "windows" : 934000,
-    "macOs" : 819000
+    "linux" : 433000,
+    "windows" : 821000,
+    "macOs" : 836000
   }, {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 355000,
-    "windows" : 562000,
-    "macOs" : 602000
+    "linux" : 390000,
+    "windows" : 612000,
+    "macOs" : 723000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.eclipse",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 413000
+    "linux" : 400000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 153000
+    "linux" : 151000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.IdeIntegrationPerformanceTest.idea",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 373000
+    "linux" : 374000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 155000
+    "linux" : 146000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = false)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 281000
+    "linux" : 271000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = false, locking = true)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 245000
+    "linux" : 247000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 237000
+    "linux" : 231000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 214000
+    "linux" : 206000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph from file repo",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 413000
+    "linux" : 396000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.ParallelDownloadsPerformanceTest.resolves dependencies from external repository",
@@ -265,13 +265,13 @@
   "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.clean assemble with rich console",
   "durations" : [ {
     "testProject" : "bigNative",
-    "linux" : 186000
+    "linux" : 205000
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 741000
+    "linux" : 744000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 809000
+    "linux" : 813000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.RichConsolePerformanceTest.cleanTest test with rich console",
@@ -283,16 +283,16 @@
   "scenario" : "org.gradle.performance.regression.corefeature.TaskCreationPerformanceTest.create many tasks",
   "durations" : [ {
     "testProject" : "createLotsOfTasks",
-    "linux" : 135000
+    "linux" : 136000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.VerboseTestOutputPerformanceTest.cleanTest test with verbose test output",
   "durations" : [ {
     "testProject" : "withVerboseJUnit",
-    "linux" : 191000
+    "linux" : 192000
   }, {
     "testProject" : "withVerboseTestNG",
-    "linux" : 175000
+    "linux" : 174000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.inception.BuildSrcApiChangePerformanceTest.buildSrc abi change",
@@ -322,28 +322,28 @@
   "scenario" : "org.gradle.performance.regression.java.JavaABIChangePerformanceTest.assemble for abi change",
   "durations" : [ {
     "testProject" : "largeGroovyMultiProject",
-    "linux" : 722000
+    "linux" : 725000
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 529000
+    "linux" : 536000
   }, {
     "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1703000
+    "linux" : 1664000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1030000
+    "linux" : 1048000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 519000
+    "linux" : 495000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 527000
+    "linux" : 530000
   }, {
     "testProject" : "mediumJavaCompositeBuild",
-    "linux" : 334000
+    "linux" : 342000
   }, {
     "testProject" : "mediumJavaPredefinedCompositeBuild",
     "linux" : 340000
@@ -352,13 +352,13 @@
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
   "durations" : [ {
     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 673000
+    "linux" : 671000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with hot daemon",
   "durations" : [ {
     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 393000
+    "linux" : 398000
   }, {
     "testProject" : "smallJavaMultiProject",
     "linux" : 188000
@@ -367,13 +367,13 @@
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with cold daemon",
   "durations" : [ {
     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 667000
+    "linux" : 673000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble storing configuration cache state with hot daemon",
   "durations" : [ {
     "testProject" : "largeJavaMultiProjectNoBuildSrc",
-    "linux" : 400000
+    "linux" : 392000
   }, {
     "testProject" : "smallJavaMultiProject",
     "linux" : 188000
@@ -382,22 +382,22 @@
   "scenario" : "org.gradle.performance.regression.java.JavaConfigurationPerformanceTest.configure",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 268000
+    "linux" : 267000
   }, {
     "testProject" : "largeJavaMultiProjectKotlinDsl",
-    "linux" : 375000
+    "linux" : 384000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 146000
+    "linux" : 148000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaDependencyReportPerformanceTest.generate dependency report",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 292000
+    "linux" : 285000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 141000
+    "linux" : 142000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaFirstUsePerformanceTest.clean checkout",
@@ -439,49 +439,49 @@
   "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 490000
+    "linux" : 484000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 114000
+    "linux" : 124000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 482000
+    "linux" : 479000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 118000
+    "linux" : 122000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaNonABIChangePerformanceTest.assemble for non-abi change",
   "durations" : [ {
     "testProject" : "largeGroovyMultiProject",
-    "linux" : 628000
+    "linux" : 623000
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 513000
+    "linux" : 506000
   }, {
     "testProject" : "largeMonolithicGroovyProject",
-    "linux" : 1666000
+    "linux" : 1687000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1033000
+    "linux" : 1027000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 300000
+    "linux" : 304000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 144000
+    "linux" : 151000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks --all",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 336000
+    "linux" : 352000
   }, {
     "testProject" : "largeMonolithicJavaProject",
     "linux" : 144000
@@ -490,83 +490,83 @@
   "scenario" : "org.gradle.performance.regression.java.JavaTestChangePerformanceTest.test for non-abi change",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 591000
+    "linux" : 589000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1480000
+    "linux" : 1456000
   }, {
     "testProject" : "mediumJavaMultiProjectWithTestNG",
-    "linux" : 297000
+    "linux" : 289000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel false)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 675000
+    "linux" : 682000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 290000
+    "linux" : 299000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 478000,
-    "windows" : 1434000
+    "linux" : 474000,
+    "windows" : 1391000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 687000
+    "linux" : 714000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 301000
+    "linux" : 309000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 483000
+    "linux" : 477000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:buildDependentsLibA0",
   "durations" : [ {
     "testProject" : "nativeDependents",
-    "linux" : 550000
+    "linux" : 556000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:dependentComponents",
   "durations" : [ {
     "testProject" : "nativeDependents",
-    "linux" : 540000
+    "linux" : 548000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with header file change",
   "durations" : [ {
     "testProject" : "bigCppApp",
-    "linux" : 236000
+    "linux" : 241000
   }, {
     "testProject" : "bigCppMulti",
-    "linux" : 285000
+    "linux" : 279000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.assemble with source file change",
   "durations" : [ {
     "testProject" : "bigCppApp",
-    "linux" : 145000
+    "linux" : 148000
   }, {
     "testProject" : "bigCppMulti",
-    "linux" : 281000
+    "linux" : 277000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeBuildPerformanceTest.up-to-date assemble (native)",
   "durations" : [ {
     "testProject" : "bigCppApp",
-    "linux" : 109000
+    "linux" : 117000
   }, {
     "testProject" : "bigCppMulti",
-    "linux" : 279000
+    "linux" : 273000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.NativeCleanBuildPerformanceTest.clean assemble (native, parallel)",
@@ -617,31 +617,31 @@
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 0 parallel workers",
   "durations" : [ {
     "testProject" : "nativeMonolithic",
-    "linux" : 1050000
+    "linux" : 976000
   }, {
     "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 970000
+    "linux" : 973000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with 12 parallel workers",
   "durations" : [ {
     "testProject" : "nativeMonolithic",
-    "linux" : 773000
+    "linux" : 774000
   }, {
     "testProject" : "nativeMonolithicOverlapping",
-    "linux" : 775000
+    "linux" : 776000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
   "durations" : [ {
     "testProject" : "smallNativeMonolithic",
-    "linux" : 616000
+    "linux" : 622000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",
   "durations" : [ {
     "testProject" : "mediumNativeMonolithic",
-    "linux" : 268000
+    "linux" : 270000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with source file change",
@@ -656,7 +656,7 @@
     "linux" : 184000
   }, {
     "testProject" : "mediumSwiftMulti",
-    "linux" : 534000
+    "linux" : 536000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftBuildPerformanceTest.up-to-date assemble (swift)",
@@ -665,7 +665,7 @@
     "linux" : 116000
   }, {
     "testProject" : "mediumSwiftMulti",
-    "linux" : 179000
+    "linux" : 176000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.SwiftCleanBuildPerformanceTest.clean assemble (swift)",
@@ -680,10 +680,10 @@
   "scenario" : "org.gradle.performance.experiment.buildcache.LocalTaskOutputCacheCrossBuildPerformanceTest.assemble with local cache (build comparison)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 1393000
+    "linux" : 1422000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1429000
+    "linux" : 1426000
   }, {
     "testProject" : "mediumMonolithicJavaProject",
     "linux" : 421000
@@ -698,19 +698,19 @@
   "scenario" : "org.gradle.performance.experiment.java.ParallelBuildPerformanceTest.clean assemble with 4 parallel workers",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 494000
+    "linux" : 504000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 357000
+    "linux" : 363000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.assemble for non-abi change (Gradle vs Maven)",
   "durations" : [ {
     "testProject" : "mediumJavaMultiProject",
-    "linux" : 672000
+    "linux" : 674000
   }, {
     "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 286000
+    "linux" : 301000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean assemble (Gradle vs Maven)",
@@ -719,13 +719,13 @@
     "linux" : 413000
   }, {
     "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 189000
+    "linux" : 201000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.clean test (Gradle vs Maven)",
   "durations" : [ {
     "testProject" : "mediumJavaMultiProject",
-    "linux" : 1200000
+    "linux" : 1209000
   }, {
     "testProject" : "mediumMonolithicJavaProject",
     "linux" : 531000
@@ -734,34 +734,34 @@
   "scenario" : "org.gradle.performance.experiment.maven.JavaTestGradleVsMavenPerformanceTest.test for non-abi change (Gradle vs Maven)",
   "durations" : [ {
     "testProject" : "mediumJavaMultiProject",
-    "linux" : 1841000
+    "linux" : 1854000
   }, {
     "testProject" : "mediumMonolithicJavaProject",
-    "linux" : 889000
+    "linux" : 866000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.nativeplatform.NativeParallelPerformanceTest.clean assemble with parallel workers",
   "durations" : [ {
     "testProject" : "bigNative",
-    "linux" : 671000
+    "linux" : 674000
   }, {
     "testProject" : "mediumNative",
     "linux" : 187000
   }, {
     "testProject" : "multiNative",
-    "linux" : 187000
+    "linux" : 1756000
   }, {
     "testProject" : "smallNative",
-    "linux" : 116000
+    "linux" : 114000
   } ]
 }, {
   "scenario" : "org.gradle.performance.experiment.nativeplatform.NativePreCompiledHeaderPerformanceTest.clean assemble with precompiled headers",
   "durations" : [ {
     "testProject" : "bigPCHNative",
-    "linux" : 1084000
+    "linux" : 1081000
   }, {
     "testProject" : "mediumPCHNative",
-    "linux" : 301000
+    "linux" : 300000
   }, {
     "testProject" : "smallPCHNative",
     "linux" : 124000
@@ -770,25 +770,25 @@
   "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster abi change (build comparison)",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 839000
+    "linux" : 875000
   }, {
     "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 425000
+    "linux" : 483000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.faster non-abi change (build comparison)",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 434000
+    "linux" : 481000
   }, {
     "testProject" : "santaTrackerAndroidJavaBuild",
-    "linux" : 403000
+    "linux" : 438000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.FasterIncrementalAndroidBuildsPerformanceTest.file system watching baseline non-abi change (build comparison)",
   "durations" : [ {
     "testProject" : "santaTrackerAndroidBuild",
-    "linux" : 1104000,
+    "linux" : 1257000,
     "windows" : 2186000,
     "macOs" : 1802000
   } ]
@@ -796,9 +796,9 @@
   "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 151000
+    "linux" : 143000
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 80000
+    "linux" : 82000
   } ]
 } ]

--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -748,6 +748,9 @@
     "testProject" : "mediumNative",
     "linux" : 187000
   }, {
+    "testProject" : "multiNative",
+    "linux" : 187000
+  }, {
     "testProject" : "smallNative",
     "linux" : 116000
   } ]

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
@@ -53,7 +53,7 @@ public class CompositeResultsStore implements ResultsStore {
     public Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentDurationsInMillis() {
         return stores.stream()
             .flatMap(store -> store.getEstimatedExperimentDurationsInMillis().entrySet().stream())
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Math::max));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Math::max, LinkedHashMap::new));
     }
 
     private ResultsStore getStoreForTest(PerformanceExperiment experiment) {


### PR DESCRIPTION
This PR updates the performance test durations with the current values from the performance database. It also adds the following improvements for generating the durations file:
- the output is now deterministic.
- improved error reporting when a duration is not found.