### PR TITLE
Disable toolchain discovery and provisioning by default for all tests

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -64,6 +64,7 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             .withStacktraceDisabled()
             .noDeprecationChecks()
             .withWarningMode(warningMode)
+            .withToolchainDetectionEnabled()
             .withArguments(filteredFlags)
             .withTasks(args);
         try {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -95,10 +95,12 @@ class AbstractIntegrationSpec extends Specification {
     def setup() {
         m2.isolateMavenLocalRepo(executer)
         executer.beforeExecute {
-            executer.withArgument("-Dorg.gradle.internal.repository.max.tentatives=$maxHttpRetries")
+            withArgument("-Dorg.gradle.internal.repository.max.tentatives=$maxHttpRetries")
             if (maxUploadAttempts != null) {
-                executer.withArgument("-Dorg.gradle.internal.network.retry.max.attempts=$maxUploadAttempts")
+                withArgument("-Dorg.gradle.internal.network.retry.max.attempts=$maxUploadAttempts")
             }
+            withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            withArgument("-Porg.gradle.java.installations.auto-download=false")
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -99,8 +99,6 @@ class AbstractIntegrationSpec extends Specification {
             if (maxUploadAttempts != null) {
                 withArgument("-Dorg.gradle.internal.network.retry.max.attempts=$maxUploadAttempts")
             }
-            withArgument("-Porg.gradle.java.installations.auto-detect=false")
-            withArgument("-Porg.gradle.java.installations.auto-download=false")
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
@@ -21,11 +21,6 @@ import org.junit.Assume
 abstract class AbstractSampleIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.withRepositoryMirrors()
-        // Disable toolchain detection and download - we want to be specific
-        executer.beforeExecute {
-            withArgument("-Porg.gradle.java.installations.auto-detect=false")
-            withArgument("-Porg.gradle.java.installations.auto-download=false")
-        }
     }
 
     def configureExecuterForToolchains(String... versions) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -166,6 +166,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     protected WarningMode warningMode = WarningMode.All;
     private boolean showStacktrace = true;
     private boolean renderWelcomeMessage;
+    private boolean disableToolchainDownload = true;
+    private boolean disableToolchainDetection = true;
+
 
     private int expectedGenericDeprecationWarnings;
     private final List<String> expectedDeprecationWarnings = new ArrayList<>();
@@ -245,6 +248,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         expectedDeprecationWarnings.clear();
         stackTraceChecksOn = true;
         renderWelcomeMessage = false;
+        disableToolchainDownload = true;
+        disableToolchainDetection = true;
         debug = Boolean.getBoolean(DEBUG_SYSPROP);
         debugLauncher = Boolean.getBoolean(LAUNCHER_DEBUG_SYSPROP);
         profiler = System.getProperty(PROFILE_SYSPROP, "");
@@ -415,6 +420,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         if (renderWelcomeMessage) {
             executer.withWelcomeMessageEnabled();
+        }
+
+        if(!disableToolchainDetection) {
+            executer.withToolchainDetectedEnabled();
+        }
+        if(!disableToolchainDownload) {
+            executer.withToolchainDownloadEnabled();
         }
 
         executer.withTestConsoleAttached(consoleAttachment);
@@ -819,6 +831,19 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     @Override
+    public GradleExecuter withToolchainDetectedEnabled() {
+        disableToolchainDetection = false;
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withToolchainDownloadEnabled() {
+        withToolchainDetectedEnabled();
+        disableToolchainDownload = false;
+        return this;
+    }
+
+    @Override
     public GradleExecuter withRepositoryMirrors() {
         beforeExecute(gradleExecuter -> usingInitScript(RepoScriptBlockUtil.createMirrorInitScript()));
         return this;
@@ -995,6 +1020,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         if (warningMode != null) {
             allArgs.add("--warning-mode=" + warningMode.toString().toLowerCase(Locale.ENGLISH));
+        }
+
+        if(disableToolchainDownload) {
+            allArgs.add("-Porg.gradle.java.installations.auto-download=false");
+        }
+        if(disableToolchainDetection) {
+            allArgs.add("-Porg.gradle.java.installations.auto-detect=false");
         }
 
         allArgs.addAll(args);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -422,10 +422,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             executer.withWelcomeMessageEnabled();
         }
 
-        if(!disableToolchainDetection) {
-            executer.withToolchainDetectedEnabled();
+        if (!disableToolchainDetection) {
+            executer.withToolchainDetectionEnabled();
         }
-        if(!disableToolchainDownload) {
+        if (!disableToolchainDownload) {
             executer.withToolchainDownloadEnabled();
         }
 
@@ -831,14 +831,14 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     @Override
-    public GradleExecuter withToolchainDetectedEnabled() {
+    public GradleExecuter withToolchainDetectionEnabled() {
         disableToolchainDetection = false;
         return this;
     }
 
     @Override
     public GradleExecuter withToolchainDownloadEnabled() {
-        withToolchainDetectedEnabled();
+        withToolchainDetectionEnabled();
         disableToolchainDownload = false;
         return this;
     }
@@ -1022,10 +1022,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             allArgs.add("--warning-mode=" + warningMode.toString().toLowerCase(Locale.ENGLISH));
         }
 
-        if(disableToolchainDownload) {
+        if (disableToolchainDownload) {
             allArgs.add("-Porg.gradle.java.installations.auto-download=false");
         }
-        if(disableToolchainDetection) {
+        if (disableToolchainDetection) {
             allArgs.add("-Porg.gradle.java.installations.auto-detect=false");
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -539,4 +539,9 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter ignoreMissingSettingsFile();
 
     GradleExecuter ignoreCleanupAssertions();
+
+    GradleExecuter withToolchainDetectedEnabled();
+
+    GradleExecuter withToolchainDownloadEnabled();
+
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -540,7 +540,7 @@ public interface GradleExecuter extends Stoppable {
 
     GradleExecuter ignoreCleanupAssertions();
 
-    GradleExecuter withToolchainDetectedEnabled();
+    GradleExecuter withToolchainDetectionEnabled();
 
     GradleExecuter withToolchainDownloadEnabled();
 

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
@@ -87,4 +87,34 @@ class AbstractGradleExecuterTest extends Specification {
         where:
         argument << ['--no-daemon', '--foreground']
     }
+
+    def "toolchain provisioning and discovery disabled by default"() {
+        when:
+        def allArgs = executer.getAllArgs()
+
+        then:
+        allArgs.contains("-Porg.gradle.java.installations.auto-detect=false")
+        allArgs.contains("-Porg.gradle.java.installations.auto-download=false")
+    }
+
+    def "toolchain detection can be enabled"() {
+        when:
+        executer.withToolchainDetectedEnabled()
+        def allArgs = executer.getAllArgs()
+
+        then:
+        !allArgs.toString().contains("-Porg.gradle.java.installations.auto-detect")
+        allArgs.contains("-Porg.gradle.java.installations.auto-download=false")
+    }
+
+    def "toolchain provisioning can be enabled"() {
+        when:
+        executer.withToolchainDownloadEnabled()
+        def allArgs = executer.getAllArgs()
+
+        then:
+        !allArgs.toString().contains("-Porg.gradle.java.installations.auto-detect")
+        !allArgs.toString().contains("-Porg.gradle.java.installations.auto-download")
+    }
+
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
@@ -99,7 +99,7 @@ class AbstractGradleExecuterTest extends Specification {
 
     def "toolchain detection can be enabled"() {
         when:
-        executer.withToolchainDetectedEnabled()
+        executer.withToolchainDetectionEnabled()
         def allArgs = executer.getAllArgs()
 
         then:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -25,13 +25,6 @@ import spock.lang.Unroll
 
 class JavaExecToolchainIntegrationTest extends AbstractPluginIntegrationTest {
 
-    def setup() {
-        executer.beforeExecute {
-            withArgument("-Porg.gradle.java.installations.auto-detect=false")
-            withArgument("-Porg.gradle.java.installations.auto-download=false")
-        }
-    }
-
     @Unroll
     @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
     def "can manually set java launcher via  #type toolchain on java exec task #jdk"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainUpToDateIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainUpToDateIntegrationTest.groovy
@@ -93,7 +93,6 @@ class JavaToolchainUpToDateIntegrationTest extends AbstractPluginIntegrationTest
 
     def runWithToolchainConfigured(Jvm jvm) {
         result = executer
-            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
             .withArgument("-Porg.gradle.java.installations.paths=" + jvm.javaHome.absolutePath)
             .withTasks("check", "javadoc")
             .run()

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -204,7 +204,6 @@ public class Foo {
 
         when:
         failure = executer
-            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
             .withArgument("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath)
             .withArgument("--info")
             .withTasks("compileJava")
@@ -303,7 +302,6 @@ public class Foo {
 
     def runWithToolchainConfigured(Jvm jvm) {
         result = executer
-            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
             .withArgument("-Porg.gradle.java.installations.paths=" + jvm.javaHome.absolutePath)
             .withArgument("--info")
             .withTasks("compileJava")

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -99,7 +99,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
 
         when:
         failure = executer
-            .withArgument("-Porg.gradle.java.installations.auto-download=false")
+            .withToolchainDetectionEnabled()
             .withTasks("compileJava")
             .runWithFailure()
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -25,13 +25,6 @@ import spock.lang.Unroll
 
 class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
 
-    def setup() {
-        executer.beforeExecute {
-            withArgument("-Porg.gradle.java.installations.auto-detect=false")
-            withArgument("-Porg.gradle.java.installations.auto-download=false")
-        }
-    }
-
     @Unroll
     @IgnoreIf({ AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) == null })
     def "can manually set javadoc tool via  #type toolchain on javadoc task #type : #jdk"() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -38,7 +38,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         failure = executer
-            .withArguments("-Porg.gradle.java.installations.auto-detect=false")
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
             .runWithFailure()
@@ -72,7 +71,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         failure = executer
-            .withArguments("-Porg.gradle.java.installations.auto-detect=false")
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
             .runWithFailure()
@@ -97,7 +95,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         """
 
         propertiesFile << """
-            org.gradle.java.installations.auto-detect=false
             org.gradle.jvm.toolchain.install.adoptopenjdk.baseUri=http://example.com
         """
 

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -40,6 +40,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         failure = executer
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
+            .withToolchainDownloadEnabled()
             .runWithFailure()
         result = failure
 
@@ -104,6 +105,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         failure = executer
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
+            .withToolchainDownloadEnabled()
             .runWithFailure()
         result = failure
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -57,9 +57,7 @@ tasks.withType(Javadoc) {
 /** Some thing. */
 public class Thing { }
 """
-        executer.withArgument("-Porg.gradle.java.installations.auto-detect=false")
-            .withArgument("-Porg.gradle.java.installations.auto-download=false")
-            .withArgument("-Porg.gradle.java.installations.paths=" + javaHome)
+        executer.withArgument("-Porg.gradle.java.installations.paths=" + javaHome)
     }
 
     def "can compile source and run JUnit tests using target Java version"() {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
@@ -35,7 +35,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
         when:
         result = executer
-            .withArguments("-Porg.gradle.java.installations.auto-detect=false", "--info")
+            .withArguments("--info")
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
             .run()

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
@@ -37,6 +37,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
         result = executer
             .withArguments("--info")
             .withTasks("compileJava")
+            .withToolchainDownloadEnabled()
             .requireOwnGradleUserHomeDir()
             .run()
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -53,7 +53,6 @@ class TestTaskToolchainIntegrationTest extends AbstractPluginIntegrationTest {
 
         when:
         result = executer
-            .withArgument("-Porg.gradle.java.installations.auto-detect=false")
             .withArgument("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath)
             .withArgument("--info")
             .withTasks("test")

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -237,8 +237,7 @@ public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
         }
 
         when:
-        succeeds("" +
-            "buildAction",
+        succeeds("buildAction",
                 "-PclientJdk=" + clientJdkVersion.majorVersion,
                 "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
                 "-PgradleVersion=" + gradleVersion)

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -28,6 +28,9 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         def compilerJdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_6)
         String compilerJavaHomePath = TextUtil.normaliseFileSeparators(compilerJdk.javaHome.absolutePath)
+        executer.beforeExecute {
+            withToolchainDetectionEnabled()
+        }
         buildFile << """
             plugins {
                 id 'java'
@@ -234,7 +237,8 @@ public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
         }
 
         when:
-        succeeds("buildAction",
+        succeeds("" +
+            "buildAction",
                 "-PclientJdk=" + clientJdkVersion.majorVersion,
                 "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
                 "-PgradleVersion=" + gradleVersion)


### PR DESCRIPTION
This is to avoid flakiness in tests that may pick up multiple JVMs from the same version but expect a specific one (e.g. `TestTaskToolchainIntegrationTest`)