### PR TITLE
Allow included/nested builds to include the root build

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 
 class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIntegrationTest {
@@ -30,6 +31,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         includedBuilds << buildC
     }
 
+    @ToBeFixedForConfigurationCache(because = "configuration cache serialization issue")
     def "two included builds can include each other"() {
         when:
         buildB.settingsFile << "includeBuild '../buildC'"

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+
+class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    BuildTestFile buildB
+    BuildTestFile buildC
+
+    def setup() {
+        buildB = singleProjectBuild("buildB")
+        includedBuilds << buildB
+        buildC = singleProjectBuild("buildC")
+        includedBuilds << buildC
+    }
+
+    def "two included builds can include each other"() {
+        when:
+        buildB.settingsFile << "includeBuild '../buildC'"
+        buildC.settingsFile << "includeBuild '../buildB'"
+
+        then:
+        execute(buildA, 'help')
+    }
+
+    def "included build can include root build"() {
+        when:
+        buildB.settingsFile << "includeBuild '../buildA'"
+        buildC.settingsFile << "includeBuild '../buildA'"
+
+        then:
+        execute(buildA, 'help')
+    }
+
+    def "nested build can include root build"() {
+        when:
+        buildB.settingsFile << "includeBuild '../buildC'"
+        buildC.settingsFile << "includeBuild '../buildA'"
+
+        then:
+        execute(buildA, 'help')
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -54,16 +54,18 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
         // Add included builds defined in settings
         List<IncludedBuildSpec> includedBuilds = settings.getIncludedBuilds();
         if (!includedBuilds.isEmpty()) {
-            Set<IncludedBuild> children = new LinkedHashSet<IncludedBuild>(includedBuilds.size());
+            Set<IncludedBuild> children = new LinkedHashSet<>(includedBuilds.size());
             for (IncludedBuildSpec includedBuildSpec : includedBuilds) {
-                IncludedBuildState includedBuild = addIncludedBuild(includedBuildSpec, gradle);
-                children.add(includedBuild.getModel());
+                if (!includedBuildSpec.rootDir.equals(buildRegistry.getRootBuild().getBuildRootDir())) {
+                    IncludedBuildState includedBuild = addIncludedBuild(includedBuildSpec, gradle);
+                    children.add(includedBuild.getModel());
+                }
             }
 
             // Set the visible included builds
             gradle.setIncludedBuilds(children);
         } else {
-            gradle.setIncludedBuilds(Collections.<IncludedBuild>emptyList());
+            gradle.setIncludedBuilds(Collections.emptyList());
         }
 
         return settings;


### PR DESCRIPTION
This is only about the `includeBuild` statement which should allow all kinds of repetition and just skip cases where the build to include was already seen. The root build needs some special handling, which this PR adds.

This is **not** about actual dependencies between projects of different builds. 