### PR TITLE
Include configured option in toolchains report

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -181,6 +181,10 @@ In order to see which toolchains got detected and their corresponding metadata, 
 
 Output of `gradle -q javaToolchains`:
 ```
+ + Options
+     | Auto-detection enabled?  Yes
+     | Auto-download enabled?   Yes
+
  + AdoptOpenJDK 1.8.0_242
      | Location:           /path/to/8.0.242.hs-adpt/jre
      | Language Version:   8

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -182,8 +182,8 @@ In order to see which toolchains got detected and their corresponding metadata, 
 Output of `gradle -q javaToolchains`:
 ```
  + Options
-     | Auto-detection enabled?  Yes
-     | Auto-download enabled?   Yes
+     | Auto-detection:     Enabled
+     | Auto-download:      Enabled
 
  + AdoptOpenJDK 1.8.0_242
      | Location:           /path/to/8.0.242.hs-adpt/jre

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/task/ShowToolchainsTask.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/task/ShowToolchainsTask.java
@@ -68,10 +68,10 @@ public class ShowToolchainsTask extends DefaultTask {
         boolean detectionEnabled = getBooleanProperty(AutoDetectingInstallationSupplier.AUTO_DETECT);
         boolean downloadEnabled = getBooleanProperty(DefaultJavaToolchainProvisioningService.AUTO_DOWNLOAD);
         output.withStyle(Identifier).println(" + Options");
-        output.withStyle(Normal).format("     | %s", Strings.padEnd("Auto-detection enabled?", 25, ' '));
-        output.withStyle(Description).println(detectionEnabled ? "Yes" : "No");
-        output.withStyle(Normal).format("     | %s", Strings.padEnd("Auto-download enabled?", 25, ' '));
-        output.withStyle(Description).println(downloadEnabled ? "Yes" : "No");
+        output.withStyle(Normal).format("     | %s", Strings.padEnd("Auto-detection:", 20, ' '));
+        output.withStyle(Description).println(detectionEnabled ? "Enabled" : "Disabled");
+        output.withStyle(Normal).format("     | %s", Strings.padEnd("Auto-download:", 20, ' '));
+        output.withStyle(Description).println(downloadEnabled ? "Enabled" : "Disabled");
         output.println();
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
@@ -66,8 +66,8 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         then:
         output.value == """
 {identifier} + Options{normal}
-     | Auto-detection enabled?  {description}Yes{normal}
-     | Auto-download enabled?   {description}Yes{normal}
+     | Auto-detection:     {description}Enabled{normal}
+     | Auto-download:      {description}Enabled{normal}
 
 {identifier} + AdoptOpenJDK JRE 1.8.0_202{normal}
      | Location:           {description}path{normal}
@@ -125,8 +125,8 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         then:
         output.value == """
 {identifier} + Options{normal}
-     | Auto-detection enabled?  {description}Yes{normal}
-     | Auto-download enabled?   {description}Yes{normal}
+     | Auto-detection:     {description}Enabled{normal}
+     | Auto-download:      {description}Enabled{normal}
 
 {identifier} + AdoptOpenJDK JRE 14{normal}
      | Location:           {description}path{normal}
@@ -154,8 +154,8 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         then:
         output.value == """
 {identifier} + Options{normal}
-     | Auto-detection enabled?  {description}No{normal}
-     | Auto-download enabled?   {description}No{normal}
+     | Auto-detection:     {description}Disabled{normal}
+     | Auto-download:      {description}Disabled{normal}
 
 """
     }
@@ -176,8 +176,8 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         then:
         output.value == """
 {identifier} + Options{normal}
-     | Auto-detection enabled?  {description}Yes{normal}
-     | Auto-download enabled?   {description}Yes{normal}
+     | Auto-detection:     {description}Enabled{normal}
+     | Auto-download:      {description}Enabled{normal}
 
 {identifier} + Invalid toolchains{normal}
 {identifier}     + path{normal}


### PR DESCRIPTION
This helps us and users to quickly see how Gradle is configured with regards to toolchains. 