### PR TITLE
Differentiate between settings and buildscript for dependency locking

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -65,4 +65,13 @@ public interface DomainObjectContext {
      */
     boolean isScript();
 
+    /**
+     * Whether the context is a root script.
+     *
+     * `Settings` is such a context.
+     *
+     * Some objects are associated with a script, that is associated with a domain object.
+     */
+    boolean isRootScript();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -90,6 +90,11 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
     }
 
     @Override
+    public boolean isRootScript() {
+        return true;
+    }
+
+    @Override
     public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
         return new CalculatedModelValueImpl<>(initialValue);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -635,6 +635,11 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     }
 
     @Override
+    public boolean isRootScript() {
+        return false;
+    }
+
+    @Override
     public String relativeProjectPath(String path) {
         return getProjectPath().relativePath(path);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -274,6 +274,11 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         public boolean isScript() {
             return true;
         }
+
+        @Override
+        public boolean isRootScript() {
+            return false;
+        }
     }
 
     protected DependencyMetaDataProvider createDependencyMetaDataProvider() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -84,7 +84,7 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
         if (metadata != null && metadata.isChanging()) {
             changing = true;
         }
-        if (identifier instanceof ModuleComponentIdentifier) {
+        if (!node.isRoot() && identifier instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) identifier;
             if (identifier instanceof MavenUniqueSnapshotComponentIdentifier) {
                 id = ((MavenUniqueSnapshotComponentIdentifier) id).getSnapshotComponent();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -53,6 +53,7 @@ public class LockFileReaderWriter {
     static final List<String> LOCKFILE_HEADER_LIST = ImmutableList.of("# This is a Gradle generated file for dependency locking.", "# Manual edits can break the build and are not advised.", "# This file is expected to be part of source control.");
     static final String EMPTY_CONFIGURATIONS_ENTRY = "empty=";
     static final String BUILD_SCRIPT_PREFIX = "buildscript-";
+    static final String SETTINGS_SCRIPT_PREFIX = "settings-";
 
     private final Path lockFilesRoot;
     private final DomainObjectContext context;
@@ -120,6 +121,9 @@ public class LockFileReaderWriter {
 
     private String decorate(String configurationName) {
         if (context.isScript()) {
+            if (context.isRootScript()) {
+                return SETTINGS_SCRIPT_PREFIX + configurationName;
+            }
             return BUILD_SCRIPT_PREFIX + configurationName;
         } else {
             return configurationName;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -100,6 +100,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
         then:
         2 * node.owner >> component
+        1 * node.root >> false
         1 * component.componentId >> identifier
         1 * identifier.version >> ''
         1 * component.metadata >> metadata
@@ -121,9 +122,30 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
         then:
         2 * node.owner >> component
+        1 * node.root >> false
         1 * component.componentId >> identifier
         1 * component.metadata >> null
         0 * _
+    }
+
+    def 'ignores root node'() {
+        given:
+        startWithState([])
+
+        DependencyGraphComponent component = Mock()
+        ComponentIdentifier identifier = Mock()
+
+        when:
+        visitor.visitNode(rootNode)
+
+        then:
+        2 * rootNode.owner >> component
+        1 * rootNode.root >> true
+        1 * component.componentId >> identifier
+        1 * component.metadata >> null
+
+        and:
+        visitor.allResolvedModules.empty
     }
 
     def 'finishes without error when visited match expected'() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -138,9 +138,8 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 }
             }
         """
-        file("gradle/dependency-locks/buildscript-incomingPlatformsForLibs.lockfile") << """
+        file("gradle/dependency-locks/settings-incomingPlatformsForLibs.lockfile") << """
 org.gradle.test:my-platform:1.0
-unspecified:unspecified:unspecified
 """
 
         buildFile << """


### PR DESCRIPTION
When locking settings, the system knows that is a different context than
the buildscript classpath. It allows to lock both without having
conflicts.