### PR TITLE
Separate missing and unreadable snapshots

### DIFF
--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -47,6 +47,7 @@ import org.gradle.internal.snapshot.PathTracker;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RelativePathTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import javax.annotation.Nullable;
 import java.io.BufferedOutputStream;
@@ -370,9 +371,14 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
                 @Override
                 public void visitMissing(MissingFileSnapshot missingSnapshot) {
                     if (!isRoot) {
-                        throw new RuntimeException(String.format("Couldn't read content of file '%s'", snapshot.getAbsolutePath()));
+                        throw new RuntimeException(String.format("Couldn't read contents of file '%s'", snapshot.getAbsolutePath()));
                     }
                     storeMissingTree(targetPath, tarOutput);
+                }
+
+                @Override
+                public void visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
+                    throw unreadableSnapshot.rethrowOnAttemptedRead();
                 }
             });
             packedEntryCount++;

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -437,7 +437,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
         when:
         fails 'brokenClasspathInput'
         then:
-        failure.assertHasCause("Couldn't read file content: '${brokenInputFile}'.")
+        failure.assertHasCause("Couldn't read file contents: '${brokenInputFile}'.")
 
         where:
         classpathType << [Classpath, CompileClasspath]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
@@ -219,7 +219,7 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         fails "producesLink"
         then:
         failureHasCause("Failed to store cache entry for task ':producesLink'")
-        errorOutput.contains("Couldn't read content of file '${link}'")
+        errorOutput.contains("Couldn't read contents of file '${link}'")
     }
 
     private TestFile cleanBuildDir() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetector.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetector.java
@@ -28,6 +28,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotUtil;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -95,6 +96,11 @@ public class DefaultOverlappingOutputDetector implements OverlappingOutputDetect
                     }
                     // Otherwise check for newly added broken symlinks and unreadable files
                     return hasNewContent(missingSnapshot);
+                }
+
+                @Override
+                public Boolean visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
+                    return hasNewContent(unreadableSnapshot);
                 }
             });
             if (newContent) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
@@ -33,6 +33,7 @@ import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -193,6 +194,11 @@ public class OutputSnapshotUtil {
 
                 @Override
                 public void visitMissing(MissingFileSnapshot missingSnapshot) {
+                    visitNonDirectoryEntry(snapshot, isRoot);
+                }
+
+                @Override
+                public void visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
                     visitNonDirectoryEntry(snapshot, isRoot);
                 }
             });

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -29,6 +29,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import org.gradle.internal.watch.registry.SnapshotCollectingDiffListener;
@@ -199,6 +200,11 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
 
                 @Override
                 public SnapshotVisitResult visitMissing(MissingFileSnapshot missingSnapshot) {
+                    return SnapshotVisitResult.CONTINUE;
+                }
+
+                @Override
+                public SnapshotVisitResult visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
                     return SnapshotVisitResult.CONTINUE;
                 }
             });

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -48,6 +48,7 @@ import org.gradle.internal.snapshot.PathTracker;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RelativePathTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -181,8 +182,13 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
                 @Override
                 public void visitMissing(MissingFileSnapshot missingSnapshot) {
                     if (!relativePath.isRoot()) {
-                        throw new RuntimeException(String.format("Couldn't read file content: '%s'.", missingSnapshot.getAbsolutePath()));
+                        throw new RuntimeException(String.format("Couldn't read file contents: '%s'.", missingSnapshot.getAbsolutePath()));
                     }
+                }
+
+                @Override
+                public void visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
+                    throw unreadableSnapshot.rethrowOnAttemptedRead();
                 }
             });
             return SnapshotVisitResult.CONTINUE;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -20,10 +20,14 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.snapshot.CompleteDirectorySnapshot;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
+import org.gradle.internal.snapshot.MissingFileSnapshot;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -53,11 +57,34 @@ public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingSt
             public SnapshotVisitResult visitEntry(CompleteFileSystemLocationSnapshot snapshot, boolean isRoot) {
                 String absolutePath = snapshot.getAbsolutePath();
                 if (processedEntries.add(absolutePath)) {
-                    builder.put(absolutePath, new DefaultFileSystemLocationFingerprint(snapshot.getAbsolutePath(), snapshot));
+                    snapshot.accept(new CompleteFileSystemLocationSnapshot.FileSystemLocationSnapshotVisitor() {
+                        @Override
+                        public void visitDirectory(CompleteDirectorySnapshot directorySnapshot) {
+                            visitReadableEntry(directorySnapshot);
+                        }
+
+                        @Override
+                        public void visitRegularFile(RegularFileSnapshot fileSnapshot) {
+                            visitReadableEntry(fileSnapshot);
+                        }
+
+                        @Override
+                        public void visitMissing(MissingFileSnapshot missingSnapshot) {
+                            visitReadableEntry(missingSnapshot);
+                        }
+
+                        @Override
+                        public void visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
+                            throw unreadableSnapshot.rethrowOnAttemptedRead();
+                        }
+
+                        private void visitReadableEntry(CompleteFileSystemLocationSnapshot snapshot) {
+                            builder.put(absolutePath, new DefaultFileSystemLocationFingerprint(snapshot.getAbsolutePath(), snapshot));
+                        }
+                    });
                 }
                 return SnapshotVisitResult.CONTINUE;
             }
-
         });
         return builder.build();
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompleteFileSystemLocationSnapshot.java
@@ -85,11 +85,13 @@ public interface CompleteFileSystemLocationSnapshot extends FileSystemSnapshot, 
         default void visitDirectory(CompleteDirectorySnapshot directorySnapshot) {};
         default void visitRegularFile(RegularFileSnapshot fileSnapshot) {};
         default void visitMissing(MissingFileSnapshot missingSnapshot) {};
+        default void visitUnreadable(UnreadableSnapshot unreadableSnapshot) {};
     }
 
     interface FileSystemLocationSnapshotTransformer<T> {
         T visitDirectory(CompleteDirectorySnapshot directorySnapshot);
         T visitRegularFile(RegularFileSnapshot fileSnapshot);
         T visitMissing(MissingFileSnapshot missingSnapshot);
+        T visitUnreadable(UnreadableSnapshot unreadableSnapshot);
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/UnreadableSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/UnreadableSnapshot.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+import org.gradle.internal.file.FileMetadata.AccessType;
+import org.gradle.internal.file.FileType;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A snapshot of an unreadable file system object (like a named pipe).
+ */
+public class UnreadableSnapshot extends AbstractCompleteFileSystemLocationSnapshot implements FileSystemLeafSnapshot {
+    private static final HashCode SIGNATURE = Hashing.signature(UnreadableSnapshot.class);
+
+    private final IOException error;
+
+    public UnreadableSnapshot(String absolutePath, String name, AccessType accessType, IOException error) {
+        super(absolutePath, name, accessType);
+        this.error = error;
+    }
+
+    public IOException getError() {
+        return error;
+    }
+
+    @Override
+    public FileType getType() {
+        throw rethrowOnAttemptedRead();
+    }
+
+    @Override
+    public HashCode getHash() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isContentAndMetadataUpToDate(CompleteFileSystemLocationSnapshot other) {
+        return other instanceof UnreadableSnapshot;
+    }
+
+    @Override
+    public boolean isContentUpToDate(CompleteFileSystemLocationSnapshot other) {
+        return other instanceof UnreadableSnapshot;
+    }
+
+    @Override
+    public SnapshotVisitResult accept(FileSystemSnapshotHierarchyVisitor visitor) {
+        return visitor.visitEntry(this);
+    }
+
+    @Override
+    public void accept(FileSystemLocationSnapshotVisitor visitor) {
+        visitor.visitUnreadable(this);
+    }
+
+    @Override
+    public <T> T accept(FileSystemLocationSnapshotTransformer<T> transformer) {
+        return transformer.visitUnreadable(this);
+    }
+
+    public Optional<FileSystemNode> invalidate(VfsRelativePath targetPath, CaseSensitivity caseSensitivity, SnapshotHierarchy.NodeDiffListener diffListener) {
+        diffListener.nodeRemoved(this);
+        return Optional.empty();
+    }
+
+    public RuntimeException rethrowOnAttemptedRead() {
+        throw new RuntimeException(String.format("Couldn't read file contents: '%s'.", getAbsolutePath()), error);
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
@@ -30,6 +30,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RelativePathTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.internal.snapshot.SnapshottingFilter;
+import org.gradle.internal.snapshot.UnreadableSnapshot;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -86,6 +87,11 @@ public class FileSystemSnapshotFilter {
 
                 @Override
                 public Boolean visitMissing(MissingFileSnapshot missingSnapshot) {
+                    return false;
+                }
+
+                @Override
+                public Boolean visitUnreadable(UnreadableSnapshot unreadableSnapshot) {
                     return false;
                 }
             });

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.snapshot.MissingFileSnapshot
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.SnapshotVisitorUtil
 import org.gradle.internal.snapshot.SnapshottingFilter
+import org.gradle.internal.snapshot.UnreadableSnapshot
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
@@ -332,7 +333,7 @@ class DirectorySnapshotterTest extends Specification {
     }
 
     @Requires(TestPrecondition.FILE_PERMISSIONS)
-    def "unreadable files and directories are snapshotted as missing"() {
+    def "unreadable files and directories are snapshotted as unreadable"() {
         given:
         def rootDir = tmpDir.createDir("root")
         rootDir.file('readableFile').createFile()
@@ -349,8 +350,8 @@ class DirectorySnapshotterTest extends Specification {
         snapshot.children.collectEntries { [it.name, it.class] } == [
             readableDirectory: CompleteDirectorySnapshot,
             readableFile: RegularFileSnapshot,
-            unreadableDirectory: MissingFileSnapshot,
-            unreadableFile: MissingFileSnapshot
+            unreadableDirectory: UnreadableSnapshot,
+            unreadableFile: UnreadableSnapshot
         ]
         snapshot.children.every { it.accessType == AccessType.DIRECT }
         0 * _
@@ -373,7 +374,7 @@ class DirectorySnapshotterTest extends Specification {
         ! actuallyFiltered.get()
         assert snapshot instanceof CompleteDirectorySnapshot
         snapshot.children.collectEntries { [it.name, it.class] } == [
-            testPipe: MissingFileSnapshot
+            testPipe: UnreadableSnapshot
         ]
         snapshot.children.every { it.accessType == AccessType.DIRECT }
         0 * _


### PR DESCRIPTION
This way we can distinguish between files that are missing (incl. broken symlinks) and file system objects that cannot be read (because of permissions, or because they are not regular files).