### PR TITLE
Use imports to simplify code

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
@@ -99,7 +99,7 @@ class GradleInvocationSpec implements InvocationSpec {
         return builder.build()
     }
 
-    static class InvocationBuilder implements InvocationSpec.Builder {
+    static class InvocationBuilder implements Builder {
         GradleDistribution gradleDistribution
         File workingDirectory
         List<String> tasksToRun = []
@@ -186,7 +186,7 @@ class GradleInvocationSpec implements InvocationSpec {
         }
 
         @Override
-        InvocationSpec.Builder expectFailure() {
+        Builder expectFailure() {
             expectFailure = true
             this
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
@@ -67,7 +67,7 @@ class MavenInvocationSpec implements InvocationSpec {
         builder
     }
 
-    static class InvocationBuilder implements InvocationSpec.Builder {
+    static class InvocationBuilder implements Builder {
         String mavenVersion
         File mavenHome
         File workingDirectory
@@ -132,7 +132,7 @@ class MavenInvocationSpec implements InvocationSpec {
         }
 
         @Override
-        InvocationSpec.Builder expectFailure() {
+        Builder expectFailure() {
             throw new UnsupportedOperationException()
         }
 


### PR DESCRIPTION
This PR is testing gradle-bot-mergify integration by fixing tiny issues in the codebase.

