### PR TITLE
Make proxy output streams more efficient

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/SafeStreams.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/SafeStreams.java
@@ -16,17 +16,16 @@
 
 package org.gradle.process.internal.streams;
 
-import java.io.*;
+import org.apache.commons.io.output.CloseShieldOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class SafeStreams {
 
     public static OutputStream systemErr() {
-        return new FilterOutputStream(System.err) {
-            @Override
-            public void close() throws IOException {
-                // Ignore
-            }
-        };
+        return new CloseShieldOutputStream(System.err);
     }
 
     public static InputStream emptyInput() {
@@ -34,11 +33,6 @@ public class SafeStreams {
     }
 
     public static OutputStream systemOut() {
-        return new FilterOutputStream(System.out) {
-            @Override
-            public void close() throws IOException {
-                // Ignore
-            }
-        };
+        return new CloseShieldOutputStream(System.out);
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/RedirectStdOutAndErr.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/RedirectStdOutAndErr.java
@@ -17,13 +17,13 @@
 package org.gradle.util;
 
 import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.io.output.ProxyOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
 import java.io.ByteArrayOutputStream;
-import java.io.FilterOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
@@ -84,7 +84,7 @@ public class RedirectStdOutAndErr implements MethodRule {
         return stdoutContent.toString();
     }
 
-    private static class RedirectingOutputStream extends FilterOutputStream {
+    private static class RedirectingOutputStream extends ProxyOutputStream {
         RedirectingOutputStream(OutputStream out) {
             super(out);
         }

--- a/subprojects/logging/build.gradle.kts
+++ b/subprojects/logging/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.julToSlf4j)
     implementation(libs.ant)
     implementation(libs.commonsLang)
+    implementation(libs.commonsIo)
     implementation(libs.guava)
     implementation(libs.jansi)
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.logging.sink;
 
+import org.apache.commons.io.output.ProxyOutputStream;
 import org.fusesource.jansi.AnsiOutputStream;
 import org.fusesource.jansi.WindowsAnsiPrintStream;
 import org.gradle.internal.os.OperatingSystem;
 
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -85,7 +85,7 @@ final class AnsiConsoleUtil {
             if (stdOutputHandle != INVALID_HANDLE_VALUE
                 && 0 != GetConsoleMode(stdOutputHandle, mode)
                 && 0 != SetConsoleMode(stdOutputHandle, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN)) {
-                return new FilterOutputStream(stream) {
+                return new ProxyOutputStream(stream) {
                     @Override
                     public void close() throws IOException {
                         write(AnsiOutputStream.RESET_CODE);
@@ -129,7 +129,7 @@ final class AnsiConsoleUtil {
         // By default we assume your Unix tty can handle ANSI codes.
         // Just wrap it up so that when we get closed, we reset the
         // attributes.
-        return new FilterOutputStream(stream) {
+        return new ProxyOutputStream(stream) {
             @Override
             public void close() throws IOException {
                 write(AnsiOutputStream.RESET_CODE);


### PR DESCRIPTION
There were some usages of FilterOutputStream in the codebase,
which weren't overriding the `write(byte[])` methods, which means
that any content written to these streams would be written to disk
one byte at a time. Instead of adding more code to these classes,
I've changed their base class to commons-io's ProxyOutputStream,
which does the right thing.

Signed-off-by: Stefan Oehme <st.oehme@gmail.com>

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
