### PR TITLE
Extract inception smoke tests to their own task and ci job

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -57,6 +57,7 @@ data class CIBuildModel(
                 SpecificBuild.BuildDistributions,
                 SpecificBuild.Gradleception,
                 SpecificBuild.SmokeTestsMaxJavaVersion,
+                SpecificBuild.GradleBuildSmokeTests,
                 SpecificBuild.ConfigCacheSmokeTestsMaxJavaVersion,
                 SpecificBuild.ConfigCacheSmokeTestsMinJavaVersion
             ),
@@ -382,6 +383,11 @@ enum class SpecificBuild {
     SmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
             return SmokeTests(model, stage, JvmCategory.MAX_VERSION)
+        }
+    },
+    GradleBuildSmokeTests {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, "gradleBuildSmokeTest")
         }
     },
     ConfigCacheSmokeTestsMinJavaVersion {

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -104,8 +104,7 @@ tasks {
         classpath = smokeTestSourceSet.runtimeClasspath
         maxParallelForks = 1 // those tests are pretty expensive, we shouldn"t execute them concurrently
         inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
-        dependsOn(*remoteProjects)
-        inputs.files(Callable { remoteProjects.map { it.map { it.outputDirectory } } })
+        inputs.files(remoteProjects.map { it.map { it.outputDirectory } })
             .withPropertyName("remoteProjectsSource")
             .withPathSensitivity(PathSensitivity.RELATIVE)
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuild.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuild.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+/**
+ * Test category for smoke tests running against the current gradle/gradle build.
+ */
+interface GradleBuild {}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.junit.experimental.categories.Category
 
 import java.text.SimpleDateFormat
 
@@ -38,10 +39,8 @@ import java.text.SimpleDateFormat
  * Smoke test building gradle/gradle with configuration cache enabled.
  *
  * gradle/gradle requires Java >=9 and <=11 to build, see {@link GradleBuildJvmSpec}.
- *
- * This test takes a while to run so is disabled for the Java 8 smoke test CI job and
- * only run on the Java 14 smoke test CI job, see the {@link Requires} annotation below.
  */
+@Category(GradleBuild)
 @Requires(value = TestPrecondition.JDK9_OR_LATER, adhoc = {
     GradleContextualExecuter.isNotConfigCache() && GradleBuildJvmSpec.isAvailable()
 })


### PR DESCRIPTION
Because they have the whole source tree as inputs the current setup always invalidate all smoke tests unnecessarily.
