### PR TITLE
Unify storage measurement unit multipliers to fractional binary, instead of decimal

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
@@ -32,6 +32,7 @@ public class NumberUtil {
     private static final MathContext MC = new MathContext(String.valueOf(KIB_BASE).length() + FRACTIONAL_DIGIT_COUNT, FLOOR);
 
     private static final String[] UNITS = new String[]{" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"};
+    private static final String[] ORDINAL_SUFFIXES = new String[]{"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
 
 
     /**
@@ -71,14 +72,13 @@ public class NumberUtil {
      * gets ordinal String representation of given value (e.g. 1 -> 1st, 12 -> 12th, 22 -> 22nd, etc.)
      */
     public static String ordinal(int value) {
-        String[] suffixes = new String[]{"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
         switch (value % 100) {
             case 11:
             case 12:
             case 13:
-                return value + "th";
+                return value + ORDINAL_SUFFIXES[0];
             default:
-                return value + suffixes[value % 10];
+                return value + ORDINAL_SUFFIXES[value % 10];
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
@@ -16,12 +16,23 @@
 
 package org.gradle.internal.util;
 
-import static java.lang.String.format;
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+import static java.math.RoundingMode.FLOOR;
 
 /**
  * Utility methods for working with numbers
  */
 public class NumberUtil {
+    public static final int BASE_LOG2 = 10;
+    public static final int KIB_BASE = 1 << BASE_LOG2;
+    private static final int FRACTIONAL_DIGIT_COUNT = 1;
+    private static final MathContext MC = new MathContext(String.valueOf(KIB_BASE).length() + FRACTIONAL_DIGIT_COUNT, FLOOR);
+
+    private static final String[] UNITS = new String[]{" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"};
+
 
     /**
      * Percentage (0-...) of given input.
@@ -41,19 +52,19 @@ public class NumberUtil {
     }
 
     /**
-     * Formats bytes, e.g. 1000 -> 1kB, -2500 -> -2.5 kB
+     * Formats bytes, e.g. 1010 -> 1010 B, -1025 -> -1 KiB, 1127 -> 1.1 KiB
      */
-    public static String formatBytes(long bytes) {
-        if (bytes < 0) {
-            return "-".concat(formatBytes(-bytes));
+    public static String formatBytes(@Nullable Long bytes) {
+        if (bytes == null) {
+            return "unknown size";
+        } else if (bytes < 0) {
+            return "-" + formatBytes(-bytes);
+        } else {
+            int baseExponent = (Long.SIZE - 1 - Long.numberOfLeadingZeros(bytes)) / BASE_LOG2;
+            BigDecimal roundedBase = BigDecimal.valueOf(1L << (baseExponent * BASE_LOG2));
+            BigDecimal result = BigDecimal.valueOf(bytes).divide(roundedBase, MC).setScale(FRACTIONAL_DIGIT_COUNT, FLOOR).stripTrailingZeros();
+            return result.toPlainString() + UNITS[baseExponent];
         }
-        int unit = 1000;
-        if (bytes < unit) {
-            return bytes + " B";
-        }
-        int exp = (int) (Math.log(bytes) / Math.log(unit));
-        char pre = "kMGTPE".charAt(exp - 1);
-        return format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
@@ -31,8 +31,7 @@ public class NumberUtil {
      */
     public static int percentOf(long fraction, long total) {
         if (total < 0 || fraction < 0) {
-            throw new IllegalArgumentException("Unable to calculate percentage: " + fraction + " of " + total
-                    + ". All inputs must be >= 0");
+            throw new IllegalArgumentException("Unable to calculate percentage: " + fraction + " of " + total + ". All inputs must be >= 0");
         }
         if (total == 0) {
             return 0;
@@ -61,14 +60,14 @@ public class NumberUtil {
      * gets ordinal String representation of given value (e.g. 1 -> 1st, 12 -> 12th, 22 -> 22nd, etc.)
      */
     public static String ordinal(int value) {
-        String[] sufixes = new String[]{"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
+        String[] suffixes = new String[]{"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
         switch (value % 100) {
             case 11:
             case 12:
             case 13:
                 return value + "th";
             default:
-                return value + sufixes[value % 10];
+                return value + suffixes[value % 10];
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/NumberUtil.java
@@ -19,8 +19,11 @@ package org.gradle.internal.util;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.List;
 
 import static java.math.RoundingMode.FLOOR;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Utility methods for working with numbers
@@ -30,9 +33,8 @@ public class NumberUtil {
     public static final int KIB_BASE = 1 << BASE_LOG2;
     private static final int FRACTIONAL_DIGIT_COUNT = 1;
     private static final MathContext MC = new MathContext(String.valueOf(KIB_BASE).length() + FRACTIONAL_DIGIT_COUNT, FLOOR);
-
-    private static final String[] UNITS = new String[]{" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"};
-    private static final String[] ORDINAL_SUFFIXES = new String[]{"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
+    private static final List<String> UNITS = unmodifiableList(asList(" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"));
+    private static final List<String> ORDINAL_SUFFIXES = unmodifiableList(asList("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"));
 
 
     /**
@@ -64,7 +66,7 @@ public class NumberUtil {
             int baseExponent = (Long.SIZE - 1 - Long.numberOfLeadingZeros(bytes)) / BASE_LOG2;
             BigDecimal roundedBase = BigDecimal.valueOf(1L << (baseExponent * BASE_LOG2));
             BigDecimal result = BigDecimal.valueOf(bytes).divide(roundedBase, MC).setScale(FRACTIONAL_DIGIT_COUNT, FLOOR).stripTrailingZeros();
-            return result.toPlainString() + UNITS[baseExponent];
+            return result.toPlainString() + UNITS.get(baseExponent);
         }
     }
 
@@ -76,9 +78,9 @@ public class NumberUtil {
             case 11:
             case 12:
             case 13:
-                return value + ORDINAL_SUFFIXES[0];
+                return value + ORDINAL_SUFFIXES.get(0);
             default:
-                return value + ORDINAL_SUFFIXES[value % 10];
+                return value + ORDINAL_SUFFIXES.get(value % 10);
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
@@ -38,7 +38,7 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
         def m2 = mavenRepo.module("test", "two", "1.2").publish()
 
         buildFile << """
-            repositories { 
+            repositories {
                 maven { url '${server.uri}' }
             }
             configurations { compile }
@@ -84,7 +84,7 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
         ConcurrentTestUtil.poll {
             outputContainsProgress(build,
                 "> :resolve > Resolve dependencies of :compile",
-                "> one-1.2.pom > 1 KB/2 KB downloaded", "> two-1.2.pom > 1 KB/2 KB downloaded"
+                "> one-1.2.pom > 1 KiB/2 KiB downloaded", "> two-1.2.pom > 1 KiB/2 KiB downloaded"
             )
         }
 
@@ -110,7 +110,7 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
         ConcurrentTestUtil.poll {
             outputContainsProgress(build,
                 "> :resolve > Resolve files of :compile",
-                "> one-1.2.jar > 1 KB/2 KB downloaded", "> two-1.2.jar > 1 KB/2 KB downloaded"
+                "> one-1.2.jar > 1 KiB/2 KiB downloaded", "> two-1.2.jar > 1 KiB/2 KiB downloaded"
             )
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/AbstractProgressLoggingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/AbstractProgressLoggingHandler.java
@@ -35,18 +35,11 @@ public class AbstractProgressLoggingHandler {
         String description = createDescription(operationType, resource);
         progressLogger.setDescription(description);
         progressLogger.started();
-        String resourceName = createShortDescription(resource);
-        return new ResourceOperation(progressLogger, operationType, contentLength, resourceName);
+        return new ResourceOperation(progressLogger, operationType, contentLength);
     }
 
     private String createDescription(ResourceOperation.Type operationType, URI resource) {
         return operationType.getCapitalized() + " " + resource.toString();
-    }
-
-    private String createShortDescription(URI resource) {
-        String rawUri = resource.toString();
-        int lastSlash = rawUri.lastIndexOf('/');
-        return lastSlash == -1 ? rawUri : rawUri.substring(lastSlash + 1);
     }
 
     protected static class ProgressLoggingInputStream extends InputStream {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.logging.progress.ProgressLogger;
 
 public class ResourceOperation {
-    public enum Type{
+    public enum Type {
         download,
         upload;
 
@@ -28,19 +28,18 @@ public class ResourceOperation {
             return StringUtils.capitalize(toString());
         }
     }
+
     private final ProgressLogger progressLogger;
     private final Type operationType;
     private final String contentLengthString;
-    private final String resourceName;
 
     private long loggedKBytes;
     private long totalProcessedBytes;
 
-    public ResourceOperation(ProgressLogger progressLogger, Type type, long contentLength, String resourceName) {
+    public ResourceOperation(ProgressLogger progressLogger, Type type, long contentLength) {
         this.progressLogger = progressLogger;
         this.operationType = type;
         this.contentLengthString = getLengthText(contentLength != 0 ? contentLength : null);
-        this.resourceName = resourceName;
     }
 
     private String getLengthText(Long bytes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
@@ -19,6 +19,9 @@ package org.gradle.internal.resource.transfer;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.logging.progress.ProgressLogger;
 
+import static org.gradle.internal.util.NumberUtil.KIB_BASE;
+import static org.gradle.internal.util.NumberUtil.formatBytes;
+
 public class ResourceOperation {
     public enum Type {
         download,
@@ -39,28 +42,15 @@ public class ResourceOperation {
     public ResourceOperation(ProgressLogger progressLogger, Type type, long contentLength) {
         this.progressLogger = progressLogger;
         this.operationType = type;
-        this.contentLengthString = getLengthText(contentLength != 0 ? contentLength : null);
-    }
-
-    private String getLengthText(Long bytes) {
-        if (bytes == null) {
-            return "unknown size";
-        }
-        if (bytes < 1024) {
-            return bytes + " B";
-        } else if (bytes < 1048576) {
-            return (bytes / 1024) + " KB";
-        } else {
-            return String.format("%.2f MB", bytes / 1048576.0);
-        }
+        this.contentLengthString = formatBytes(contentLength == 0 ? null : contentLength);
     }
 
     public void logProcessedBytes(long processedBytes) {
         totalProcessedBytes += processedBytes;
-        long processedKB = totalProcessedBytes / 1024;
-        if (processedKB > loggedKBytes) {
-            loggedKBytes = processedKB;
-            String progressMessage = String.format("%s/%s %sed", getLengthText(totalProcessedBytes), contentLengthString, operationType);
+        long processedKiB = totalProcessedBytes / KIB_BASE;
+        if (processedKiB > loggedKBytes) {
+            loggedKBytes = processedKiB;
+            String progressMessage = String.format("%s/%s %sed", formatBytes(totalProcessedBytes), contentLengthString, operationType);
             progressLogger.progress(progressMessage);
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessorTest.groovy
@@ -16,16 +16,16 @@
 
 package org.gradle.internal.resource.transfer
 
-import org.gradle.internal.resource.metadata.ExternalResourceMetaData
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     ExternalResourceAccessor accessor = Mock()
-    ProgressLoggerFactory progressLoggerFactory = Mock();
+    ProgressLoggerFactory progressLoggerFactory = Mock()
     ProgressLoggingExternalResourceAccessor progressLoggerAccessor = new ProgressLoggingExternalResourceAccessor(accessor, progressLoggerFactory)
     ProgressLogger progressLogger = Mock()
     ExternalResourceReadResponse externalResource = Mock()
@@ -99,9 +99,9 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
         then:
         1 * progressLoggerFactory.newOperation(_) >> progressLogger
         1 * progressLogger.started()
-        1 * progressLogger.progress('1 KB/4 KB downloaded')
-        1 * progressLogger.progress('3 KB/4 KB downloaded')
-        1 * progressLogger.progress('4 KB/4 KB downloaded')
+        1 * progressLogger.progress('1.5 KiB/4 KiB downloaded')
+        1 * progressLogger.progress('3 KiB/4 KiB downloaded')
+        1 * progressLogger.progress('4 KiB/4 KiB downloaded')
         1 * progressLogger.completed()
         0 * progressLogger.progress(_)
     }
@@ -121,7 +121,7 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
         then:
         1 * progressLoggerFactory.newOperation(_) >> progressLogger
         1 * progressLogger.started()
-        1 * progressLogger.progress('1 KB/4 KB downloaded')
+        1 * progressLogger.progress('1.5 KiB/4 KiB downloaded')
         1 * progressLogger.completed()
         0 * progressLogger.progress(_)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ResourceOperationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ResourceOperationTest.groovy
@@ -19,22 +19,24 @@ package org.gradle.internal.resource.transfer
 import org.gradle.internal.logging.progress.ProgressLogger
 import spock.lang.Specification
 
+import static org.gradle.internal.resource.transfer.ResourceOperation.Type
+
 class ResourceOperationTest extends Specification {
 
     ProgressLogger progressLogger = Mock()
 
-    def "no progress event is logged for files < 1024bytes"() {
+    def "no progress event is logged for files < 1024 bytes"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1023)
+        def operation = new ResourceOperation(progressLogger, Type.download, 1023)
         when:
         operation.logProcessedBytes(1023)
         then:
         0 * progressLogger.progress(_)
     }
 
-    def "logs processed bytes in kbyte intervals"() {
+    def "logs processed bytes in KiB intervals"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1024 * 10)
+        def operation = new ResourceOperation(progressLogger, Type.download, 1024 * 10)
         when:
         operation.logProcessedBytes(512 * 0)
         operation.logProcessedBytes(512 * 1)
@@ -45,19 +47,19 @@ class ResourceOperationTest extends Specification {
         operation.logProcessedBytes(512 * 1)
         operation.logProcessedBytes(512 * 2)
         then:
-        1 * progressLogger.progress("1 KB/10 KB downloaded")
-        1 * progressLogger.progress("2 KB/10 KB downloaded")
+        1 * progressLogger.progress("1 KiB/10 KiB downloaded")
+        1 * progressLogger.progress("2 KiB/10 KiB downloaded")
         0 * progressLogger.progress(_)
     }
 
-    def "last chunk of bytes <1k is not logged"() {
+    def "last chunk of bytes <1KiB is not logged"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 2000)
+        def operation = new ResourceOperation(progressLogger, Type.download, 2000)
         when:
         operation.logProcessedBytes(1000)
         operation.logProcessedBytes(1000)
         then:
-        1 * progressLogger.progress("1 KB/1 KB downloaded")
+        1 * progressLogger.progress("1.9 KiB/1.9 KiB downloaded")
         0 * progressLogger.progress(_)
     }
 
@@ -69,27 +71,27 @@ class ResourceOperationTest extends Specification {
         then:
         1 * progressLogger.progress(message)
         where:
-        type                            | message
-        ResourceOperation.Type.download | "1 KB/10 KB downloaded"
-        ResourceOperation.Type.upload   | "1 KB/10 KB uploaded"
+        type          | message
+        Type.download | "1 KiB/10 KiB downloaded"
+        Type.upload   | "1 KiB/10 KiB uploaded"
     }
 
-    void "completed completes progressLogger"() {
+    def "completed completes progressLogger"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 1)
+        def operation = new ResourceOperation(progressLogger, Type.upload, 1)
         when:
         operation.completed()
         then:
         1 * progressLogger.completed()
     }
 
-    void "handles unknown content length"() {
+    def "handles unknown content length"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 0)
+        def operation = new ResourceOperation(progressLogger, Type.upload, 0)
         when:
         operation.logProcessedBytes(1024)
         then:
-        1 * progressLogger.progress("1 KB/unknown size uploaded")
+        1 * progressLogger.progress("1 KiB/unknown size uploaded")
     }
 }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ResourceOperationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ResourceOperationTest.groovy
@@ -16,16 +16,16 @@
 
 package org.gradle.internal.resource.transfer
 
-import spock.lang.Specification
 import org.gradle.internal.logging.progress.ProgressLogger
+import spock.lang.Specification
 
 class ResourceOperationTest extends Specification {
 
     ProgressLogger progressLogger = Mock()
 
-    def "no progress event is logged for files < 1024bytes"(){
+    def "no progress event is logged for files < 1024bytes"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1023, "res")
+        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1023)
         when:
         operation.logProcessedBytes(1023)
         then:
@@ -34,7 +34,7 @@ class ResourceOperationTest extends Specification {
 
     def "logs processed bytes in kbyte intervals"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1024 * 10, "res")
+        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 1024 * 10)
         when:
         operation.logProcessedBytes(512 * 0)
         operation.logProcessedBytes(512 * 1)
@@ -50,9 +50,9 @@ class ResourceOperationTest extends Specification {
         0 * progressLogger.progress(_)
     }
 
-    def "last chunk of bytes <1k is not logged"(){
+    def "last chunk of bytes <1k is not logged"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 2000, "res")
+        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.download, 2000)
         when:
         operation.logProcessedBytes(1000)
         operation.logProcessedBytes(1000)
@@ -63,7 +63,7 @@ class ResourceOperationTest extends Specification {
 
     def "adds operationtype information in progress output"() {
         given:
-        def operation = new ResourceOperation(progressLogger, type, 1024 * 10, "res")
+        def operation = new ResourceOperation(progressLogger, type, 1024 * 10)
         when:
         operation.logProcessedBytes(1024)
         then:
@@ -76,7 +76,7 @@ class ResourceOperationTest extends Specification {
 
     void "completed completes progressLogger"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 1, "res")
+        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 1)
         when:
         operation.completed()
         then:
@@ -85,7 +85,7 @@ class ResourceOperationTest extends Specification {
 
     void "handles unknown content length"() {
         given:
-        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 0, "res")
+        def operation = new ResourceOperation(progressLogger, ResourceOperation.Type.upload, 0)
         when:
         operation.logProcessedBytes(1024)
         then:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -123,7 +123,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.module > 1 KB/1 KB uploaded")
+            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.module > 1.8 KiB/1.8 KiB uploaded")
         }
 
         when:


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/14540

Ended up using `BigDecimal` for greater precision - `double` had measurable rounding errors around big transitions.

Also unified the fractional part to be displayed in both cases - validated against https://www.ibm.com/support/knowledgecenter/SSQRB8/com.ibm.spectrum.si.doc/fqz0_r_units_measurement_data.html#fqz0_r_data_storage_values__percentage_diff_between_decimal_binary.

Decided to always round down, even though the `IEEE 754R Decimal64` format uses `HALF_EVEN` - we don't need to avoid rounding biases here, so truncation is more predictable.