### PR TITLE
Alternate implementation for bundle and version accessors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -168,7 +168,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                         require "1.0"
                     }
                     alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("my", ["lib", "lib2"])
+                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -178,7 +178,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle)
+                implementation(libs.bundles.myBundle)
             }
         """
 
@@ -208,7 +208,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                         require "1.0"
                     }
                     alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("my", ["lib", "lib2"])
+                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -218,7 +218,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle) {
+                implementation(libs.bundles.myBundle) {
                     version {
                         require '1.1'
                     }
@@ -628,7 +628,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         settingsFile << """
             dependencyResolutionManagement {
                 dependenciesModel("libs") {
-                    version("lib") {
+                    version("libVersion") {
                         $notation
                     }
                 }
@@ -639,7 +639,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
             apply plugin: 'java-library'
 
             dependencies {
-                implementation "org.gradle.test:lib:\${libs.libVersion.get()}"
+                implementation "org.gradle.test:lib:\${libs.versions.libVersion.get()}"
             }
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -156,7 +156,7 @@ lib2.module = "org.gradle.test:lib2"
 lib2.version = "1.0
 
 [bundles]
-my = ["lib", "lib2"]
+myBundle = ["lib", "lib2"]
 """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.0").publish()
         def lib2 = mavenHttpRepo.module("org.gradle.test", "lib2", "1.0").publish()
@@ -164,7 +164,7 @@ my = ["lib", "lib2"]
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle)
+                implementation(libs.bundles.myBundle)
             }
         """
 
@@ -193,7 +193,7 @@ lib2.module = "org.gradle.test:lib2"
 lib2.version = "1.0
 
 [bundles]
-my = ["lib", "lib2"]
+myBundle = ["lib", "lib2"]
 """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1").publish()
         def lib2 = mavenHttpRepo.module("org.gradle.test", "lib2", "1.1").publish()
@@ -201,7 +201,7 @@ my = ["lib", "lib2"]
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myBundle) {
+                implementation(libs.bundles.myBundle) {
                     version {
                         require '1.1'
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -34,41 +34,46 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         this.providers = providers;
     }
 
-    /**
-     * Returns a single version string from a rich version
-     * constraint, assuming the user knows what they are doing.
-     * @param name the name of the version alias
-     * @return a single version string or an empty string
-     */
-    protected Provider<String> getVersion(String name) {
-        return providers.provider(() -> doGetVersion(name));
-    }
-
-    private String doGetVersion(String name) {
-        ImmutableVersionConstraint version = config.getVersion(name).getVersion();
-        String requiredVersion = version.getRequiredVersion();
-        if (!requiredVersion.isEmpty()) {
-            return requiredVersion;
-        }
-        String strictVersion = version.getStrictVersion();
-        if (!strictVersion.isEmpty()) {
-            return strictVersion;
-        }
-        return version.getPreferredVersion();
-    }
-
     protected Provider<MinimalExternalModuleDependency> create(String alias) {
         return providers.of(DependencyValueSource.class,
             spec -> spec.getParameters().getDependencyData().set(config.getDependencyData(alias)))
             .forUseAtConfigurationTime();
     }
 
-    protected Provider<ExternalModuleDependencyBundle> createBundle(String name) {
-        return providers.of(DependencyBundleValueSource.class,
-            spec -> spec.parameters(params -> {
-                params.getConfig().set(config);
-                params.getBundleName().set(name);
-            }))
-            .forUseAtConfigurationTime();
+    protected class VersionFactory {
+        /**
+         * Returns a single version string from a rich version
+         * constraint, assuming the user knows what they are doing.
+         *
+         * @param name the name of the version alias
+         * @return a single version string or an empty string
+         */
+        protected Provider<String> getVersion(String name) {
+            return providers.provider(() -> doGetVersion(name));
+        }
+
+        private String doGetVersion(String name) {
+            ImmutableVersionConstraint version = config.getVersion(name).getVersion();
+            String requiredVersion = version.getRequiredVersion();
+            if (!requiredVersion.isEmpty()) {
+                return requiredVersion;
+            }
+            String strictVersion = version.getStrictVersion();
+            if (!strictVersion.isEmpty()) {
+                return strictVersion;
+            }
+            return version.getPreferredVersion();
+        }
+    }
+
+    protected class BundleFactory {
+        protected Provider<ExternalModuleDependencyBundle> createBundle(String name) {
+            return providers.of(DependencyBundleValueSource.class,
+                spec -> spec.parameters(params -> {
+                    params.getConfig().set(config);
+                    params.getBundleName().set(name);
+                }))
+                .forUseAtConfigurationTime();
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesModelBuilder.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 public class DefaultDependenciesModelBuilder implements DependenciesModelBuilderInternal {
     private final static Logger LOGGER = Logging.getLogger(DefaultDependenciesModelBuilder.class);
     private final static Attribute<String> INTERNAL_COUNTER = Attribute.of("org.gradle.internal.dm.model.builder.id", String.class);
+    private final static List<String> FORBIDDEN_ALIAS_SUFFIX = ImmutableList.of("bundles", "versions", "version", "bundle");
 
     private final Interner<String> strings;
     private final Interner<ImmutableVersionConstraint> versionConstraintInterner;
@@ -279,6 +280,18 @@ public class DefaultDependenciesModelBuilder implements DependenciesModelBuilder
     private static void validateName(String type, String value) {
         if (!DependenciesModelHelper.ALIAS_PATTERN.matcher(value).matches()) {
             throw new InvalidUserDataException("Invalid " + type + " name '" + value + "': it must match the following regular expression: " + DependenciesModelHelper.ALIAS_REGEX);
+        }
+        if ("alias".equals(type)) {
+            validateAlias(value);
+        }
+    }
+
+    private static void validateAlias(String alias) {
+        for (String suffix : FORBIDDEN_ALIAS_SUFFIX) {
+            String sl = alias.toLowerCase();
+            if (sl.endsWith(suffix)) {
+                throw new InvalidUserDataException("Invalid alias name '" + alias + "': it must not end with '" + suffix + "'");
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultDependenciesModelBuilderTest.groovy
@@ -60,6 +60,25 @@ class DefaultDependenciesModelBuilderTest extends Specification {
         notation << ["", "a", "1a", "A", "Aa", "abc\$", "abc&"]
     }
 
+    @Unroll
+    def "forbids using #name as a dependency alias"() {
+        when:
+        builder.alias(name).to("org:foo:1.0")
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == "Invalid alias name '$name': it must not end with '$suffix'"
+
+        where:
+        name          | suffix
+        "bundles"     | "bundles"
+        "versions"    | "versions"
+        "fooBundle"   | "bundle"
+        "fooVersion"  | "version"
+        "foo.bundle"  | "bundle"
+        "foo.version" | "version"
+    }
+
     @Unroll("#notation is an invalid bundle name")
     def "reasonable error message if bundle name is invalid"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -111,10 +111,12 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasBundle(name, method)
 
         where:
-        name        | method
-        'test'      | 'getTestBundle'
-        'test.json' | 'getTestJsonBundle'
-        'a.b'       | 'getABBundle'
+        name          | method
+        'test'        | 'getTest'
+        'testBundle'  | 'getTestBundle'
+        'test.bundle' | 'getTestBundle'
+        'test.json'   | 'getTestJson'
+        'a.b'         | 'getAB'
     }
 
     @Unroll
@@ -128,12 +130,14 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasVersion(name, method)
 
         where:
-        name          | method
-        'groovy'      | 'getGroovyVersion'
-        'groovy-json' | 'getGroovyJsonVersion'
-        'groovy.json' | 'getGroovyJsonVersion'
-        'groovyJson'  | 'getGroovyJsonVersion'
-        'lang3'       | 'getLang3Version'
+        name             | method
+        'groovy'         | 'getGroovy'
+        'groovyVersion'  | 'getGroovyVersion'
+        'groovy.version' | 'getGroovyVersion'
+        'groovy-json'    | 'getGroovyJson'
+        'groovy.json'    | 'getGroovyJson'
+        'groovyJson'     | 'getGroovyJson'
+        'lang3Version'   | 'getLang3Version'
     }
 
     def "reasonable error message if methods have the same name"() {
@@ -196,37 +200,12 @@ class DependenciesSourceGeneratorTest extends Specification {
   - dependency bundles other.cool and otherCool and other_cool are mapped to the same accessor name getOtherCoolBundle()'''
     }
 
-    def 'reasonable error message if an alias ends with bundle'() {
-        when:
-        generate {
-            alias('foo') to 'g:a:v'
-            alias('barBundle') to 'g:a:v'
-        }
-
-        then:
-        InvalidUserDataException ex = thrown()
-        ex.message == "Cannot generate dependency accessors because alias barBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'"
-
-        when:
-        generate {
-            alias('foo') to 'g:a:v'
-            alias('bazBundle') to 'g:a:v'
-            alias('barBundle') to 'g:a:v'
-        }
-
-        then:
-        ex = thrown()
-        normaliseLineSeparators(ex.message) == """Cannot generate dependency accessors because:
-  - alias barBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'
-  - alias bazBundle isn't a valid: it shouldn't end with 'Bundle' or 'Version'"""
-    }
-
     def "generated sources can be compiled"() {
         when:
         generate {
             alias('foo') to 'g:a:v'
             alias('bar') to 'g2:a2:v2'
-            bundle('my', ['foo', 'bar'])
+            bundle('myBundle', ['foo', 'bar'])
         }
 
         then:
@@ -241,7 +220,7 @@ class DependenciesSourceGeneratorTest extends Specification {
         assert bar.module.name == 'a2'
         assert bar.versionConstraint.requiredVersion == 'v2'
 
-        def bundle = libs.myBundle.get()
+        def bundle = libs.bundles.myBundle.get()
         assert bundle == [foo, bar]
     }
 
@@ -267,19 +246,19 @@ class DependenciesSourceGeneratorTest extends Specification {
             description.set("Some description for tests")
             withContext(context) {
                 alias("some-alias").to 'g:a:v'
-                bundle("b0", ["some-alias"])
+                bundle("b0Bundle", ["some-alias"])
                 withContext(innerContext) {
-                    version("v0", "1.0")
+                    version("v0Version", "1.0")
                 }
-                alias("other").to("g", "a").versionRef("v0")
+                alias("other").to("g", "a").versionRef("v0Version")
             }
         }
 
         then:
         sources.assertClass('Generated', 'Some description for tests')
         sources.hasDependencyAlias('some-alias', 'getSomeAlias', "This dependency was declared in ${context}")
-        sources.hasBundle('b0', 'getB0Bundle', "This bundle was declared in ${context}")
-        sources.hasVersion('v0', 'getV0Version', "This version was declared in ${innerContext}")
+        sources.hasBundle('b0Bundle', 'getB0Bundle', "This bundle was declared in ${context}")
+        sources.hasVersion('v0Version', 'getV0Version', "This version was declared in ${innerContext}")
         sources.hasDependencyAlias('other', 'getOther', "This dependency was declared in ${context}")
     }
 


### PR DESCRIPTION
This is an alternate proposal for bundles and dependencies accessors.

Instead of adding them to the main extension, create "sub" accessors:

- libs.versions.foo
- libs.bundles.uber

This avoids the creation of "magic" suffixes.

