### PR TITLE
Extract common interface for Gradle caches

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanConstructors.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanConstructors.kt
@@ -33,7 +33,7 @@ class BeanConstructors(
     val cache: CrossBuildInMemoryCache<Class<*>, Constructor<out Any>> = cacheFactory.newClassCache()
 
     fun constructorForSerialization(beanType: Class<*>): Constructor<out Any> {
-        return cache.get(beanType) { type -> createConstructor(type) }
+        return cache.get(beanType) { -> createConstructor(beanType) }
     }
 
     private

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -23,7 +23,6 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
-import org.gradle.api.Transformer;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
@@ -36,13 +35,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @NonNullApi
 public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
     private final CrossBuildInMemoryCache<Class<?>, TaskClassInfo> classInfos;
-    private final Transformer<TaskClassInfo, Class<?>> taskClassInfoFactory = aClass -> createTaskClassInfo(aClass.asSubclass(Task.class));
+    private final Function<Class<?>, TaskClassInfo> taskClassInfoFactory = aClass -> createTaskClassInfo(aClass.asSubclass(Task.class));
 
     public DefaultTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory) {
         this.classInfos = cacheFactory.newClassCache();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -42,12 +42,7 @@ import java.util.stream.Stream;
 @NonNullApi
 public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
     private final CrossBuildInMemoryCache<Class<?>, TaskClassInfo> classInfos;
-    private final Transformer<TaskClassInfo, Class<?>> taskClassInfoFactory = new Transformer<TaskClassInfo, Class<?>>() {
-        @Override
-        public TaskClassInfo transform(Class<?> aClass) {
-            return createTaskClassInfo(aClass.asSubclass(Task.class));
-        }
-    };
+    private final Transformer<TaskClassInfo, Class<?>> taskClassInfoFactory = aClass -> createTaskClassInfo(aClass.asSubclass(Task.class));
 
     public DefaultTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory) {
         this.classInfos = cacheFactory.newClassCache();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.properties;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import org.gradle.api.Transformer;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.tasks.properties.annotations.AbstractOutputPropertyAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler;
@@ -43,6 +42,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.gradle.api.internal.tasks.properties.ModifierAnnotationCategory.NORMALIZATION;
 import static org.gradle.internal.reflect.AnnotationCategory.TYPE;
@@ -56,7 +56,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
     private final CrossBuildInMemoryCache<Class<?>, TypeMetadata> cache;
     private final TypeAnnotationMetadataStore typeAnnotationMetadataStore;
     private final String displayName;
-    private final Transformer<TypeMetadata, Class<?>> typeMetadataFactory = this::createTypeMetadata;
+    private final Function<Class<?>, TypeMetadata> typeMetadataFactory = this::createTypeMetadata;
 
     public DefaultTypeMetadataStore(
         Collection<? extends TypeAnnotationHandler> typeAnnotationHandlers,

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.initialization.SessionLifecycleListener;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.event.ListenerManager;
@@ -30,6 +29,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.function.Function;
 
 /**
  * A factory for {@link CrossBuildInMemoryCache} instances.
@@ -112,7 +112,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         }
 
         @Override
-        public V get(K key, Transformer<? extends V, ? super K> factory) {
+        public V get(K key, Function<? super K, ? extends V> factory) {
             synchronized (lock) {
                 V v = getIfPresent(key);
                 if (v != null) {
@@ -120,7 +120,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
                 }
 
                 // TODO - do not hold lock while computing value
-                v = factory.transform(key);
+                v = factory.apply(key);
 
                 retainValue(key, v);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/CrossBuildCachingNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/CrossBuildCachingNotationConverter.java
@@ -33,7 +33,7 @@ public class CrossBuildCachingNotationConverter<T> implements NotationConverter<
 
     @Override
     public void convert(Object notation, NotationConvertResult<? super T> result) throws TypeConversionException {
-        T value = cache.get(notation, key -> delegate.parseNotation(notation));
+        T value = cache.get(notation, () -> delegate.parseNotation(notation));
         result.converted(value);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
@@ -28,13 +28,12 @@ import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 /**
  * A simple in-memory cache, used by the testing fixtures.
  */
 public class InMemoryIndexedCache<K, V> implements PersistentIndexedCache<K, V> {
-    private final Map<Object, byte[]> entries = new ConcurrentHashMap<Object, byte[]>();
+    private final Map<Object, byte[]> entries = new ConcurrentHashMap<>();
     private final ProducerGuard<K> producerGuard = ProducerGuard.serial();
     private final Serializer<V> valueSerializer;
 
@@ -59,14 +58,11 @@ public class InMemoryIndexedCache<K, V> implements PersistentIndexedCache<K, V> 
 
     @Override
     public V get(final K key, final Transformer<? extends V, ? super K> producer) {
-        return producerGuard.guardByKey(key, new Supplier<V>() {
-            @Override
-            public V get() {
-                if (!entries.containsKey(key)) {
-                    put(key, producer.transform(key));
-                }
-                return InMemoryIndexedCache.this.get(key);
+        return producerGuard.guardByKey(key, () -> {
+            if (!entries.containsKey(key)) {
+                put(key, producer.transform(key));
             }
+            return InMemoryIndexedCache.this.get(key);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.testfixtures.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.UncheckedException;
@@ -28,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * A simple in-memory cache, used by the testing fixtures.
@@ -57,10 +57,10 @@ public class InMemoryIndexedCache<K, V> implements PersistentIndexedCache<K, V> 
     }
 
     @Override
-    public V get(final K key, final Transformer<? extends V, ? super K> producer) {
+    public V get(final K key, final Function<? super K, ? extends V> producer) {
         return producerGuard.guardByKey(key, () -> {
             if (!entries.containsKey(key)) {
-                put(key, producer.transform(key));
+                put(key, producer.apply(key));
             }
             return InMemoryIndexedCache.this.get(key);
         });

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
@@ -45,7 +45,7 @@ class TestCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFacto
         }
 
         @Override
-        V get(K key, Transformer<V, K> factory) {
+        V get(K key, Transformer<? extends V, ? super K> factory) {
             def v = values.get(key)
             if (v == null) {
                 v = factory.transform(key)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.api.Transformer
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Function
 
 class TestCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFactory {
     @Override
@@ -45,10 +45,10 @@ class TestCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFacto
         }
 
         @Override
-        V get(K key, Transformer<? extends V, ? super K> factory) {
+        V get(K key, Function<? super K, ? extends V> factory) {
             def v = values.get(key)
             if (v == null) {
-                v = factory.transform(key)
+                v = factory.apply(key)
                 values.put(key, v)
             }
             return v

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ReadOnlyArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ReadOnlyArtifactCacheLockingManager.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.CacheBuilder;
@@ -29,6 +28,7 @@ import org.gradle.internal.serialize.Serializer;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
+import java.util.function.Function;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
@@ -98,8 +98,8 @@ public class ReadOnlyArtifactCacheLockingManager implements ArtifactCacheLocking
         }
 
         @Override
-        public V get(K key, Transformer<? extends V, ? super K> producer) {
-            return producer.transform(key);
+        public V get(K key, Function<? super K, ? extends V> producer) {
+            return producer.apply(key);
         }
 
         @Override
@@ -128,7 +128,7 @@ public class ReadOnlyArtifactCacheLockingManager implements ArtifactCacheLocking
         }
 
         @Override
-        public V get(K key, Transformer<? extends V, ? super K> producer) {
+        public V get(K key, Function<? super K, ? extends V> producer) {
             return failSafe(() -> delegate.get(key, producer));
         }
 
@@ -169,7 +169,7 @@ public class ReadOnlyArtifactCacheLockingManager implements ArtifactCacheLocking
         }
 
         @Override
-        public V get(final K key, final Transformer<? extends V, ? super K> producer) {
+        public V get(final K key, final Function<? super K, ? extends V> producer) {
             return cache.useCache(() -> persistentCache.get(key, producer));
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.internal.filestore.DefaultArtifactIdentifierFileStore;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
@@ -36,6 +35,7 @@ import org.gradle.internal.serialize.Serializer;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
+import java.util.function.Function;
 
 import static org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_EXTERNAL_CACHE_ENTRIES;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
@@ -117,7 +117,7 @@ public class WritableArtifactCacheLockingManager implements ArtifactCacheLocking
         }
 
         @Override
-        public V get(final K key, final Transformer<? extends V, ? super K> producer) {
+        public V get(final K key, final Function<? super K, ? extends V> producer) {
             return cache.useCache(() -> persistentCache.get(key, producer));
         }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisCache.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.compile.incremental.analyzer;
 
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
-import org.gradle.cache.internal.Cache;
+import org.gradle.cache.Cache;
 import org.gradle.internal.hash.HashCode;
 
 public interface ClassAnalysisCache extends Cache<HashCode, ClassAnalysis> {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotCache.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import org.gradle.cache.internal.Cache;
+import org.gradle.cache.Cache;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
+import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.MinimalPersistentCache;
 import org.gradle.internal.hash.HashCode;
@@ -23,7 +24,6 @@ import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
 import java.io.File;
-import java.util.function.Supplier;
 
 public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapshotCache {
     private final FileSystemAccess fileSystemAccess;
@@ -41,11 +41,11 @@ public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapsho
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File key, Supplier<ClasspathEntrySnapshot> supplier) {
+    public ClasspathEntrySnapshot get(File key, Transformer<ClasspathEntrySnapshot, File> supplier) {
         HashCode fileContentHash = fileSystemAccess.read(
             key.getAbsolutePath(),
             CompleteFileSystemLocationSnapshot::getHash
         );
-        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> supplier.get().getData()));
+        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> supplier.transform(key).getData()));
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
@@ -18,12 +18,12 @@ package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.MinimalPersistentCache;
-import org.gradle.internal.Factory;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapshotCache {
     private final FileSystemAccess fileSystemAccess;
@@ -41,11 +41,11 @@ public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapsho
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File key, final Factory<ClasspathEntrySnapshot> factory) {
+    public ClasspathEntrySnapshot get(File key, Supplier<ClasspathEntrySnapshot> supplier) {
         HashCode fileContentHash = fileSystemAccess.read(
             key.getAbsolutePath(),
             CompleteFileSystemLocationSnapshot::getHash
         );
-        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> factory.create().getData()));
+        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> supplier.get().getData()));
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.MinimalPersistentCache;
 import org.gradle.internal.hash.HashCode;
@@ -24,6 +23,7 @@ import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
 import java.io.File;
+import java.util.function.Function;
 
 public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapshotCache {
     private final FileSystemAccess fileSystemAccess;
@@ -41,9 +41,9 @@ public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapsho
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File key, Transformer<? extends ClasspathEntrySnapshot, ? super File> supplier) {
+    public ClasspathEntrySnapshot get(File key, Function<? super File, ? extends ClasspathEntrySnapshot> factory) {
         HashCode fileContentHash = getFileContentHash(key);
-        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> supplier.transform(key).getData()));
+        return new ClasspathEntrySnapshot(cache.get(fileContentHash, () -> factory.apply(key).getData()));
     }
 
     private HashCode getFileContentHash(File key) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotCache.java
@@ -41,7 +41,7 @@ public class DefaultClasspathEntrySnapshotCache implements ClasspathEntrySnapsho
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File key, Transformer<ClasspathEntrySnapshot, File> supplier) {
+    public ClasspathEntrySnapshot get(File key, Transformer<? extends ClasspathEntrySnapshot, ? super File> supplier) {
         HashCode fileContentHash = fileSystemAccess.read(
             key.getAbsolutePath(),
             CompleteFileSystemLocationSnapshot::getHash

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -50,10 +50,24 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
 
     @Override
     public ClasspathEntrySnapshot get(File entry, Transformer<? extends ClasspathEntrySnapshot, ? super File> supplier) {
-        if (globalCacheLocations.isInsideGlobalCache(entry.getPath())) {
-            return globalCache.get(entry, supplier);
+        return getCacheFor(entry).get(entry, supplier);
+    }
+
+    @Override
+    public ClasspathEntrySnapshot get(File key) {
+        return getCacheFor(key).get(key);
+    }
+
+    @Override
+    public void put(File key, ClasspathEntrySnapshot value) {
+        getCacheFor(key).put(key, value);
+    }
+
+    private ClasspathEntrySnapshotCache getCacheFor(File location) {
+        if (globalCacheLocations.isInsideGlobalCache(location.getPath())) {
+            return globalCache;
         } else {
-            return localCache.get(entry, supplier);
+            return localCache;
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -17,12 +17,12 @@
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
 import org.gradle.cache.GlobalCacheLocations;
-import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.Closeable;
 import java.io.File;
+import java.util.function.Supplier;
 
 /**
  * A {@link ClasspathEntrySnapshotCache} that delegates to the global cache for files that are known to be immutable.
@@ -49,11 +49,11 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File entry, Factory<ClasspathEntrySnapshot> factory) {
+    public ClasspathEntrySnapshot get(File entry, Supplier<ClasspathEntrySnapshot> supplier) {
         if (globalCacheLocations.isInsideGlobalCache(entry.getPath())) {
-            return globalCache.get(entry, factory);
+            return globalCache.get(entry, supplier);
         } else {
-            return localCache.get(entry, factory);
+            return localCache.get(entry, supplier);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -49,7 +49,7 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File entry, Transformer<ClasspathEntrySnapshot, File> supplier) {
+    public ClasspathEntrySnapshot get(File entry, Transformer<? extends ClasspathEntrySnapshot, ? super File> supplier) {
         if (globalCacheLocations.isInsideGlobalCache(entry.getPath())) {
             return globalCache.get(entry, supplier);
         } else {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.GlobalCacheLocations;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.Closeable;
 import java.io.File;
+import java.util.function.Function;
 
 /**
  * A {@link ClasspathEntrySnapshotCache} that delegates to the global cache for files that are known to be immutable.
@@ -49,8 +49,8 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File entry, Transformer<? extends ClasspathEntrySnapshot, ? super File> supplier) {
-        return getCacheFor(entry).get(entry, supplier);
+    public ClasspathEntrySnapshot get(File entry, Function<? super File, ? extends ClasspathEntrySnapshot> factory) {
+        return getCacheFor(entry).get(entry, factory);
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/SplitClasspathEntrySnapshotCache.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
+import org.gradle.api.Transformer;
 import org.gradle.cache.GlobalCacheLocations;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.Closeable;
 import java.io.File;
-import java.util.function.Supplier;
 
 /**
  * A {@link ClasspathEntrySnapshotCache} that delegates to the global cache for files that are known to be immutable.
@@ -49,7 +49,7 @@ public class SplitClasspathEntrySnapshotCache implements ClasspathEntrySnapshotC
     }
 
     @Override
-    public ClasspathEntrySnapshot get(File entry, Supplier<ClasspathEntrySnapshot> supplier) {
+    public ClasspathEntrySnapshot get(File entry, Transformer<ClasspathEntrySnapshot, File> supplier) {
         if (globalCacheLocations.isInsideGlobalCache(entry.getPath())) {
             return globalCache.get(entry, supplier);
         } else {

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/AnalysisStoreProvider.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/AnalysisStoreProvider.java
@@ -18,25 +18,17 @@ package org.gradle.api.internal.tasks.scala;
 
 import org.gradle.cache.internal.Cache;
 import org.gradle.cache.internal.MapBackedCache;
-import org.gradle.internal.Factory;
 import xsbti.compile.AnalysisStore;
 import xsbti.compile.FileAnalysisStore;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class AnalysisStoreProvider {
 
-    private final Cache<File, AnalysisStore> cache = new MapBackedCache<File, AnalysisStore>(new ConcurrentHashMap<>());
+    private final Cache<File, AnalysisStore> cache = new MapBackedCache<>(new ConcurrentHashMap<>());
 
     AnalysisStore get(final File analysisFile) {
-        return AnalysisStore.getCachedStore(cache.get(analysisFile, new Factory<AnalysisStore>() {
-            @Nullable
-            @Override
-            public AnalysisStore create() {
-                return AnalysisStore.getThreadSafeStore(FileAnalysisStore.getDefault(analysisFile));
-            }
-        }));
+        return AnalysisStore.getCachedStore(cache.get(analysisFile, () -> AnalysisStore.getThreadSafeStore(FileAnalysisStore.getDefault(analysisFile))));
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/AnalysisStoreProvider.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/AnalysisStoreProvider.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.scala;
 
-import org.gradle.cache.internal.Cache;
+import org.gradle.cache.Cache;
 import org.gradle.cache.internal.MapBackedCache;
 import xsbti.compile.AnalysisStore;
 import xsbti.compile.FileAnalysisStore;

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -24,7 +24,6 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.cache.internal.MapBackedCache;
-import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
@@ -67,7 +66,6 @@ import xsbti.compile.Setup;
 import xsbti.compile.TransactionalManagerType;
 import xsbti.compile.analysis.Stamp;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Arrays;
@@ -199,16 +197,8 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec> {
 
         @Override
         public DefinesClass definesClass(File classpathEntry) {
-            Optional<DefinesClass> dc = analysis(classpathEntry).map(a -> a instanceof Analysis ? (Analysis) a : null).map(a -> new AnalysisBakedDefineClass(a));
-            return dc.orElseGet(() -> {
-                return definesClassCache.get(classpathEntry, new Factory<DefinesClass>() {
-                    @Nullable
-                    @Override
-                    public DefinesClass create() {
-                        return Locate.definesClass(classpathEntry);
-                    }
-                });
-            });
+            Optional<DefinesClass> dc = analysis(classpathEntry).map(a -> a instanceof Analysis ? (Analysis) a : null).map(AnalysisBakedDefineClass::new);
+            return dc.orElseGet(() -> definesClassCache.get(classpathEntry, Locate::definesClass));
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/registry/DaemonRegistryServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/registry/DaemonRegistryServices.java
@@ -19,7 +19,6 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.cache.internal.Cache;
 import org.gradle.cache.internal.CacheAccessSerializer;
 import org.gradle.cache.internal.MapBackedCache;
-import org.gradle.internal.Factory;
 import org.gradle.internal.file.Chmod;
 
 import java.io.File;
@@ -34,9 +33,9 @@ public class DaemonRegistryServices {
     private final File daemonBaseDir;
     private final Cache<File, DaemonRegistry> daemonRegistryCache;
 
-    private static final Map<File, DaemonRegistry> REGISTRY_STORAGE = new HashMap<File, DaemonRegistry>();
-    private static final Cache<File, DaemonRegistry> REGISTRY_CACHE = new CacheAccessSerializer<File, DaemonRegistry>(
-            new MapBackedCache<File, DaemonRegistry>(REGISTRY_STORAGE)
+    private static final Map<File, DaemonRegistry> REGISTRY_STORAGE = new HashMap<>();
+    private static final Cache<File, DaemonRegistry> REGISTRY_CACHE = new CacheAccessSerializer<>(
+        new MapBackedCache<>(REGISTRY_STORAGE)
     );
 
     public DaemonRegistryServices(File daemonBaseDir) {
@@ -54,12 +53,7 @@ public class DaemonRegistryServices {
 
     DaemonRegistry createDaemonRegistry(DaemonDir daemonDir, final FileLockManager fileLockManager, final Chmod chmod) {
         final File daemonRegistryFile = daemonDir.getRegistry();
-        return daemonRegistryCache.get(daemonRegistryFile, new Factory<DaemonRegistry>() {
-            @Override
-            public DaemonRegistry create() {
-                return new PersistentDaemonRegistry(daemonRegistryFile, fileLockManager, chmod);
-            }
-        });
+        return daemonRegistryCache.get(daemonRegistryFile, () -> new PersistentDaemonRegistry(daemonRegistryFile, fileLockManager, chmod));
     }
 
     Properties createProperties() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/registry/DaemonRegistryServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/registry/DaemonRegistryServices.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.launcher.daemon.registry;
 
+import org.gradle.cache.Cache;
 import org.gradle.cache.FileLockManager;
-import org.gradle.cache.internal.Cache;
 import org.gradle.cache.internal.CacheAccessSerializer;
 import org.gradle.cache.internal.MapBackedCache;
 import org.gradle.internal.file.Chmod;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -74,12 +74,7 @@ public class NamedObjectInstantiator implements ManagedFactory {
     private final CrossBuildInMemoryCache<Class<?>, LoadingCache<String, Object>> generatedTypes;
     private final String implSuffix;
     private final String factorySuffix;
-    private final Transformer<LoadingCache<String, Object>, Class<?>> cacheFactory = new Transformer<LoadingCache<String, Object>, Class<?>>() {
-        @Override
-        public LoadingCache<String, Object> transform(Class<?> type) {
-            return CacheBuilder.newBuilder().build(loaderFor(type));
-        }
-    };
+    private final Transformer<LoadingCache<String, Object>, Class<?>> cacheFactory = type -> CacheBuilder.newBuilder().build(loaderFor(type));
 
     public NamedObjectInstantiator(CrossBuildInMemoryCacheFactory cacheFactory) {
         implSuffix = ClassGeneratorSuffixRegistry.assign("$Impl");

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import groovy.lang.GroovyObject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
-import org.gradle.api.Transformer;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -44,6 +43,7 @@ import org.objectweb.asm.Type;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.function.Function;
 
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
@@ -74,7 +74,7 @@ public class NamedObjectInstantiator implements ManagedFactory {
     private final CrossBuildInMemoryCache<Class<?>, LoadingCache<String, Object>> generatedTypes;
     private final String implSuffix;
     private final String factorySuffix;
-    private final Transformer<LoadingCache<String, Object>, Class<?>> cacheFactory = type -> CacheBuilder.newBuilder().build(loaderFor(type));
+    private final Function<Class<?>, LoadingCache<String, Object>> cacheFactory = type -> CacheBuilder.newBuilder().build(loaderFor(type));
 
     public NamedObjectInstantiator(CrossBuildInMemoryCacheFactory cacheFactory) {
         implSuffix = ClassGeneratorSuffixRegistry.assign("$Impl");

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -32,7 +32,6 @@ import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
-import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
@@ -81,6 +80,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -116,7 +116,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     private final ImmutableSet<Class<? extends Annotation>> disabledAnnotations;
     private final ImmutableSet<Class<? extends Annotation>> enabledAnnotations;
     private final ImmutableMultimap<Class<? extends Annotation>, TypeToken<?>> allowedTypesForAnnotation;
-    private final Transformer<GeneratedClassImpl, Class<?>> generator = type -> generateUnderLock(type);
+    private final Function<Class<?>, GeneratedClassImpl> generator = this::generateUnderLock;
     private final PropertyRoleAnnotationHandler roleHandler;
 
     protected AbstractClassGenerator(Collection<? extends InjectAnnotationHandler> allKnownAnnotations,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -92,7 +92,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
             // TODO - The baseClass can be inferred from the implType, so attach the serialization constructor onto the GeneratedClass rather than parameterizing and caching here
             try {
-                ClassGenerator.SerializationConstructor<?> constructor = constructorCache.get(implType, type -> classGenerator.generate(implType).getSerializationConstructor(baseClass));
+                ClassGenerator.SerializationConstructor<?> constructor = constructorCache.get(implType, () -> classGenerator.generate(implType).getSerializationConstructor(baseClass));
                 return implType.cast(constructor.newInstance(services, nestedGenerator));
             } catch (InvocationTargetException e) {
                 throw new ObjectInstantiationException(implType, e.getCause());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -177,7 +177,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     @Override
     public TypeAnnotationMetadata getTypeAnnotationMetadata(Class<?> type) {
-        return cache.get(type, t -> createTypeAnnotationMetadata(type));
+        return cache.get(type, () -> createTypeAnnotationMetadata(type));
     }
 
     private TypeAnnotationMetadata createTypeAnnotationMetadata(Class<?> type) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/Cache.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.cache.internal;
+package org.gradle.cache;
 
 import javax.annotation.Nullable;
 import java.util.function.Function;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
@@ -16,13 +16,14 @@
 package org.gradle.cache;
 
 import org.gradle.api.Transformer;
+import org.gradle.cache.internal.Cache;
 
 import javax.annotation.Nullable;
 
 /**
  * A persistent store of objects of type V indexed by a key of type K.
  */
-public interface PersistentIndexedCache<K, V> {
+public interface PersistentIndexedCache<K, V> extends Cache<K, V> {
     /**
      * Fetches the value mapped to the given key from this cache, blocking until it is available.
      *
@@ -30,6 +31,7 @@ public interface PersistentIndexedCache<K, V> {
      *
      * @return The value, or null if no value associated with the key.
      */
+    @Override
     @Nullable
     V get(K key);
 
@@ -44,6 +46,7 @@ public interface PersistentIndexedCache<K, V> {
      *
      * @return The value.
      */
+    @Override
     V get(K key, Transformer<? extends V, ? super K> producer);
 
     /**
@@ -51,6 +54,7 @@ public interface PersistentIndexedCache<K, V> {
      *
      * The implementation may do this synchronously or asynchronously. A file lock is held until the value has been written to the persistent store.
      */
+    @Override
     void put(K key, V value);
 
     /**

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.cache;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.internal.Cache;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 /**
  * A persistent store of objects of type V indexed by a key of type K.
@@ -47,7 +47,7 @@ public interface PersistentIndexedCache<K, V> extends Cache<K, V> {
      * @return The value.
      */
     @Override
-    V get(K key, Transformer<? extends V, ? super K> producer);
+    V get(K key, Function<? super K, ? extends V> producer);
 
     /**
      * Maps the given value to the given key, replacing any existing value.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentIndexedCache.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.cache;
 
-import org.gradle.cache.internal.Cache;
-
 import javax.annotation.Nullable;
 import java.util.function.Function;
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
@@ -16,13 +16,12 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.AsyncCacheAccess;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.MultiProcessSafePersistentIndexedCache;
-import org.gradle.internal.Factory;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentIndexedCache<K, V> {
     private final AsyncCacheAccess asyncCacheAccess;
@@ -41,30 +40,22 @@ public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsy
     @Nullable
     @Override
     public V get(final K key) {
-        return asyncCacheAccess.read(new Factory<V>() {
-            @Override
-            public V create() {
-                return persistentCache.get(key);
-            }
-        });
+        return asyncCacheAccess.read(() -> persistentCache.get(key));
     }
 
     @Override
-    public V get(K key, Transformer<? extends V, ? super K> producer, Runnable completion) {
+    public V get(K key, Function<? super K, ? extends V> producer, Runnable completion) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void putLater(final K key, final V value, final Runnable completion) {
         try {
-            asyncCacheAccess.enqueue(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        persistentCache.put(key, value);
-                    } finally {
-                        completion.run();
-                    }
+            asyncCacheAccess.enqueue(() -> {
+                try {
+                    persistentCache.put(key, value);
+                } finally {
+                    completion.run();
                 }
             });
         } catch (RuntimeException e) {
@@ -76,14 +67,11 @@ public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsy
     @Override
     public void removeLater(final K key, final Runnable completion) {
         try {
-            asyncCacheAccess.enqueue(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        persistentCache.remove(key);
-                    } finally {
-                        completion.run();
-                    }
+            asyncCacheAccess.enqueue(() -> {
+                try {
+                    persistentCache.remove(key);
+                } finally {
+                    completion.run();
                 }
             });
         } catch (RuntimeException e) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
@@ -20,8 +20,14 @@ import org.gradle.api.Transformer;
 import java.util.function.Supplier;
 
 public interface Cache<K, V>  {
-    V get(K key, Supplier<V> supplier);
-    default V get(K key, Transformer<V, K> supplier) {
-        return get(key, () -> supplier.transform(key));
+    /**
+     * Locates the given entry, using the supplied factory when the entry is not present or has been discarded, to recreate the entry in the cache.
+     *
+     * <p>Implementations may prevent more than one thread calculating the same key at the same time or not.
+     */
+    V get(K key, Transformer<V, K> supplier);
+
+    default V get(K key, Supplier<V> supplier) {
+        return get(key, __ -> supplier.get());
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
@@ -17,6 +17,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Transformer;
 
+import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 public interface Cache<K, V>  {
@@ -30,4 +31,15 @@ public interface Cache<K, V>  {
     default V get(K key, Supplier<? extends V> supplier) {
         return get(key, __ -> supplier.get());
     }
+
+    /**
+     * Locates the given entry, if present. Returns {@code null} when missing.
+     */
+    @Nullable
+    V get(K key);
+
+    /**
+     * Adds the given value to the cache, replacing any existing value.
+     */
+    void put(K key, V value);
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
@@ -15,9 +15,8 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
-
 import javax.annotation.Nullable;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface Cache<K, V>  {
@@ -26,7 +25,7 @@ public interface Cache<K, V>  {
      *
      * <p>Implementations may prevent more than one thread calculating the same key at the same time or not.
      */
-    V get(K key, Transformer<? extends V, ? super K> supplier);
+    V get(K key, Function<? super K, ? extends V> factory);
 
     default V get(K key, Supplier<? extends V> supplier) {
         return get(key, __ -> supplier.get());

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
@@ -15,8 +15,13 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.internal.Factory;
+import org.gradle.api.Transformer;
+
+import java.util.function.Supplier;
 
 public interface Cache<K, V>  {
-    V get(K key, Factory<V> factory);
+    V get(K key, Supplier<V> supplier);
+    default V get(K key, Transformer<V, K> supplier) {
+        return get(key, () -> supplier.transform(key));
+    }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/Cache.java
@@ -25,9 +25,9 @@ public interface Cache<K, V>  {
      *
      * <p>Implementations may prevent more than one thread calculating the same key at the same time or not.
      */
-    V get(K key, Transformer<V, K> supplier);
+    V get(K key, Transformer<? extends V, ? super K> supplier);
 
-    default V get(K key, Supplier<V> supplier) {
+    default V get(K key, Supplier<? extends V> supplier) {
         return get(key, __ -> supplier.get());
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -28,7 +28,7 @@ public class CacheAccessSerializer<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(final K key, final Transformer<V, K> supplier) {
+    public V get(final K key, final Transformer<? extends V, ? super K> supplier) {
         return synchronizer.synchronize(() -> cache.get(key, supplier));
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -15,8 +15,9 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.internal.concurrent.Synchronizer;
+
+import java.util.function.Function;
 
 public class CacheAccessSerializer<K, V> implements Cache<K, V> {
 
@@ -28,8 +29,8 @@ public class CacheAccessSerializer<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(final K key, final Transformer<? extends V, ? super K> supplier) {
-        return synchronizer.synchronize(() -> cache.get(key, supplier));
+    public V get(final K key, final Function<? super K, ? extends V> factory) {
+        return synchronizer.synchronize(() -> cache.get(key, factory));
     }
 
     @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -15,9 +15,8 @@
  */
 package org.gradle.cache.internal;
 
+import org.gradle.api.Transformer;
 import org.gradle.internal.concurrent.Synchronizer;
-
-import java.util.function.Supplier;
 
 public class CacheAccessSerializer<K, V> implements Cache<K, V> {
 
@@ -29,7 +28,7 @@ public class CacheAccessSerializer<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(final K key, final Supplier<V> supplier) {
+    public V get(final K key, final Transformer<V, K> supplier) {
         return synchronizer.synchronize(() -> cache.get(key, supplier));
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -15,8 +15,9 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.Synchronizer;
+
+import java.util.function.Supplier;
 
 public class CacheAccessSerializer<K, V> implements Cache<K, V> {
 
@@ -28,13 +29,8 @@ public class CacheAccessSerializer<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(final K key, final Factory<V> factory) {
-        return synchronizer.synchronize(new Factory<V>() {
-            @Override
-            public V create() {
-                return cache.get(key, factory);
-            }
-        });
+    public V get(final K key, final Supplier<V> supplier) {
+        return synchronizer.synchronize(() -> cache.get(key, supplier));
     }
 
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -32,4 +32,13 @@ public class CacheAccessSerializer<K, V> implements Cache<K, V> {
         return synchronizer.synchronize(() -> cache.get(key, supplier));
     }
 
+    @Override
+    public V get(K key) {
+        return synchronizer.synchronize(() -> cache.get(key));
+    }
+
+    @Override
+    public void put(K key, V value) {
+        synchronizer.synchronize(() -> cache.put(key, value));
+    }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessSerializer.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.cache.internal;
 
+import org.gradle.cache.Cache;
 import org.gradle.internal.concurrent.Synchronizer;
 
 import java.util.function.Function;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.internal.Factory;
+import java.util.function.Supplier;
 
 public abstract class CacheSupport<K, V> implements Cache<K, V> {
 
     @Override
-    public V get(K key, Factory<V> factory) {
+    public V get(K key, Supplier<V> supplier) {
         V value = doGet(key);
         if (value == null) {
-            value = factory.create();
+            value = supplier.get();
             doCache(key, value);
         }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -30,6 +30,16 @@ public abstract class CacheSupport<K, V> implements Cache<K, V> {
         return value;
     }
 
+    @Override
+    public V get(K key) {
+        return doGet(key);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        doCache(key, value);
+    }
+
     abstract protected <T extends K> V doGet(T key);
 
     abstract protected <T extends K, N extends V> void doCache(T key, N value);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
+import java.util.function.Function;
 
 public abstract class CacheSupport<K, V> implements Cache<K, V> {
 
     @Override
-    public V get(K key, Transformer<? extends V, ? super K> supplier) {
+    public V get(K key, Function<? super K, ? extends V> factory) {
         V value = doGet(key);
         if (value == null) {
-            value = supplier.transform(key);
+            value = factory.apply(key);
             doCache(key, value);
         }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.cache.internal;
 
-import java.util.function.Supplier;
+import org.gradle.api.Transformer;
 
 public abstract class CacheSupport<K, V> implements Cache<K, V> {
 
     @Override
-    public V get(K key, Supplier<V> supplier) {
+    public V get(K key, Transformer<V, K> supplier) {
         V value = doGet(key);
         if (value == null) {
-            value = supplier.get();
+            value = supplier.transform(key);
             doCache(key, value);
         }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -20,7 +20,7 @@ import org.gradle.api.Transformer;
 public abstract class CacheSupport<K, V> implements Cache<K, V> {
 
     @Override
-    public V get(K key, Transformer<V, K> supplier) {
+    public V get(K key, Transformer<? extends V, ? super K> supplier) {
         V value = doGet(key);
         if (value == null) {
             value = supplier.transform(key);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheSupport.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.cache.internal;
 
+import org.gradle.cache.Cache;
+
 import java.util.function.Function;
 
 public abstract class CacheSupport<K, V> implements Cache<K, V> {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -20,23 +20,19 @@ import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import java.util.function.Supplier;
 
 /**
  * An in-memory cache of calculated values that are used across builds. The implementation takes care of cleaning up state that is no longer required.
  */
 @ThreadSafe
-public interface CrossBuildInMemoryCache<K, V> {
+public interface CrossBuildInMemoryCache<K, V> extends Cache<K, V> {
     /**
      * Locates the given entry, using the supplied factory when the entry is not present or has been discarded, to recreate the entry in the cache.
      *
      * <p>Implementations must prevent more than one thread calculating the same key at the same time.
      */
+    @Override
     V get(K key, Transformer<V, K> factory);
-
-    default V get(K key, Supplier<V> factory) {
-        return get(key, __ -> factory.get());
-    }
 
     /**
      * Locates the given entry, if present. Returns {@code null} when missing.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -16,10 +16,11 @@
 
 package org.gradle.cache.internal;
 
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Supplier;
 
 /**
  * An in-memory cache of calculated values that are used across builds. The implementation takes care of cleaning up state that is no longer required.
@@ -32,6 +33,10 @@ public interface CrossBuildInMemoryCache<K, V> {
      * <p>Implementations must prevent more than one thread calculating the same key at the same time.
      */
     V get(K key, Transformer<V, K> factory);
+
+    default V get(K key, Supplier<V> factory) {
+        return get(key, __ -> factory.get());
+    }
 
     /**
      * Locates the given entry, if present. Returns {@code null} when missing.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -32,7 +32,7 @@ public interface CrossBuildInMemoryCache<K, V> extends Cache<K, V> {
      * <p>Implementations must prevent more than one thread calculating the same key at the same time.
      */
     @Override
-    V get(K key, Transformer<V, K> factory);
+    V get(K key, Transformer<? extends V, ? super K> factory);
 
     /**
      * Locates the given entry, if present. Returns {@code null} when missing.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -16,9 +16,8 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
-
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Function;
 
 /**
  * An in-memory cache of calculated values that are used across builds. The implementation takes care of cleaning up state that is no longer required.
@@ -31,7 +30,7 @@ public interface CrossBuildInMemoryCache<K, V> extends Cache<K, V> {
      * <p>Implementations must prevent more than one thread calculating the same key at the same time.
      */
     @Override
-    V get(K key, Transformer<? extends V, ? super K> factory);
+    V get(K key, Function<? super K, ? extends V> factory);
 
     /**
      * Removes all entries from this cache.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Transformer;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -33,16 +32,6 @@ public interface CrossBuildInMemoryCache<K, V> extends Cache<K, V> {
      */
     @Override
     V get(K key, Transformer<? extends V, ? super K> factory);
-
-    /**
-     * Locates the given entry, if present. Returns {@code null} when missing.
-     */
-    @Nullable V get(K key);
-
-    /**
-     * Adds the given value to the cache, replacing any existing value.
-     */
-    void put(K key, V value);
 
     /**
      * Removes all entries from this cache.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -16,6 +16,8 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.cache.Cache;
+
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.function.Function;
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossProcessSynchronizingCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossProcessSynchronizingCache.java
@@ -16,13 +16,12 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.CrossProcessCacheAccess;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.MultiProcessSafePersistentIndexedCache;
-import org.gradle.internal.Factory;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 /**
  * Applies cross-process file locking to a backing cache, to ensure that any in-memory and on file state is kept in sync while this process is read from or writing to the cache.
@@ -44,16 +43,11 @@ public class CrossProcessSynchronizingCache<K, V> implements MultiProcessSafePer
     @Nullable
     @Override
     public V get(final K key) {
-        return cacheAccess.withFileLock(new Factory<V>() {
-            @Override
-            public V create() {
-                return target.get(key);
-            }
-        });
+        return cacheAccess.withFileLock(() -> target.get(key));
     }
 
     @Override
-    public V get(final K key, final Transformer<? extends V, ? super K> producer) {
+    public V get(final K key, final Function<? super K, ? extends V> producer) {
         Runnable runnable = cacheAccess.acquireFileLock();
         return target.get(key, producer, runnable);
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.gradle.api.Transformer;
 import org.gradle.cache.AsyncCacheAccess;
 import org.gradle.cache.CacheDecorator;
 import org.gradle.cache.CrossProcessCacheAccess;
@@ -59,18 +58,15 @@ public class DefaultInMemoryCacheDecoratorFactory implements InMemoryCacheDecora
         }
         int targetSize = cacheSizer.scaleCacheSize(maxEntriesToKeepInMemory);
         CacheDetails cacheDetails = getCache(cacheId, targetSize);
-        return new InMemoryDecoratedCache<K, V>(backingCache, cacheDetails.entries, cacheId, cacheDetails.lockState);
+        return new InMemoryDecoratedCache<>(backingCache, cacheDetails.entries, cacheId, cacheDetails.lockState);
     }
 
     private CacheDetails getCache(final String cacheId, final int maxSize) {
-        CacheDetails cacheDetails = caches.get(cacheId, new Transformer<CacheDetails, String>() {
-            @Override
-            public CacheDetails transform(String cacheId) {
-                Cache<Object, Object> entries = createInMemoryCache(cacheId, maxSize);
-                CacheDetails cacheDetails = new CacheDetails(cacheId, maxSize, entries, new AtomicReference<FileLock.State>(null));
-                LOG.debug("Creating in-memory store for cache {} (max size: {})", cacheId, maxSize);
-                return cacheDetails;
-            }
+        CacheDetails cacheDetails = caches.get(cacheId, () -> {
+            Cache<Object, Object> entries = createInMemoryCache(cacheId, maxSize);
+            CacheDetails details = new CacheDetails(cacheId, maxSize, entries, new AtomicReference<>(null));
+            LOG.debug("Creating in-memory store for cache {} (max size: {})", cacheId, maxSize);
+            return details;
         });
         if (cacheDetails.maxEntries != maxSize) {
             throw new IllegalStateException("Mismatched in-memory store size for cache " + cacheId + ", expected: " + maxSize + ", found: " + cacheDetails.maxEntries);
@@ -114,9 +110,9 @@ public class DefaultInMemoryCacheDecoratorFactory implements InMemoryCacheDecora
 
         @Override
         public <K, V> MultiProcessSafePersistentIndexedCache<K, V> decorate(String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache<K, V> persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess) {
-            MultiProcessSafeAsyncPersistentIndexedCache<K, V> asyncCache = new AsyncCacheAccessDecoratedCache<K, V>(asyncCacheAccess, persistentCache);
+            MultiProcessSafeAsyncPersistentIndexedCache<K, V> asyncCache = new AsyncCacheAccessDecoratedCache<>(asyncCacheAccess, persistentCache);
             MultiProcessSafeAsyncPersistentIndexedCache<K, V> memCache = applyInMemoryCaching(cacheId, asyncCache, maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses);
-            return new CrossProcessSynchronizingCache<K, V>(memCache, crossProcessCacheAccess);
+            return new CrossProcessSynchronizingCache<>(memCache, crossProcessCacheAccess);
         }
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultMultiProcessSafePersistentIndexedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultMultiProcessSafePersistentIndexedCache.java
@@ -15,13 +15,14 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.FileAccess;
 import org.gradle.cache.FileIntegrityViolationException;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.MultiProcessSafePersistentIndexedCache;
 import org.gradle.cache.internal.btree.BTreePersistentIndexedCache;
 import org.gradle.internal.Factory;
+
+import java.util.function.Function;
 
 public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements MultiProcessSafePersistentIndexedCache<K, V> {
     private final FileAccess fileAccess;
@@ -42,22 +43,17 @@ public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements Mult
     public V get(final K key) {
         final BTreePersistentIndexedCache<K, V> cache = getCache();
         try {
-            return fileAccess.readFile(new Factory<V>() {
-                @Override
-                public V create() {
-                    return cache.get(key);
-                }
-            });
+            return fileAccess.readFile((Factory<V>) () -> cache.get(key));
         } catch (FileIntegrityViolationException e) {
             return null;
         }
     }
 
     @Override
-    public V get(K key, Transformer<? extends V, ? super K> producer) {
+    public V get(K key, Function<? super K, ? extends V> producer) {
         V value = get(key);
         if (value == null) {
-            value = producer.transform(key);
+            value = producer.apply(key);
             put(key, value);
         }
         return value;
@@ -68,12 +64,7 @@ public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements Mult
         final BTreePersistentIndexedCache<K, V> cache = getCache();
         // Use writeFile because the cache can internally recover from datafile
         // corruption, so we don't care at this level if it's corrupt
-        fileAccess.writeFile(new Runnable() {
-            @Override
-            public void run() {
-                cache.put(key, value);
-            }
-        });
+        fileAccess.writeFile(() -> cache.put(key, value));
     }
 
     @Override
@@ -81,12 +72,7 @@ public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements Mult
         final BTreePersistentIndexedCache<K, V> cache = getCache();
         // Use writeFile because the cache can internally recover from datafile
         // corruption, so we don't care at this level if it's corrupt
-        fileAccess.writeFile(new Runnable() {
-            @Override
-            public void run() {
-                cache.remove(key);
-            }
-        });
+        fileAccess.writeFile(() -> cache.remove(key));
     }
 
     @Override
@@ -97,12 +83,7 @@ public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements Mult
     public void finishWork() {
         if (cache != null) {
             try {
-                fileAccess.writeFile(new Runnable() {
-                    @Override
-                    public void run() {
-                        cache.close();
-                    }
-                });
+                fileAccess.writeFile(() -> cache.close());
             } finally {
                 cache = null;
             }
@@ -117,12 +98,7 @@ public class DefaultMultiProcessSafePersistentIndexedCache<K, V> implements Mult
         if (cache == null) {
             // Use writeFile because the cache can internally recover from datafile
             // corruption, so we don't care at this level if it's corrupt
-            fileAccess.writeFile(new Runnable() {
-                @Override
-                public void run() {
-                    cache = factory.create();
-                }
-            });
+            fileAccess.writeFile(() -> cache = factory.create());
         }
         return cache;
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -20,7 +20,6 @@ import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 
 import javax.annotation.Nullable;
-import java.util.function.Supplier;
 
 public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     private final PersistentIndexedCache<K, V> cache;
@@ -30,21 +29,7 @@ public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(K key, Supplier<V> supplier) {
-        V cached = cache.get(key);
-        if (cached != null) {
-            return cached;
-        }
-
-        V value = supplier.get(); //don't synchronize value creation
-        //we could potentially avoid creating value that is already being created by a different thread.
-
-        cache.put(key, value);
-        return value;
-    }
-
-    @Override
-    public V get(K key, Transformer<V, K> supplier) {
+    public V get(K key, Transformer<? extends V, ? super K> supplier) {
         V cached = cache.get(key);
         if (cached != null) {
             return cached;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -17,7 +17,8 @@
 package org.gradle.cache.internal;
 
 import org.gradle.cache.PersistentIndexedCache;
-import org.gradle.internal.Factory;
+
+import java.util.function.Supplier;
 
 public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     private final PersistentIndexedCache<K, V> cache;
@@ -27,13 +28,13 @@ public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(K key, Factory<V> factory) {
+    public V get(K key, Supplier<V> supplier) {
         V cached = cache.get(key);
         if (cached != null) {
             return cached;
         }
 
-        V value = factory.create(); //don't synchronize value creation
+        V value = supplier.get(); //don't synchronize value creation
         //we could potentially avoid creating value that is already being created by a different thread.
 
         cache.put(key, value);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -16,8 +16,10 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 
+import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 public class MinimalPersistentCache<K, V> implements Cache<K, V> {
@@ -41,6 +43,21 @@ public class MinimalPersistentCache<K, V> implements Cache<K, V> {
         return value;
     }
 
+    @Override
+    public V get(K key, Transformer<V, K> supplier) {
+        V cached = cache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        V value = supplier.transform(key); //don't synchronize value creation
+        //we could potentially avoid creating value that is already being created by a different thread.
+
+        cache.put(key, value);
+        return value;
+    }
+
+    @Nullable
     public V get(K value) {
         return cache.get(value);
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -16,8 +16,9 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
+
+import java.util.function.Function;
 
 public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     private final PersistentIndexedCache<K, V> cache;
@@ -27,13 +28,13 @@ public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V get(K key, Transformer<? extends V, ? super K> supplier) {
+    public V get(K key, Function<? super K, ? extends V> factory) {
         V cached = cache.get(key);
         if (cached != null) {
             return cached;
         }
 
-        V value = supplier.transform(key); //don't synchronize value creation
+        V value = factory.apply(key); //don't synchronize value creation
         //we could potentially avoid creating value that is already being created by a different thread.
 
         cache.put(key, value);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -19,8 +19,6 @@ package org.gradle.cache.internal;
 import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 
-import javax.annotation.Nullable;
-
 public class MinimalPersistentCache<K, V> implements Cache<K, V> {
     private final PersistentIndexedCache<K, V> cache;
 
@@ -42,8 +40,13 @@ public class MinimalPersistentCache<K, V> implements Cache<K, V> {
         return value;
     }
 
-    @Nullable
+    @Override
     public V get(K value) {
         return cache.get(value);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        cache.put(key, value);
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MinimalPersistentCache.java
@@ -16,6 +16,7 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.cache.Cache;
 import org.gradle.cache.PersistentIndexedCache;
 
 import java.util.function.Function;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MultiProcessSafeAsyncPersistentIndexedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/MultiProcessSafeAsyncPersistentIndexedCache.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.cache.internal;
 
-import org.gradle.api.Transformer;
 import org.gradle.cache.UnitOfWorkParticipant;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 /**
  * An indexed cache that may perform updates asynchronously.
@@ -33,7 +33,7 @@ public interface MultiProcessSafeAsyncPersistentIndexedCache<K, V> extends UnitO
     /**
      * Fetches the given entry, producing if necessary, blocking until the result is available. This method may or may not block until any updates have completed and will invoke the given completion action when the operation is complete.
      */
-    V get(K key, Transformer<? extends V, ? super K> producer, Runnable completion);
+    V get(K key, Function<? super K, ? extends V> producer, Runnable completion);
 
     /**
      * Submits an update to be applied later. This method may or may not block, and will invoke the given completion action when the operation is complete.

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/MapBackedCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/MapBackedCacheTest.groovy
@@ -15,8 +15,9 @@
  */
 package org.gradle.cache.internal
 
-import org.gradle.internal.Factory
 import spock.lang.Specification
+
+import java.util.function.Supplier
 
 class MapBackedCacheTest extends Specification {
 
@@ -30,8 +31,8 @@ class MapBackedCacheTest extends Specification {
         def cache = cache(map)
 
         expect:
-        cache.get("a", { 1 } as Factory) == 1
-        cache.get("a", { 2 } as Factory) == 1
+        cache.get("a", { 1 } as Supplier) == 1
+        cache.get("a", { 2 } as Supplier) == 1
 
         and:
         map.a == 1
@@ -40,7 +41,7 @@ class MapBackedCacheTest extends Specification {
         map.clear()
 
         then:
-        cache.get("a", { 2 } as Factory) == 2
+        cache.get("a", { 2 } as Supplier) == 2
     }
 
 }


### PR DESCRIPTION
This is a preparation for using a Gradle `Cache` in `IdentityCacheStep` instead of a Guava cache.