### PR TITLE
Drop org.gradle.vfs.debug in favor of org.gradle.vfs.verbose

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -32,7 +32,6 @@ public class StartParameterInternal extends StartParameter {
     private boolean watchFileSystemDebugLogging;
     private boolean watchFileSystemUsingDeprecatedOption;
     private boolean vfsVerboseLogging;
-    private boolean vfsDebugLogging;
 
     private boolean configurationCache;
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
@@ -57,7 +56,6 @@ public class StartParameterInternal extends StartParameter {
         p.watchFileSystemDebugLogging = watchFileSystemDebugLogging;
         p.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
         p.vfsVerboseLogging = vfsVerboseLogging;
-        p.vfsDebugLogging = vfsDebugLogging;
         p.configurationCache = configurationCache;
         p.configurationCacheProblems = configurationCacheProblems;
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
@@ -120,14 +118,6 @@ public class StartParameterInternal extends StartParameter {
 
     public void setVfsVerboseLogging(boolean vfsVerboseLogging) {
         this.vfsVerboseLogging = vfsVerboseLogging;
-    }
-
-    public boolean isVfsDebugLogging() {
-        return vfsDebugLogging;
-    }
-
-    public void setVfsDebugLogging(boolean vfsDebugLogging) {
-        this.vfsDebugLogging = vfsDebugLogging;
     }
 
     public boolean isConfigurationCache() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -66,7 +66,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         options.add(new WatchFileSystemDebugLoggingOption());
         options.add(new DeprecatedWatchFileSystemOption());
         options.add(new VfsVerboseLoggingOption());
-        options.add(new VfsDebugLoggingOption());
         options.add(new BuildScanOption());
         options.add(new DependencyLockingWriteOption());
         options.add(new DependencyVerificationWriteOption());
@@ -352,19 +351,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
             startParameter.setVfsVerboseLogging(value);
-        }
-    }
-
-    public static class VfsDebugLoggingOption extends BooleanBuildOption<StartParameterInternal> {
-        public static final String GRADLE_PROPERTY = "org.gradle.vfs.debug";
-
-        public VfsDebugLoggingOption() {
-            super(GRADLE_PROPERTY);
-        }
-
-        @Override
-        public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
-            startParameter.setVfsDebugLogging(value);
         }
     }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/LoggingFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/LoggingFileSystemWatchingIntegrationTest.groovy
@@ -37,12 +37,22 @@ class LoggingFileSystemWatchingIntegrationTest extends AbstractFileSystemWatchin
         then:
         !(result.output =~ /Received \d+ file system events since last build while watching \d+ hierarchies/)
         !(result.output =~ /Virtual file system retained information about \d+ files, \d+ directories and \d+ missing files since last build/)
+        result.output =~ /VFS> Statistics since last build:/
+        result.output =~ /VFS> > Stat: Executed stat\(\) x 0. getUnixMode\(\) x 0/
+        result.output =~ /VFS> > FileHasher: Hashed 0 files \(0 bytes\)/
+        result.output =~ /VFS> > DirectorySnapshotter: Snapshot 0 directory hierarchies \(visited 0 directories, 0 files and 0 failed files\)/
         result.output =~ /Received \d+ file system events during the current build while watching \d+ hierarchies/
         result.output =~ /Virtual file system retains information about \d+ files, \d+ directories and \d+ missing files until next build/
+        result.output =~ /VFS> Statistics during current build:/
+        result.output =~ /VFS> > Stat: Executed stat\(\) x .*. getUnixMode\(\) x .*/
+        result.output =~ /VFS> > FileHasher: Hashed .* files \(.* bytes\)/
+        result.output =~ /VFS> > DirectorySnapshotter: Snapshot .* directory hierarchies \(visited .* directories, .* files and .* failed files\)/
 
         when:
         withWatchFs().run("assemble", "-D${StartParameterBuildOptions.VfsVerboseLoggingOption.GRADLE_PROPERTY}=true")
         then:
+        result.output =~ /VFS> Statistics since last build:/
+        result.output =~ /VFS> Statistics during current build:/
         result.output =~ /Received \d+ file system events since last build while watching \d+ hierarchies/
         result.output =~ /Virtual file system retained information about \d+ files, \d+ directories and \d+ missing files since last build/
         result.output =~ /Received \d+ file system events during the current build while watching \d+ hierarchies/
@@ -51,6 +61,8 @@ class LoggingFileSystemWatchingIntegrationTest extends AbstractFileSystemWatchin
         when:
         withWatchFs().run("assemble", "-D${StartParameterBuildOptions.VfsVerboseLoggingOption.GRADLE_PROPERTY}=false")
         then:
+        !(result.output =~ /VFS> Statistics since last build:/)
+        !(result.output =~ /VFS> Statistics during current build:/)
         !(result.output =~ /Received \d+ file system events since last build while watching \d+ hierarchies/)
         !(result.output =~ /Virtual file system retained information about \d+ files, \d+ directories and \d+ missing files since last build/)
         !(result.output =~ /Received \d+ file system events during the current build while watching \d+ hierarchies/)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -119,7 +119,6 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isWatchFileSystemDebugLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystemUsingDeprecatedOption());
             encoder.writeBoolean(startParameter.isVfsVerboseLogging());
-            encoder.writeBoolean(startParameter.isVfsDebugLogging());
             encoder.writeBoolean(startParameter.isConfigurationCache());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeSmallInt(startParameter.getConfigurationCacheMaxProblems());
@@ -200,7 +199,6 @@ public class BuildActionSerializer {
             startParameter.setWatchFileSystemDebugLogging(decoder.readBoolean());
             startParameter.setWatchFileSystemUsingDeprecatedOption(decoder.readBoolean());
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
-            startParameter.setVfsDebugLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheMaxProblems(decoder.readSmallInt());

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -62,7 +62,6 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         WatchLogging debugWatchLogging = startParameter.isWatchFileSystemDebugLogging()
             ? WatchLogging.DEBUG
             : WatchLogging.NORMAL;
-        boolean vfsDebugLogging = startParameter.isVfsDebugLogging();
 
         logMessageForDeprecatedWatchFileSystemProperty(startParameter);
         logMessageForDeprecatedVfsRetentionProperty(startParameter);
@@ -70,7 +69,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         if (watchFileSystem) {
             dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
         }
-        if (vfsDebugLogging) {
+        if (verboseVfsLogging == VfsLogging.VERBOSE) {
             logVfsStatistics("since last build", statStatisticsCollector, fileHasherStatisticsCollector, directorySnapshotterStatisticsCollector);
         }
         virtualFileSystem.afterBuildStarted(watchFileSystem, verboseVfsLogging, debugWatchLogging, buildOperationRunner);
@@ -79,7 +78,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         } finally {
             int maximumNumberOfWatchedHierarchies = VirtualFileSystemServices.getMaximumNumberOfWatchedHierarchies(startParameter);
             virtualFileSystem.beforeBuildFinished(watchFileSystem, verboseVfsLogging, debugWatchLogging, buildOperationRunner, maximumNumberOfWatchedHierarchies);
-            if (vfsDebugLogging) {
+            if (verboseVfsLogging == VfsLogging.VERBOSE) {
                 logVfsStatistics("during current build", statStatisticsCollector, fileHasherStatisticsCollector, directorySnapshotterStatisticsCollector);
             }
         }


### PR DESCRIPTION
Both these flags have a similar target audience and support the same use case of understanding internal workings of the VFS, so no need to separate them.