### PR TITLE
Register root build as included build so that it can be addressed

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -56,4 +56,74 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         then:
         execute(buildA, 'help')
     }
+
+    def "included build can see included root build"() {
+        when:
+        buildA.settingsFile << """
+            rootProject.name = 'theNameOfBuildA'
+        """
+        buildB.settingsFile << "includeBuild '../buildA'"
+        buildB.buildFile << """
+            assert gradle.includedBuilds.collect { it.name } == ['theNameOfBuildA']
+        """
+
+        then:
+        execute(buildA, 'help')
+    }
+
+    def "the root build cannot be renamed"() {
+        when:
+        buildA.settingsFile << """
+            rootProject.name = 'theNameOfBuildA'
+        """
+        buildB.settingsFile << "includeBuild('../buildA') { name = 'some-other-name' }"
+        buildB.buildFile << """
+            assert gradle.includedBuilds.collect { it.name } == ['theNameOfBuildA']
+        """
+
+        then:
+        execute(buildA, 'help')
+    }
+
+    def "included root build is only configured one time"() {
+        given:
+        buildA.buildFile << """
+            println("Configuring \$identityPath")
+        """
+        buildB.settingsFile << "includeBuild '../buildA'"
+
+        when:
+        execute(buildA, 'help')
+
+        then:
+        output.count("Configuring :") == 1
+        outputDoesNotContain("Configuring :buildA")
+    }
+
+    def "can address root build task from included build"() {
+        given:
+        buildA.buildFile << """
+            tasks.register('task1') {
+                dependsOn gradle.includedBuild('buildB').task(':task2')
+            }
+            tasks.register('task3') { }
+        """
+        buildA.settingsFile << """
+            rootProject.name = 'theNameOfBuildA'
+        """
+        buildB.settingsFile << "includeBuild '../buildA'"
+        buildB.buildFile << """
+            tasks.register('task2') {
+                dependsOn gradle.includedBuild('theNameOfBuildA').task(':task3')
+            }
+        """
+
+        when:
+        fails(buildA, 'task1')
+
+        then:
+        // If we get here, the tasks were all found and registered. Once the cycle restrictions back to the root build are removed, this test should pass.
+        failure.assertHasDescription("Could not find build ':'")
+        // result.assertTaskExecuted(':task3', ':buildB:task2', 'task1')
+    }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -57,7 +57,6 @@ import org.gradle.vcs.internal.VcsMappingsStore
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
-import java.util.ArrayList
 
 
 internal
@@ -254,20 +253,21 @@ class ConfigurationCacheState(
 
     private
     suspend fun DefaultWriteContext.writeIncludedBuildState(includedBuild: IncludedBuild, storedBuilds: StoredBuilds) {
-        val buildState = includedBuild as IncludedBuildState
-        val includedGradle = buildState.configuredBuild
-        val buildDefinition = includedGradle.serviceOf<BuildDefinition>()
-        writeBuildDefinition(buildDefinition)
-        when {
-            storedBuilds.store(buildDefinition) -> {
-                writeBoolean(true)
-                includedGradle.serviceOf<ConfigurationCacheIO>().writeIncludedBuildStateTo(
-                    stateFileFor(buildDefinition),
-                    storedBuilds
-                )
-            }
-            else -> {
-                writeBoolean(false)
+        if (includedBuild is IncludedBuildState) {
+            val includedGradle = includedBuild.configuredBuild
+            val buildDefinition = includedGradle.serviceOf<BuildDefinition>()
+            writeBuildDefinition(buildDefinition)
+            when {
+                storedBuilds.store(buildDefinition) -> {
+                    writeBoolean(true)
+                    includedGradle.serviceOf<ConfigurationCacheIO>().writeIncludedBuildStateTo(
+                        stateFileFor(buildDefinition),
+                        storedBuilds
+                    )
+                }
+                else -> {
+                    writeBoolean(false)
+                }
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -59,6 +59,8 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
                 if (!includedBuildSpec.rootDir.equals(buildRegistry.getRootBuild().getBuildRootDir())) {
                     IncludedBuildState includedBuild = addIncludedBuild(includedBuildSpec, gradle);
                     children.add(includedBuild.getModel());
+                } else {
+                    children.add(new IncludedRootBuild(buildRegistry.getRootBuild()));
                 }
             }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedRootBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedRootBuild.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.composite;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.TaskReference;
+import org.gradle.internal.build.RootBuildState;
+import org.gradle.util.Path;
+
+import java.io.File;
+
+public class IncludedRootBuild implements IncludedBuild {
+    private final RootBuildState rootBuild;
+
+    public IncludedRootBuild(RootBuildState rootBuild) {
+        this.rootBuild = rootBuild;
+    }
+
+    public RootBuildState getRootBuild() {
+        return rootBuild;
+    }
+
+    @Override
+    public String getName() {
+        return rootBuild.getLoadedSettings().getRootProject().getName();
+    }
+
+    @Override
+    public File getProjectDir() {
+        return rootBuild.getBuildRootDir();
+    }
+
+    @Override
+    public TaskReference task(String path) {
+        Preconditions.checkArgument(path.startsWith(":"), "Task path '%s' is not a qualified task path (e.g. ':task' or ':project:task').", path);
+        return new IncludedRootBuildTaskReference(rootBuild, path);
+    }
+
+    public class IncludedRootBuildTaskReference implements TaskReference, TaskDependencyContainer {
+        private final String taskPath;
+        private final RootBuildState rootBuildState;
+
+        public IncludedRootBuildTaskReference(RootBuildState rootBuildState, String taskPath) {
+            this.rootBuildState = rootBuildState;
+            this.taskPath = taskPath;
+        }
+
+        @Override
+        public String getName() {
+            return Path.path(taskPath).getName();
+        }
+
+        public BuildIdentifier getBuildIdentifier() {
+            return rootBuildState.getBuildIdentifier();
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            context.add(resolveTask());
+        }
+
+        private Task resolveTask() {
+            return rootBuildState.getBuild().getRootProject().getTasks().getByPath(taskPath);
+        }
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -60,9 +60,11 @@ public class GradleBuildBuilder implements ToolingModelBuilder {
         }
 
         for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
-            Gradle includedGradle = ((IncludedBuildState) includedBuild).getConfiguredBuild();
-            DefaultGradleBuild convertedIncludedBuild = convert(includedGradle, all);
-            model.addIncludedBuild(convertedIncludedBuild);
+            if (includedBuild instanceof IncludedBuildState) {
+                Gradle includedGradle = ((IncludedBuildState) includedBuild).getConfiguredBuild();
+                DefaultGradleBuild convertedIncludedBuild = convert(includedGradle, all);
+                model.addIncludedBuild(convertedIncludedBuild);
+            }
         }
 
         if (gradle.getParent() == null) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/AbstractClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/AbstractClientProvidedBuildActionRunner.java
@@ -68,8 +68,10 @@ public abstract class AbstractClientProvidedBuildActionRunner implements BuildAc
     private void forceFullConfiguration(GradleInternal gradle) {
         gradle.getServices().get(ProjectConfigurer.class).configureHierarchyFully(gradle.getRootProject());
         for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
-            GradleInternal build = ((IncludedBuildState) includedBuild).getConfiguredBuild();
-            forceFullConfiguration(build);
+            if (includedBuild instanceof IncludedBuildState) {
+                GradleInternal build = ((IncludedBuildState) includedBuild).getConfiguredBuild();
+                forceFullConfiguration(build);
+            }
         }
     }
 


### PR DESCRIPTION
This is a follow up to: #15011

If the root build is included by a child, it should be in the list of included builds.
