### PR TITLE
Pass work separately of context

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -295,8 +295,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Override
-        public CachingResult execute(BeforeExecutionContext context) {
-            UpToDateResult result = delegate.execute(new CachingContext() {
+        public CachingResult execute(UnitOfWork work, BeforeExecutionContext context) {
+            UpToDateResult result = delegate.execute(work, new CachingContext() {
                 @Override
                 public CachingState getCachingState() {
                     return CachingState.NOT_DETERMINED;
@@ -335,11 +335,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 @Override
                 public Optional<BeforeExecutionState> getBeforeExecutionState() {
                     return context.getBeforeExecutionState();
-                }
-
-                @Override
-                public UnitOfWork getWork() {
-                    return context.getWork();
                 }
             });
             return new CachingResult() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/Context.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/Context.java
@@ -17,5 +17,4 @@
 package org.gradle.internal.execution;
 
 public interface Context {
-    UnitOfWork getWork();
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/DeferredExecutionAwareStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/DeferredExecutionAwareStep.java
@@ -21,5 +21,5 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.UnitOfWork.Identity;
 
 public interface DeferredExecutionAwareStep<C extends Context, R extends Result> extends Step<C, R> {
-    <T, O> T executeDeferred(C context, Cache<Identity, Try<O>> cache, DeferredResultProcessor<O, T> processor);
+    <T, O> T executeDeferred(UnitOfWork work, C context, Cache<Identity, Try<O>> cache, DeferredResultProcessor<O, T> processor);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/Step.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/Step.java
@@ -17,5 +17,5 @@
 package org.gradle.internal.execution;
 
 public interface Step<C extends Context, R extends Result> {
-    R execute(C context);
+    R execute(UnitOfWork work, C context);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
@@ -38,31 +38,24 @@ public class DefaultExecutionEngine implements ExecutionEngine {
 
     @Override
     public CachingResult execute(UnitOfWork work, @Nullable String rebuildReason) {
-        return executeStep.execute(new Request(work, rebuildReason));
+        return executeStep.execute(work, new Request(rebuildReason));
     }
 
     @Override
     public <T, O> T executeDeferred(UnitOfWork work, @Nullable String rebuildReason, Cache<Identity, Try<O>> cache, DeferredResultProcessor<O, T> processor) {
-        return executeStep.executeDeferred(new Request(work, rebuildReason), cache, processor);
+        return executeStep.executeDeferred(work, new Request(rebuildReason), cache, processor);
     }
 
     private static class Request implements ExecutionRequestContext {
         private final String rebuildReason;
-        private final UnitOfWork work;
 
-        public Request(UnitOfWork work, @Nullable String rebuildReason) {
+        public Request(@Nullable String rebuildReason) {
             this.rebuildReason = rebuildReason;
-            this.work = work;
         }
 
         @Override
         public Optional<String> getRebuildReason() {
             return Optional.ofNullable(rebuildReason);
-        }
-
-        @Override
-        public UnitOfWork getWork() {
-            return work;
         }
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AssignWorkspaceStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AssignWorkspaceStep.java
@@ -36,14 +36,8 @@ public class AssignWorkspaceStep<C extends IdentityContext, R extends Result> im
     }
 
     @Override
-    public R execute(C context) {
-        UnitOfWork work = context.getWork();
-        return work.withWorkspace(context.getIdentity().getUniqueId(), workspace -> delegate.execute(new WorkspaceContext() {
-            @Override
-            public UnitOfWork getWork() {
-                return work;
-            }
-
+    public R execute(UnitOfWork work, C context) {
+        return work.withWorkspace(context.getIdentity().getUniqueId(), workspace -> delegate.execute(work, new WorkspaceContext() {
             @Override
             public Optional<String> getRebuildReason() {
                 return context.getRebuildReason();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BroadcastChangingOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BroadcastChangingOutputsStep.java
@@ -41,8 +41,7 @@ public class BroadcastChangingOutputsStep<C extends WorkspaceContext, R extends 
     }
 
     @Override
-    public R execute(C context) {
-        UnitOfWork work = context.getWork();
+    public R execute(UnitOfWork work, C context) {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
@@ -61,6 +60,6 @@ public class BroadcastChangingOutputsStep<C extends WorkspaceContext, R extends 
             }
         });
         outputChangeListener.beforeOutputChange(builder.build());
-        return delegate.execute(context);
+        return delegate.execute(work, context);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
@@ -39,8 +39,8 @@ public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> imp
     }
 
     @Override
-    public R execute(C context) {
-        context.getWork().visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
+    public R execute(UnitOfWork work, C context) {
+        work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 ensureOutput(propertyName, root, type);
@@ -51,7 +51,7 @@ public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> imp
                 ensureOutput("local state", localStateRoot, TreeType.FILE);
             }
         });
-        return delegate.execute(context);
+        return delegate.execute(work, context);
     }
 
     private static void ensureOutput(String name, File outputRoot, TreeType type) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -40,8 +40,7 @@ public class ExecuteStep<C extends InputChangesContext> implements Step<C, Resul
     }
 
     @Override
-    public Result execute(C context) {
-        UnitOfWork work = context.getWork();
+    public Result execute(UnitOfWork work, C context) {
         return buildOperationExecutor.call(new CallableBuildOperation<Result>() {
             @Override
             public Result call(BuildOperationContext operationContext) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadExecutionStateStep.java
@@ -38,12 +38,11 @@ public class LoadExecutionStateStep<C extends WorkspaceContext, R extends Result
     }
 
     @Override
-    public R execute(C context) {
-        UnitOfWork work = context.getWork();
+    public R execute(UnitOfWork work, C context) {
         Identity identity = context.getIdentity();
         Optional<AfterPreviousExecutionState> afterPreviousExecutionState = work.getHistory()
             .flatMap(history -> history.load(identity.getUniqueId()));
-        return delegate.execute(new AfterPreviousExecutionContext() {
+        return delegate.execute(work, new AfterPreviousExecutionContext() {
             @Override
             public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
                 return afterPreviousExecutionState;
@@ -72,11 +71,6 @@ public class LoadExecutionStateStep<C extends WorkspaceContext, R extends Result
             @Override
             public File getWorkspace() {
                 return context.getWorkspace();
-            }
-
-            @Override
-            public UnitOfWork getWork() {
-                return work;
             }
         });
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RecordOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RecordOutputsStep.java
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.steps;
 import org.gradle.internal.execution.Context;
 import org.gradle.internal.execution.CurrentSnapshotResult;
 import org.gradle.internal.execution.Step;
+import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.OutputFilesRepository;
 
 public class RecordOutputsStep<C extends Context> implements Step<C, CurrentSnapshotResult> {
@@ -34,8 +35,8 @@ public class RecordOutputsStep<C extends Context> implements Step<C, CurrentSnap
     }
 
     @Override
-    public CurrentSnapshotResult execute(C context) {
-        CurrentSnapshotResult result = delegate.execute(context);
+    public CurrentSnapshotResult execute(UnitOfWork work, C context) {
+        CurrentSnapshotResult result = delegate.execute(work, context);
         outputFilesRepository.recordOutputs(result.getFinalOutputs().values());
         return result;
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -55,9 +55,8 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
     }
 
     @Override
-    public R execute(C context) {
+    public R execute(UnitOfWork work, C context) {
         if (!context.isIncrementalExecution()) {
-            UnitOfWork work = context.getWork();
             if (work.shouldCleanupOutputsOnNonIncrementalExecution()) {
                 boolean hasOverlappingOutputs = context.getBeforeExecutionState()
                     .flatMap(BeforeExecutionState::getDetectedOverlappingOutputs)
@@ -69,7 +68,7 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
                 }
             }
         }
-        return delegate.execute(context);
+        return delegate.execute(work, context);
     }
 
     private void cleanupOverlappingOutputs(BeforeExecutionContext context, UnitOfWork work) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -68,8 +68,7 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
     }
 
     @Override
-    public CachingResult execute(BeforeExecutionContext context) {
-        UnitOfWork work = context.getWork();
+    public CachingResult execute(UnitOfWork work, BeforeExecutionContext context) {
         CachingState cachingState;
         if (!buildCache.isEnabled() && !buildScansEnabled) {
             cachingState = BUILD_CACHE_DISABLED_STATE;
@@ -93,7 +92,7 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
             logDisabledReasons(disabledReasons, work);
         }
 
-        UpToDateResult result = delegate.execute(new CachingContext() {
+        UpToDateResult result = delegate.execute(work, new CachingContext() {
             @Override
             public CachingState getCachingState() {
                 return cachingState;
@@ -132,11 +131,6 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
             @Override
             public Optional<BeforeExecutionState> getBeforeExecutionState() {
                 return context.getBeforeExecutionState();
-            }
-
-            @Override
-            public UnitOfWork getWork() {
-                return work;
             }
         });
         return new CachingResult() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -56,8 +56,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
     }
 
     @Override
-    public R execute(CachingContext context) {
-        UnitOfWork work = context.getWork();
+    public R execute(UnitOfWork work, CachingContext context) {
         Optional<BeforeExecutionState> beforeExecutionState = context.getBeforeExecutionState();
         ExecutionStateChanges changes = context.getRebuildReason()
             .<ExecutionStateChanges>map(rebuildReason ->
@@ -80,7 +79,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                     .orElse(null)
             );
 
-        return delegate.execute(new IncrementalChangesContext() {
+        return delegate.execute(work, new IncrementalChangesContext() {
             @Override
             public Optional<ExecutionStateChanges> getChanges() {
                 return Optional.ofNullable(changes);
@@ -124,11 +123,6 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
             @Override
             public Optional<BeforeExecutionState> getBeforeExecutionState() {
                 return beforeExecutionState;
-            }
-
-            @Override
-            public UnitOfWork getWork() {
-                return work;
             }
         });
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
@@ -45,12 +45,11 @@ public class ResolveInputChangesStep<C extends IncrementalChangesContext> implem
     }
 
     @Override
-    public Result execute(C context) {
-        UnitOfWork work = context.getWork();
+    public Result execute(UnitOfWork work, C context) {
         Optional<InputChangesInternal> inputChanges = work.getInputChangeTrackingStrategy().requiresInputChanges()
             ? Optional.of(determineInputChanges(work, context))
             : Optional.empty();
-        return delegate.execute(new InputChangesContext() {
+        return delegate.execute(work, new InputChangesContext() {
             @Override
             public Optional<InputChangesInternal> getInputChanges() {
                 return inputChanges;
@@ -94,11 +93,6 @@ public class ResolveInputChangesStep<C extends IncrementalChangesContext> implem
             @Override
             public Optional<BeforeExecutionState> getBeforeExecutionState() {
                 return context.getBeforeExecutionState();
-            }
-
-            @Override
-            public UnitOfWork getWork() {
-                return work;
             }
         });
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
@@ -39,8 +39,7 @@ public class SkipEmptyWorkStep<C extends AfterPreviousExecutionContext> implemen
     }
 
     @Override
-    public CachingResult execute(C context) {
-        UnitOfWork work = context.getWork();
+    public CachingResult execute(UnitOfWork work, C context) {
         ImmutableSortedMap<String, FileCollectionFingerprint> outputFilesAfterPreviousExecution = context.getAfterPreviousExecutionState()
             .map(AfterPreviousExecutionState::getOutputFileProperties)
             .orElse(ImmutableSortedMap.of());
@@ -86,6 +85,6 @@ public class SkipEmptyWorkStep<C extends AfterPreviousExecutionContext> implemen
                     }
                 };
             })
-            .orElseGet(() -> delegate.execute(context));
+            .orElseGet(() -> delegate.execute(work, context));
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipUpToDateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipUpToDateStep.java
@@ -48,8 +48,7 @@ public class SkipUpToDateStep<C extends IncrementalChangesContext> implements St
     }
 
     @Override
-    public UpToDateResult execute(C context) {
-        final UnitOfWork work = context.getWork();
+    public UpToDateResult execute(UnitOfWork work, C context) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Determining if {} is up-to-date", work.getDisplayName());
         }
@@ -93,14 +92,14 @@ public class SkipUpToDateStep<C extends IncrementalChangesContext> implements St
                     }
                 };
             } else {
-                return executeBecause(reasons, context);
+                return executeBecause(work, reasons, context);
             }
-        }).orElseGet(() -> executeBecause(CHANGE_TRACKING_DISABLED, context));
+        }).orElseGet(() -> executeBecause(work, CHANGE_TRACKING_DISABLED, context));
     }
 
-    private UpToDateResult executeBecause(ImmutableList<String> reasons, C context) {
-        logExecutionReasons(reasons, context.getWork());
-        CurrentSnapshotResult result = delegate.execute(context);
+    private UpToDateResult executeBecause(UnitOfWork work, ImmutableList<String> reasons, C context) {
+        logExecutionReasons(reasons, work);
+        CurrentSnapshotResult result = delegate.execute(work, context);
         return new UpToDateResult() {
             @Override
             public ImmutableList<String> getExecutionReasons() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SnapshotOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SnapshotOutputsStep.java
@@ -61,20 +61,20 @@ public class SnapshotOutputsStep<C extends BeforeExecutionContext> extends Build
     }
 
     @Override
-    public CurrentSnapshotResult execute(C context) {
-        Result result = delegate.execute(context);
+    public CurrentSnapshotResult execute(UnitOfWork work, C context) {
+        Result result = delegate.execute(work, context);
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> finalOutputs = operation(
             operationContext -> {
-                ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputSnapshots = captureOutputs(context);
+                ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputSnapshots = captureOutputs(work, context);
                 operationContext.setResult(Operation.Result.INSTANCE);
                 return outputSnapshots;
             },
             BuildOperationDescriptor
-                .displayName("Snapshot outputs after executing " + context.getWork().getDisplayName())
+                .displayName("Snapshot outputs after executing " + work.getDisplayName())
                 .details(Operation.Details.INSTANCE)
         );
 
-        OriginMetadata originMetadata = new OriginMetadata(buildInvocationScopeId.asString(), context.getWork().markExecutionTime());
+        OriginMetadata originMetadata = new OriginMetadata(buildInvocationScopeId.asString(), work.markExecutionTime());
 
         return new CurrentSnapshotResult() {
             @Override
@@ -99,9 +99,7 @@ public class SnapshotOutputsStep<C extends BeforeExecutionContext> extends Build
         };
     }
 
-    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> captureOutputs(BeforeExecutionContext context) {
-        UnitOfWork work = context.getWork();
-
+    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> captureOutputs(UnitOfWork work, BeforeExecutionContext context) {
         ImmutableSortedMap<String, FileCollectionFingerprint> afterPreviousExecutionOutputFingerprints = context.getAfterPreviousExecutionState()
             .map(AfterPreviousExecutionState::getOutputFileProperties)
             .orElse(ImmutableSortedMap.of());

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
@@ -40,10 +40,10 @@ public class StoreExecutionStateStep<C extends BeforeExecutionContext> implement
     }
 
     @Override
-    public CurrentSnapshotResult execute(C context) {
-        CurrentSnapshotResult result = delegate.execute(context);
+    public CurrentSnapshotResult execute(UnitOfWork work, C context) {
+        CurrentSnapshotResult result = delegate.execute(work, context);
         UnitOfWork.Identity identity = context.getIdentity();
-        context.getWork().getHistory()
+        work.getHistory()
             .ifPresent(history -> storeState(context, history, identity.getUniqueId(), result));
         return result;
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
@@ -41,24 +41,23 @@ public class TimeoutStep<C extends Context> implements Step<C, Result> {
     }
 
     @Override
-    public Result execute(C context) {
-        UnitOfWork work = context.getWork();
+    public Result execute(UnitOfWork work, C context) {
         Optional<Duration> timeoutProperty = work.getTimeout();
         if (timeoutProperty.isPresent()) {
             Duration timeout = timeoutProperty.get();
             if (timeout.isNegative()) {
                 throw new InvalidUserDataException("Timeout of " + work.getDisplayName() + " must be positive, but was " + timeout.toString().substring(2));
             }
-            return executeWithTimeout(context, timeout);
+            return executeWithTimeout(work, context, timeout);
         } else {
-            return executeWithoutTimeout(context);
+            return executeWithoutTimeout(work, context);
         }
     }
 
-    private Result executeWithTimeout(C context, Duration timeout) {
+    private Result executeWithTimeout(UnitOfWork work, C context, Duration timeout) {
         Timeout taskTimeout = timeoutHandler.start(Thread.currentThread(), timeout);
         try {
-            return executeWithoutTimeout(context);
+            return executeWithoutTimeout(work, context);
         } finally {
             if (taskTimeout.stop()) {
                 //noinspection ResultOfMethodCallIgnored
@@ -69,7 +68,7 @@ public class TimeoutStep<C extends Context> implements Step<C, Result> {
         }
     }
 
-    private Result executeWithoutTimeout(C context) {
-        return delegate.execute(context);
+    private Result executeWithoutTimeout(UnitOfWork work, C context) {
+        return delegate.execute(work, context);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -45,9 +45,9 @@ public class ValidateStep<C extends Context, R extends Result> implements Step<C
     }
 
     @Override
-    public R execute(C context) {
+    public R execute(UnitOfWork work, C context) {
         DefaultWorkValidationContext validationContext = new DefaultWorkValidationContext();
-        context.getWork().validate(validationContext);
+        work.validate(validationContext);
 
         ImmutableMultimap<Severity, String> problems = validationContext.getProblems();
         ImmutableCollection<String> warnings = problems.get(Severity.WARNING);
@@ -61,7 +61,7 @@ public class ValidateStep<C extends Context, R extends Result> implements Step<C
                     errors.size() == 1
                         ? "A problem was"
                         : "Some problems were",
-                    context.getWork().getDisplayName(),
+                    work.getDisplayName(),
                     describeTypesChecked(validationContext.getTypes())
                 ),
                 errors.stream()
@@ -71,7 +71,7 @@ public class ValidateStep<C extends Context, R extends Result> implements Step<C
                     .collect(Collectors.toList())
             );
         }
-        return delegate.execute(context);
+        return delegate.execute(work, context);
     }
 
     private static String describeTypesChecked(ImmutableList<Class<?>> types) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsFinishedStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsFinishedStep.java
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.steps.legacy;
 import org.gradle.internal.execution.CachingContext;
 import org.gradle.internal.execution.Result;
 import org.gradle.internal.execution.Step;
+import org.gradle.internal.execution.UnitOfWork;
 
 /**
  * This is a temporary measure for Gradle tasks to track a legacy measurement of all input snapshotting together.
@@ -31,8 +32,8 @@ public class MarkSnapshottingInputsFinishedStep<R extends Result> implements Ste
     }
 
     @Override
-    public R execute(CachingContext context) {
-        context.getWork().markLegacySnapshottingInputsFinished(context.getCachingState());
-        return delegate.execute(context);
+    public R execute(UnitOfWork work, CachingContext context) {
+        work.markLegacySnapshottingInputsFinished(context.getCachingState());
+        return delegate.execute(work, context);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsStartedStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsStartedStep.java
@@ -32,11 +32,10 @@ public class MarkSnapshottingInputsStartedStep<C extends Context, R extends Resu
     }
 
     @Override
-    public R execute(C context) {
-        UnitOfWork work = context.getWork();
+    public R execute(UnitOfWork work, C context) {
         work.markLegacySnapshottingInputsStarted();
         try {
-            return delegate.execute(context);
+            return delegate.execute(work, context);
         } finally {
             work.ensureLegacySnapshottingInputsClosed();
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignWorkspaceStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignWorkspaceStepTest.groovy
@@ -33,7 +33,7 @@ class AssignWorkspaceStepTest extends StepSpec<IdentityContext> {
     def "delegates with assigned workspace"() {
         def workspace = file("workspace")
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -41,7 +41,7 @@ class AssignWorkspaceStepTest extends StepSpec<IdentityContext> {
             def actionResult = action.executeInWorkspace(workspace)
             return actionResult
         }
-        1 * delegate.execute(_) >> { WorkspaceContext context ->
+        1 * delegate.execute(work, _ as WorkspaceContext) >> { UnitOfWork work, WorkspaceContext context ->
             assert context.workspace == workspace
             return delegateResult
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BroadcastChangingOutputsStepTest.groovy
@@ -39,7 +39,7 @@ class BroadcastChangingOutputsStepTest extends StepSpec<WorkspaceContext> {
         def destroyableDir = file("destroyable-dir")
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -58,7 +58,7 @@ class BroadcastChangingOutputsStepTest extends StepSpec<WorkspaceContext> {
         ])
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -61,7 +61,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         def localStateFile = file("local-state.txt") << "local state"
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionResult.get().outcome == ExecutionOutcome.FROM_CACHE
@@ -95,7 +95,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
     def "executes work and stores in cache on cache miss"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -108,7 +108,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         1 * buildCacheController.load(loadCommand) >> Optional.empty()
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         1 * delegateResult.executionResult >> Try.successful(Mock(Result.ExecutionResult))
 
         then:
@@ -122,7 +122,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         def loadedOutputDir = file("output")
 
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         def ex = thrown Exception
@@ -147,7 +147,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
     def "does not store result of failed execution in cache"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -161,7 +161,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         1 * buildCacheController.load(loadCommand) >> Optional.empty()
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         1 * delegateResult.executionResult >> Try.failure(new RuntimeException("failure"))
 
         then:
@@ -171,7 +171,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
     def "does not load but stores when loading is disabled"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -182,7 +182,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         _ * work.allowedToLoadFromCache >> false
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         1 * delegateResult.executionResult >> Try.successful(Mock(Result.ExecutionResult))
 
         then:
@@ -194,7 +194,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         def failure = new RuntimeException("store failure")
 
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         def ex = thrown Exception
@@ -207,7 +207,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         _ * work.allowedToLoadFromCache >> false
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         1 * delegateResult.executionResult >> Try.successful(Mock(Result.ExecutionResult))
 
         then:
@@ -217,7 +217,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
     def "executes and doesn't store when caching is disabled"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -225,7 +225,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
         _ * context.cachingState >> cachingState
         1 * cachingState.disabledReasons >> ImmutableList.of(new CachingDisabledReason(CachingDisabledReasonCategory.UNKNOWN, "Unknown"))
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
@@ -28,12 +28,12 @@ class CancelExecutionStepTest extends ContextInsensitiveStepSpec {
 
     def "executes normally when cancellation is not requested"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         0 *_
@@ -44,12 +44,12 @@ class CancelExecutionStepTest extends ContextInsensitiveStepSpec {
         cancellationToken.cancel()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         thrown BuildCancelledException
 
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         0 *_
@@ -57,12 +57,12 @@ class CancelExecutionStepTest extends ContextInsensitiveStepSpec {
 
     def "interrupts task worker when cancellation is requested"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         thrown BuildCancelledException
 
-        1 * delegate.execute(context) >>  {
+        1 * delegate.execute(work, context) >>  {
             cancellationToken.cancel()
             wait()
             delegateResult

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
@@ -38,7 +38,7 @@ class CreateOutputsStepTest extends StepSpec<WorkspaceContext> {
         def destroyableFile = file("destroyable/file.txt")
 
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
@@ -55,20 +55,20 @@ class CreateOutputsStepTest extends StepSpec<WorkspaceContext> {
         !destroyableFile.parentFile.exists()
 
         then:
-        1 * delegate.execute(context)
+        1 * delegate.execute(work, context)
         0 * _
     }
 
     def "result is preserved"() {
         def expected = Mock(Result)
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == expected
 
         _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor)
-        1 * delegate.execute(context) >> expected
+        1 * delegate.execute(work, context) >> expected
         0 * _
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -35,7 +35,7 @@ class ExecuteStepTest extends StepSpec<InputChangesContext> {
     @Unroll
     def "result #workResult yields outcome #expectedOutcome (incremental false)"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionResult.get().outcome == expectedOutcome
@@ -55,7 +55,7 @@ class ExecuteStepTest extends StepSpec<InputChangesContext> {
     @Unroll
     def "failure #failure.class.simpleName is handled"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         !result.executionResult.successful
@@ -72,7 +72,7 @@ class ExecuteStepTest extends StepSpec<InputChangesContext> {
     @Unroll
     def "incremental work with result #workResult yields outcome #outcome (executed incrementally: #incrementalExecution)"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionResult.get().outcome == expectedOutcome

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -41,7 +41,7 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
 
     def "delegates with assigned workspace"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -63,7 +63,7 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
                 { -> Mock(CurrentFileCollectionFingerprint) })
         }
 
-        1 * delegate.execute(_) >> { IdentityContext delegateContext ->
+        1 * delegate.execute(work, _ as IdentityContext) >> { UnitOfWork work, IdentityContext delegateContext ->
             assert delegateContext.inputProperties.keySet() == ["identity"] as Set
             assert delegateContext.inputFileProperties.keySet() == ["identity-file"] as Set
             delegateResult

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentityCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentityCacheStepTest.groovy
@@ -48,7 +48,7 @@ class IdentityCacheStepTest extends StepSpec<IdentityContext> {
         }
 
         when:
-        def actual = step.executeDeferred(context, cache, processor)
+        def actual = step.executeDeferred(work, context, cache, processor)
 
         then:
         actual == processed
@@ -58,7 +58,7 @@ class IdentityCacheStepTest extends StepSpec<IdentityContext> {
         }
 
         then:
-        _ * delegate.execute(context) >> delegateResult
+        _ * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 
@@ -69,7 +69,7 @@ class IdentityCacheStepTest extends StepSpec<IdentityContext> {
         cache.put(identity, cachedOutput)
 
         when:
-        def actual = step.executeDeferred(context, cache, processor)
+        def actual = step.executeDeferred(work, context, cache, processor)
 
         then:
         actual == processed

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RecordOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RecordOutputsStepTest.groovy
@@ -30,11 +30,11 @@ class RecordOutputsStepTest extends ContextInsensitiveStepSpec implements Finger
 
     def "outputs are recorded after execution"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * delegateResult.finalOutputs >> finalOutputs

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -54,12 +54,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.dir.createDir("some/notOutput2")
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupOverlappingOutputs(outputs)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         !outputs.file.exists()
@@ -77,12 +77,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.fingerprint()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupOverlappingOutputs(outputs)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         !outputs.file.exists()
@@ -97,12 +97,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.fingerprint()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupOverlappingOutputs(outputs)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         !outputs.file.exists()
@@ -115,12 +115,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.createContents()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupExclusiveOutputs(outputs)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         !outputs.file.exists()
@@ -134,12 +134,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.file.parentFile.mkdirs()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupExclusiveOutputs(outputs)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         !outputs.file.exists()
@@ -148,20 +148,20 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
 
     def "does not cleanup outputs when build is incremental"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         _ * context.incrementalExecution >> true
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 
     def "does not cleanup outputs when work does not opt-in"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         _ * context.incrementalExecution >> false
         _ * work.shouldCleanupOutputsOnNonIncrementalExecution() >> false
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 
@@ -170,12 +170,12 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
         outputs.createContents()
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         interaction {
             cleanupExclusiveOutputs(outputs, false)
         }
-        1 * delegate.execute(_) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.steps
 import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.internal.execution.BeforeExecutionContext
 import org.gradle.internal.execution.CachingContext
+import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 
@@ -34,11 +35,11 @@ class ResolveCachingStateStepTest extends StepSpec<BeforeExecutionContext> {
 
     def "build cache disabled reason is reported when build cache is disabled"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         _ * buildCache.enabled >> false
         _ * context.beforeExecutionState >> Optional.empty()
-        1 * delegate.execute(_) >> { CachingContext context ->
+        1 * delegate.execute(work, _ as CachingContext) >> { UnitOfWork work, CachingContext context ->
             assert context.cachingState.disabledReasons.get(0).category == CachingDisabledReasonCategory.BUILD_CACHE_DISABLED
         }
     }
@@ -47,12 +48,12 @@ class ResolveCachingStateStepTest extends StepSpec<BeforeExecutionContext> {
         def disabledReason = new CachingDisabledReason(CachingDisabledReasonCategory.DISABLE_CONDITION_SATISFIED, "Something disabled")
 
         when:
-        step.execute(context)
+        step.execute(work, context)
         then:
         _ * buildCache.enabled >> true
         _ * context.beforeExecutionState >> Optional.empty()
         _ * work.shouldDisableCaching(null) >> Optional.of(disabledReason)
-        1 * delegate.execute(_) >> { CachingContext context ->
+        1 * delegate.execute(work, _ as CachingContext) >> { UnitOfWork work, CachingContext context ->
             assert context.cachingState.disabledReasons.get(0) == disabledReason
         }
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
@@ -40,13 +40,13 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
 
     def "doesn't provide input file changes when rebuild is forced"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
         _ * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.NONE
-        1 * delegate.execute(_) >> { IncrementalChangesContext delegateContext ->
+        1 * delegate.execute(work, _ as IncrementalChangesContext) >> { UnitOfWork work, IncrementalChangesContext delegateContext ->
             def changes = delegateContext.changes.get()
             assert changes.allChangeMessages == ImmutableList.of("Forced rebuild.")
             try {
@@ -64,12 +64,12 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
 
     def "doesn't provide changes when change tracking is disabled"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
-        1 * delegate.execute(_) >> { IncrementalChangesContext delegateContext ->
+        1 * delegate.execute(work, _ as IncrementalChangesContext) >> { UnitOfWork work, IncrementalChangesContext delegateContext ->
             assert !delegateContext.changes.present
             return delegateResult
         }
@@ -80,13 +80,13 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
 
     def "doesn't provide input file changes when no history is available"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
         _ * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.NONE
-        1 * delegate.execute(_) >> { IncrementalChangesContext delegateContext ->
+        1 * delegate.execute(work, _ as IncrementalChangesContext) >> { UnitOfWork work, IncrementalChangesContext delegateContext ->
             def changes = delegateContext.changes.get()
             assert !changes.createInputChanges().incremental
             assert changes.allChangeMessages == ImmutableList.of("No history is available.")
@@ -105,12 +105,12 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
         def changes = Mock(ExecutionStateChanges)
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
-        1 * delegate.execute(_) >> { IncrementalChangesContext delegateContext ->
+        1 * delegate.execute(work, _ as IncrementalChangesContext) >> { UnitOfWork work, IncrementalChangesContext delegateContext ->
             assert delegateContext.changes.get() == changes
             return delegateResult
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveInputChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveInputChangesStepTest.groovy
@@ -38,13 +38,13 @@ class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext> {
 
     def "resolves input changes when required"() {
         when:
-        def returnedResult = step.execute(context)
+        def returnedResult = step.execute(work, context)
         then:
         _ * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.INCREMENTAL_PARAMETERS
         _ * context.changes >> optionalChanges
         1 * changes.createInputChanges() >> inputChanges
         1 * inputChanges.incremental >> true
-        1 * delegate.execute(_) >> { InputChangesContext context ->
+        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork work, InputChangesContext context ->
             assert context.inputChanges.get() == inputChanges
             return result
         }
@@ -55,10 +55,10 @@ class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext> {
 
     def "do not resolve input changes when not required"() {
         when:
-        def returnedResult = step.execute(context)
+        def returnedResult = step.execute(work, context)
         then:
         _ * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.NONE
-        1 * delegate.execute(_) >> { InputChangesContext context ->
+        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork work, InputChangesContext context ->
             assert context.inputChanges == Optional.empty()
             return result
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
@@ -44,7 +44,7 @@ class SkipEmptyWorkStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
     def "delegates when work is not skipped"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -54,14 +54,14 @@ class SkipEmptyWorkStepTest extends StepSpec<AfterPreviousExecutionContext> {
         _ * work.skipIfInputsEmpty(outputFingerprints) >> Optional.empty()
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 
     @Unroll
     def "removes execution history when empty work is skipped (outcome: #outcome)"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionResult.get().outcome == outcome

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
@@ -38,7 +38,7 @@ class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
 
     def "skips when outputs are up to date"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionResult.get().outcome == ExecutionOutcome.UP_TO_DATE
@@ -56,7 +56,7 @@ class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
         def delegateFinalOutputs = ImmutableSortedMap.copyOf([test: EmptyCurrentFileCollectionFingerprint.EMPTY])
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionReasons == ["change"]
@@ -64,7 +64,7 @@ class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
 
         _ * context.changes >> Optional.of(changes)
         1 * changes.allChangeMessages >> ImmutableList.of("change")
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
 
         when:
@@ -88,13 +88,13 @@ class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
 
     def "executes when change tracking is disabled"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result.executionReasons == ["Change tracking is disabled."]
 
         _ * context.changes >> Optional.empty()
-        1 * delegate.execute(context)
+        1 * delegate.execute(work, context)
         0 * _
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
@@ -44,7 +44,6 @@ abstract class StepSpec<C extends Context> extends Specification {
     abstract protected C createContext()
 
     def setup() {
-        _ * context.work >> work
         _ * context.identity >> identity
         _ * work.displayName >> displayName
         _ * work.identify(_, _) >> identity

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -62,11 +62,11 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
 
     def "output snapshots are stored after successful execution"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * delegateResult.finalOutputs >> finalOutputs
@@ -80,11 +80,11 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
 
     def "output snapshots are stored after failed execution when there's no previous state available"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * delegateResult.finalOutputs >> finalOutputs
@@ -103,11 +103,11 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
         def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * delegateResult.finalOutputs >> finalOutputs
@@ -127,11 +127,11 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
         def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * delegateResult.finalOutputs >> finalOutputs

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/TimeoutStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/TimeoutStepTest.groovy
@@ -31,7 +31,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
 
     def "negative timeout is reported"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         thrown InvalidUserDataException
@@ -42,7 +42,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
 
     def "executing without timeout succeeds"() {
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -50,7 +50,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
         _ * work.timeout >> Optional.empty()
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
         0 * _
     }
 
@@ -59,7 +59,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
         def timeout = Mock(Timeout)
 
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
@@ -70,7 +70,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
         timeoutHandler.start(_ as Thread, duration) >> timeout
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * timeout.stop() >> false
@@ -82,7 +82,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
         def timeout = Mock(Timeout)
 
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         _ * work.timeout >> Optional.of(duration)
@@ -91,7 +91,7 @@ class TimeoutStepTest extends ContextInsensitiveStepSpec {
         1 * timeoutHandler.start(_ as Thread, duration) >> timeout
 
         then:
-        1 * delegate.execute(context) >> delegateResult
+        1 * delegate.execute(work, context) >> delegateResult
 
         then:
         1 * timeout.stop() >> true

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -31,14 +31,12 @@ class ValidateStepTest extends ContextInsensitiveStepSpec {
     def "executes work when there are no violations"() {
         boolean validated = false
         when:
-        def result = step.execute(context)
+        def result = step.execute(work, context)
 
         then:
         result == delegateResult
 
-        1 * delegate.execute(_) >> { ctx ->
-            delegateResult
-        }
+        1 * delegate.execute(work, context) >> delegateResult
         _ * work.validate(_ as  WorkValidationContext) >> { validated = true }
 
         then:
@@ -48,7 +46,7 @@ class ValidateStepTest extends ContextInsensitiveStepSpec {
 
     def "fails when there is a single violation"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         def ex = thrown WorkValidationException
@@ -64,7 +62,7 @@ class ValidateStepTest extends ContextInsensitiveStepSpec {
 
     def "fails when there are multiple violations"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         def ex = thrown WorkValidationException
@@ -82,7 +80,7 @@ class ValidateStepTest extends ContextInsensitiveStepSpec {
 
     def "reports deprecation warning for validation warning"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         _ * work.validate(_ as  WorkValidationContext) >> {  WorkValidationContext validationContext ->
@@ -93,13 +91,13 @@ class ValidateStepTest extends ContextInsensitiveStepSpec {
         1 * warningReporter.reportValidationWarning("Type '$Object.simpleName': Validation warning.")
 
         then:
-        1 * delegate.execute(context)
+        1 * delegate.execute(work, context)
         0 * _
     }
 
     def "reports deprecation warning even when there's also an error"() {
         when:
-        step.execute(context)
+        step.execute(work, context)
 
         then:
         _ * work.validate(_ as  WorkValidationContext) >> {  WorkValidationContext validationContext ->


### PR DESCRIPTION
Work is the thing that produces the context, so it'd be nice to pass it around separately.