### PR TITLE
Do not require implementation to be specified for a unit of work

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -101,7 +101,9 @@ public interface UnitOfWork extends Describable {
      *
      * TODO Move this to {@link #visitInputs(InputVisitor)}
      */
-    void visitImplementations(ImplementationVisitor visitor);
+    default void visitImplementations(ImplementationVisitor visitor) {
+        visitor.visitImplementation(getClass());
+    }
 
     interface ImplementationVisitor {
         void visitImplementation(Class<?> implementation);

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -161,10 +161,6 @@ class GenerateProjectAccessors(
 
     override fun getDisplayName(): String = "Kotlin DSL accessors for $project"
 
-    override fun visitImplementations(visitor: UnitOfWork.ImplementationVisitor) {
-        visitor.visitImplementation(GenerateProjectAccessors::class.java)
-    }
-
     override fun visitInputs(visitor: UnitOfWork.InputVisitor) {
         visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY, IDENTITY) { hashCodeFor(projectSchema) }
         visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, NON_INCREMENTAL, IDENTITY, classPath) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -162,10 +162,6 @@ class GeneratePluginAccessors(
 
     override fun getDisplayName(): String = "Kotlin DSL plugin accessors for classpath '$classLoaderHash'"
 
-    override fun visitImplementations(visitor: UnitOfWork.ImplementationVisitor) {
-        visitor.visitImplementation(GeneratePluginAccessors::class.java)
-    }
-
     override fun visitInputs(visitor: UnitOfWork.InputVisitor) {
         visitor.visitInputProperty(BUILD_SRC_CLASSLOADER_INPUT_PROPERTY, IDENTITY) { classLoaderHash }
     }


### PR DESCRIPTION
We only need to specify an implementation type for user-defined work units. For others we can default to using the type itself automatically.

@bot-gradle test QFL please.