### PR TITLE
Improve traceability of imported dependencies

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.internal.Actions;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.List;
@@ -32,6 +33,13 @@ import java.util.List;
 @Incubating
 @HasInternalProtocol
 public interface DependenciesModelBuilder {
+
+    /**
+     * A description for the dependencies model, which will be used in
+     * the generated sources as documentation.
+     * @return the description for this model
+     */
+    Property<String> getDescription();
 
     /**
      * Configures the model by reading it from a version catalog.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
@@ -259,7 +259,7 @@ class TomlDependenciesFileParserTest extends Specification {
     }
 
     void hasBundle(String id, List<String> expectedElements) {
-        def bundle = model.getBundle(id)
+        def bundle = model.getBundle(id)?.components
         assert bundle != null: "Expected a bundle with name $id but it wasn't found"
         assert bundle == expectedElements
     }
@@ -269,7 +269,7 @@ class TomlDependenciesFileParserTest extends Specification {
     }
 
     void hasVersion(String id, String version) {
-        def versionConstraint = model.getVersion(id)
+        def versionConstraint = model.getVersion(id)?.version
         assert versionConstraint != null : "Expected a version constraint with name $id but didn't find one"
         def actual = versionConstraint.toString()
         assert actual == version

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -639,7 +639,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation "org.gradle.test:lib:\${libs.libVersion}"
+                implementation "org.gradle.test:lib:\${libs.libVersion.get()}"
             }
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -168,7 +168,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                         require "1.0"
                     }
                     alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("my", ["lib", "lib2"])
+                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -178,7 +178,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle)
+                implementation(libs.bundles.myBundle)
             }
         """
 
@@ -208,7 +208,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                         require "1.0"
                     }
                     alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("my", ["lib", "lib2"])
+                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -218,7 +218,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle) {
+                implementation(libs.bundles.myBundle) {
                     version {
                         require '1.1'
                     }
@@ -628,7 +628,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    version("lib") {
+                    version("libVersion") {
                         $notation
                     }
                 }
@@ -639,7 +639,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation "org.gradle.test:lib:\${libs.libVersion.get()}"
+                implementation "org.gradle.test:lib:\${libs.versions.libVersion.get()}"
             }
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -156,7 +156,7 @@ lib2.module = "org.gradle.test:lib2"
 lib2.version = "1.0
 
 [bundles]
-my = ["lib", "lib2"]
+myBundle = ["lib", "lib2"]
 """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.0").publish()
         def lib2 = mavenHttpRepo.module("org.gradle.test", "lib2", "1.0").publish()
@@ -164,7 +164,7 @@ my = ["lib", "lib2"]
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle)
+                implementation(libs.bundles.myBundle)
             }
         """
 
@@ -193,7 +193,7 @@ lib2.module = "org.gradle.test:lib2"
 lib2.version = "1.0
 
 [bundles]
-my = ["lib", "lib2"]
+myBundle = ["lib", "lib2"]
 """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1").publish()
         def lib2 = mavenHttpRepo.module("org.gradle.test", "lib2", "1.1").publish()
@@ -201,7 +201,7 @@ my = ["lib", "lib2"]
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle) {
+                implementation(libs.bundles.myBundle) {
                     version {
                         require '1.1'
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractContextAwareModel.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractContextAwareModel.java
@@ -13,12 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.management;
+package org.gradle.api.internal.std;
 
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
-import org.gradle.api.internal.std.AllDependenciesModel;
+import javax.annotation.Nullable;
+import java.io.Serializable;
 
-public interface DependenciesModelBuilderInternal extends DependenciesModelBuilder {
-    AllDependenciesModel build();
-    void withContext(String context, Runnable action);
+public class AbstractContextAwareModel implements Serializable {
+    protected final String context;
+
+    public AbstractContextAwareModel(@Nullable String context) {
+        this.context = context;
+    }
+
+    /**
+     * The context where this dependency model was built from, used
+     * for debugging and giving hints to the user.
+     * It's intentionally not part of the identity.
+     *
+     * @return the context
+     */
+    @Nullable
+    public String getContext() {
+        return context;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -40,7 +40,11 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
      * @param name the name of the version alias
      * @return a single version string or an empty string
      */
-    protected String getVersion(String name) {
+    protected Provider<String> getVersion(String name) {
+        return providers.provider(() -> doGetVersion(name));
+    }
+
+    private String doGetVersion(String name) {
         ImmutableVersionConstraint version = config.getVersion(name);
         String requiredVersion = version.getRequiredVersion();
         if (!requiredVersion.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -45,7 +45,7 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
     }
 
     private String doGetVersion(String name) {
-        ImmutableVersionConstraint version = config.getVersion(name);
+        ImmutableVersionConstraint version = config.getVersion(name).getVersion();
         String requiredVersion = version.getRequiredVersion();
         if (!requiredVersion.isEmpty()) {
             return requiredVersion;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -34,41 +34,46 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         this.providers = providers;
     }
 
-    /**
-     * Returns a single version string from a rich version
-     * constraint, assuming the user knows what they are doing.
-     * @param name the name of the version alias
-     * @return a single version string or an empty string
-     */
-    protected Provider<String> getVersion(String name) {
-        return providers.provider(() -> doGetVersion(name));
-    }
-
-    private String doGetVersion(String name) {
-        ImmutableVersionConstraint version = config.getVersion(name).getVersion();
-        String requiredVersion = version.getRequiredVersion();
-        if (!requiredVersion.isEmpty()) {
-            return requiredVersion;
-        }
-        String strictVersion = version.getStrictVersion();
-        if (!strictVersion.isEmpty()) {
-            return strictVersion;
-        }
-        return version.getPreferredVersion();
-    }
-
     protected Provider<MinimalExternalModuleDependency> create(String alias) {
         return providers.of(DependencyValueSource.class,
             spec -> spec.getParameters().getDependencyData().set(config.getDependencyData(alias)))
             .forUseAtConfigurationTime();
     }
 
-    protected Provider<ExternalModuleDependencyBundle> createBundle(String name) {
-        return providers.of(DependencyBundleValueSource.class,
-            spec -> spec.parameters(params -> {
-                params.getConfig().set(config);
-                params.getBundleName().set(name);
-            }))
-            .forUseAtConfigurationTime();
+    protected class VersionFactory {
+        /**
+         * Returns a single version string from a rich version
+         * constraint, assuming the user knows what they are doing.
+         *
+         * @param name the name of the version alias
+         * @return a single version string or an empty string
+         */
+        protected Provider<String> getVersion(String name) {
+            return providers.provider(() -> doGetVersion(name));
+        }
+
+        private String doGetVersion(String name) {
+            ImmutableVersionConstraint version = config.getVersion(name).getVersion();
+            String requiredVersion = version.getRequiredVersion();
+            if (!requiredVersion.isEmpty()) {
+                return requiredVersion;
+            }
+            String strictVersion = version.getStrictVersion();
+            if (!strictVersion.isEmpty()) {
+                return strictVersion;
+            }
+            return version.getPreferredVersion();
+        }
+    }
+
+    protected class BundleFactory {
+        protected Provider<ExternalModuleDependencyBundle> createBundle(String name) {
+            return providers.of(DependencyBundleValueSource.class,
+                spec -> spec.parameters(params -> {
+                    params.getConfig().set(config);
+                    params.getBundleName().set(name);
+                }))
+                .forUseAtConfigurationTime();
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AllDependenciesModel.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AllDependenciesModel.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.internal.std;
 
-import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -24,15 +22,19 @@ import java.util.stream.Collectors;
 
 public class AllDependenciesModel implements Serializable {
     private final String name;
+    private final String description;
     private final Map<String, DependencyModel> aliasToDependency;
-    private final Map<String, List<String>> bundles;
-    private final Map<String, ImmutableVersionConstraint> versions;
+    private final Map<String, BundleModel> bundles;
+    private final Map<String, VersionModel> versions;
     private final int hashCode;
 
-    public AllDependenciesModel(String name, Map<String, DependencyModel> aliasToDependency,
-                                Map<String, List<String>> bundles,
-                                Map<String, ImmutableVersionConstraint> versions) {
+    public AllDependenciesModel(String name,
+                                String description,
+                                Map<String, DependencyModel> aliasToDependency,
+                                Map<String, BundleModel> bundles,
+                                Map<String, VersionModel> versions) {
         this.name = name;
+        this.description = description;
         this.aliasToDependency = aliasToDependency;
         this.bundles = bundles;
         this.versions = versions;
@@ -41,6 +43,11 @@ public class AllDependenciesModel implements Serializable {
 
     public String getName() {
         return name;
+    }
+
+    // Intentionally not part of state
+    public String getDescription() {
+        return description;
     }
 
     public List<String> getDependencyAliases() {
@@ -68,11 +75,11 @@ public class AllDependenciesModel implements Serializable {
             .collect(Collectors.toList());
     }
 
-    public List<String> getBundle(String name) {
+    public BundleModel getBundle(String name) {
         return bundles.get(name);
     }
 
-    public ImmutableVersionConstraint getVersion(String name) {
+    public VersionModel getVersion(String name) {
         return versions.get(name);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/BundleModel.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/BundleModel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.std;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class BundleModel extends AbstractContextAwareModel {
+    private final List<String> components;
+
+    public BundleModel(List<String> components, @Nullable String context) {
+        super(context);
+        this.components = components;
+    }
+
+    public List<String> getComponents() {
+        return components;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BundleModel that = (BundleModel) o;
+
+        return components.equals(that.components);
+    }
+
+    @Override
+    public int hashCode() {
+        return components.hashCode();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 public class DefaultDependenciesModelBuilder implements DependenciesModelBuilderInternal {
     private final static Logger LOGGER = Logging.getLogger(DefaultDependenciesModelBuilder.class);
     private final static Attribute<String> INTERNAL_COUNTER = Attribute.of("org.gradle.internal.dm.model.builder.id", String.class);
+    private final static List<String> FORBIDDEN_ALIAS_SUFFIX = ImmutableList.of("bundles", "versions", "version", "bundle");
 
     private final Interner<String> strings;
     private final Interner<ImmutableVersionConstraint> versionConstraintInterner;
@@ -279,6 +280,18 @@ public class DefaultDependenciesModelBuilder implements DependenciesModelBuilder
     private static void validateName(String type, String value) {
         if (!DependenciesModelHelper.ALIAS_PATTERN.matcher(value).matches()) {
             throw new InvalidUserDataException("Invalid " + type + " name '" + value + "': it must match the following regular expression: " + DependenciesModelHelper.ALIAS_REGEX);
+        }
+        if ("alias".equals(type)) {
+            validateAlias(value);
+        }
+    }
+
+    private static void validateAlias(String alias) {
+        for (String suffix : FORBIDDEN_ALIAS_SUFFIX) {
+            String sl = alias.toLowerCase();
+            if (sl.endsWith(suffix)) {
+                throw new InvalidUserDataException("Invalid alias name '" + alias + "': it must not end with '" + suffix + "'");
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependenciesSourceGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependenciesSourceGenerator.java
@@ -104,7 +104,7 @@ public class DependenciesSourceGenerator extends AbstractSourceGenerator {
             writeLn("     * If the version is a rich version and that its not expressable as a");
             writeLn("     * single version string, then an empty string is returned.");
             writeLn("     */");
-            writeLn("    public String get" + toJavaName(version) + "Version() { return getVersion(\"" + version + "\"); }");
+            writeLn("    public Provider<String> get" + toJavaName(version) + "Version() { return getVersion(\"" + version + "\"); }");
             writeLn();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyBundleValueSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyBundleValueSource.java
@@ -26,7 +26,6 @@ import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public abstract class DependencyBundleValueSource implements ValueSource<ExternalModuleDependencyBundle, DependencyBundleValueSource.Params> {
@@ -41,8 +40,8 @@ public abstract class DependencyBundleValueSource implements ValueSource<Externa
     public ExternalModuleDependencyBundle obtain() {
         String bundle = getParameters().getBundleName().get();
         AllDependenciesModel config = getParameters().getConfig().get();
-        List<String> aliases = config.getBundle(bundle);
-        return aliases.stream()
+        BundleModel bundleModel = config.getBundle(bundle);
+        return bundleModel.getComponents().stream()
             .map(config::getDependencyData)
             .map(this::createDependency)
             .collect(Collectors.toCollection(DefaultBundle::new));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyModel.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyModel.java
@@ -18,9 +18,8 @@ package org.gradle.api.internal.std;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 
 import javax.annotation.Nullable;
-import java.io.Serializable;
 
-public class DependencyModel implements Serializable {
+public class DependencyModel extends AbstractContextAwareModel {
     private final String group;
     private final String name;
     private final ImmutableVersionConstraint version;
@@ -30,7 +29,9 @@ public class DependencyModel implements Serializable {
     public DependencyModel(String group,
                            String name,
                            @Nullable String versionRef,
-                           ImmutableVersionConstraint version) {
+                           ImmutableVersionConstraint version,
+                           @Nullable String context) {
+        super(context);
         this.group = group;
         this.name = name;
         this.version = version;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/VersionModel.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/VersionModel.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.std;
+
+import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
+
+import javax.annotation.Nullable;
+
+public class VersionModel extends AbstractContextAwareModel {
+    private final ImmutableVersionConstraint version;
+
+    public VersionModel(ImmutableVersionConstraint version, @Nullable String context) {
+        super(context);
+        this.version = version;
+    }
+
+    public ImmutableVersionConstraint getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        VersionModel that = (VersionModel) o;
+
+        return version.equals(that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return version.hashCode();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -147,7 +147,8 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         validateName(name);
         DependenciesModelBuilderInternal model = dependenciesModelBuilders.computeIfAbsent(name, n ->
             objects.newInstance(DefaultDependenciesModelBuilder.class, n, strings, versions, objects, providers, plugins, dependencyResolutionServices));
-        spec.execute(model);
+        UserCodeApplicationContext.Application current = context.current();
+        model.withContext(current == null ? "Settings" : current.getDisplayName().getDisplayName(), () -> spec.execute(model));
     }
 
     private static void validateName(String name) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -60,6 +60,25 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         notation << ["", "a", "1a", "A", "Aa", "abc\$", "abc&"]
     }
 
+    @Unroll
+    def "forbids using #name as a dependency alias"() {
+        when:
+        builder.alias(name).to("org:foo:1.0")
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == "Invalid alias name '$name': it must not end with '$suffix'"
+
+        where:
+        name          | suffix
+        "bundles"     | "bundles"
+        "versions"    | "versions"
+        "fooBundle"   | "bundle"
+        "fooVersion"  | "version"
+        "foo.bundle"  | "bundle"
+        "foo.version" | "version"
+    }
+
     @Unroll("#notation is an invalid bundle name")
     def "reasonable error message if bundle name is invalid"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -140,7 +140,7 @@ class DefaultDependenciesModelBuilderTest extends Specification {
 
         then:
         model.bundleAliases == ["groovy"]
-        model.getBundle("groovy") == ["groovy", "groovy-json"]
+        model.getBundle("groovy").components == ["groovy", "groovy-json"]
 
         model.dependencyAliases == ["groovy", "groovy-json", "guava"]
         model.getDependencyData("guava").version.requiredVersion == '17.0'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -304,7 +304,7 @@ class DependenciesSourceGeneratorTest extends Specification {
         }
 
         void hasVersion(String name, String methodName = "get${toJavaName(name)}Version") {
-            def lookup = "public String $methodName() { return getVersion(\"$name\"); }"
+            def lookup = "public Provider<String> $methodName() { return getVersion(\"$name\"); }"
             assert lines.find {
                 it.contains(lookup)
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -111,10 +111,12 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasBundle(name, method)
 
         where:
-        name        | method
-        'test'      | 'getTestBundle'
-        'test.json' | 'getTestJsonBundle'
-        'a.b'       | 'getABBundle'
+        name          | method
+        'test'        | 'getTest'
+        'testBundle'  | 'getTestBundle'
+        'test.bundle' | 'getTestBundle'
+        'test.json'   | 'getTestJson'
+        'a.b'         | 'getAB'
     }
 
     @Unroll
@@ -128,12 +130,14 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasVersion(name, method)
 
         where:
-        name          | method
-        'groovy'      | 'getGroovyVersion'
-        'groovy-json' | 'getGroovyJsonVersion'
-        'groovy.json' | 'getGroovyJsonVersion'
-        'groovyJson'  | 'getGroovyJsonVersion'
-        'lang3'       | 'getLang3Version'
+        name             | method
+        'groovy'         | 'getGroovy'
+        'groovyVersion'  | 'getGroovyVersion'
+        'groovy.version' | 'getGroovyVersion'
+        'groovy-json'    | 'getGroovyJson'
+        'groovy.json'    | 'getGroovyJson'
+        'groovyJson'     | 'getGroovyJson'
+        'lang3Version'   | 'getLang3Version'
     }
 
     def "reasonable error message if methods have the same name"() {
@@ -196,37 +200,12 @@ class DependenciesSourceGeneratorTest extends Specification {
   - dependency bundles other.cool and otherCool and other_cool are mapped to the same accessor name getOtherCoolBundle()'''
     }
 
-    def 'reasonable error message if an alias ends with bundle'() {
-        when:
-        generate {
-            alias('foo') to 'g:a:v'
-            alias('barBundle') to 'g:a:v'
-        }
-
-        then:
-        InvalidUserDataException ex = thrown()
-        ex.message == "Cannot generate dependency accessors because alias barBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'"
-
-        when:
-        generate {
-            alias('foo') to 'g:a:v'
-            alias('bazBundle') to 'g:a:v'
-            alias('barBundle') to 'g:a:v'
-        }
-
-        then:
-        ex = thrown()
-        normaliseLineSeparators(ex.message) == """Cannot generate dependency accessors because:
-  - alias barBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'
-  - alias bazBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'"""
-    }
-
     def "generated sources can be compiled"() {
         when:
         generate {
             alias('foo') to 'g:a:v'
             alias('bar') to 'g2:a2:v2'
-            bundle('my', ['foo', 'bar'])
+            bundle('myBundle', ['foo', 'bar'])
         }
 
         then:
@@ -241,7 +220,7 @@ class DependenciesSourceGeneratorTest extends Specification {
         assert bar.module.name == 'a2'
         assert bar.versionConstraint.requiredVersion == 'v2'
 
-        def bundle = libs.myBundle.get()
+        def bundle = libs.bundles.myBundle.get()
         assert bundle == [foo, bar]
     }
 
@@ -267,19 +246,19 @@ class DependenciesSourceGeneratorTest extends Specification {
             description.set("Some description for tests")
             withContext(context) {
                 alias("some-alias").to 'g:a:v'
-                bundle("b0", ["some-alias"])
+                bundle("b0Bundle", ["some-alias"])
                 withContext(innerContext) {
-                    version("v0", "1.0")
+                    version("v0Version", "1.0")
                 }
-                alias("other").to("g", "a").versionRef("v0")
+                alias("other").to("g", "a").versionRef("v0Version")
             }
         }
 
         then:
         sources.assertClass('Generated', 'Some description for tests')
         sources.hasDependencyAlias('some-alias', 'getSomeAlias', "This dependency was declared in ${context}")
-        sources.hasBundle('b0', 'getB0Bundle', "This bundle was declared in ${context}")
-        sources.hasVersion('v0', 'getV0Version', "This version was declared in ${innerContext}")
+        sources.hasBundle('b0Bundle', 'getB0Bundle', "This bundle was declared in ${context}")
+        sources.hasVersion('v0Version', 'getV0Version', "This version was declared in ${innerContext}")
         sources.hasDependencyAlias('other', 'getOther', "This dependency was declared in ${context}")
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlWriter.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlWriter.java
@@ -48,7 +48,7 @@ class TomlWriter {
         writeTableHeader("versions");
         for (String alias : versions) {
             writer.print(alias + " = ");
-            writer.println(versionString(model.getVersion(alias)));
+            writer.println(versionString(model.getVersion(alias).getVersion()));
         }
         writer.println();
     }
@@ -90,7 +90,7 @@ class TomlWriter {
         }
         writeTableHeader("bundles");
         for (String alias : aliases) {
-            List<String> bundle = model.getBundle(alias);
+            List<String> bundle = model.getBundle(alias).getComponents();
             writer.println(alias + " = [" + bundle.stream().map(TomlWriter::quoted).collect(Collectors.joining(", ")) + "]");
         }
         writer.println();


### PR DESCRIPTION
### Context

Following comments from @JLLeitschuh about the current `dependenciesModel` API, this PR improves the traceability of dependency declarations by capturing the context in which the model is fed and outputting it in the generated sources for the accessors.

As a consequence, users can see quick hints about where a dependency was declared:

![image](https://user-images.githubusercontent.com/316357/97974943-a000be00-1dc8-11eb-9d06-552cc67bac6e.png)

It also changes the type of the returned strings for versions accessors from `String` to `Provider<String>`, which should help us in the future to provide more context about where something is declared.

This PR does _not_ improve the dependency insight report to provide information about where a dependency declaration comes from as it is a much trickier problem, particularly performance-wise.
