### PR TITLE
Update tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,3 +1,3 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=3.4.3,3.5.4,3.6.4,4.0.2,4.1.0,4.2.0-alpha13
-nightly=4.2.0-20201011012117+0000
+latests=3.4.3,3.5.4,3.6.4,4.0.2,4.1.0,4.2.0-alpha15
+nightly=4.2.0-20201018014119+0000


### PR DESCRIPTION
from 4.2.0-alpha13 to 4.2.0-alpha15
bump 4.2 nightly
