### PR TITLE
Ignore stacktraces from Jetty

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1314,6 +1314,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
                     } else if (line.matches(".*w: .* is deprecated\\..*")) {
                         // A kotlinc warning, ignore
                         i++;
+                    } else if (line.contains("java.nio.channels.CancelledKeyException")) {
+                        // Verbose logging by Jetty when connector is shutdown
+                        // https://github.com/eclipse/jetty.project/issues/3529
+                        i++;
                     } else if (isDeprecationMessageInHelpDescription(line)) {
                         i++;
                     } else if (expectedDeprecationWarnings.remove(line)) {


### PR DESCRIPTION
When shutting down the connector, Jetty sometimes prints a
`CancelledKeyException` to the console which makes our tests fail.

* [Failures and flaky tests](https://ge.gradle.org/scans/tests?search.relativeStartTime=P7D&search.timeZoneId=Europe/Berlin&tests.container=org.gradle.integtests.resolve.suppliers.DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest&tests.sortField=FAILED&tests.test=can%20cache%20the%20result%20of%20processing%20a%20rule%20across%20projects%20%5Bwithout%20Gradle%20metadata,%20Ivy%20repository%5D&tests.unstableOnly=true)

Example stacktrace:
```
java.nio.channels.CancelledKeyException	
	at java.base/sun.nio.ch.SelectionKeyImpl.ensureValid(SelectionKeyImpl.java:74)	
	at java.base/sun.nio.ch.SelectionKeyImpl.interestOps(SelectionKeyImpl.java:99)	
	at org.eclipse.jetty.io.ChannelEndPoint.updateKey(ChannelEndPoint.java:378)	
	at org.eclipse.jetty.io.ManagedSelector$SelectorProducer.updateKeys(ManagedSelector.java:677)	
	at org.eclipse.jetty.io.ManagedSelector$SelectorProducer.produce(ManagedSelector.java:507)	
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produceTask(EatWhatYouKill.java:360)	
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:184)	
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)	
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)	
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)	
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)	
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)	
	at java.base/java.lang.Thread.run(Thread.java:832)
```