### PR TITLE
Find root build tasks when calculating an included build task graph

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -155,10 +155,10 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
 
     def "can depend back on root build"() {
         given:
-        def buildX = multiProjectBuild('buildX', ['x1', 'x2']) {
+        def rootBuild = multiProjectBuild('rootBuild', ['root1', 'root2']) {
             buildFile << """
                 subprojects { apply plugin: 'java-library'}
-                project(':x1') {
+                project(':root1') {
                     dependencies { implementation 'org.test:theNameOfBuildA' }
                 }
             """
@@ -169,28 +169,28 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
 
         buildA.buildFile << """
             apply plugin: 'java-library'
-            dependencies { implementation 'org.test:x2' }
+            dependencies { implementation 'org.test:root2' }
         """
         buildA.settingsFile << """
             rootProject.name = 'theNameOfBuildA'
         """
 
         when:
-        execute(buildX, ':x1:compileJava')
+        execute(rootBuild, ':root1:compileJava')
 
         then:
-        result.assertTasksExecuted(':x2:compileJava', ':buildA:compileJava', ':x1:compileJava')
+        result.assertTasksExecuted(':root2:compileJava', ':buildA:compileJava', ':root1:compileJava')
     }
 
     def "can depend back on root build and back on an included build"() {
         given:
-        def buildX = multiProjectBuild('buildX', ['x1', 'x2', 'x3']) {
+        def rootBuild = multiProjectBuild('rootBuild', ['root1', 'root2', 'x3']) {
             buildFile << """
                 subprojects { apply plugin: 'java-library'}
-                project(':x1') {
+                project(':root1') {
                     dependencies { api 'org.test:theNameOfBuildA' }
                 }
-                project(':x2') {
+                project(':root2') {
                     dependencies { api 'org.test:buildB' }
                 }
             """
@@ -202,7 +202,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
 
         buildA.buildFile << """
             apply plugin: 'java-library'
-            dependencies { api 'org.test:x2' }
+            dependencies { api 'org.test:root2' }
         """
         buildA.settingsFile << """
             rootProject.name = 'theNameOfBuildA'
@@ -213,9 +213,9 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         """
 
         when:
-        execute(buildX, ':x1:compileJava')
+        execute(rootBuild, ':root1:compileJava')
 
         then:
-        result.assertTasksExecuted(':x3:compileJava', ':buildB:compileJava', ':x2:compileJava', ':buildA:compileJava', ':x1:compileJava')
+        result.assertTasksExecuted(':x3:compileJava', ':buildB:compileJava', ':root2:compileJava', ':buildA:compileJava', ':root1:compileJava')
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.build.BuildTestFile
-import org.gradle.util.ToBeImplemented
 
 class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildIntegrationTest {
 
@@ -48,7 +47,6 @@ class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildInt
         result.assertTaskExecuted(":compileJava")
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/6229")
     def "included build can depend on including build"() {
         given:
         def buildB = singleProjectBuild("buildB") {
@@ -67,11 +65,13 @@ class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildInt
         dependency(buildB, "org.test:buildA")
 
         when:
-        fails(buildA, "buildBJar")
+        execute(buildA, "buildBJar")
 
         then:
-        failure.assertHasDescription("Could not find build ':'")
-        // result.assertTaskExecuted(":buildB:compileJava")
-        // result.assertTaskExecuted(":compileJava")
+        result.assertTaskExecuted(":compileJava")
+        result.assertTaskExecuted(":jar")
+        result.assertTaskExecuted(":buildB:compileJava")
+        result.assertTaskExecuted(":buildB:jar")
+        result.assertTaskExecuted(":buildBJar")
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
@@ -26,13 +26,14 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.Pair;
 import org.gradle.internal.build.AbstractBuildState;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public abstract class AbstractCompositeParticipantBuildState extends AbstractBuildState {
+public abstract class AbstractCompositeParticipantBuildState extends AbstractBuildState implements CompositeBuildParticipantBuildState {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCompositeParticipantBuildState.class);
 
     private Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules;

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -78,8 +78,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new LocalComponentInAnotherBuildProvider(projectRegistry, new IncludedBuildDependencyMetadataBuilder());
         }
 
-        public IncludedBuildTaskGraph createIncludedBuildTaskGraph(IncludedBuildControllers controllers) {
-            return new DefaultIncludedBuildTaskGraph(controllers);
+        public IncludedBuildTaskGraph createIncludedBuildTaskGraph(IncludedBuildControllers controllers, BuildStateRegistry buildRegistry) {
+            return new DefaultIncludedBuildTaskGraph(controllers, buildRegistry);
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -26,6 +26,7 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildFactory;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.build.NestedRootBuild;
@@ -162,7 +163,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     @Override
     public void afterConfigureRootBuild() {
         if (!includedBuildsByRootDir.isEmpty()) {
-            dependencySubstitutionsBuilder.build(rootBuild);
+            dependencySubstitutionsBuilder.build((CompositeBuildParticipantBuildState) rootBuild);
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -64,7 +64,14 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
     @Override
     public IncludedBuildTaskResource.State getTaskState(BuildIdentifier targetBuild, String taskPath) {
         if (isRoot(targetBuild)) {
-            return IncludedBuildTaskResource.State.SUCCESS;
+            TaskInternal task = getTask(targetBuild, taskPath);
+            if (task.getState().getFailure() != null) {
+                return IncludedBuildTaskResource.State.FAILED;
+            } else if (task.getState().getExecuted()) {
+                return IncludedBuildTaskResource.State.SUCCESS;
+            } else {
+                return IncludedBuildTaskResource.State.WAITING;
+            }
         } else {
             return buildControllerFor(targetBuild).getTaskState(taskPath);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -19,10 +19,10 @@ package org.gradle.composite.internal;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.concurrent.Stoppable;
@@ -32,7 +32,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 
-class DefaultNestedBuild extends AbstractCompositeParticipantBuildState implements StandAloneNestedBuild, Stoppable {
+class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild, Stoppable {
     private final Path identityPath;
     private final BuildState owner;
     private final BuildIdentifier buildIdentifier;
@@ -100,10 +100,5 @@ class DefaultNestedBuild extends AbstractCompositeParticipantBuildState implemen
     @Override
     public File getBuildRootDir() {
         return gradleLauncher.getBuildRootDir();
-    }
-
-    @Override
-    public GradleInternal getBuild() {
-        return gradleLauncher.getGradle();
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -19,6 +19,7 @@ package org.gradle.composite.internal;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
@@ -100,5 +101,10 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     @Override
     public File getBuildRootDir() {
         return gradleLauncher.getBuildRootDir();
+    }
+
+    @Override
+    public GradleInternal getBuild() {
+        return gradleLauncher.getGradle();
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -118,4 +118,8 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
     public GradleInternal getBuild() {
         return gradleLauncher.getGradle();
     }
+
+    public synchronized void addTasks(Iterable<String> taskPaths) {
+        gradleLauncher.scheduleTasks(taskPaths);
+    }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -118,8 +118,4 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
     public GradleInternal getBuild() {
         return gradleLauncher.getGradle();
     }
-
-    public synchronized void addTasks(Iterable<String> taskPaths) {
-        gradleLauncher.scheduleTasks(taskPaths);
-    }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
@@ -19,14 +19,14 @@ package org.gradle.composite.internal;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
-import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
 import java.io.File;
 
 public class IncludedBuildDependencyMetadataBuilder {
-    public LocalComponentMetadata build(BuildState build, ProjectComponentIdentifier projectIdentifier) {
+    public LocalComponentMetadata build(CompositeBuildParticipantBuildState build, ProjectComponentIdentifier projectIdentifier) {
         GradleInternal gradle = build.getBuild();
         LocalComponentRegistry localComponentRegistry = gradle.getServices().get(LocalComponentRegistry.class);
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(projectIdentifier);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -23,8 +23,8 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.slf4j.Logger;
@@ -66,7 +66,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
         }
     }
 
-    public void build(RootBuildState rootBuildState) {
+    public void build(CompositeBuildParticipantBuildState rootBuildState) {
         context.addAvailableModules(rootBuildState.getAvailableModules());
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
@@ -25,7 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponent
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
@@ -63,7 +63,7 @@ public class LocalComponentInAnotherBuildProvider implements LocalComponentProvi
     private LocalComponentMetadata getRegisteredProject(final ProjectComponentIdentifier projectId) {
         ProjectState projectState = projectRegistry.stateFor(projectId);
         // TODO - this should work for any build, rather than just an included build
-        BuildState buildState = projectState.getOwner();
+        CompositeBuildParticipantBuildState buildState = (CompositeBuildParticipantBuildState) projectState.getOwner();
         if (buildState instanceof IncludedBuildState) {
             // make sure the build is configured now (not do this for the root build, as we are already configuring it right now)
             ((IncludedBuildState) buildState).getConfiguredBuild();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -27,6 +27,7 @@ import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RunNestedBuildBuildOperationType;
 import org.gradle.internal.InternalBuildAdapter;
+import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.NestedRootBuild;
@@ -40,7 +41,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 
-public class RootOfNestedBuildTree extends AbstractCompositeParticipantBuildState implements NestedRootBuild {
+public class RootOfNestedBuildTree extends AbstractBuildState implements NestedRootBuild {
     private final BuildIdentifier buildIdentifier;
     private final Path identityPath;
     private final BuildState owner;
@@ -139,11 +140,6 @@ public class RootOfNestedBuildTree extends AbstractCompositeParticipantBuildStat
         } finally {
             buildController.stop();
         }
-    }
-
-    @Override
-    public GradleInternal getBuild() {
-        return gradleLauncher.getGradle();
     }
 }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -141,6 +141,11 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
             buildController.stop();
         }
     }
+
+    @Override
+    public GradleInternal getBuild() {
+        return gradleLauncher.getGradle();
+    }
 }
 
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -38,6 +38,11 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     void addEntryTasks(Iterable<? extends Task> tasks);
 
     /**
+     * Adds an additional entry task that may be discovered in a composition of task graphs.
+     */
+    void addAdditionalEntryTask(String taskPath);
+
+    /**
      * Adds the given nodes to this graph.
      */
     void addNodes(Collection<? extends Node> nodes);

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -16,18 +16,14 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
-import org.gradle.internal.Pair;
 import org.gradle.util.Path;
 
 import java.io.File;
-import java.util.Set;
 
 /**
  * Encapsulates the identity and state of a particular build in a build tree.
@@ -88,16 +84,4 @@ public interface BuildState {
      * The root directory of the build.
      */
     File getBuildRootDir();
-
-    /**
-     * Identities of the modules represented by the projects of this build.
-     */
-    Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
-
-    GradleInternal getBuild();
-
-    /**
-     * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build
-     */
-    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -18,6 +18,7 @@ package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
@@ -84,4 +85,6 @@ public interface BuildState {
      * The root directory of the build.
      */
     File getBuildRootDir();
+
+    GradleInternal getBuild();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
@@ -37,4 +37,6 @@ public interface CompositeBuildParticipantBuildState extends BuildState {
      */
     ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 
+    void addTasks(Iterable<String> tasks);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.Pair;
+
+import java.util.Set;
+
+public interface CompositeBuildParticipantBuildState extends BuildState {
+
+    /**
+     * Identities of the modules represented by the projects of this build.
+     */
+    Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
+
+    GradleInternal getBuild();
+
+    /**
+     * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build
+     */
+    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
@@ -18,7 +18,6 @@ package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.Pair;
 
 import java.util.Set;
@@ -29,8 +28,6 @@ public interface CompositeBuildParticipantBuildState extends BuildState {
      * Identities of the modules represented by the projects of this build.
      */
     Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
-
-    GradleInternal getBuild();
 
     /**
      * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build

--- a/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/CompositeBuildParticipantBuildState.java
@@ -34,6 +34,4 @@ public interface CompositeBuildParticipantBuildState extends BuildState {
      */
     ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 
-    void addTasks(Iterable<String> tasks);
-
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -38,7 +38,6 @@ public interface IncludedBuildState extends NestedBuildState, CompositeBuildPart
 
     GradleInternal getConfiguredBuild();
     void finishBuild();
-    void addTasks(Iterable<String> tasks);
     void execute(Iterable<String> tasks, Object listener);
 
     <T> T withState(Transformer<T, ? super GradleInternal> action);

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -28,7 +28,7 @@ import java.io.File;
 /**
  * Encapsulates the identity and state of an included build. An included build is a nested build that participates in dependency resolution and task execution with the root build and other included builds in the build tree.
  */
-public interface IncludedBuildState extends NestedBuildState {
+public interface IncludedBuildState extends NestedBuildState, CompositeBuildParticipantBuildState {
     String getName();
     File getRootDirectory();
     IncludedBuild getModel();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -38,6 +38,7 @@ public interface IncludedBuildState extends NestedBuildState, CompositeBuildPart
 
     GradleInternal getConfiguredBuild();
     void finishBuild();
+    void addTasks(Iterable<String> tasks);
     void execute(Iterable<String> tasks, Object listener);
 
     <T> T withState(Transformer<T, ? super GradleInternal> action);

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.SettingsLoader;
 import org.gradle.internal.build.BuildStateRegistry;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.reflect.Instantiator;
@@ -60,7 +61,7 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
                     IncludedBuildState includedBuild = addIncludedBuild(includedBuildSpec, gradle);
                     children.add(includedBuild.getModel());
                 } else {
-                    children.add(new IncludedRootBuild(buildRegistry.getRootBuild()));
+                    children.add(new IncludedRootBuild((CompositeBuildParticipantBuildState) buildRegistry.getRootBuild()));
                 }
             }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedRootBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedRootBuild.java
@@ -23,19 +23,19 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.TaskReference;
-import org.gradle.internal.build.RootBuildState;
+import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.util.Path;
 
 import java.io.File;
 
 public class IncludedRootBuild implements IncludedBuild {
-    private final RootBuildState rootBuild;
+    private final CompositeBuildParticipantBuildState rootBuild;
 
-    public IncludedRootBuild(RootBuildState rootBuild) {
+    public IncludedRootBuild(CompositeBuildParticipantBuildState rootBuild) {
         this.rootBuild = rootBuild;
     }
 
-    public RootBuildState getRootBuild() {
+    public CompositeBuildParticipantBuildState getRootBuild() {
         return rootBuild;
     }
 
@@ -57,9 +57,9 @@ public class IncludedRootBuild implements IncludedBuild {
 
     public class IncludedRootBuildTaskReference implements TaskReference, TaskDependencyContainer {
         private final String taskPath;
-        private final RootBuildState rootBuildState;
+        private final CompositeBuildParticipantBuildState rootBuildState;
 
-        public IncludedRootBuildTaskReference(RootBuildState rootBuildState, String taskPath) {
+        public IncludedRootBuildTaskReference(CompositeBuildParticipantBuildState rootBuildState, String taskPath) {
             this.rootBuildState = rootBuildState;
             this.taskPath = taskPath;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -232,7 +232,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         ListenerBroadcast<TaskExecutionGraphListener> graphListeners,
         ListenerManager listenerManager,
         ProjectStateRegistry projectStateRegistry,
-        ServiceRegistry gradleScopedServices
+        ServiceRegistry gradleScopedServices,
+        TaskSelector taskSelector
     ) {
         return new DefaultTaskExecutionGraph(
             planExecutor,
@@ -247,7 +248,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             taskListeners,
             listenerManager.getBroadcaster(BuildScopeListenerRegistrationListener.class),
             projectStateRegistry,
-            gradleScopedServices
+            gradleScopedServices,
+            taskSelector
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -120,6 +120,7 @@ public class ProjectBuilderImpl {
 
         GradleInternal gradle = buildServices.get(InstantiatorFactory.class).decorateLenient().newInstance(DefaultGradle.class, null, startParameter, buildServices.get(ServiceRegistryFactory.class));
         gradle.setIncludedBuilds(Collections.emptyList());
+        build.setGradle(gradle); // the TestRootBuild instance cannot be created after GradleInternal
 
         ProjectDescriptorRegistry projectDescriptorRegistry = buildServices.get(ProjectDescriptorRegistry.class);
         DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null, name, projectDir, projectDescriptorRegistry, buildServices.get(FileResolver.class));
@@ -198,6 +199,7 @@ public class ProjectBuilderImpl {
 
     private static class TestRootBuild extends AbstractBuildState implements RootBuildState {
         private final File rootProjectDir;
+        private GradleInternal gradle;
 
         public TestRootBuild(File rootProjectDir) {
             this.rootProjectDir = rootProjectDir;
@@ -260,6 +262,15 @@ public class ProjectBuilderImpl {
         @Override
         public File getBuildRootDir() {
             return rootProjectDir;
+        }
+
+        @Override
+        public GradleInternal getBuild() {
+            return gradle;
+        }
+
+        public void setGradle(GradleInternal gradle) {
+            this.gradle = gradle;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -19,7 +19,6 @@ package org.gradle.testfixtures.internal;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildType;
@@ -44,7 +43,6 @@ import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ProjectDescriptorRegistry;
 import org.gradle.internal.FileUtils;
-import org.gradle.internal.Pair;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -73,7 +71,6 @@ import org.gradle.util.Path;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.Set;
 
 import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
 
@@ -123,7 +120,6 @@ public class ProjectBuilderImpl {
 
         GradleInternal gradle = buildServices.get(InstantiatorFactory.class).decorateLenient().newInstance(DefaultGradle.class, null, startParameter, buildServices.get(ServiceRegistryFactory.class));
         gradle.setIncludedBuilds(Collections.emptyList());
-        build.setGradle(gradle); // the TestRootBuild instance cannot be created after GradleInternal
 
         ProjectDescriptorRegistry projectDescriptorRegistry = buildServices.get(ProjectDescriptorRegistry.class);
         DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null, name, projectDir, projectDescriptorRegistry, buildServices.get(FileResolver.class));
@@ -202,7 +198,6 @@ public class ProjectBuilderImpl {
 
     private static class TestRootBuild extends AbstractBuildState implements RootBuildState {
         private final File rootProjectDir;
-        private GradleInternal gradle;
 
         public TestRootBuild(File rootProjectDir) {
             this.rootProjectDir = rootProjectDir;
@@ -265,25 +260,6 @@ public class ProjectBuilderImpl {
         @Override
         public File getBuildRootDir() {
             return rootProjectDir;
-        }
-
-        @Override
-        public Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public GradleInternal getBuild() {
-            return gradle;
-        }
-
-        @Override
-        public ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier) {
-            throw new UnsupportedOperationException();
-        }
-
-        public void setGradle(GradleInternal gradle) {
-            this.gradle = gradle;
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -38,6 +38,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.composite.internal.IncludedBuildTaskGraph
 import org.gradle.configuration.internal.TestListenerBuildOperationDecorator
+import org.gradle.execution.TaskSelector
 import org.gradle.execution.plan.AbstractExecutionPlanSpec
 import org.gradle.execution.plan.DefaultPlanExecutor
 import org.gradle.execution.plan.LocalTaskNode
@@ -75,7 +76,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(IncludedBuildTaskGraph))
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
     def projectStateRegistry = Stub(ProjectStateRegistry)
-    def taskGraph = new DefaultTaskExecutionGraph(new DefaultPlanExecutor(parallelismConfiguration, executorFactory, workerLeases, cancellationToken, coordinationService), [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry))
+    def taskGraph = new DefaultTaskExecutionGraph(new DefaultPlanExecutor(parallelismConfiguration, executorFactory, workerLeases, cancellationToken, coordinationService), [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry), Stub(TaskSelector))
     WorkerLeaseRegistry.WorkerLeaseCompletion parentWorkerLease
     def executedTasks = []
     def failures = []
@@ -363,7 +364,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
     def "notifies graph listener before first execute"() {
         def planExecutor = Mock(PlanExecutor)
-        def taskGraph = new DefaultTaskExecutionGraph(planExecutor, [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry))
+        def taskGraph = new DefaultTaskExecutionGraph(planExecutor, [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry), Stub(TaskSelector))
         TaskExecutionGraphListener listener = Mock(TaskExecutionGraphListener)
         Task a = task("a")
 
@@ -388,7 +389,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
     def "executes whenReady listener before first execute"() {
         def planExecutor = Mock(PlanExecutor)
-        def taskGraph = new DefaultTaskExecutionGraph(planExecutor, [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry))
+        def taskGraph = new DefaultTaskExecutionGraph(planExecutor, [nodeExecutor], buildOperationExecutor, listenerBuildOperationDecorator, coordinationService, thisBuild, taskNodeFactory, dependencyResolver, graphListeners, taskExecutionListeners, listenerRegistrationListener, projectStateRegistry, Stub(ServiceRegistry), Stub(TaskSelector))
         def closure = Mock(Closure)
         def action = Mock(Action)
         Task a = task("a")


### PR DESCRIPTION
Fixes the test cases that are part of this PR.

The actual change is in this commit: 981bda426c1c1b8544722b58d87070132ece1a91

see #6229.