### PR TITLE
Add support for the strict version shorthand notation in settings DSL and TOML parser

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
@@ -17,7 +17,6 @@ package org.gradle.api.initialization.dsl;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.HasInternalProtocol;
@@ -84,14 +83,7 @@ public interface DependenciesModelBuilder {
      * @param alias the alias for the dependency
      * @param gavCoordinates the gav coordinates notation
      */
-    default void alias(String alias, String gavCoordinates) {
-        String[] coordinates = gavCoordinates.split(":");
-        if (coordinates.length == 3) {
-            alias(alias, coordinates[0], coordinates[1], vc -> vc.require(coordinates[2]));
-        } else {
-            throw new InvalidUserDataException("Invalid dependency notation: it must consist of 3 parts separated by colons, eg: my.group:artifact:1.2");
-        }
-    }
+    void alias(String alias, String gavCoordinates);
 
     /**
      * Configures an alias, using the supplied group and name, and a version which corresponds

--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/StrictVersionParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/StrictVersionParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.std;
+
+import com.google.common.collect.Interner;
+import org.gradle.api.InvalidUserCodeException;
+
+import javax.annotation.Nullable;
+
+public class StrictVersionParser {
+    private final Interner<String> stringInterner;
+
+    public StrictVersionParser(Interner<String> stringInterner) {
+        this.stringInterner = stringInterner;
+    }
+
+    public RichVersion parse(@Nullable String version) {
+        if (version == null) {
+            return RichVersion.EMPTY;
+        }
+        int idx = version.indexOf("!!");
+        if (idx == 0) {
+            throw new InvalidUserCodeException("The strict version modifier (!!) must be appended to a valid version number");
+        }
+        if (idx > 0) {
+            String strictly = stringInterner.intern(version.substring(0, idx));
+            String prefer = stringInterner.intern(version.substring(idx+2));
+            return new RichVersion(null, strictly, prefer);
+        }
+        return new RichVersion(stringInterner.intern(version), null, null);
+    }
+
+    public static class RichVersion {
+        public static final RichVersion EMPTY = new RichVersion(null, null, null);
+
+        public final String require;
+        public final String strictly;
+        public final String prefer;
+
+        private RichVersion(@Nullable String require, @Nullable String strictly, @Nullable String prefer) {
+            this.require = require;
+            this.strictly = strictly;
+            this.prefer = prefer;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
@@ -148,6 +148,19 @@ public class TomlDependenciesFileParser {
     }
 
     private static void parseDependency(String alias, TomlTable dependenciesTable, DependenciesModelBuilder builder) {
+        Object gav = dependenciesTable.get(alias);
+        if (gav instanceof String) {
+            List<String> splitted = SPLITTER.splitToList((String) gav);
+            if (splitted.size() == 3) {
+                String group = notEmpty(splitted.get(0), "group", alias);
+                String name = notEmpty(splitted.get(1), "name", alias);
+                String require = notEmpty(splitted.get(2), "version", alias);
+                registerDependency(builder, alias, group, name, null, require, null, null, null, null);
+                return;
+            } else {
+                throw new InvalidUserDataException("Invalid GAV notation '" + gav + "' for alias '" + alias + "': it must consist of 3 parts separated by colons, eg: my.group:artifact:1.2");
+            }
+        }
         String group = expectString("alias", alias, dependenciesTable, "group");
         String name = expectString("alias", alias, dependenciesTable, "name");
         Object version = dependenciesTable.get(alias + ".version");
@@ -167,17 +180,6 @@ public class TomlDependenciesFileParser {
         String prefer = null;
         List<String> rejectedVersions = null;
         Boolean rejectAll = null;
-        String gav = expectString("alias", alias, dependenciesTable, "gav");
-        if (gav != null) {
-            List<String> splitted = SPLITTER.splitToList(gav);
-            if (splitted.size() == 3) {
-                group = notEmpty(splitted.get(0), "group", alias);
-                name = notEmpty(splitted.get(1), "name", alias);
-                require = notEmpty(splitted.get(2), "version", alias);
-            } else {
-                throw new InvalidUserDataException("Invalid GAV notation '" + gav + "' for alias '" + alias + "': it must consist of 3 parts separated by colons, eg: my.group:artifact:1.2");
-            }
-        }
         if (version instanceof String) {
             require = notEmpty((String) version, "version", alias);
         } else if (version instanceof TomlTable) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
@@ -169,6 +169,28 @@ class TomlDependenciesFileParserTest extends Specification {
                 prefer '2.5.6'
             }
         }
+        hasDependency('groovy-with-ref3') {
+            withGroup 'org.codehaus.groovy'
+            withName 'groovy'
+            withVersion {
+                strictly '1.7'
+            }
+        }
+        hasDependency('strict-with-bang') {
+            withGroup('g')
+            withName('a')
+            withVersion {
+                strictly '1.1'
+            }
+        }
+        hasDependency('strict-with-bang-and-range') {
+            withGroup('g')
+            withName('a')
+            withVersion {
+                strictly '[1.0,2.0]'
+                prefer '1.1'
+            }
+        }
     }
 
     def "parses bundles"() {

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/dependency-notations.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/dependency-notations.toml
@@ -7,7 +7,7 @@ simple-with-rich4 = { group = "foo", name = "bar", version.strictly = "1.0" }
 simple-with-rich5 = { group = "foo", name = "bar", version = { rejectAll = true } }
 simple-with-rich6 = { group = "foo", name = "bar", version = { require = "1.0", reject = ["1.1", "1.2"] } }
 
-shortcut.gav = "g:a:1.0"
+shortcut = "g:a:1.0"
 
 indirect.module = "g:b"
 indirect.version = "1.2"

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/dependency-notations.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/dependency-notations.toml
@@ -22,7 +22,12 @@ incremental2.version = { strictly = "[1.0, 2.0[", prefer = "1.5" }
 
 groovy-with-ref = { group = "org.codehaus.groovy", name = "groovy", version.ref = "groovy" }
 groovy-with-ref2 = { group = "org.codehaus.groovy", name = "groovy", version.ref = "rich-groovy" }
+groovy-with-ref3 = { group = "org.codehaus.groovy", name = "groovy", version.ref = "version-with-bang" }
+
+strict-with-bang = "g:a:1.1!!"
+strict-with-bang-and-range = { module="g:a", version="[1.0,2.0]!!1.1"}
 
 [versions]
 groovy = "2.5.6"
 rich-groovy = { strictly = "[2.5, 3.0[", prefer = "2.5.6" }
+version-with-bang="1.7!!"

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid1.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid1.toml
@@ -1,2 +1,2 @@
 [dependencies]
-module.gav = "foo"
+module = "foo"

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid3.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid3.toml
@@ -1,2 +1,2 @@
 [dependencies]
-module.gav = "foo::1.0"
+module = "foo::1.0"

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid4.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid4.toml
@@ -1,2 +1,2 @@
 [dependencies]
-module.gav = ":bar:1.0"
+module = ":bar:1.0"

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid5.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/invalid5.toml
@@ -1,2 +1,2 @@
 [dependencies]
-module.gav = "foo:bar:"
+module = "foo:bar:"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -40,7 +40,7 @@ class TomlDependenciesExtensionIntegrationTest extends AbstractCentralDependenci
     @UnsupportedWithConfigurationCache(because = "the test uses an extension directly in the task body")
     def "dependencies declared in TOML file trigger the creation of an extension (notation=#notation)"() {
         tomlFile << """[dependencies]
-foo.gav = 'org.gradle.test:lib:1.0'
+foo = 'org.gradle.test:lib:1.0'
 """
 
         buildFile << """
@@ -80,7 +80,7 @@ bar = {group="org.gradle.test", name="bar", version="1.0"}
         operations.hasOperation("Generate dependency accessors for libs")
 
         when: "updating a version in the model"
-        tomlFile.text = tomlFile.text.replace('{group="org.gradle.test", name="bar", version="1.0"}', '.gav="org.gradle.test:bar:1.1"')
+        tomlFile.text = tomlFile.text.replace('{group="org.gradle.test", name="bar", version="1.0"}', '="org.gradle.test:bar:1.1"')
         run 'verifyExtension'
 
         then: "extension is not regenerated"
@@ -272,7 +272,7 @@ lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
 
     def "libraries extension is not visible in buildSrc"() {
         tomlFile << """[dependencies]
-lib.gav = "org.gradle.test:lib:1.0"
+lib = "org.gradle.test:lib:1.0"
 """
         file("buildSrc/build.gradle") << """
             dependencies {
@@ -289,7 +289,7 @@ lib.gav = "org.gradle.test:lib:1.0"
 
     def "libraries extension can be made visible to buildSrc"() {
         tomlFile << """[dependencies]
-lib.gav = "org.gradle.test:lib:1.0"
+lib = "org.gradle.test:lib:1.0"
 """
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
@@ -318,10 +318,10 @@ lib.gav = "org.gradle.test:lib:1.0"
 
     def "buildSrc and main project have different libraries extensions"() {
         tomlFile << """[dependencies]
-lib.gav="org.gradle.test:lib:1.0"
+lib="org.gradle.test:lib:1.0"
 """
         file("buildSrc/gradle/dependencies.toml") << """[dependencies]
-build-src-lib.gav="org.gradle.test:buildsrc-lib:1.0"
+build-src-lib="org.gradle.test:buildsrc-lib:1.0"
 """
         file("buildSrc/build.gradle") << """
             repositories {
@@ -373,7 +373,7 @@ build-src-lib.gav="org.gradle.test:buildsrc-lib:1.0"
             }
         """
         file("included/gradle/dependencies.toml") << """[dependencies]
-from-included.gav="org.gradle.test:other:1.1"
+from-included="org.gradle.test:other:1.1"
 """
         file("included/settings.gradle") << """
             rootProject.name = 'included'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -147,6 +147,20 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         model.getDependencyData("groovy-json").version.preferredVersion == '3.0.5'
     }
 
+    def "can use rich versions in short-hand notation"() {
+        builder.alias("dummy", "g:a:1.5!!")
+        builder.alias("alias", "g:a:[1.0,2.0[!!1.7")
+
+        when:
+        def model = builder.build()
+
+        then:
+        model.dependencyAliases == ["alias", "dummy"]
+        model.getDependencyData("dummy").version.strictVersion == '1.5'
+        model.getDependencyData("alias").version.strictVersion == '[1.0,2.0['
+        model.getDependencyData("alias").version.preferredVersion == '1.7'
+    }
+
     def "strings are interned"() {
         builder.alias("foo", "bar", "baz") {
             it.require "1.0"


### PR DESCRIPTION
Everything is in the title.
