### PR TITLE
Fix duplicate test execution

### DIFF
--- a/buildSrc/subprojects/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
+++ b/buildSrc/subprojects/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
@@ -42,7 +42,7 @@ class ReleasedVersionsDetails(currentBaseVersion: GradleVersion, releasedVersion
 
         val latestFinalRelease = releasedVersions.finalReleases.first()
         val latestRelease = listOf(releasedVersions.latestReleaseSnapshot, releasedVersions.latestRc).filter { it.gradleVersion() > latestFinalRelease.gradleVersion() }.maxBy { it.buildTimeStamp() } ?: latestFinalRelease
-        val previousVersions = (listOf(latestRelease) + releasedVersions.finalReleases).filter { it.gradleVersion() >= lowestInterestingVersion && it.gradleVersion().baseVersion < currentBaseVersion }
+        val previousVersions = (listOf(latestRelease) + releasedVersions.finalReleases).filter { it.gradleVersion() >= lowestInterestingVersion && it.gradleVersion().baseVersion < currentBaseVersion }.distinct()
         allPreviousVersions = previousVersions.map { it.gradleVersion() }
         mostRecentRelease = previousVersions.first().gradleVersion()
         mostRecentSnapshot = releasedVersions.latestReleaseSnapshot.gradleVersion()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleDistributionTool.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleDistributionTool.java
@@ -19,6 +19,8 @@ package org.gradle.integtests.fixtures;
 import org.gradle.integtests.fixtures.executer.GradleDistribution;
 import org.gradle.util.GradleVersion;
 
+import java.util.Objects;
+
 public class GradleDistributionTool implements AbstractContextualMultiVersionSpecRunner.VersionedTool {
     private final GradleDistribution distribution;
     private final String ignored;
@@ -43,5 +45,22 @@ public class GradleDistributionTool implements AbstractContextualMultiVersionSpe
 
     public String getIgnored() {
         return ignored;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GradleDistributionTool that = (GradleDistributionTool) o;
+        return Objects.equals(distribution.getVersion(), that.distribution.getVersion());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(distribution.getVersion());
     }
 }


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle-private/issues/3222

The released versions are not deduplicated, which results in cross
version tests execution twice.
