### PR TITLE
Fix end tags in normalization Kotlin samples

### DIFF
--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/build.gradle.kts
@@ -20,7 +20,7 @@ normalization {
         }
     }
 }
-// end::ignore-metainf-manifest[]
+// end::ignore-metainf-properties[]
 
 // tag::ignore-metainf-manifest[]
 normalization {
@@ -30,7 +30,7 @@ normalization {
         }
     }
 }
-// end::ignore-metainf-completely[]
+// end::ignore-metainf-manifest[]
 
 // tag::ignore-metainf-completely[]
 normalization {


### PR DESCRIPTION
Using the wrong end tags caused all samples to be rendered at once.
