### PR TITLE
Support cyclic build includes in IDE import

### DIFF
--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/FetchEclipseProjects.java
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/FetchEclipseProjects.java
@@ -29,18 +29,23 @@ public class FetchEclipseProjects implements BuildAction<List<EclipseProject>> {
 
     @Override
     public List<EclipseProject> execute(BuildController controller) {
-        List<EclipseProject> eclipseProjects = new ArrayList<EclipseProject>();
+        List<EclipseProject> eclipseProjects = new ArrayList<>();
         GradleBuild build = controller.getBuildModel();
-        collectEclipseProjects(build, eclipseProjects, controller);
+        ArrayList<GradleBuild> all = new ArrayList<>();
+        all.add(build);
+        collectEclipseProjects(build, eclipseProjects, controller, all);
         return eclipseProjects;
     }
 
-    private void collectEclipseProjects(GradleBuild build, List<EclipseProject> eclipseProjects, BuildController controller) {
+    private void collectEclipseProjects(GradleBuild build, List<EclipseProject> eclipseProjects, BuildController controller, List<GradleBuild> all) {
         for (BasicGradleProject project : build.getProjects()) {
             eclipseProjects.add(controller.getModel(project, EclipseProject.class));
         }
         for (GradleBuild includedBuild : build.getIncludedBuilds()) {
-            collectEclipseProjects(includedBuild, eclipseProjects, controller);
+            if (!all.contains(includedBuild)) {
+                all.add(includedBuild);
+                collectEclipseProjects(includedBuild, eclipseProjects, controller, all);
+            }
         }
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/CompositeBuildModuleCycleCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/CompositeBuildModuleCycleCrossVersionSpec.groovy
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r68
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.plugins.ide.tooling.r31.IdeaProjectUtil
+import org.gradle.plugins.ide.tooling.r33.FetchEclipseProjects
+
+@ToolingApiVersion('>=6.8')
+@TargetGradleVersion(">=6.8")
+class CompositeBuildModuleCycleCrossVersionSpec extends ToolingApiSpecification {
+
+    private compositeWithDirectIncludeCycle() {
+        settingsFile << """
+            rootProject.name = 'module-root'
+            includeBuild('module-a')
+        """
+        file('module-a').mkdir()
+        file('module-b').mkdir()
+        file('module-a/settings.gradle') << """
+            includeBuild('../module-b')
+        """
+        file('module-b/settings.gradle') << """
+            includeBuild('../module-a')
+        """
+    }
+
+    private compositeWithIndirectIncludeCycle() {
+        settingsFile << """
+            rootProject.name = 'module-root'
+            includeBuild('module-a')
+        """
+        file('module-a').mkdir()
+        file('module-b').mkdir()
+        file('module-c').mkdir()
+        file('module-a/settings.gradle') << """
+            includeBuild('../module-b')
+        """
+        file('module-b/settings.gradle') << """
+            includeBuild('../module-c')
+        """
+        file('module-c/settings.gradle') << """
+            includeBuild('../module-a')
+        """
+    }
+
+    private compositeWithRootInvolvingIncludeCycle() {
+        settingsFile << """
+            rootProject.name = 'module-root'
+            includeBuild('module-a')
+        """
+        file('module-a').mkdir()
+        file('module-a/settings.gradle') << """
+            includeBuild('..')
+        """
+    }
+
+    def "IDEA can handle direct cycles between included builds"() {
+        given:
+        compositeWithDirectIncludeCycle()
+
+        when:
+        def allProjects = withConnection {c -> c.action(new IdeaProjectUtil.GetAllIdeaProjectsAction()).run() }
+
+        then:
+        allProjects.allIdeaProjects.collect { it.name } == ['module-root', 'module-a', 'module-b']
+        allProjects.includedBuildIdeaProjects.keySet().collect { it.buildIdentifier.rootDir.name } == ['module-a', 'module-b']
+    }
+
+    def "IDEA can handle indirect cycles between included builds"() {
+        given:
+        compositeWithIndirectIncludeCycle()
+
+        when:
+        def allProjects = withConnection {c -> c.action(new IdeaProjectUtil.GetAllIdeaProjectsAction()).run() }
+
+        then:
+        allProjects.allIdeaProjects.collect { it.name } == ['module-root', 'module-a', 'module-b', 'module-c']
+        allProjects.includedBuildIdeaProjects.values().collect { it.name } == ['module-a', 'module-b', 'module-c']
+    }
+
+    def "IDEA can handle cycles involving the root build"() {
+        given:
+        compositeWithRootInvolvingIncludeCycle()
+
+        when:
+        def allProjects = withConnection {c -> c.action(new IdeaProjectUtil.GetAllIdeaProjectsAction()).run() }
+
+        then:
+        allProjects.allIdeaProjects.collect { it.name } == ['module-root', 'module-a']
+        allProjects.includedBuildIdeaProjects.values().collect { it.name } == ['module-a', 'module-root']
+    }
+
+    def "Eclipse can handle cycles between included builds"() {
+        given:
+        compositeWithDirectIncludeCycle()
+
+        when:
+        def eclipseProjects = withConnection { action(new FetchEclipseProjects()).run() }
+
+        then:
+        eclipseProjects.collect { it.name } == ['module-root', 'module-a', 'module-b']
+    }
+
+    def "Eclipse can handle indirect cycles between included builds"() {
+        given:
+        compositeWithIndirectIncludeCycle()
+
+        when:
+        def eclipseProjects = withConnection { action(new FetchEclipseProjects()).run() }
+
+        then:
+        eclipseProjects.collect { it.name } == ['module-root', 'module-a', 'module-b', 'module-c']
+    }
+
+    def "Eclipse can handle cycles involving the root build"() {
+        given:
+        compositeWithRootInvolvingIncludeCycle()
+
+        when:
+        def eclipseProjects = withConnection { action(new FetchEclipseProjects()).run() }
+
+        then:
+        eclipseProjects.collect { it.name } == ['module-root', 'module-a']
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -20,13 +20,12 @@ import org.gradle.api.Project;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.build.IncludedBuildState;
+import org.gradle.internal.composite.IncludedRootBuild;
 import org.gradle.plugins.ide.internal.tooling.model.BasicGradleProject;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultGradleBuild;
 import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -40,12 +39,16 @@ public class GradleBuildBuilder implements ToolingModelBuilder {
     @Override
     public DefaultGradleBuild buildAll(String modelName, Project target) {
         Gradle gradle = target.getGradle();
-        return convert(gradle, new ArrayList<DefaultGradleBuild>());
+        return convert(gradle, null, new LinkedHashMap<>());
     }
 
-    private DefaultGradleBuild convert(Gradle gradle, Collection<DefaultGradleBuild> all) {
+    private DefaultGradleBuild convert(Gradle gradle, DefaultGradleBuild rootBuild, Map<Gradle, DefaultGradleBuild> all) {
         DefaultGradleBuild model = new DefaultGradleBuild();
-        Map<Project, BasicGradleProject> convertedProjects = new LinkedHashMap<Project, BasicGradleProject>();
+        Map<Project, BasicGradleProject> convertedProjects = new LinkedHashMap<>();
+
+        if (rootBuild == null) {
+            rootBuild = model;
+        }
 
         Project rootProject = gradle.getRootProject();
         BasicGradleProject convertedRootProject = convert(rootProject, convertedProjects);
@@ -56,19 +59,26 @@ public class GradleBuildBuilder implements ToolingModelBuilder {
         }
 
         if (gradle.getParent() != null) {
-            all.add(model);
+            all.put(gradle, model);
         }
 
         for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
             if (includedBuild instanceof IncludedBuildState) {
                 Gradle includedGradle = ((IncludedBuildState) includedBuild).getConfiguredBuild();
-                DefaultGradleBuild convertedIncludedBuild = convert(includedGradle, all);
+                DefaultGradleBuild convertedIncludedBuild = all.get(includedGradle);
+                if (convertedIncludedBuild == null) {
+                    convertedIncludedBuild = convert(includedGradle, rootBuild, all);
+                }
                 model.addIncludedBuild(convertedIncludedBuild);
+            } else if (includedBuild instanceof IncludedRootBuild){
+                model.addIncludedBuild(rootBuild);
+            } else {
+                throw new IllegalStateException("Unknown build type: " + includedBuild.getClass().getName());
             }
         }
 
         if (gradle.getParent() == null) {
-            model.addBuilds(all);
+            model.addBuilds(all.values());
         }
 
         return model;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/model/DefaultGradleBuild.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/model/DefaultGradleBuild.java
@@ -28,9 +28,9 @@ import java.util.Set;
 public class DefaultGradleBuild implements Serializable, GradleBuildIdentity {
     private PartialBasicGradleProject rootProject;
     private DefaultBuildIdentifier buildIdentifier;
-    private Set<PartialBasicGradleProject> projects = new LinkedHashSet<PartialBasicGradleProject>();
-    private Set<DefaultGradleBuild> includedBuilds = new LinkedHashSet<DefaultGradleBuild>();
-    private Set<DefaultGradleBuild> allBuilds = new LinkedHashSet<DefaultGradleBuild>();
+    private final Set<PartialBasicGradleProject> projects = new LinkedHashSet<>();
+    private final Set<DefaultGradleBuild> includedBuilds = new LinkedHashSet<>();
+    private final Set<DefaultGradleBuild> allBuilds = new LinkedHashSet<>();
 
     public PartialBasicGradleProject getRootProject() {
         return rootProject;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/AbstractClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/AbstractClientProvidedBuildActionRunner.java
@@ -32,6 +32,8 @@ import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
 import org.gradle.tooling.internal.protocol.PhasedActionResult;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class AbstractClientProvidedBuildActionRunner implements BuildActionRunner {
     protected Result runClientAction(ClientAction action, BuildController buildController) {
@@ -65,12 +67,15 @@ public abstract class AbstractClientProvidedBuildActionRunner implements BuildAc
         return Result.of(action.getResult());
     }
 
-    private void forceFullConfiguration(GradleInternal gradle) {
+    private void forceFullConfiguration(GradleInternal gradle, List<GradleInternal> alreadyConfigured) {
         gradle.getServices().get(ProjectConfigurer.class).configureHierarchyFully(gradle.getRootProject());
         for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
             if (includedBuild instanceof IncludedBuildState) {
                 GradleInternal build = ((IncludedBuildState) includedBuild).getConfiguredBuild();
-                forceFullConfiguration(build);
+                if (!alreadyConfigured.contains(build)) {
+                    alreadyConfigured.add(build);
+                    forceFullConfiguration(build, alreadyConfigured);
+                }
             }
         }
     }
@@ -101,7 +106,7 @@ public abstract class AbstractClientProvidedBuildActionRunner implements BuildAc
 
         @Override
         public void projectsEvaluated(Gradle gradle) {
-            forceFullConfiguration(this.gradle);
+            forceFullConfiguration(this.gradle, new ArrayList<>());
             runAction(clientAction.getProjectsEvaluatedAction(), PhasedActionResult.Phase.PROJECTS_LOADED);
         }
 


### PR DESCRIPTION
Although it is possible since a long time to have cycles through 'includeBuild(...)' statements, IDE import never supported this. There were several places in the code assuming there won't be cycles which ran into infinite recursions. These places are fixed and the missing test coverage is added.

Since this concerns both idea/eclipse plugin code and TAPI code, this fix requires both the running Gradle and the TAPI to be on the latest version.
