### PR TITLE
Add support for matching toolchain by vendor

### DIFF
--- a/subprojects/platform-jvm/build.gradle.kts
+++ b/subprojects/platform-jvm/build.gradle.kts
@@ -58,6 +58,7 @@ integrationTestUsesSampleDir("subprojects/platform-jvm/src/main")
 classycle {
     excludePatterns.set(listOf(
         // Needed for the factory methods in the interface
-        "org/gradle/jvm/toolchain/JavaLanguageVersion**"
+        "org/gradle/jvm/toolchain/JavaLanguageVersion**",
+        "org/gradle/jvm/toolchain/internal/**"
     ))
 }

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -80,7 +80,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("No compatible toolchains found for request filter: {languageVersion=14} (auto-detect false, auto-download false)")
+            .assertHasCause("No compatible toolchains found for request filter: {languageVersion=14, vendor=any} (auto-detect false, auto-download false)")
     }
 
     @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
@@ -112,7 +112,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause('Unable to download toolchain matching these requirements: {languageVersion=99}')
+            .assertHasCause('Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any}')
             .assertThatCause(CoreMatchers.startsWith('Attempting to download a JDK from an insecure URI http://example.com'))
     }
 

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -47,7 +47,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("Unable to download toolchain matching these requirements: {languageVersion=99}")
+            .assertHasCause("Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any}")
             .assertHasCause("Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.")
             .assertThatCause(CoreMatchers.startsWith("Could not read 'https://api.adoptopenjdk.net/v3/binary/latest/99/ga/"))
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -36,4 +36,6 @@ public interface JavaToolchainSpec extends Describable {
      */
     Property<JavaLanguageVersion> getLanguageVersion();
 
+    Property<JvmVendorSpec> getVendor();
+
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -36,6 +36,12 @@ public interface JavaToolchainSpec extends Describable {
      */
     Property<JavaLanguageVersion> getLanguageVersion();
 
+    /**
+     * The vendor of the toolchain.
+     * <p>By default, toolchains from any vendor are eligible.</p>
+     *
+     * @since 6.8
+     */
     Property<JvmVendorSpec> getVendor();
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+import org.gradle.api.Incubating;
+import org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor;
+import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
+
+/**
+ * Represents a filter for a vendor of a Java Virtual Machine implementation.
+ *
+ * @since 6.8
+ */
+@Incubating
+public abstract class JvmVendorSpec {
+
+    public static final JvmVendorSpec ADOPTOPENJDK = matching(KnownJvmVendor.ADOPTOPENJDK);
+    public static final JvmVendorSpec AMAZON = matching(KnownJvmVendor.AMAZON);
+    public static final JvmVendorSpec APPLE = matching(KnownJvmVendor.APPLE);
+    public static final JvmVendorSpec AZUL = matching(KnownJvmVendor.AZUL);
+    public static final JvmVendorSpec BELLSOFT = matching(KnownJvmVendor.BELLSOFT);
+    public static final JvmVendorSpec HEWLETT_PACKARD = matching(KnownJvmVendor.HEWLETT_PACKARD);
+    public static final JvmVendorSpec IBM = matching(KnownJvmVendor.IBM);
+    public static final JvmVendorSpec ORACLE = matching(KnownJvmVendor.ORACLE);
+    public static final JvmVendorSpec SAP = matching(KnownJvmVendor.SAP);
+
+    /**
+     * Returns a vendor spec that matches a VM by its vendor.
+     * <p>
+     * A VM is determined eligible if the system property <code>java.vendor</code> contains
+     * the given match string. The comparison is done case-insensitive.
+     * </p>
+     * @param match the sequence to search for
+     * @return a new filter object
+     */
+    public static JvmVendorSpec matching(String match) {
+        return new DefaultJvmVendorSpec(match);
+    }
+
+    private static JvmVendorSpec matching(KnownJvmVendor vendor) {
+        return new DefaultJvmVendorSpec(vendor);
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -48,11 +48,11 @@ public abstract class JvmVendorSpec {
      * @return a new filter object
      */
     public static JvmVendorSpec matching(String match) {
-        return new DefaultJvmVendorSpec(match);
+        return DefaultJvmVendorSpec.matching(match);
     }
 
     private static JvmVendorSpec matching(KnownJvmVendor vendor) {
-        return new DefaultJvmVendorSpec(vendor);
+        return DefaultJvmVendorSpec.of(vendor);
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -19,10 +19,10 @@ package org.gradle.jvm.toolchain.install.internal;
 import net.rubygrapefruit.platform.SystemInfo;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.gradle.jvm.toolchain.JvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 
 import javax.inject.Inject;
@@ -56,8 +56,9 @@ public class AdoptOpenJdkRemoteBinary {
 
     private boolean canProvideMatchingJdk(JavaToolchainSpec spec) {
         final boolean matchesLanguageVersion = getLanguageVersion(spec).canCompileOrRun(8);
-        final JvmVendorSpec vendorSpec = spec.getVendor().get();
-        boolean matchesVendor = vendorSpec == JvmVendorSpec.ADOPTOPENJDK || vendorSpec == DefaultJvmVendorSpec.any();
+        final DefaultJvmVendorSpec vendorSpec = (DefaultJvmVendorSpec) spec.getVendor().get();
+        JvmVendor vendor = JvmVendor.fromString("adoptopenjdk");
+        boolean matchesVendor = vendorSpec == DefaultJvmVendorSpec.any() || vendorSpec.test(vendor);
         return matchesLanguageVersion && matchesVendor;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -22,6 +22,8 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
+import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -44,7 +46,7 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     public Optional<File> download(JavaToolchainSpec spec, File destinationFile) {
-        if (!canProvidesMatchingJdk(spec)) {
+        if (!canProvideMatchingJdk(spec)) {
             return Optional.empty();
         }
         URI source = toDownloadUri(spec);
@@ -52,8 +54,11 @@ public class AdoptOpenJdkRemoteBinary {
         return Optional.of(destinationFile);
     }
 
-    private boolean canProvidesMatchingJdk(JavaToolchainSpec spec) {
-        return getLanguageVersion(spec).canCompileOrRun(8);
+    private boolean canProvideMatchingJdk(JavaToolchainSpec spec) {
+        final boolean matchesLanguageVersion = getLanguageVersion(spec).canCompileOrRun(8);
+        final JvmVendorSpec vendorSpec = spec.getVendor().get();
+        boolean matchesVendor = vendorSpec == JvmVendorSpec.ADOPTOPENJDK || vendorSpec == DefaultJvmVendorSpec.ANY;
+        return matchesLanguageVersion && matchesVendor;
     }
 
     URI toDownloadUri(JavaToolchainSpec spec) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -57,7 +57,7 @@ public class AdoptOpenJdkRemoteBinary {
     private boolean canProvideMatchingJdk(JavaToolchainSpec spec) {
         final boolean matchesLanguageVersion = getLanguageVersion(spec).canCompileOrRun(8);
         final JvmVendorSpec vendorSpec = spec.getVendor().get();
-        boolean matchesVendor = vendorSpec == JvmVendorSpec.ADOPTOPENJDK || vendorSpec == DefaultJvmVendorSpec.ANY;
+        boolean matchesVendor = vendorSpec == JvmVendorSpec.ADOPTOPENJDK || vendorSpec == DefaultJvmVendorSpec.any();
         return matchesLanguageVersion && matchesVendor;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.internal.jvm.inspection.JvmVendor;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
+
+import java.util.function.Predicate;
+
+public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<JavaToolchain> {
+
+    public static final JvmVendorSpec ANY = new DefaultJvmVendorSpec(v -> true, "any");
+
+    private final Predicate<JvmVendor> matcher;
+    private final String description;
+
+    public DefaultJvmVendorSpec(String match) {
+        this(vendor -> StringUtils.containsIgnoreCase(vendor.getRawVendor(), match), "matching('" + match + "')");
+    }
+
+    public DefaultJvmVendorSpec(JvmVendor.KnownJvmVendor knownVendor) {
+        this(vendor -> vendor.getKnownVendor() == knownVendor, knownVendor.toString());
+    }
+
+    private DefaultJvmVendorSpec(Predicate<JvmVendor> predicate, String description) {
+        this.matcher = predicate;
+        this.description = description;
+    }
+
+    @Override
+    public boolean test(JavaToolchain toolchain) {
+        return matcher.test(toolchain.getVendor());
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -48,7 +48,12 @@ public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<Jav
 
     @Override
     public boolean test(JavaToolchain toolchain) {
-        return matcher.test(toolchain.getVendor());
+        final JvmVendor vendor = toolchain.getVendor();
+        return test(vendor);
+    }
+
+    public boolean test(JvmVendor vendor) {
+        return matcher.test(vendor);
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -24,17 +24,21 @@ import java.util.function.Predicate;
 
 public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<JavaToolchain> {
 
-    public static final JvmVendorSpec ANY = new DefaultJvmVendorSpec(v -> true, "any");
+    private static final JvmVendorSpec ANY = new DefaultJvmVendorSpec(v -> true, "any");
 
     private final Predicate<JvmVendor> matcher;
     private final String description;
 
-    public DefaultJvmVendorSpec(String match) {
-        this(vendor -> StringUtils.containsIgnoreCase(vendor.getRawVendor(), match), "matching('" + match + "')");
+    public static JvmVendorSpec matching(String match) {
+        return new DefaultJvmVendorSpec(vendor -> StringUtils.containsIgnoreCase(vendor.getRawVendor(), match), "matching('" + match + "')");
     }
 
-    public DefaultJvmVendorSpec(JvmVendor.KnownJvmVendor knownVendor) {
-        this(vendor -> vendor.getKnownVendor() == knownVendor, knownVendor.toString());
+    public static JvmVendorSpec of(JvmVendor.KnownJvmVendor knownVendor) {
+        return new DefaultJvmVendorSpec(vendor -> vendor.getKnownVendor() == knownVendor, knownVendor.toString());
+    }
+
+    public static JvmVendorSpec any() {
+        return ANY;
     }
 
     private DefaultJvmVendorSpec(Predicate<JvmVendor> predicate, String description) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -16,25 +16,34 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import com.google.common.base.MoreObjects;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import javax.inject.Inject;
 
 public class DefaultToolchainSpec implements JavaToolchainSpec {
 
     private final Property<JavaLanguageVersion> languageVersion;
+    private final Property<JvmVendorSpec> vendor;
 
     @Inject
     public DefaultToolchainSpec(ObjectFactory factory) {
         this.languageVersion = factory.property(JavaLanguageVersion.class);
+        this.vendor = factory.property(JvmVendorSpec.class).convention(DefaultJvmVendorSpec.ANY);
     }
 
     @Override
     public Property<JavaLanguageVersion> getLanguageVersion() {
         return languageVersion;
+    }
+
+    @Override
+    public Property<JvmVendorSpec> getVendor() {
+        return vendor;
     }
 
     public boolean isConfigured() {
@@ -43,7 +52,11 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
 
     @Override
     public String getDisplayName() {
-        return "{languageVersion=" + languageVersion.map(JavaLanguageVersion::toString).getOrElse("unspecified") + "}";
+        final MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper("");
+        builder.omitNullValues();
+        builder.add("languageVersion", languageVersion.map(JavaLanguageVersion::toString).getOrElse("unspecified"));
+        builder.add("vendor", vendor.map(JvmVendorSpec::toString).getOrNull());
+        return builder.toString();
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -33,7 +33,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
     @Inject
     public DefaultToolchainSpec(ObjectFactory factory) {
         this.languageVersion = factory.property(JavaLanguageVersion.class);
-        this.vendor = factory.property(JvmVendorSpec.class).convention(DefaultJvmVendorSpec.ANY);
+        this.vendor = factory.property(JvmVendorSpec.class).convention(DefaultJvmVendorSpec.any());
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -48,7 +48,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     @Inject
     public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory) {
         this.javaHome = fileFactory.dir(computeEnclosingJavaHome(metadata.getJavaHome()).toFile());
-        this.javaVersion = JavaLanguageVersion.of(metadata.getLangageVersion().getMajorVersion());
+        this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
         this.isJdk = metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.JAVA_COMPILER);
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
+import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
@@ -42,19 +43,17 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     private final Directory javaHome;
     private final VersionNumber implementationVersion;
     private final JavaLanguageVersion javaVersion;
+    private final JvmVendor vendor;
 
     @Inject
     public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory) {
-        this(metadata.getJavaHome(), JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion()), metadata.getImplementationVersion(), metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.JAVA_COMPILER), compilerFactory, toolFactory, fileFactory);
-    }
-
-    JavaToolchain(Path javaHome, JavaLanguageVersion version, String implementationJavaVersion, boolean isJdk, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory) {
-        this.javaHome = fileFactory.dir(computeEnclosingJavaHome(javaHome).toFile());
-        this.javaVersion = version;
-        this.isJdk = isJdk;
+        this.javaHome = fileFactory.dir(computeEnclosingJavaHome(metadata.getJavaHome()).toFile());
+        this.javaVersion = JavaLanguageVersion.of(metadata.getLangageVersion().getMajorVersion());
+        this.isJdk = metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.JAVA_COMPILER);
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
-        this.implementationVersion = VersionNumber.parse(implementationJavaVersion);
+        this.implementationVersion = VersionNumber.parse(metadata.getImplementationVersion());
+        this.vendor = metadata.getVendor();
     }
 
     @Internal
@@ -90,6 +89,11 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     @Internal
     public boolean isJdk() {
         return isJdk;
+    }
+
+    @Internal
+    JvmVendor getVendor() {
+        return vendor;
     }
 
     @Internal

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -80,7 +80,14 @@ public class JavaToolchainQueryService {
     }
 
     private Predicate<JavaToolchain> matchingToolchain(JavaToolchainSpec spec) {
-        return toolchain -> toolchain.getLanguageVersion().equals(spec.getLanguageVersion().get());
+        final Predicate<JavaToolchain> languagePredicate = toolchain -> toolchain.getLanguageVersion().equals(spec.getLanguageVersion().get());
+        final Predicate<? super JavaToolchain> vendorSpec = getVendorPredicate(spec);
+        return languagePredicate.and(vendorSpec);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Predicate<? super JavaToolchain> getVendorPredicate(JavaToolchainSpec spec) {
+        return (Predicate<? super JavaToolchain>) spec.getVendor().get();
     }
 
     private JavaToolchain asToolchain(File javaHome) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -168,10 +169,11 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         vendor << [JvmVendorSpec.AMAZON, JvmVendorSpec.IBM]
     }
 
-    def "downloads with matching vendor spec"() {
+    @Unroll
+    def "downloads with matching vendor spec using #vendor"() {
         given:
         def spec = newSpec(12)
-        spec.vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+        spec.vendor.set(vendor)
         def systemInfo = Mock(SystemInfo)
         systemInfo.architecture >> SystemInfo.Architecture.amd64
         def operatingSystem = OperatingSystem.MAC_OS
@@ -184,6 +186,9 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
 
         then:
         1 * downloader.download(URI.create("https://api.adoptopenjdk.net/v3/binary/latest/12/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"), _)
+
+        where:
+        vendor << [JvmVendorSpec.ADOPTOPENJDK, JvmVendorSpec.matching("adoptopenjdk"), DefaultJvmVendorSpec.any()]
     }
 
     def newSpec(int jdkVersion = 11) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpecTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpecTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.internal.jvm.inspection.JvmVendor
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import spock.lang.Specification
+
+import java.util.function.Predicate
+
+class DefaultJvmVendorSpecTest extends Specification {
+
+    def "unknown does not match known vendor"() {
+        given:
+        def toolchain = Mock(JavaToolchain) {
+            getVendor() >> JvmVendor.fromString("some unknown")
+        }
+
+        when:
+        def asPredicate = (Predicate<JavaToolchain>)JvmVendorSpec.ADOPTOPENJDK
+
+        then:
+        !asPredicate.test(toolchain)
+    }
+
+    def "matches known vendors"() {
+        given:
+        def toolchain = Mock(JavaToolchain) {
+            getVendor() >> JvmVendor.fromString("bellsoft")
+        }
+
+        expect:
+        assertMatches(JvmVendorSpec.BELLSOFT, toolchain)
+        assertDoesNotMatch(JvmVendorSpec.IBM, toolchain)
+    }
+
+    def "matches by raw string"() {
+        given:
+        def toolchain = Mock(JavaToolchain) {
+            getVendor() >> JvmVendor.fromString("someCustomJdk")
+        }
+
+        expect:
+        assertDoesNotMatch(JvmVendorSpec.IBM, toolchain)
+        assertDoesNotMatch(JvmVendorSpec.AMAZON, toolchain)
+        assertMatches(JvmVendorSpec.matching("customjdk"), toolchain)
+    }
+
+    void assertMatches(JvmVendorSpec spec, actualToolchain) {
+        assert ((Predicate<JavaToolchain>) spec).test(actualToolchain)
+    }
+
+    void assertDoesNotMatch(JvmVendorSpec spec, actualToolchain) {
+        assert !((Predicate<JavaToolchain>) spec).test(actualToolchain)
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -22,10 +22,12 @@ import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector
+import org.gradle.internal.jvm.inspection.JvmVendor
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainSpec
+import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.install.internal.JavaToolchainProvisioningService
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -96,7 +98,7 @@ class JavaToolchainQueryServiceTest extends Specification {
 
         then:
         def e = thrown(NoToolchainAvailableException)
-        e.message == "No compatible toolchains found for request filter: {languageVersion=12} (auto-detect true, auto-download true)"
+        e.message == "No compatible toolchains found for request filter: {languageVersion=12, vendor=any} (auto-detect true, auto-download true)"
     }
 
     def "returns no toolchain if filter is not configured"() {
@@ -111,6 +113,32 @@ class JavaToolchainQueryServiceTest extends Specification {
 
         then:
         !toolchain.isPresent()
+    }
+
+    def "returns toolchain matching vendor"() {
+        given:
+        def registry = createInstallationRegistry(["8-0", "8-1", "8-2", "8-3"])
+        def vendors = ["amazon", "bellsoft", "ibm", "zulu"]
+        def compilerFactory = Mock(JavaCompilerFactory)
+        def toolFactory = Mock(ToolchainToolFactory)
+        def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
+            JavaToolchain newInstance(File javaHome) {
+                def vendor = vendors[Integer.valueOf(javaHome.name.substring(2))]
+                def metadata = newMetadata(new File("/path/8"), vendor)
+                return new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory())
+            }
+        }
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), createProviderFactory())
+
+        when:
+        def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
+        filter.languageVersion.set(JavaLanguageVersion.of(8))
+        filter.vendor.set(JvmVendorSpec.BELLSOFT)
+        def toolchain = queryService.findMatchingToolchain(filter)
+
+        then:
+        toolchain.isPresent()
+        toolchain.get().vendor.knownVendor == JvmVendor.KnownJvmVendor.BELLSOFT
     }
 
     def "install toolchain if no matching toolchain found"() {
@@ -147,12 +175,13 @@ class JavaToolchainQueryServiceTest extends Specification {
         toolchainFactory
     }
 
-    def newMetadata(File javaHome) {
+    def newMetadata(File javaHome, String vendor = "") {
         Mock(JvmInstallationMetadata) {
             getLanguageVersion() >> JavaVersion.toVersion(javaHome.name)
             getJavaHome() >> javaHome.absoluteFile.toPath()
             getImplementationVersion() >> javaHome.name.replace("zzz", "999")
             getCapabilities() >> Collections.emptySet()
+            getVendor() >> JvmVendor.fromString(vendor)
         }
     }
 


### PR DESCRIPTION
Example using a known vendor:
```
java {
  toolchain {
    languageVersion = JavaLanguageVersion.of(11)
    vendor = JvmVendorSpec.AMAZON
  }
}
```

Example for vendors we don't know about:
```
java {
  toolchain {
    languageVersion = JavaLanguageVersion.of(11)
    vendor = JvmVendorSpec.matching("myCustomJdkVendorString")
  }
}
```