### PR TITLE
Do not canonicalize paths for mutation info

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestBuildCache
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.Actions
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -651,9 +651,39 @@ task someTask(type: SomeTask) {
         succeeds "foo"
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references other task")
     def "input and output properties are not evaluated too often"() {
         buildFile << """
+            import org.gradle.api.services.BuildServiceParameters
+
+            abstract class EvaluationCountBuildService implements BuildService<BuildServiceParameters.None> {
+                int outputFileCount = 0
+                int inputFileCount = 0
+                int inputValueCount = 0
+                int nestedInputCount = 0
+                int nestedInputValueCount = 0
+
+                void outputFile() {
+                    outputFileCount++
+                }
+
+                void inputFile() {
+                    inputFileCount++
+                }
+
+                void inputValue() {
+                    inputValueCount++
+                }
+
+                void nestedInput() {
+                    nestedInputCount++
+                }
+
+                void nestedInputValue() {
+                    nestedInputValueCount++
+                }
+            }
+            def evaluationCount = project.getGradle().getSharedServices().registerIfAbsent("evaluationCount", EvaluationCountBuildService) {}
+
             @CacheableTask
             abstract class CustomTask extends DefaultTask {
 
@@ -661,40 +691,32 @@ task someTask(type: SomeTask) {
                 abstract ProjectLayout getLayout()
 
                 @Internal
-                int outputFileCount = 0
-                @Internal
-                int inputFileCount = 0
-                @Internal
-                int inputValueCount = 0
-                @Internal
-                int nestedInputCount = 0
-                @Internal
-                int nestedInputValueCount = 0
+                abstract Property<EvaluationCountBuildService> getEvaluationCountService()
 
                 private NestedBean bean = new NestedBean()
 
                 @OutputFile
                 File getOutputFile() {
-                    count("outputFile", ++outputFileCount)
+                    count("outputFile")
                     return layout.buildDirectory.file("foo.bar").get().asFile
                 }
 
                 @InputFile
                 @PathSensitive(PathSensitivity.NONE)
                 File getInputFile() {
-                    count("inputFile", ++inputFileCount)
+                    count("inputFile")
                     return layout.projectDirectory.file("input.txt").asFile
                 }
 
                 @Input
                 String getInput() {
-                    count("inputValue", ++inputValueCount)
+                    count("inputValue")
                     return "Input"
                 }
 
                 @Nested
                 Object getBean() {
-                    count("nestedInput", ++nestedInputCount)
+                    count("nestedInput")
                     return bean
                 }
 
@@ -703,13 +725,16 @@ task someTask(type: SomeTask) {
                     outputFile.text = inputFile.text
                 }
 
-                void count(String name, int currentValue) {
+                void count(String name) {
+                    def service = evaluationCountService.get()
+                    service."\${name}"()
+                    def currentValue = service."\${name}Count"
                     println "Evaluating \${name} \${currentValue}"
                 }
 
                 class NestedBean {
                     @Input getFirst() {
-                        count("nestedInputValue", ++nestedInputValueCount)
+                        count("nestedInputValue")
                         return "first"
                     }
 
@@ -719,13 +744,17 @@ task someTask(type: SomeTask) {
                 }
             }
 
-            task myTask(type: CustomTask)
+            task myTask(type: CustomTask) {
+                evaluationCountService = evaluationCount
+            }
 
             task assertInputCounts {
                 dependsOn myTask
+                def propertyNames = ['outputFileCount', 'inputFileCount', 'inputValueCount', 'nestedInputCount', 'nestedInputValueCount']
+                def gradleProperties = propertyNames.collectEntries { [(it) : providers.gradleProperty(it)]}
                 doLast {
                     ['outputFileCount', 'inputFileCount', 'inputValueCount', 'nestedInputCount', 'nestedInputValueCount'].each { name ->
-                        assert myTask."\$name" == providers.gradleProperty(name).get() as Integer
+                        assert evaluationCount.get()."\$name" == gradleProperties[name].get() as Integer
                     }
                 }
             }
@@ -733,8 +762,14 @@ task someTask(type: SomeTask) {
         def inputFile = file('input.txt')
         inputFile.text = "input"
         def expectedCounts = [inputFile: 3, outputFile: 2, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
-        def expectedUpToDateCounts = [inputFile: 2, outputFile: 1, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+        def expectedIncrementalCounts = GradleContextualExecuter.configCache ?
+            [inputFile: 2, outputFile: 2, nestedInput: 1, inputValue: 1, nestedInputValue: 1]
+            : expectedCounts
+        def expectedUpToDateCounts = GradleContextualExecuter.configCache ?
+            [inputFile: 1, outputFile: 1, nestedInput: 1, inputValue: 1, nestedInputValue: 1]
+            : [inputFile: 2, outputFile: 1, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
         def arguments = ["assertInputCounts"] + expectedCounts.collect { name, count -> "-P${name}Count=${count}" }
+        def incrementalBuildArguments = ["assertInputCounts"] + expectedIncrementalCounts.collect { name, count -> "-P${name}Count=${count}" }
         def upToDateArguments = ["assertInputCounts"] + expectedUpToDateCounts.collect { name, count -> "-P${name}Count=${count}" }
         def localCache = new TestBuildCache(file('cache-dir'))
         settingsFile << localCache.localCacheConfiguration()
@@ -746,7 +781,7 @@ task someTask(type: SomeTask) {
         when:
         inputFile.text = "changed"
         then:
-        withBuildCache().succeeds(*arguments)
+        withBuildCache().succeeds(*incrementalBuildArguments)
         executedAndNotSkipped(':myTask')
         and:
         succeeds(*upToDateArguments)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -732,8 +732,8 @@ task someTask(type: SomeTask) {
         """
         def inputFile = file('input.txt')
         inputFile.text = "input"
-        def expectedCounts = [inputFile: 3, outputFile: 3, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
-        def expectedUpToDateCounts = [inputFile: 2, outputFile: 2, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
+        def expectedCounts = [inputFile: 3, outputFile: 2, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+        def expectedUpToDateCounts = [inputFile: 2, outputFile: 1, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
         def arguments = ["assertInputCounts"] + expectedCounts.collect { name, count -> "-P${name}Count=${count}" }
         def upToDateArguments = ["assertInputCounts"] + expectedUpToDateCounts.collect { name, count -> "-P${name}Count=${count}" }
         def localCache = new TestBuildCache(file('cache-dir'))

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -139,7 +139,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     }
 
     public ImmutableSortedSet<OutputFilePropertySpec> getFileProperties() {
-        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileCollectionFactory);
+        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileCollectionFactory, false);
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.getFileProperties();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -53,8 +53,8 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     private final PropertyWalker propertyWalker;
     private final FileCollectionFactory fileCollectionFactory;
     private AndSpec<TaskInternal> upToDateSpec = AndSpec.empty();
-    private List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<SelfDescribingSpec<TaskInternal>>();
-    private List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<SelfDescribingSpec<TaskInternal>>();
+    private List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
+    private List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
     private FileCollection previousOutputFiles;
     private final FilePropertyContainer<TaskOutputFilePropertyRegistration> registeredFileProperties = FilePropertyContainer.create();
     private final TaskInternal task;
@@ -82,21 +82,15 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public void upToDateWhen(final Closure upToDateClosure) {
-        taskMutator.mutate("TaskOutputs.upToDateWhen(Closure)", new Runnable() {
-            @Override
-            public void run() {
-                upToDateSpec = upToDateSpec.and(upToDateClosure);
-            }
+        taskMutator.mutate("TaskOutputs.upToDateWhen(Closure)", () -> {
+            upToDateSpec = upToDateSpec.and(upToDateClosure);
         });
     }
 
     @Override
     public void upToDateWhen(final Spec<? super Task> spec) {
-        taskMutator.mutate("TaskOutputs.upToDateWhen(Spec)", new Runnable() {
-            @Override
-            public void run() {
-                upToDateSpec = upToDateSpec.and(spec);
-            }
+        taskMutator.mutate("TaskOutputs.upToDateWhen(Spec)", () -> {
+            upToDateSpec = upToDateSpec.and(spec);
         });
     }
 
@@ -107,21 +101,15 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public void cacheIf(final String cachingEnabledReason, final Spec<? super Task> spec) {
-        taskMutator.mutate("TaskOutputs.cacheIf(Spec)", new Runnable() {
-            @Override
-            public void run() {
-                cacheIfSpecs.add(new SelfDescribingSpec<TaskInternal>(spec, cachingEnabledReason));
-            }
+        taskMutator.mutate("TaskOutputs.cacheIf(Spec)", () -> {
+            cacheIfSpecs.add(new SelfDescribingSpec<>(spec, cachingEnabledReason));
         });
     }
 
     @Override
     public void doNotCacheIf(final String cachingDisabledReason, final Spec<? super Task> spec) {
-        taskMutator.mutate("TaskOutputs.doNotCacheIf(Spec)", new Runnable() {
-            @Override
-            public void run() {
-                doNotCacheIfSpecs.add(new SelfDescribingSpec<TaskInternal>(spec, cachingDisabledReason));
-            }
+        taskMutator.mutate("TaskOutputs.doNotCacheIf(Spec)", () -> {
+            doNotCacheIfSpecs.add(new SelfDescribingSpec<>(spec, cachingDisabledReason));
         });
     }
 
@@ -158,55 +146,43 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public TaskOutputFilePropertyBuilder file(final Object path) {
-        return taskMutator.mutate("TaskOutputs.file(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
-            @Override
-            public TaskOutputFilePropertyBuilder call() {
-                StaticValue value = new StaticValue(path);
-                value.attachProducer(task);
-                TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.FILE);
-                registeredFileProperties.add(registration);
-                return registration;
-            }
+        return taskMutator.mutate("TaskOutputs.file(Object)", (Callable<TaskOutputFilePropertyBuilder>) () -> {
+            StaticValue value = new StaticValue(path);
+            value.attachProducer(task);
+            TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.FILE);
+            registeredFileProperties.add(registration);
+            return registration;
         });
     }
 
     @Override
     public TaskOutputFilePropertyBuilder dir(final Object path) {
-        return taskMutator.mutate("TaskOutputs.dir(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
-            @Override
-            public TaskOutputFilePropertyBuilder call() {
-                StaticValue value = new StaticValue(path);
-                value.attachProducer(task);
-                TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.DIRECTORY);
-                registeredFileProperties.add(registration);
-                return registration;
-            }
+        return taskMutator.mutate("TaskOutputs.dir(Object)", (Callable<TaskOutputFilePropertyBuilder>) () -> {
+            StaticValue value = new StaticValue(path);
+            value.attachProducer(task);
+            TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.DIRECTORY);
+            registeredFileProperties.add(registration);
+            return registration;
         });
     }
 
     @Override
     public TaskOutputFilePropertyBuilder files(final @Nullable Object... paths) {
-        return taskMutator.mutate("TaskOutputs.files(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
-            @Override
-            public TaskOutputFilePropertyBuilder call() {
-                StaticValue value = new StaticValue(resolveSingleArray(paths));
-                TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.FILES);
-                registeredFileProperties.add(registration);
-                return registration;
-            }
+        return taskMutator.mutate("TaskOutputs.files(Object...)", (Callable<TaskOutputFilePropertyBuilder>) () -> {
+            StaticValue value = new StaticValue(resolveSingleArray(paths));
+            TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.FILES);
+            registeredFileProperties.add(registration);
+            return registration;
         });
     }
 
     @Override
     public TaskOutputFilePropertyBuilder dirs(final Object... paths) {
-        return taskMutator.mutate("TaskOutputs.dirs(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
-            @Override
-            public TaskOutputFilePropertyBuilder call() {
-                StaticValue value = new StaticValue(resolveSingleArray(paths));
-                TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.DIRECTORIES);
-                registeredFileProperties.add(registration);
-                return registration;
-            }
+        return taskMutator.mutate("TaskOutputs.dirs(Object...)", (Callable<TaskOutputFilePropertyBuilder>) () -> {
+            StaticValue value = new StaticValue(resolveSingleArray(paths));
+            TaskOutputFilePropertyRegistration registration = new DefaultTaskOutputFilePropertyRegistration(value, OutputFilePropertyType.DIRECTORIES);
+            registeredFileProperties.add(registration);
+            return registration;
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -53,8 +53,8 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     private final PropertyWalker propertyWalker;
     private final FileCollectionFactory fileCollectionFactory;
     private AndSpec<TaskInternal> upToDateSpec = AndSpec.empty();
-    private List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
-    private List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
+    private final List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
+    private final List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
     private FileCollection previousOutputFiles;
     private final FilePropertyContainer<TaskOutputFilePropertyRegistration> registeredFileProperties = FilePropertyContainer.create();
     private final TaskInternal task;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -44,8 +44,6 @@ public interface TaskExecutionContext {
      */
     long markExecutionTime();
 
-    void setTaskProperties(TaskProperties properties);
-
     TaskProperties getTaskProperties();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -73,11 +73,11 @@ public class TaskStateInternal implements TaskState {
             this.failure = failure;
         } else if (this.failure instanceof TaskExecutionException) {
             TaskExecutionException taskExecutionException = (TaskExecutionException) this.failure;
-            List<Throwable> causes = new ArrayList<Throwable>(taskExecutionException.getCauses());
+            List<Throwable> causes = new ArrayList<>(taskExecutionException.getCauses());
             CollectionUtils.addAll(causes, failure.getCauses());
             taskExecutionException.initCauses(causes);
         } else {
-            List<Throwable> causes = new ArrayList<Throwable>();
+            List<Throwable> causes = new ArrayList<>();
             causes.add(this.failure);
             causes.addAll(failure.getCauses());
             failure.initCauses(causes);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -28,15 +28,16 @@ import java.util.Optional;
 public class DefaultTaskExecutionContext implements TaskExecutionContext {
 
     private final LocalTaskNode localTaskNode;
+    private final TaskProperties properties;
     private TaskExecutionMode taskExecutionMode;
-    private TaskProperties properties;
     private Long executionTime;
     private BuildOperationContext snapshotTaskInputsBuildOperationContext;
 
     private final Timer executionTimer;
 
-    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode) {
+    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode, TaskProperties taskProperties) {
         this.localTaskNode = localTaskNode;
+        this.properties = taskProperties;
         this.executionTimer = Time.startTimer();
     }
 
@@ -62,11 +63,6 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
         }
 
         return this.executionTime = executionTimer.getElapsedMillis();
-    }
-
-    @Override
-    public void setTaskProperties(TaskProperties properties) {
-        this.properties = properties;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -54,7 +54,7 @@ public class DefaultTaskProperties implements TaskProperties {
         String beanName = task.toString();
         GetInputPropertiesVisitor inputPropertiesVisitor = new GetInputPropertiesVisitor();
         GetInputFilesVisitor inputFilesVisitor = new GetInputFilesVisitor(beanName, fileCollectionFactory);
-        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, fileCollectionFactory);
+        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, fileCollectionFactory, true);
         GetLocalStateVisitor localStateVisitor = new GetLocalStateVisitor(beanName, fileCollectionFactory);
         GetDestroyablesVisitor destroyablesVisitor = new GetDestroyablesVisitor(beanName, fileCollectionFactory);
         ValidationVisitor validationVisitor = new ValidationVisitor();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
@@ -28,18 +28,20 @@ public class GetOutputFilesVisitor extends PropertyVisitor.Adapter {
     private final List<OutputFilePropertySpec> specs = Lists.newArrayList();
     private final String ownerDisplayName;
     private final FileCollectionFactory fileCollectionFactory;
+    private final boolean locationOnly;
     private ImmutableSortedSet<OutputFilePropertySpec> fileProperties;
     private boolean hasDeclaredOutputs;
 
-    public GetOutputFilesVisitor(String ownerDisplayName, FileCollectionFactory fileCollectionFactory) {
+    public GetOutputFilesVisitor(String ownerDisplayName, FileCollectionFactory fileCollectionFactory, boolean locationOnly) {
         this.ownerDisplayName = ownerDisplayName;
         this.fileCollectionFactory = fileCollectionFactory;
+        this.locationOnly = locationOnly;
     }
 
     @Override
     public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
         hasDeclaredOutputs = true;
-        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, false, specs::add);
+        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, locationOnly, specs::add);
     }
 
     public ImmutableSortedSet<OutputFilePropertySpec> getFileProperties() {

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -40,7 +40,6 @@ import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
-import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
@@ -118,7 +117,6 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         ListenerManager listenerManager,
         OutputChangeListener outputChangeListener,
         OutputFilesRepository outputFilesRepository,
-        PropertyWalker propertyWalker,
         ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
         TaskActionListener actionListener,
         TaskCacheabilityResolver taskCacheabilityResolver,
@@ -158,7 +156,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             executer
         );
         executer = new FinalizePropertiesTaskExecuter(executer);
-        executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, executer);
+        executer = new ResolveTaskExecutionModeExecuter(repository, executer);
         executer = new SkipTaskWithNoActionsExecuter(taskExecutionGraph, executer);
         executer = new SkipOnlyIfTaskExecuter(executer);
         executer = new CatchExceptionTaskExecuter(executer);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -22,14 +22,9 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
-import org.gradle.api.internal.tasks.TaskPropertyUtils;
-import org.gradle.api.internal.tasks.properties.FileParameterUtils;
-import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
-import org.gradle.api.internal.tasks.properties.OutputFilePropertyType;
-import org.gradle.api.internal.tasks.properties.PropertyValue;
-import org.gradle.api.internal.tasks.properties.PropertyVisitor;
+import org.gradle.api.internal.tasks.properties.DefaultTaskProperties;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
-import org.gradle.api.tasks.FileNormalizer;
+import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.resources.ResourceDeadlockException;
@@ -49,6 +44,7 @@ public class LocalTaskNode extends TaskNode {
     private ImmutableActionSet<Task> postAction = ImmutableActionSet.empty();
     private boolean isolated;
     private List<? extends ResourceLock> resourceLocks;
+    private TaskProperties taskProperties;
 
     public LocalTaskNode(TaskInternal task) {
         this.task = task;
@@ -95,6 +91,10 @@ public class LocalTaskNode extends TaskNode {
     @Override
     public Action<? super Task> getPostAction() {
         return postAction;
+    }
+
+    public TaskProperties getTaskProperties() {
+        return taskProperties;
     }
 
     @Override
@@ -190,58 +190,38 @@ public class LocalTaskNode extends TaskNode {
         final FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
         PropertyWalker propertyWalker = serviceRegistry.get(PropertyWalker.class);
         try {
-            TaskPropertyUtils.visitProperties(propertyWalker, task, new PropertyVisitor.Adapter() {
-                @Override
-                public void visitOutputFileProperty(final String propertyName, boolean optional, final PropertyValue value, final OutputFilePropertyType filePropertyType) {
-                    withDeadlockHandling(
-                        taskNode,
-                        "an output",
-                        "output property '" + propertyName + "'",
-                        () -> FileParameterUtils.resolveOutputFilePropertySpecs(
-                            task.toString(),
-                            propertyName,
-                            value,
-                            filePropertyType,
-                            fileCollectionFactory,
-                            true,
-                            outputFilePropertySpec -> {
-                                File outputLocation = outputFilePropertySpec.getOutputFile();
-                                if (outputLocation != null) {
-                                    mutations.outputPaths.add(outputLocation.getAbsolutePath());
-                                }
-                            }
-                        )
-                    );
-                    mutations.hasOutputs = true;
-                }
+            taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
+            taskProperties.getOutputFileProperties()
+                .forEach(spec -> withDeadlockHandling(
+                    taskNode,
+                    "an output",
+                    "output property '" + spec.getPropertyName() + "'",
+                    () -> {
+                        File outputLocation = spec.getOutputFile();
+                        if (outputLocation != null) {
+                            mutations.outputPaths.add(outputLocation.getAbsolutePath());
+                        }
+                        mutations.hasOutputs = true;
+                    }
+                ));
 
-                @Override
-                public void visitLocalStateProperty(final Object value) {
-                    withDeadlockHandling(
-                        taskNode,
-                        "a local state", "local state properties",
-                        () -> fileCollectionFactory.resolving(value)
-                            .forEach(file -> mutations.outputPaths.add(file.getAbsolutePath()))
-                    );
-                    mutations.hasLocalState = true;
-                }
+            withDeadlockHandling(
+                taskNode,
+                "a local state", "local state properties",
+                () -> taskProperties.getLocalStateFiles()
+                    .forEach(file -> {
+                        mutations.outputPaths.add(file.getAbsolutePath());
+                        mutations.hasLocalState = true;
+                    })
+            );
 
-                @Override
-                public void visitDestroyableProperty(final Object value) {
-                    withDeadlockHandling(
-                        taskNode,
-                        "a destroyable",
-                        "destroyables",
-                        () -> fileCollectionFactory.resolving(value)
-                            .forEach(file -> mutations.destroyablePaths.add(file.getAbsolutePath()))
-                    );
-                }
-
-                @Override
-                public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
-                    mutations.hasFileInputs = true;
-                }
-            });
+            withDeadlockHandling(
+                taskNode,
+                "a destroyable", "destroyables",
+                () -> taskProperties.getDestroyableFiles()
+                    .forEach(file -> mutations.destroyablePaths.add(file.getAbsolutePath()))
+            );
+            mutations.hasFileInputs = !taskProperties.getInputFileProperties().isEmpty();
         } catch (Exception e) {
             throw new TaskExecutionException(task, e);
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -36,7 +36,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
                 // This should move earlier in task scheduling, so that a worker thread does not even bother trying to run this task
                 return true;
             }
-            TaskExecutionContext ctx = new DefaultTaskExecutionContext(localTaskNode);
+            TaskExecutionContext ctx = new DefaultTaskExecutionContext(localTaskNode, localTaskNode.getTaskProperties());
             TaskExecuter taskExecuter = context.getService(TaskExecuter.class);
             taskExecuter.execute(task, state, ctx);
             localTaskNode.getPostAction().execute(task);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.execution.plan;
 
 
-import com.google.common.collect.Maps;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.GradleInternal;
@@ -25,17 +24,15 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.composite.internal.IncludedBuildTaskGraph;
 import org.gradle.internal.build.BuildState;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 public class TaskNodeFactory {
-    private final Map<Task, TaskNode> nodes = new HashMap<Task, TaskNode>();
+    private final Map<Task, TaskNode> nodes = new HashMap<>();
     private final IncludedBuildTaskGraph taskGraph;
     private final GradleInternal thisBuild;
     private final BuildIdentifier currentBuildId;
-    private final Map<File, String> canonicalizedFileCache = Maps.newIdentityHashMap();
 
     public TaskNodeFactory(GradleInternal thisBuild, IncludedBuildTaskGraph taskGraph) {
         this.thisBuild = thisBuild;
@@ -51,7 +48,7 @@ public class TaskNodeFactory {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, canonicalizedFileCache);
+                node = new LocalTaskNode((TaskInternal) task);
             } else {
                 node = TaskInAnotherBuild.of((TaskInternal) task, currentBuildId, taskGraph);
             }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -18,10 +18,13 @@ package org.gradle.test.fixtures
 
 import org.gradle.api.Task
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
+import org.gradle.api.internal.tasks.properties.DefaultTaskProperties
+import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.execution.ProjectExecutionServices
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -59,7 +62,7 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     }
 
     void execute(Task task) {
-        executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, new DefaultTaskExecutionContext(null))
+        executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, new DefaultTaskExecutionContext(null, DefaultTaskProperties.resolve(executionServices.get(PropertyWalker), executionServices.get(FileCollectionFactory), task as TaskInternal)))
         task.state.rethrowFailure()
     }
 }


### PR DESCRIPTION
We should handle canonicalization consistently between
the VFS and the rest of the code. Currently, we don't do
canonicalization, so let's do the same for mutation info.

This should improve performance when there are many
tasks/outputs to canonicalize.