### PR TITLE
Deprecate and hide software model related help tasks

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
@@ -30,7 +30,7 @@ class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
         run "help", "--task", "dependentComponents"
 
         then:
-        output.contains("Displays the dependent components of components in root project 'test'. [incubating]")
+        output.contains("Displays the dependent components of components in root project 'test'. [deprecated]")
         output.contains("--all     Show all components (non-buildable and test suites).")
         output.contains("--non-buildable     Show non-buildable components.")
         output.contains("--test-suites     Show test suites components.")

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
@@ -27,7 +27,7 @@ class ModelReportTaskIntegrationTest extends AbstractIntegrationSpec {
         run "help", "--task", "model"
 
         then:
-        output.contains("Displays the configuration model of root project '${getTestDirectory().name}'. [incubating]")
+        output.contains("Displays the configuration model of root project '${getTestDirectory().name}'. [deprecated]")
     }
 
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
@@ -47,13 +47,10 @@ wrapper - Generates Gradle wrapper files.
 Help tasks
 ----------
 buildEnvironment - Displays all buildscript dependencies declared in root project '$projectName'.
-components - Displays the components produced by root project '$projectName'. [incubating]
 dependencies - Displays all dependencies declared in root project '$projectName'.
 dependencyInsight - Displays the insight into a specific dependency in root project '$projectName'.
-dependentComponents - Displays the dependent components of components in root project '$projectName'. [incubating]
 help - Displays a help message.
 javaToolchains - Displays the detected java toolchains. [incubating]
-model - Displays the configuration model of root project '$projectName'. [incubating]
 outgoingVariants - Displays the outgoing variants of root project '$projectName'.
 projects - Displays the sub-projects of root project '$projectName'.
 properties - Displays the properties of root project '$projectName'.
@@ -401,6 +398,7 @@ b
     @ToBeFixedForConfigurationCache
     def "renders tasks with dependencies created by model rules running #tasks"() {
         when:
+        settingsFile << "rootProject.name = 'test-project'"
         buildScript """
             model {
                 tasks {
@@ -431,7 +429,10 @@ $otherGroupHeader
 a
 b
 c
+components - Displays the components produced by root project 'test-project'. [deprecated]
 d
+dependentComponents - Displays the dependent components of components in root project 'test-project'. [deprecated]
+model - Displays the configuration model of root project 'test-project'. [deprecated]
 """) == rendersTasks
 
         where:

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -24,9 +24,6 @@ import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.reporting.components.ComponentReport;
-import org.gradle.api.reporting.dependents.DependentComponentsReport;
-import org.gradle.api.reporting.model.ModelReport;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
@@ -70,14 +67,19 @@ public class HelpTasksPlugin implements Plugin<Project> {
         tasks.register(DEPENDENCY_INSIGHT_TASK, DependencyInsightReportTask.class, new DependencyInsightReportTaskAction(projectName));
         tasks.register(DEPENDENCIES_TASK, DependencyReportTask.class, new DependencyReportTaskAction(projectName));
         tasks.register(BuildEnvironmentReportTask.TASK_NAME, BuildEnvironmentReportTask.class, new BuildEnvironmentReportTaskAction(projectName));
-        tasks.register(COMPONENTS_TASK, ComponentReport.class, new ComponentReportAction(projectName));
-        tasks.register(MODEL_TASK, ModelReport.class, new ModelReportAction(projectName));
-        tasks.register(DEPENDENT_COMPONENTS_TASK, DependentComponentsReport.class, new DependentComponentsReportAction(projectName));
+        registerDeprecatedTasks(tasks, projectName);
         tasks.register(OUTGOING_VARIANTS_TASK, OutgoingVariantsReportTask.class, task -> {
             task.setDescription("Displays the outgoing variants of " + projectName + ".");
             task.setGroup(HELP_GROUP);
             task.setImpliesSubProjects(true);
         });
+    }
+
+    @SuppressWarnings("deprecation")
+    private void registerDeprecatedTasks(TaskContainer tasks, String projectName) {
+        tasks.register(COMPONENTS_TASK, org.gradle.api.reporting.components.ComponentReport.class, new ComponentReportAction(projectName));
+        tasks.register(MODEL_TASK, org.gradle.api.reporting.model.ModelReport.class, new ModelReportAction(projectName));
+        tasks.register(DEPENDENT_COMPONENTS_TASK, org.gradle.api.reporting.dependents.DependentComponentsReport.class, new DependentComponentsReportAction(projectName));
     }
 
     private static class HelpAction implements Action<Help> {
@@ -191,7 +193,8 @@ public class HelpTasksPlugin implements Plugin<Project> {
         }
     }
 
-    private static class ComponentReportAction implements Action<ComponentReport> {
+    @SuppressWarnings("deprecation")
+    private static class ComponentReportAction implements Action<org.gradle.api.reporting.components.ComponentReport> {
         private final String projectName;
 
         public ComponentReportAction(String projectName) {
@@ -199,14 +202,14 @@ public class HelpTasksPlugin implements Plugin<Project> {
         }
 
         @Override
-        public void execute(ComponentReport task) {
-            task.setDescription("Displays the components produced by " + projectName + ". [incubating]");
-            task.setGroup(HELP_GROUP);
+        public void execute(org.gradle.api.reporting.components.ComponentReport task) {
+            task.setDescription("Displays the components produced by " + projectName + ". [deprecated]");
             task.setImpliesSubProjects(true);
         }
     }
 
-    private static class ModelReportAction implements Action<ModelReport> {
+    @SuppressWarnings("deprecation")
+    private static class ModelReportAction implements Action<org.gradle.api.reporting.model.ModelReport> {
         private final String projectName;
 
         public ModelReportAction(String projectName) {
@@ -214,14 +217,14 @@ public class HelpTasksPlugin implements Plugin<Project> {
         }
 
         @Override
-        public void execute(ModelReport task) {
-            task.setDescription("Displays the configuration model of " + projectName + ". [incubating]");
-            task.setGroup(HELP_GROUP);
+        public void execute(org.gradle.api.reporting.model.ModelReport task) {
+            task.setDescription("Displays the configuration model of " + projectName + ". [deprecated]");
             task.setImpliesSubProjects(true);
         }
     }
 
-    private static class DependentComponentsReportAction implements Action<DependentComponentsReport> {
+    @SuppressWarnings("deprecation")
+    private static class DependentComponentsReportAction implements Action<org.gradle.api.reporting.dependents.DependentComponentsReport> {
         private final String projectName;
 
         public DependentComponentsReportAction(String projectName) {
@@ -229,9 +232,8 @@ public class HelpTasksPlugin implements Plugin<Project> {
         }
 
         @Override
-        public void execute(DependentComponentsReport task) {
-            task.setDescription("Displays the dependent components of components in " + projectName + ". [incubating]");
-            task.setGroup(HELP_GROUP);
+        public void execute(org.gradle.api.reporting.dependents.DependentComponentsReport task) {
+            task.setDescription("Displays the dependent components of components in " + projectName + ". [deprecated]");
             task.setImpliesSubProjects(true);
         }
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/ComponentReport.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/ComponentReport.java
@@ -17,7 +17,6 @@
 package org.gradle.api.reporting.components;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reporting.components.internal.ComponentReportRenderer;
@@ -42,7 +41,7 @@ import static org.gradle.model.internal.type.ModelTypes.modelMap;
 /**
  * Displays some details about the software components produced by the project.
  */
-@Incubating
+@Deprecated
 public class ComponentReport extends DefaultTask {
     @Inject
     protected StyledTextOutputFactory getTextOutputFactory() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
@@ -20,7 +20,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reporting.dependents.internal.TextDependentComponentsReportRenderer;
@@ -44,7 +43,7 @@ import static org.gradle.api.reporting.dependents.internal.DependentComponentsUt
 /**
  * Displays dependent components.
  */
-@Incubating
+@Deprecated
 public class DependentComponentsReport extends DefaultTask {
 
     private boolean showNonBuildable;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/ModelReport.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/ModelReport.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
  * Displays some details about the configuration model of the project.
  * An instance of this type is used when you execute the {@code model} task from the command-line.
  */
+@Deprecated
 public class ModelReport extends DefaultTask {
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
@@ -20,7 +20,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import org.gradle.api.reporting.model.ModelReport;
 import org.gradle.api.tasks.diagnostics.internal.text.TextReportBuilder;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.model.internal.core.ModelNode;
@@ -41,15 +40,18 @@ public class ModelNodeRenderer extends ReportRenderer<ModelNode, TextReportBuild
     private static final int LABEL_LENGTH = 7;
 
     private final boolean showHidden;
-    private final ModelReport.Format format;
+    @SuppressWarnings("deprecation")
+    private final org.gradle.api.reporting.model.ModelReport.Format format;
 
-    public ModelNodeRenderer(boolean showHidden, ModelReport.Format format) {
+    @SuppressWarnings("deprecation")
+    public ModelNodeRenderer(boolean showHidden, org.gradle.api.reporting.model.ModelReport.Format format) {
         this.showHidden = showHidden;
         this.format = format;
     }
 
+    @SuppressWarnings("deprecation")
     private boolean omitDetails() {
-        return ModelReport.Format.SHORT == format;
+        return org.gradle.api.reporting.model.ModelReport.Format.SHORT == format;
     }
 
     @Override

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/plugins/HelpTasksPluginSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/plugins/HelpTasksPluginSpec.groovy
@@ -17,10 +17,10 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.reporting.components.ComponentReport
 import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask
 import org.gradle.api.tasks.diagnostics.DependencyReportTask
+import org.gradle.api.tasks.diagnostics.OutgoingVariantsReportTask
 import org.gradle.api.tasks.diagnostics.ProjectReportTask
 import org.gradle.api.tasks.diagnostics.PropertyReportTask
 import org.gradle.api.tasks.diagnostics.TaskReportTask
@@ -41,7 +41,7 @@ class HelpTasksPluginSpec extends AbstractProjectBuilderSpec {
         hasHelpTask(ProjectInternal.PROJECTS_TASK, ProjectReportTask)
         hasHelpTask(ProjectInternal.TASKS_TASK, TaskReportTask)
         hasHelpTask(HelpTasksPlugin.PROPERTIES_TASK, PropertyReportTask)
-        hasHelpTask(HelpTasksPlugin.COMPONENTS_TASK, ComponentReport)
+        hasHelpTask(HelpTasksPlugin.OUTGOING_VARIANTS_TASK, OutgoingVariantsReportTask)
         hasHelpTask(BuildEnvironmentReportTask.TASK_NAME, BuildEnvironmentReportTask)
     }
 

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -238,7 +238,13 @@ abstract class ToolingApiSpecification extends Specification {
      * Returns the set of invisible implicit task names expected for a root project for the target Gradle version.
      */
     Set<String> getRootProjectImplicitInvisibleTasks() {
-        return targetVersion >= GradleVersion.version("5.3") ? ['prepareKotlinBuildScriptModel'] : []
+        if (targetVersion >= GradleVersion.version("6.8")) {
+            return ['prepareKotlinBuildScriptModel', 'components', 'dependentComponents', 'model']
+        } else if (targetVersion >= GradleVersion.version("5.3")) {
+            return ['prepareKotlinBuildScriptModel']
+        } else {
+            return []
+        }
     }
 
     /**


### PR DESCRIPTION
To not clutter the "Help tasks" list with these soon-to-be-removed tasks which are irrelevant for almost all users now.