### PR TITLE
Upgrade to test Kotlin 1.4.20-RC and AGP 4.2.0-alpha16

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,3 +1,3 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=3.4.3,3.5.4,3.6.4,4.0.2,4.1.0,4.2.0-alpha15
+latests=3.4.3,3.5.4,3.6.4,4.0.2,4.1.0,4.2.0-alpha16
 nightly=4.2.0-20201018014119+0000

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -22,7 +22,7 @@ package org.gradle.integtests.fixtures.versions
 class KotlinGradlePluginVersions {
 
     // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-    private static final List<String> LATEST_VERSIONS = ['1.3.21', '1.3.31', '1.3.41', '1.3.50', '1.3.61', '1.3.72', '1.4.0', '1.4.10', '1.4.20-M2']
+    private static final List<String> LATEST_VERSIONS = ['1.3.21', '1.3.31', '1.3.41', '1.3.50', '1.3.61', '1.3.72', '1.4.0', '1.4.10', '1.4.20-RC']
 
     List<String> getLatests() {
         return LATEST_VERSIONS

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -101,7 +101,10 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(*AGP_VERSIONS.latestsPlusNightly)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll { !it.contains('-M') && !it.contains('-RC') })
+        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll {
+            def lowerCaseVersion = it.toLowerCase(Locale.US)
+            !lowerCaseVersion.contains('-m') && !lowerCaseVersion.contains('-rc') && !(lowerCaseVersion.contains('-beta'))
+        })
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "3.0.3"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -101,7 +101,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(*AGP_VERSIONS.latestsPlusNightly)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll { !it.contains('-M')})
+        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll { !it.contains('-M') && !it.contains('-RC') })
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "3.0.3"


### PR DESCRIPTION
AGP 4.2.0-alpha16 contains a fix for a performance problem when filtering dependencies for dynamic features.