### PR TITLE
Use normalized build jvm opts in TAPI tests

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
@@ -23,7 +23,7 @@ import org.gradle.tooling.model.gradle.GradleBuild
 import org.junit.Rule
 
 class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
-    private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"]
+    private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + NORMALIZED_BUILD_JVM_OPTS
 
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/DaemonReuseCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/DaemonReuseCrossVersionSpec.groovy
@@ -68,12 +68,13 @@ class DaemonReuseCrossVersionSpec extends ToolingApiSpecification {
     private void runBuildViaTAPI() {
         withConnection {
             def build = newBuild()
+            build.setJvmArguments(NORMALIZED_BUILD_JVM_OPTS)
             build.forTasks("help")
             build.run()
         }
     }
 
     private void runBuildViaCLI() {
-        executer.withTasks("help").run()
+        executer.withArguments("-Dorg.gradle.jvmargs=${NORMALIZED_BUILD_JVM_OPTS.join(" ")}").withTasks("help").run()
     }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -62,6 +62,11 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 @RunWith(ToolingApiCompatibilitySuiteRunner)
 @Retry(condition = { onIssueWithReleasedGradleVersion(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 abstract class ToolingApiSpecification extends Specification {
+    /**
+     * See https://github.com/gradle/gradle-private/issues/3216
+     * To avoid flakiness when reusing daemons between CLI and TAPI
+     */
+    public static final List NORMALIZED_BUILD_JVM_OPTS = ["-Dfile.encoding=UTF-8", "-Duser.country=US", "-Duser.language=en", "-Duser.variant"]
 
     @Rule
     public final SetSystemProperties sysProperties = new SetSystemProperties()


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle-private/issues/3216
Sometimes the daemon reuse tests fail because of different locale
system properties: user.country/user.language, etc. We normalize
these system properties before the tests.