### PR TITLE
Make sure the dependencies model supports no version

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/DependenciesModelBuilder.java
@@ -129,5 +129,12 @@ public interface DependenciesModelBuilder {
          * @param versionRef the version reference
          */
         void versionRef(String versionRef);
+
+        /**
+         * Do not associate this alias to a particular version, in which
+         * case the dependency notation will just have group and artifact.
+         *
+         */
+        void withoutVersion();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
@@ -184,7 +184,7 @@ public class TomlDependenciesFileParser {
         List<String> rejectedVersions = null;
         Boolean rejectAll = null;
         if (version instanceof String) {
-            require = notEmpty((String) version, "version", alias);
+            require = (String) version;
             StrictVersionParser.RichVersion richVersion = strictVersionParser.parse(require);
             require = richVersion.require;
             prefer = richVersion.prefer;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
@@ -238,6 +238,22 @@ class TomlDependenciesFileParserTest extends Specification {
         'invalid15' | "Referenced version 'nope' doesn't exist on dependency com:foo"
     }
 
+    def "supports dependencies without version"() {
+        when:
+        parse 'without-version'
+
+        then:
+        hasDependency("alias1") {
+            withGAV("g:a:")
+        }
+        hasDependency("alias2") {
+            withGAV("g:a:")
+        }
+        hasDependency("alias3") {
+            withGAV("g:a:")
+        }
+    }
+
     void hasDependency(String name, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = DependencySpec) Closure<Void> spec) {
         def data = model.getDependencyData(name)
         assert data != null: "Expected a dependency with alias $name but it wasn't found"
@@ -314,7 +330,8 @@ class TomlDependenciesFileParserTest extends Specification {
 
         void withGAV(String gav) {
             def coord = gav.split(':')
-            withGAV(coord[0], coord[1], coord[2])
+            def v = coord.length>2 ? coord[2] : ''
+            withGAV(coord[0], coord[1], v)
         }
 
         void withGAV(String group, String name, String version) {

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/std/without-version.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/std/without-version.toml
@@ -1,0 +1,4 @@
+[dependencies]
+alias1 = { module = "g:a" }
+alias2 = { group = "g", name = "a", version = "" }
+alias3 = { group = "g", name = "a" }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
@@ -267,6 +267,11 @@ public class DefaultDependenciesModelBuilder implements DependenciesModelBuilder
         public void versionRef(String versionRef) {
             owner.createAliasWithVersionRef(alias, group, name, versionRef);
         }
+
+        @Override
+        public void withoutVersion() {
+            version("");
+        }
     }
 
     private void createAliasWithVersionRef(String alias, String group, String name, String versionRef) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -189,6 +189,16 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         model.getDependencyData("foo").version.strictVersion == "1.7"
     }
 
+    def "can create an alias with an empty version"() {
+        builder.alias("foo").to("org", "foo").withoutVersion()
+
+        when:
+        def model = builder.build()
+
+        then:
+        model.getDependencyData("foo").version.requiredVersion == ""
+    }
+
     def "reasonable error message if referenced version doesn't exist"() {
         builder.alias("foo").to("org", "foo").versionRef("nope")
 


### PR DESCRIPTION
There are cases where the version is going to be set by a platform so you
effectively don't want to use a version (e.g, jupiter-engine).
