### PR TITLE
Make the dependencies model builder more convenient

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.api.initialization.dsl;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.MutableVersionConstraint;
-import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.io.File;
@@ -45,7 +44,7 @@ public interface DependenciesModelBuilder {
 
     /**
      * Configures a dependency version which can then be referenced using
-     * the {@link #aliasWithVersionRef(String, String, String, String)} )} method.
+     * the {@link DependenciesModelBuilder.LibraryAliasBuilder#versionRef(String)} )} method.
      *
      * @param name an identifier for the version
      * @param versionSpec the dependency version spec
@@ -55,50 +54,24 @@ public interface DependenciesModelBuilder {
 
     /**
      * Configures a dependency version which can then be referenced using
-     * the {@link #aliasWithVersionRef(String, String, String, String)} method.
+     * the {@link DependenciesModelBuilder.LibraryAliasBuilder#versionRef(String)} method.
      *
      * @param name an identifier for the version
-     * @param requiredVersion the version string, interpreted as a required version
+     * @param version the version string
      */
-    default String version(String name, String requiredVersion) {
-        return version(name, vc -> vc.require(requiredVersion));
-    }
+    String version(String name, String version);
 
     /**
-     * Declares an alias for a dependency
-     * @param alias the alias for the dependency
-     * @param group the group of the dependency
-     * @param name the module name of the dependency
-     * @param versionSpec the version specification
+     * Entry point for registering an alias for a library
+     * @param alias the alias identifer
+     * @return a builder for this alias
      */
-    void alias(String alias, String group, String name, Action<? super MutableVersionConstraint> versionSpec);
-
-    /**
-     * A shorthand notation to declare a simple dependency with group,
-     * artifact, version coordinates. The notation must consist of 3 colon
-     * separated parts: group:artifact:version.
-     *
-     * The version is implicity {@link VersionConstraint#getRequiredVersion() required}.
-     *
-     * @param alias the alias for the dependency
-     * @param gavCoordinates the gav coordinates notation
-     */
-    void alias(String alias, String gavCoordinates);
-
-    /**
-     * Configures an alias, using the supplied group and name, and a version which corresponds
-     * to a version name created by {@link #version(String, Action)}.
-     * @param alias the alias for the dependency
-     * @param group the group of the dependency
-     * @param name the name of the dependency
-     * @param versionRef the name of a version declared via the  {@link #version(String, Action)} method.
-     */
-    void aliasWithVersionRef(String alias, String group, String name, String versionRef);
+    AliasBuilder alias(String alias);
 
     /**
      * Declares a bundle of dependencies. A bundle consists of a name for the bundle,
      * and a list of aliases. The aliases must correspond to aliases defined via
-     * the {@link #alias(String, String, String, Action)} method.
+     * the {@link #alias(String)} method.
      *
      * @param name the name of the bundle
      * @param aliases the aliases of the dependencies included in the bundle
@@ -109,4 +82,52 @@ public interface DependenciesModelBuilder {
      * Returns the name of the extension configured by this builder
      */
     String getLibrariesExtensionName();
+
+    /**
+     * Allows configuring an alias
+     *
+     * @since 6.8
+     */
+    @Incubating
+    interface AliasBuilder {
+        /**
+         * Sets GAV coordinates for this alias
+         * @param groupArtifactVersion the GAV coordinates, in the group:artifact:version form
+         */
+        void to(String groupArtifactVersion);
+
+        /**
+         * Sets the group and name of this alias
+         * @param group the group
+         * @param name the name (or artifact id)
+         * @return a builder to configure the version
+         */
+        LibraryAliasBuilder to(String group, String name);
+    }
+
+    /**
+     * Allows configuring the version of a library
+     *
+     * @since 6.8
+     */
+    @Incubating
+    interface LibraryAliasBuilder {
+        /**
+         * Configures the version for this alias
+         */
+        void version(Action<? super MutableVersionConstraint> versionSpec);
+
+        /**
+         * Configures the required version for this alias
+         */
+        void version(String version);
+
+        /**
+         * Configures this alias to use a version reference, created
+         * via the {@link #version(String, Action)} method.
+         *
+         * @param versionRef the version reference
+         */
+        void versionRef(String versionRef);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
@@ -264,11 +264,12 @@ public class TomlDependenciesFileParser {
                                            @Nullable String prefer,
                                            @Nullable List<String> rejectedVersions,
                                            @Nullable Boolean rejectAll) {
+        DependenciesModelBuilder.LibraryAliasBuilder aliasBuilder = builder.alias(alias).to(group, name);
         if (versionRef != null) {
-            builder.aliasWithVersionRef(alias, group, name, versionRef);
+            aliasBuilder.versionRef(versionRef);
             return;
         }
-        builder.alias(alias, group, name, v -> {
+        aliasBuilder.version(v -> {
             if (require != null) {
                 v.require(require);
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -64,7 +64,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("bar", "org.gradle.test:bar:1.0")
+                    alias("bar") to "org.gradle.test:bar:1.0"
                 }
             }
         """
@@ -82,8 +82,9 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
 
         where:
         notation << [
-            'alias("foo", "org.gradle.test:lib:1.0")',
-            'alias("foo", "org.gradle.test", "lib") { require "1.0" }'
+            'alias("foo").to("org.gradle.test:lib:1.0")',
+            'alias("foo").to("org.gradle.test", "lib").version { require "1.0" }',
+            'alias("foo").to("org.gradle.test", "lib").version("1.0")'
         ]
     }
 
@@ -91,7 +92,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
@@ -125,7 +126,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
@@ -163,10 +164,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("lib", "org.gradle.test", "lib") {
+                    alias("lib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
-                    alias("lib2", "org.gradle.test:lib2:1.0")
+                    alias("lib2").to("org.gradle.test:lib2:1.0")
                     bundle("my", ["lib", "lib2"])
                 }
             }
@@ -203,10 +204,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("lib", "org.gradle.test", "lib") {
+                    alias("lib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
-                    alias("lib2", "org.gradle.test:lib2:1.0")
+                    alias("lib2").to("org.gradle.test:lib2:1.0")
                     bundle("my", ["lib", "lib2"])
                 }
             }
@@ -247,7 +248,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libraries") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
@@ -281,12 +282,12 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libraries") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
                 dependenciesModel("other") {
-                    alias("great", "org.gradle.test", "lib2") {
+                    alias("great").to("org.gradle.test", "lib2").version {
                         require "1.1"
                     }
                 }
@@ -327,12 +328,12 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libraries") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
                 dependenciesModel("other") {
-                    alias("myLib", "org.gradle.test", "lib") {
+                    alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
@@ -367,7 +368,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("lib", "org.gradle.test:lib:1.0")
+                    alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
             include 'other'
@@ -412,7 +413,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("lib", "org.gradle.test:lib:1.0")
+                    alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
         """
@@ -433,7 +434,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("lib", "org.gradle.test:lib:1.0")
+                    alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
         """
@@ -449,7 +450,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("build-src-lib", "org.gradle.test:buildsrc-lib:1.0")
+                    alias("build-src-lib").to("org.gradle.test:buildsrc-lib:1.0")
                 }
             }
         """
@@ -501,7 +502,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                     maven { url "${mavenHttpRepo.uri}" }
                 }
                 dependenciesModel("libs") {
-                    alias('from-included', 'org.gradle.test:other:1.1')
+                    alias('from-included').to('org.gradle.test:other:1.1')
                 }
             }
         """
@@ -543,8 +544,8 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                     version("myVersion") {
                         require "1.0"
                     }
-                    aliasWithVersionRef("myLib", "org.gradle.test", "lib", "myVersion")
-                    aliasWithVersionRef("myOtherLib", "org.gradle.test", "lib2", "myOtherVersion")
+                    alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
+                    alias("myOtherLib").to("org.gradle.test", "lib2").versionRef("myOtherVersion")
                     version("myOtherVersion") {
                         // intentionnally declared AFTER
                         strictly "1.1"
@@ -588,8 +589,8 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                     def myVersion = version("myVersion") {
                         require "1.0"
                     }
-                    aliasWithVersionRef("myLib", "org.gradle.test", "lib", "myVersion")
-                    aliasWithVersionRef("myOtherLib", "org.gradle.test", "lib2", myVersion)
+                    alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
+                    alias("myOtherLib").to("org.gradle.test", "lib2").versionRef(myVersion)
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -46,7 +46,7 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
         settingsKotlinFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias("my-lib", "org.gradle.test:lib:1.0")
+                    alias("my-lib").to("org.gradle.test:lib:1.0")
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -432,7 +432,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias('other', 'org.gradle.test:other:1.0')
+                    alias('other').to('org.gradle.test:other:1.0')
                 }
             }
         """
@@ -470,7 +470,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.1"}
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    alias('my-lib', 'org.gradle.test:lib:1.0')
+                    alias('my-lib').to('org.gradle.test:lib:1.0')
                 }
             }
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
@@ -131,47 +131,26 @@ public class DefaultDependenciesModelBuilder implements DependenciesModelBuilder
     }
 
     @Override
-    public void alias(String alias, String group, String name, Action<? super MutableVersionConstraint> versionSpec) {
-        validateName("alias", alias);
-        MutableVersionConstraint versionBuilder = new DefaultMutableVersionConstraint("");
-        versionSpec.execute(versionBuilder);
-        ImmutableVersionConstraint version = versionConstraintInterner.intern(DefaultImmutableVersionConstraint.of(versionBuilder));
-        DependencyModel model = new DependencyModel(intern(group), intern(name), version);
-        Supplier<DependencyModel> previous = dependencies.put(intern(alias), () -> model);
-        if (previous != null) {
-            LOGGER.warn("Duplicate entry for alias '{}': {} is replaced with {}", alias, previous.get(), model);
-        }
+    public String version(String name, String version) {
+        StrictVersionParser.RichVersion richVersion = strictVersionParser.parse(version);
+        version(name, vc -> {
+            if (richVersion.require != null) {
+                vc.require(richVersion.require);
+            }
+            if (richVersion.prefer != null) {
+                vc.prefer(richVersion.prefer);
+            }
+            if (richVersion.strictly != null) {
+                vc.strictly(richVersion.strictly);
+            }
+        });
+        return name;
     }
 
     @Override
-    public void alias(String alias, String gavCoordinates) {
-        String[] coordinates = gavCoordinates.split(":");
-        if (coordinates.length == 3) {
-            alias(alias, coordinates[0], coordinates[1], vc -> {
-                String version = coordinates[2];
-                StrictVersionParser.RichVersion richVersion = strictVersionParser.parse(version);
-                if (richVersion.require != null) {
-                    vc.require(richVersion.require);
-                }
-                if (richVersion.prefer != null) {
-                    vc.prefer(richVersion.prefer);
-                }
-                if (richVersion.strictly != null) {
-                    vc.strictly(richVersion.strictly);
-                }
-            });
-        } else {
-            throw new InvalidUserDataException("Invalid dependency notation: it must consist of 3 parts separated by colons, eg: my.group:artifact:1.2");
-        }
-    }
-
-    @Override
-    public void aliasWithVersionRef(String alias, String group, String name, String versionRef) {
+    public AliasBuilder alias(String alias) {
         validateName("alias", alias);
-        Supplier<DependencyModel> previous = dependencies.put(intern(alias), new VersionReferencingDependencyModel(group, name, versionRef));
-        if (previous != null) {
-            LOGGER.warn("Duplicate entry for alias '{}': {} is replaced with {}", alias, previous.get(), model);
-        }
+        return new DefaultAliasBuilder(alias);
     }
 
     private static void validateName(String type, String value) {
@@ -215,6 +194,85 @@ public class DefaultDependenciesModelBuilder implements DependenciesModelBuilder
                 throw new InvalidUserDataException("Referenced version '" + versionRef + "' doesn't exist on dependency " + group + ":" + name);
             }
             return new DependencyModel(group, name, constraint);
+        }
+    }
+
+    private class DefaultAliasBuilder implements AliasBuilder {
+        private final String alias;
+
+        public DefaultAliasBuilder(String alias) {
+            this.alias = alias;
+        }
+
+        @Override
+        public void to(String gavCoordinates) {
+            String[] coordinates = gavCoordinates.split(":");
+            if (coordinates.length == 3) {
+                to(coordinates[0], coordinates[1]).version(coordinates[2]);
+            } else {
+                throw new InvalidUserDataException("Invalid dependency notation: it must consist of 3 parts separated by colons, eg: my.group:artifact:1.2");
+            }
+        }
+
+        @Override
+        public LibraryAliasBuilder to(String group, String name) {
+            return objects.newInstance(DefaultLibraryAliasBuilder.class, DefaultDependenciesModelBuilder.this, alias, group, name);
+        }
+    }
+
+    // static public for injection!
+    public static class DefaultLibraryAliasBuilder implements LibraryAliasBuilder {
+        private final DefaultDependenciesModelBuilder owner;
+        private final String alias;
+        private final String group;
+        private final String name;
+
+        @Inject
+        public DefaultLibraryAliasBuilder(DefaultDependenciesModelBuilder owner, String alias, String group, String name) {
+            this.owner = owner;
+            this.alias = alias;
+            this.group = group;
+            this.name = name;
+        }
+
+        @Override
+        public void version(Action<? super MutableVersionConstraint> versionSpec) {
+            MutableVersionConstraint versionBuilder = new DefaultMutableVersionConstraint("");
+            versionSpec.execute(versionBuilder);
+            ImmutableVersionConstraint version = owner.versionConstraintInterner.intern(DefaultImmutableVersionConstraint.of(versionBuilder));
+            DependencyModel model = new DependencyModel(owner.intern(group), owner.intern(name), version);
+            Supplier<DependencyModel> previous = owner.dependencies.put(owner.intern(alias), () -> model);
+            if (previous != null) {
+                LOGGER.warn("Duplicate entry for alias '{}': {} is replaced with {}", alias, previous.get(), model);
+            }
+        }
+
+        @Override
+        public void version(String version) {
+            StrictVersionParser.RichVersion richVersion = owner.strictVersionParser.parse(version);
+            version(vc -> {
+                if (richVersion.require != null) {
+                    vc.require(richVersion.require);
+                }
+                if (richVersion.prefer != null) {
+                    vc.prefer(richVersion.prefer);
+                }
+                if (richVersion.strictly != null) {
+                    vc.strictly(richVersion.strictly);
+                }
+            });
+        }
+
+        @Override
+        public void versionRef(String versionRef) {
+            owner.createAliasWithVersionRef(alias, group, name, versionRef);
+        }
+    }
+
+    private void createAliasWithVersionRef(String alias, String group, String name, String versionRef) {
+        Supplier<DependencyModel> previous = dependencies.put(intern(alias), new VersionReferencingDependencyModel(group, name, versionRef));
+        if (previous != null) {
+            LOGGER.warn("Duplicate entry for alias '{}': {} is replaced with {}", alias, previous.get(), model);
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesAccessorsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesAccessorsTest.groovy
@@ -60,7 +60,7 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
     def "generates accessors only if the model keys change"() {
         model {
-            alias("foo", "g:a:v")
+            alias("foo") to "g:a:v"
         }
 
         when:
@@ -72,7 +72,7 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("foo", "g:a:v2")
+            alias("foo") to "g:a:v2"
         }
         accessors.generateAccessors([builder], scope, settings)
 
@@ -82,7 +82,7 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("foo", "other:a:v2")
+            alias("foo") to "other:a:v2"
         }
         accessors.generateAccessors([builder], scope, settings)
 
@@ -92,7 +92,7 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("bar", "changes:key:1.0")
+            alias("bar").to "changes:key:1.0"
         }
         accessors.generateAccessors([builder], scope, settings)
 
@@ -102,8 +102,8 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("foo", "my:key:1.0")
-            alias("bar", "my:key:1.0")
+            alias("foo") to "my:key:1.0"
+            alias("bar") to "my:key:1.0"
             bundle("myBundle", ["foo"])
         }
         accessors.generateAccessors([builder], scope, settings)
@@ -114,8 +114,8 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("foo", "my:key:1.0")
-            alias("bar", "my:key:1.0")
+            alias("foo") to "my:key:1.0"
+            alias("bar") to "my:key:1.0"
             bundle("myBundle", ["bar"])
         }
         accessors.generateAccessors([builder], scope, settings)
@@ -127,8 +127,8 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
     def "accessors key is order-independent"() {
         model {
-            alias("foo", "g:a:v")
-            alias("bar", "g2:a2:v2")
+            alias("foo") to "g:a:v"
+            alias("bar") to "g2:a2:v2"
         }
 
         when:
@@ -140,8 +140,8 @@ class DefaultDependenciesAccessorsTest extends Specification {
 
         when:
         model {
-            alias("bar", "g2:a2:v2")
-            alias("foo", "g:a:v")
+            alias("bar") to "g2:a2:v2"
+            alias("foo") to "g:a:v"
         }
         accessors.generateAccessors([builder], scope, settings)
 
@@ -153,7 +153,7 @@ class DefaultDependenciesAccessorsTest extends Specification {
     def "generates accessors if workspace is missing"() {
         def workspaceDir = tmpDir.createDir("id")
         model {
-            alias("foo", "g:a:v")
+            alias("foo") to "g:a:v"
         }
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -35,7 +35,7 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     @Unroll("#notation is an invalid notation")
     def "reasonable error message if notation is invalid"() {
         when:
-        builder.alias("foo", notation)
+        builder.alias("foo").to(notation)
 
         then:
         InvalidUserDataException ex = thrown()
@@ -48,7 +48,7 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     @Unroll("#notation is an invalid alias")
     def "reasonable error message if alias is invalid"() {
         when:
-        builder.alias(notation, "org:foo:1.0")
+        builder.alias(notation).to("org:foo:1.0")
 
         then:
         InvalidUserDataException ex = thrown()
@@ -79,10 +79,10 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         loggingManager.addStandardOutputListener(listener)
         loggingManager.start()
 
-        builder.alias("foo", "a:b:1.0")
+        builder.alias("foo").to("a:b:1.0")
 
         when:
-        builder.alias("foo", "e:f:1.1")
+        builder.alias("foo").to("e:f:1.1")
 
         then:
         1 * listener.onOutput("Duplicate entry for alias 'foo': dependency {group='a', name='b', version='1.0'} is replaced with dependency {group='e', name='f', version='1.1'}")
@@ -112,7 +112,7 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     }
 
     def "fails building the model if a bundle references a non-existing alias"() {
-        builder.alias("guava", "com.google.guava:guava:17.0")
+        builder.alias("guava").to("com.google.guava:guava:17.0")
         builder.bundle("toto", ["foo"])
 
         when:
@@ -124,11 +124,11 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     }
 
     def "model reflects what is declared"() {
-        builder.alias("guava", "com.google.guava:guava:17.0")
-        builder.alias("groovy", "org.codehaus.groovy", "groovy") {
+        builder.alias("guava").to("com.google.guava:guava:17.0")
+        builder.alias("groovy").to("org.codehaus.groovy", "groovy").version {
             it.strictly("3.0.5")
         }
-        builder.alias("groovy-json", "org.codehaus.groovy", "groovy-json") {
+        builder.alias("groovy-json").to("org.codehaus.groovy", "groovy-json").version {
             it.prefer("3.0.5")
         }
         builder.bundle("groovy", ["groovy", "groovy-json"])
@@ -148,8 +148,8 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     }
 
     def "can use rich versions in short-hand notation"() {
-        builder.alias("dummy", "g:a:1.5!!")
-        builder.alias("alias", "g:a:[1.0,2.0[!!1.7")
+        builder.alias("dummy").to("g:a:1.5!!")
+        builder.alias("alias").to("g:a:[1.0,2.0[!!1.7")
 
         when:
         def model = builder.build()
@@ -162,10 +162,10 @@ class DefaultDependenciesModelBuilderTest extends Specification {
     }
 
     def "strings are interned"() {
-        builder.alias("foo", "bar", "baz") {
+        builder.alias("foo").to("bar", "baz").version {
             it.require "1.0"
         }
-        builder.alias("baz", "foo", "bar") {
+        builder.alias("baz").to("foo", "bar").version {
             it.prefer "1.0"
         }
         when:
@@ -176,5 +176,27 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         model.getDependencyData("foo").group.is(model.getDependencyData("baz").name)
         model.getDependencyData("foo").name.is(bazKey)
         model.getDependencyData("foo").version.requiredVersion.is(model.getDependencyData("baz").version.preferredVersion)
+    }
+
+    def "can create an alias to a referenced version"() {
+        builder.version("ver", "1.7!!")
+        builder.alias("foo").to("org", "foo").versionRef("ver")
+
+        when:
+        def model = builder.build()
+
+        then:
+        model.getDependencyData("foo").version.strictVersion == "1.7"
+    }
+
+    def "reasonable error message if referenced version doesn't exist"() {
+        builder.alias("foo").to("org", "foo").versionRef("nope")
+
+        when:
+        builder.build()
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == "Referenced version 'nope' doesn't exist on dependency org:foo"
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -81,7 +81,7 @@ class DependenciesSourceGeneratorTest extends Specification {
     def "generates an accessor for #name as method #method"() {
         when:
         generate {
-            alias(name, 'g:a:v')
+            alias(name).to 'g:a:v'
         }
 
         then:
@@ -100,8 +100,8 @@ class DependenciesSourceGeneratorTest extends Specification {
     def "generates an accessor for bundle #name as method #method"() {
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('bar', 'g:a:v')
+            alias('foo') to 'g:a:v'
+            alias('bar') to 'g:a:v'
             bundle(name, ['foo', 'bar'])
         }
 
@@ -137,8 +137,8 @@ class DependenciesSourceGeneratorTest extends Specification {
     def "reasonable error message if methods have the same name"() {
         when:
         generate {
-            alias('groovy.json', 'g:a:v')
-            alias('groovyJson', 'g:a:v')
+            alias('groovy.json') to 'g:a:v'
+            alias('groovyJson') to 'g:a:v'
         }
 
         then:
@@ -147,12 +147,12 @@ class DependenciesSourceGeneratorTest extends Specification {
 
         when:
         generate {
-            alias('groovy.json', 'g:a:v')
-            alias('groovyJson', 'g:a:v')
+            alias('groovy.json') to 'g:a:v'
+            alias('groovyJson') to 'g:a:v'
 
-            alias('tada_one', 'g:a:v')
-            alias('tada.one', 'g:a:v')
-            alias('tadaOne', 'g:a:v')
+            alias('tada_one') to 'g:a:v'
+            alias('tada.one') to 'g:a:v'
+            alias('tadaOne') to 'g:a:v'
         }
 
         then:
@@ -165,8 +165,8 @@ class DependenciesSourceGeneratorTest extends Specification {
     def "reasonable error message if bundles have the same name"() {
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('bar', 'g:a:v')
+            alias('foo') to 'g:a:v'
+            alias('bar') to 'g:a:v'
             bundle('one.cool', ['foo', 'bar'])
             bundle('oneCool', ['foo', 'bar'])
         }
@@ -177,8 +177,8 @@ class DependenciesSourceGeneratorTest extends Specification {
 
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('bar', 'g:a:v')
+            alias('foo') to 'g:a:v'
+            alias('bar') to 'g:a:v'
             bundle('one.cool', ['foo', 'bar'])
             bundle('oneCool', ['foo', 'bar'])
 
@@ -197,8 +197,8 @@ class DependenciesSourceGeneratorTest extends Specification {
     def 'reasonable error message if an alias ends with bundle'() {
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('barBundle', 'g:a:v')
+            alias('foo') to 'g:a:v'
+            alias('barBundle') to 'g:a:v'
         }
 
         then:
@@ -207,9 +207,9 @@ class DependenciesSourceGeneratorTest extends Specification {
 
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('bazBundle', 'g:a:v')
-            alias('barBundle', 'g:a:v')
+            alias('foo') to 'g:a:v'
+            alias('bazBundle') to 'g:a:v'
+            alias('barBundle') to 'g:a:v'
         }
 
         then:
@@ -222,8 +222,8 @@ class DependenciesSourceGeneratorTest extends Specification {
     def "generated sources can be compiled"() {
         when:
         generate {
-            alias('foo', 'g:a:v')
-            alias('bar', 'g2:a2:v2')
+            alias('foo') to 'g:a:v'
+            alias('bar') to 'g2:a2:v2'
             bundle('my', ['foo', 'bar'])
         }
 
@@ -247,7 +247,7 @@ class DependenciesSourceGeneratorTest extends Specification {
         when:
         generate {
             16000.times { n ->
-                alias("alias$n", "g:a$n:1.0")
+                alias("alias$n").to("g:a$n:1.0")
                 bundle("foo$n", ["alias$n".toString()])
             }
         }


### PR DESCRIPTION
### Context

Following feedback from @bigdaz 

Instead of using methods with multiple arguments, add a DSL which
makes it more explicit what the arguments are.

For example:

alias("my-alias").to("org", "foo").version("1.5")

alias("my-alias").to("org:foo:1.5")

alias("my-alias").to("org", "foo").versionRef("ref")

