### PR TITLE
Remove conflict check for 'included build name' vs 'root build root project name'

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
@@ -220,7 +220,7 @@ class CompositeBuildNestingIntegrationTest extends AbstractCompositeBuildIntegra
         failure.assertHasDescription("Included build in ${buildC} has name 'buildC' which is the same as a project of the main build.")
     }
 
-    def "reports failure for included build name that conflicts with root project name"() {
+    def "included build name can be the same as root project name"() {
         given:
         def buildC = singleProjectBuild("buildC") {
             settingsFile << """
@@ -232,12 +232,11 @@ class CompositeBuildNestingIntegrationTest extends AbstractCompositeBuildIntegra
                 includeBuild('${buildC.toURI()}')
             """
         }
-        includeBuild(buildB)
 
         when:
-        fails(buildA, "help")
+        includeBuild(buildB)
 
         then:
-        failure.assertHasDescription("Included build in ${buildC} has the same root project name 'buildA' as the main build.")
+        execute(buildA, "help")
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -98,15 +98,28 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         failure.assertHasDescription("Included build in ${buildB} has name 'buildB' which is the same as a project of the main build.")
     }
 
-    def "reports failure for included build name that conflicts with root project name"() {
-        def buildC = singleProjectBuild("buildC")
-        buildC.settingsFile.text = "rootProject.name = 'buildA'"
-        includedBuilds << buildC
+    def "included build name can be the same as root project name"() {
+        given:
+        buildB.settingsFile.text = "rootProject.name = 'buildA'"
 
         when:
-        fails(buildA, "help")
+        includedBuilds << buildB
 
         then:
-        failure.assertHasDescription("Included build in ${buildC} has the same root project name 'buildA' as the main build.")
+        execute(buildA, "help")
     }
+
+    def "allows to rename included build that conflicts with subproject name"() {
+        given:
+        buildA.settingsFile << """
+            include 'buildB'
+        """
+
+        when:
+        includeBuildAs(buildB, "buildB-build")
+
+        then:
+        execute(buildA, "help")
+    }
+
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -168,14 +168,9 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public void finalizeIncludedBuilds() {
-        SettingsInternal rootSettings = getRootBuild().getLoadedSettings();
         while (!pendingIncludedBuilds.isEmpty()) {
             IncludedBuildState build = pendingIncludedBuilds.removeFirst();
-            SettingsInternal includedBuildSettings = build.loadSettings();
-            String includedBuildRootProjectName = includedBuildSettings.getRootProject().getName();
-            if (rootSettings.getRootProject().getName().equals(includedBuildRootProjectName)) {
-                throw new GradleException("Included build in " + build.getRootDirectory() + " has the same root project name '" + includedBuildRootProjectName + "' as the main build.");
-            }
+            build.loadSettings();
         }
     }
 


### PR DESCRIPTION
This removes a restriction which was introduced in b5c1d4e

It is unclear why this was introduced, as there is no integration test showing a problematic case. The root build's root project name is not used for an (identity) path. The path of that build is always ':'. Hence there should be no need for this restriction.