### PR TITLE
Rename "dependencies model" to "version catalog"

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
@@ -25,14 +25,14 @@ import org.gradle.internal.HasInternalProtocol;
 import java.util.List;
 
 /**
- * A dependencies model builder. Dependencies defined via this model
+ * A version catalog builder. Dependencies defined via this model
  * will trigger the generation of accessors available in build scripts.
  *
  * @since 6.8
  */
 @Incubating
 @HasInternalProtocol
-public interface DependenciesModelBuilder {
+public interface VersionCatalogBuilder {
 
     /**
      * A description for the dependencies model, which will be used in
@@ -72,7 +72,7 @@ public interface DependenciesModelBuilder {
 
     /**
      * Configures a dependency version which can then be referenced using
-     * the {@link DependenciesModelBuilder.LibraryAliasBuilder#versionRef(String)} )} method.
+     * the {@link VersionCatalogBuilder.LibraryAliasBuilder#versionRef(String)} )} method.
      *
      * @param name an identifier for the version
      * @param versionSpec the dependency version spec
@@ -82,7 +82,7 @@ public interface DependenciesModelBuilder {
 
     /**
      * Configures a dependency version which can then be referenced using
-     * the {@link DependenciesModelBuilder.LibraryAliasBuilder#versionRef(String)} method.
+     * the {@link VersionCatalogBuilder.LibraryAliasBuilder#versionRef(String)} method.
      *
      * @param name an identifier for the version
      * @param version the version string

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -20,7 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.provider.Property;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -54,12 +54,11 @@ public interface DependencyResolutionManagement {
     ComponentMetadataHandler getComponents();
 
     /**
-     * Configures the dependency model, which will be used
-     * to generate type safe accessors for dependencies.
+     * Configures a version catalog which will be used to generate type safe accessors for dependencies.
      * @param name the name of the extension which is going to be generated for this model
      * @param spec the spec to configure the dependencies
      */
-    void dependenciesModel(String name, Action<? super DependenciesModelBuilder> spec);
+    void versionCatalog(String name, Action<? super VersionCatalogBuilder> spec);
 
     /**
      * Returns the name of the extension generated for type-safe project accessors.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlDependenciesFileParser.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Interners;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.plugin.use.PluginDependenciesSpec;
 import org.tomlj.Toml;
 import org.tomlj.TomlArray;
@@ -50,7 +50,7 @@ public class TomlDependenciesFileParser {
         VERSIONS_KEY
     );
 
-    public static void parse(InputStream in, DependenciesModelBuilder builder, PluginDependenciesSpec plugins, ImportConfiguration importConfig) throws IOException {
+    public static void parse(InputStream in, VersionCatalogBuilder builder, PluginDependenciesSpec plugins, ImportConfiguration importConfig) throws IOException {
         StrictVersionParser strictVersionParser = new StrictVersionParser(Interners.newStrongInterner());
         TomlParseResult result = Toml.parse(in);
         TomlTable dependenciesTable = result.getTable(DEPENDENCIES_KEY);
@@ -67,7 +67,7 @@ public class TomlDependenciesFileParser {
         parseVersions(versionsTable, builder, strictVersionParser, importConfig);
     }
 
-    private static void parseDependencies(@Nullable TomlTable dependenciesTable, DependenciesModelBuilder builder, StrictVersionParser strictVersionParser, ImportConfiguration importConfig) {
+    private static void parseDependencies(@Nullable TomlTable dependenciesTable, VersionCatalogBuilder builder, StrictVersionParser strictVersionParser, ImportConfiguration importConfig) {
         if (dependenciesTable == null) {
             return;
         }
@@ -83,7 +83,7 @@ public class TomlDependenciesFileParser {
         }
     }
 
-    private static void parseVersions(@Nullable TomlTable versionsTable, DependenciesModelBuilder builder, StrictVersionParser strictVersionParser, ImportConfiguration importConfig) {
+    private static void parseVersions(@Nullable TomlTable versionsTable, VersionCatalogBuilder builder, StrictVersionParser strictVersionParser, ImportConfiguration importConfig) {
         if (versionsTable == null) {
             return;
         }
@@ -99,7 +99,7 @@ public class TomlDependenciesFileParser {
         }
     }
 
-    private static void parseBundles(@Nullable TomlTable bundlesTable, DependenciesModelBuilder builder, ImportConfiguration importConfig) {
+    private static void parseBundles(@Nullable TomlTable bundlesTable, VersionCatalogBuilder builder, ImportConfiguration importConfig) {
         if (bundlesTable == null) {
             return;
         }
@@ -157,7 +157,7 @@ public class TomlDependenciesFileParser {
         }
     }
 
-    private static void parseDependency(String alias, TomlTable dependenciesTable, DependenciesModelBuilder builder, StrictVersionParser strictVersionParser) {
+    private static void parseDependency(String alias, TomlTable dependenciesTable, VersionCatalogBuilder builder, StrictVersionParser strictVersionParser) {
         Object gav = dependenciesTable.get(alias);
         if (gav instanceof String) {
             List<String> splitted = SPLITTER.splitToList((String) gav);
@@ -221,7 +221,7 @@ public class TomlDependenciesFileParser {
         registerDependency(builder, alias, group, name, versionRef, require, strictly, prefer, rejectedVersions, rejectAll);
     }
 
-    private static void parseVersion(String alias, TomlTable versionsTable, DependenciesModelBuilder builder, StrictVersionParser strictVersionParser) {
+    private static void parseVersion(String alias, TomlTable versionsTable, VersionCatalogBuilder builder, StrictVersionParser strictVersionParser) {
         String require = null;
         String strictly = null;
         String prefer = null;
@@ -262,7 +262,7 @@ public class TomlDependenciesFileParser {
         return string;
     }
 
-    private static void registerDependency(DependenciesModelBuilder builder,
+    private static void registerDependency(VersionCatalogBuilder builder,
                                            String alias,
                                            String group,
                                            String name,
@@ -272,7 +272,7 @@ public class TomlDependenciesFileParser {
                                            @Nullable String prefer,
                                            @Nullable List<String> rejectedVersions,
                                            @Nullable Boolean rejectAll) {
-        DependenciesModelBuilder.LibraryAliasBuilder aliasBuilder = builder.alias(alias).to(group, name);
+        VersionCatalogBuilder.LibraryAliasBuilder aliasBuilder = builder.alias(alias).to(group, name);
         if (versionRef != null) {
             aliasBuilder.versionRef(versionRef);
             return;
@@ -296,7 +296,7 @@ public class TomlDependenciesFileParser {
         });
     }
 
-    private static void registerVersion(DependenciesModelBuilder builder,
+    private static void registerVersion(VersionCatalogBuilder builder,
                                         String alias,
                                         @Nullable String require,
                                         @Nullable String strictly,

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -80,7 +80,7 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         String defaultLibrary = dm.getDefaultLibrariesExtensionName().get();
         File dependenciesFile = new File(settings.getSettingsDir(), "gradle/dependencies.toml");
         if (dependenciesFile.exists()) {
-            dm.dependenciesModel(defaultLibrary, builder -> builder.from(services.get(FileCollectionFactory.class).fixed(dependenciesFile)));
+            dm.versionCatalog(defaultLibrary, builder -> builder.from(services.get(FileCollectionFactory.class).fixed(dependenciesFile)));
         }
         accessors.generateAccessors(dm.getDependenciesModelBuilders(), classLoaderScope, settings);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DependenciesAccessors.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DependenciesAccessors.java
@@ -16,7 +16,7 @@
 package org.gradle.initialization;
 
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.classpath.ClassPath;
@@ -24,7 +24,7 @@ import org.gradle.internal.classpath.ClassPath;
 import java.util.List;
 
 public interface DependenciesAccessors {
-    void generateAccessors(List<DependenciesModelBuilder> builders, ClassLoaderScope classLoaderScope, Settings settings);
+    void generateAccessors(List<VersionCatalogBuilder> builders, ClassLoaderScope classLoaderScope, Settings settings);
     void createExtensions(ProjectInternal project);
     ClassPath getSources();
     ClassPath getClasses();

--- a/subprojects/core/src/main/java/org/gradle/internal/management/DependencyResolutionManagementInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/management/DependencyResolutionManagementInternal.java
@@ -17,7 +17,7 @@ package org.gradle.internal.management;
 
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.initialization.resolve.RulesMode;
@@ -42,7 +42,7 @@ public interface DependencyResolutionManagementInternal extends DependencyResolu
 
     Property<String> getDefaultProjectsExtensionName();
 
-    List<DependenciesModelBuilder> getDependenciesModelBuilders();
+    List<VersionCatalogBuilder> getDependenciesModelBuilders();
 
     void setPluginsSpec(PluginManagementSpec pluginManagementSpec);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
@@ -20,7 +20,7 @@ import com.google.common.collect.Interners
 import groovy.transform.CompileStatic
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.MutableVersionConstraint
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -36,7 +36,7 @@ import static org.gradle.api.internal.std.IncludeExcludePredicate.acceptAll
 
 class TomlDependenciesFileParserTest extends Specification {
     final ImportConfiguration importConf = new ImportConfiguration(acceptAll(), acceptAll(), acceptAll(), acceptAll())
-    final DependenciesModelBuilder builder = new DefaultDependenciesModelBuilder("libs",
+    final VersionCatalogBuilder builder = new DefaultVersionCatalogBuilder("libs",
         Interners.newStrongInterner(),
         Interners.newStrongInterner(),
         TestUtil.objectFactory(),
@@ -51,7 +51,7 @@ class TomlDependenciesFileParserTest extends Specification {
             plugins[id]
         }
     }
-    AllDependenciesModel model
+    DefaultVersionCatalog model
 
     def "parses a file with a single dependency and nothing else"() {
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -26,7 +26,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "dependencies declared in settings trigger the creation of an extension (notation=#notation)"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     $notation
                 }
             }
@@ -63,7 +63,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         when: "adding a library to the model"
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("bar") to "org.gradle.test:bar:1.0"
                 }
             }
@@ -91,7 +91,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -125,7 +125,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency and override the version"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -163,7 +163,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     void "can add several dependencies at once using a bundle"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("lib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -203,7 +203,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     void "overriding the version of a bundle overrides the version of all dependencies of the bundle"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("lib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -247,7 +247,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure a different libraries extension"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libraries") {
+                versionCatalog("libraries") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -281,12 +281,12 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure multiple libraries extension"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libraries") {
+                versionCatalog("libraries") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
-                dependenciesModel("other") {
+                versionCatalog("other") {
                     alias("great").to("org.gradle.test", "lib2").version {
                         require "1.1"
                     }
@@ -327,12 +327,12 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure multiple libraries extension with same contents"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libraries") {
+                versionCatalog("libraries") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
                 }
-                dependenciesModel("other") {
+                versionCatalog("other") {
                     alias("myLib").to("org.gradle.test", "lib").version {
                         require "1.0"
                     }
@@ -367,7 +367,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "extension can be used in any subproject"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
@@ -412,7 +412,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "libraries extension is not visible in buildSrc"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
@@ -433,7 +433,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "buildSrc and main project have different libraries extensions"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("lib").to("org.gradle.test:lib:1.0")
                 }
             }
@@ -449,7 +449,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         """
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("build-src-lib").to("org.gradle.test:buildsrc-lib:1.0")
                 }
             }
@@ -501,7 +501,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                 repositories {
                     maven { url "${mavenHttpRepo.uri}" }
                 }
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias('from-included').to('org.gradle.test:other:1.1')
                 }
             }
@@ -540,7 +540,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can declare a version with a name and reference it"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     version("myVersion") {
                         require "1.0"
                     }
@@ -585,7 +585,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "multiple libraries can use the same version reference"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     def myVersion = version("myVersion") {
                         require "1.0"
                     }
@@ -627,7 +627,7 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can generate a version accessor and use it in a build script"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     version("libVersion") {
                         $notation
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -45,7 +45,7 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
         def lib = mavenHttpRepo.module('org.gradle.test', 'lib', '1.1').publish()
         settingsKotlinFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias("my-lib").to("org.gradle.test:lib:1.0")
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -294,7 +294,7 @@ lib = "org.gradle.test:lib:1.0"
 """
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from(files("../gradle/dependencies.toml"))
                 }
             }
@@ -432,7 +432,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
         """
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias('other').to('org.gradle.test:other:1.0')
                 }
             }
@@ -470,7 +470,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.1"}
         """
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     alias('my-lib').to('org.gradle.test:lib:1.0')
                 }
             }
@@ -653,7 +653,7 @@ my-other-lib = {group = "org.gradle.test", name="lib2", version.ref="rich"}
         def path = file("missing.toml").absolutePath
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel('libs') {
+                versionCatalog('libs') {
                     from(files("missing.toml"))
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -24,11 +24,11 @@ import org.gradle.api.provider.ProviderFactory;
 import javax.inject.Inject;
 
 public abstract class AbstractExternalDependencyFactory implements ExternalModuleDependencyFactory {
-    private final AllDependenciesModel config;
+    private final DefaultVersionCatalog config;
     private final ProviderFactory providers;
 
     @Inject
-    protected AbstractExternalDependencyFactory(AllDependenciesModel config,
+    protected AbstractExternalDependencyFactory(DefaultVersionCatalog config,
                                                 ProviderFactory providers) {
         this.config = config;
         this.providers = providers;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
@@ -49,7 +49,7 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
-import org.gradle.internal.management.DependenciesModelBuilderInternal;
+import org.gradle.internal.management.VersionCatalogBuilderInternal;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.ValueSnapshot;
@@ -113,7 +113,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
             this.classLoaderScope = classLoaderScope;
             this.models.clear(); // this is used in tests only, shouldn't happen in real context
             for (VersionCatalogBuilder builder : builders) {
-                DefaultVersionCatalog model = ((DependenciesModelBuilderInternal) builder).build();
+                DefaultVersionCatalog model = ((VersionCatalogBuilderInternal) builder).build();
                 models.add(model);
             }
             if (models.stream().anyMatch(DefaultVersionCatalog::isNotEmpty)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Maps;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.SettingsInternal;
@@ -83,7 +83,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     private final ExecutionEngine engine;
     private final FileCollectionFactory fileCollectionFactory;
     private final ClasspathFingerprinter fingerprinter;
-    private final List<AllDependenciesModel> models = Lists.newArrayList();
+    private final List<DefaultVersionCatalog> models = Lists.newArrayList();
     private final Map<String, Class<? extends ExternalModuleDependencyFactory>> factories = Maps.newHashMap();
 
     private ClassLoaderScope classLoaderScope;
@@ -108,17 +108,17 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     }
 
     @Override
-    public void generateAccessors(List<DependenciesModelBuilder> builders, ClassLoaderScope classLoaderScope, Settings settings) {
+    public void generateAccessors(List<VersionCatalogBuilder> builders, ClassLoaderScope classLoaderScope, Settings settings) {
         try {
             this.classLoaderScope = classLoaderScope;
             this.models.clear(); // this is used in tests only, shouldn't happen in real context
-            for (DependenciesModelBuilder builder : builders) {
-                AllDependenciesModel model = ((DependenciesModelBuilderInternal) builder).build();
+            for (VersionCatalogBuilder builder : builders) {
+                DefaultVersionCatalog model = ((DependenciesModelBuilderInternal) builder).build();
                 models.add(model);
             }
-            if (models.stream().anyMatch(AllDependenciesModel::isNotEmpty)) {
+            if (models.stream().anyMatch(DefaultVersionCatalog::isNotEmpty)) {
                 IncubationLogger.incubatingFeatureUsed("Type-safe dependency accessors");
-                for (AllDependenciesModel model : models) {
+                for (DefaultVersionCatalog model : models) {
                     if (model.isNotEmpty()) {
                         writeDependenciesAccessors(model);
                     }
@@ -133,7 +133,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
         }
     }
 
-    private void writeDependenciesAccessors(AllDependenciesModel model) {
+    private void writeDependenciesAccessors(DefaultVersionCatalog model) {
         executeWork(new DependencyAccessorUnitOfWork(model));
     }
 
@@ -201,7 +201,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
         ExtensionContainer container = project.getExtensions();
         try {
             if (!models.isEmpty()) {
-                for (AllDependenciesModel model : models) {
+                for (DefaultVersionCatalog model : models) {
                     if (model.isNotEmpty()) {
                         Class<? extends ExternalModuleDependencyFactory> factory;
                         synchronized (this) {
@@ -312,9 +312,9 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
         private static final String IN_MODEL_NAME = "modelName";
         private static final String IN_CLASSPATH = "classpath";
 
-        private final AllDependenciesModel model;
+        private final DefaultVersionCatalog model;
 
-        private DependencyAccessorUnitOfWork(AllDependenciesModel model) {
+        private DependencyAccessorUnitOfWork(DefaultVersionCatalog model) {
             this.model = model;
         }
 
@@ -389,9 +389,9 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     private static class DependenciesAccessorClassSource implements ClassSource {
 
         private final String name;
-        private final AllDependenciesModel model;
+        private final DefaultVersionCatalog model;
 
-        private DependenciesAccessorClassSource(String name, AllDependenciesModel model) {
+        private DependenciesAccessorClassSource(String name, DefaultVersionCatalog model) {
             this.name = name;
             this.model = model;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalog.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalog.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class AllDependenciesModel implements Serializable {
+public class DefaultVersionCatalog implements Serializable {
     private final String name;
     private final String description;
     private final Map<String, DependencyModel> aliasToDependency;
@@ -28,11 +28,11 @@ public class AllDependenciesModel implements Serializable {
     private final Map<String, VersionModel> versions;
     private final int hashCode;
 
-    public AllDependenciesModel(String name,
-                                String description,
-                                Map<String, DependencyModel> aliasToDependency,
-                                Map<String, BundleModel> bundles,
-                                Map<String, VersionModel> versions) {
+    public DefaultVersionCatalog(String name,
+                                 String description,
+                                 Map<String, DependencyModel> aliasToDependency,
+                                 Map<String, BundleModel> bundles,
+                                 Map<String, VersionModel> versions) {
         this.name = name;
         this.description = description;
         this.aliasToDependency = aliasToDependency;
@@ -92,7 +92,7 @@ public class AllDependenciesModel implements Serializable {
             return false;
         }
 
-        AllDependenciesModel that = (AllDependenciesModel) o;
+        DefaultVersionCatalog that = (DefaultVersionCatalog) o;
 
         if (!aliasToDependency.equals(that.aliasToDependency)) {
             return false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalogBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalogBuilder.java
@@ -48,7 +48,7 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.Actions;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.lazy.Lazy;
-import org.gradle.internal.management.DependenciesModelBuilderInternal;
+import org.gradle.internal.management.VersionCatalogBuilderInternal;
 import org.gradle.plugin.use.PluginDependenciesSpec;
 
 import javax.annotation.Nullable;
@@ -64,7 +64,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class DefaultVersionCatalogBuilder implements DependenciesModelBuilderInternal {
+public class DefaultVersionCatalogBuilder implements VersionCatalogBuilderInternal {
     private final static Logger LOGGER = Logging.getLogger(DefaultVersionCatalogBuilder.class);
     private final static Attribute<String> INTERNAL_COUNTER = Attribute.of("org.gradle.internal.dm.model.builder.id", String.class);
     private final static List<String> FORBIDDEN_ALIAS_SUFFIX = ImmutableList.of("bundles", "versions", "version", "bundle");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependenciesSourceGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependenciesSourceGenerator.java
@@ -31,16 +31,16 @@ import java.util.stream.Collectors;
 public class DependenciesSourceGenerator extends AbstractSourceGenerator {
 
     private static final int MAX_ENTRIES = 30000;
-    private final AllDependenciesModel config;
+    private final DefaultVersionCatalog config;
 
     public DependenciesSourceGenerator(Writer writer,
-                                       AllDependenciesModel config) {
+                                       DefaultVersionCatalog config) {
         super(writer);
         this.config = config;
     }
 
     public static void generateSource(Writer writer,
-                                      AllDependenciesModel config,
+                                      DefaultVersionCatalog config,
                                       String packageName,
                                       String className) {
         DependenciesSourceGenerator generator = new DependenciesSourceGenerator(writer, config);
@@ -61,7 +61,7 @@ public class DependenciesSourceGenerator extends AbstractSourceGenerator {
         addImport("org.gradle.api.provider.Provider");
         addImport("org.gradle.api.provider.ProviderFactory");
         addImport("org.gradle.api.internal.std.AbstractExternalDependencyFactory");
-        addImport("org.gradle.api.internal.std.AllDependenciesModel");
+        addImport("org.gradle.api.internal.std.DefaultVersionCatalog");
         addImport("java.util.Map");
         addImport("javax.inject.Inject");
         writeLn();
@@ -80,7 +80,7 @@ public class DependenciesSourceGenerator extends AbstractSourceGenerator {
         writeLn("    private final " + bundlesClassName + " bundles = new " + bundlesClassName + "();");
         writeLn();
         writeLn("    @Inject");
-        writeLn("    public " + className + "(AllDependenciesModel config, ProviderFactory providers) {");
+        writeLn("    public " + className + "(DefaultVersionCatalog config, ProviderFactory providers) {");
         writeLn("        super(config, providers);");
         writeLn("    }");
         writeLn();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyBundleValueSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DependencyBundleValueSource.java
@@ -33,13 +33,13 @@ public abstract class DependencyBundleValueSource implements ValueSource<Externa
     interface Params extends ValueSourceParameters {
         Property<String> getBundleName();
 
-        Property<AllDependenciesModel> getConfig();
+        Property<DefaultVersionCatalog> getConfig();
     }
 
     @Override
     public ExternalModuleDependencyBundle obtain() {
         String bundle = getParameters().getBundleName().get();
-        AllDependenciesModel config = getParameters().getConfig().get();
+        DefaultVersionCatalog config = getParameters().getConfig().get();
         BundleModel bundleModel = config.getBundle(bundle);
         return bundleModel.getComponents().stream()
             .map(config::getDependencyData)

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -32,7 +32,7 @@ import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.initialization.resolve.RulesMode;
@@ -47,7 +47,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.std.DefaultDependenciesModelBuilder;
+import org.gradle.api.internal.std.DefaultVersionCatalogBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -80,7 +80,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     private final Property<RulesMode> rulesMode;
     private final Property<String> librariesExtensionName;
     private final Property<String> projectsExtensionName;
-    private final Map<String, DependenciesModelBuilderInternal> dependenciesModelBuilders = Maps.newHashMap();
+    private final Map<String, DependenciesModelBuilderInternal> versionCatalogBuilders = Maps.newHashMap();
     private final ObjectFactory objects;
     private final ProviderFactory providers;
     private final Interner<String> strings = Interners.newStrongInterner();
@@ -143,10 +143,10 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     }
 
     @Override
-    public void dependenciesModel(String name, Action<? super DependenciesModelBuilder> spec) {
+    public void versionCatalog(String name, Action<? super VersionCatalogBuilder> spec) {
         validateName(name);
-        DependenciesModelBuilderInternal model = dependenciesModelBuilders.computeIfAbsent(name, n ->
-            objects.newInstance(DefaultDependenciesModelBuilder.class, n, strings, versions, objects, providers, plugins, dependencyResolutionServices));
+        DependenciesModelBuilderInternal model = versionCatalogBuilders.computeIfAbsent(name, n ->
+            objects.newInstance(DefaultVersionCatalogBuilder.class, n, strings, versions, objects, providers, plugins, dependencyResolutionServices));
         UserCodeApplicationContext.Application current = context.current();
         model.withContext(current == null ? "Settings" : current.getDisplayName().getDisplayName(), () -> spec.execute(model));
     }
@@ -174,8 +174,8 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     }
 
     @Override
-    public List<DependenciesModelBuilder> getDependenciesModelBuilders() {
-        return ImmutableList.copyOf(dependenciesModelBuilders.values());
+    public List<VersionCatalogBuilder> getDependenciesModelBuilders() {
+        return ImmutableList.copyOf(versionCatalogBuilders.values());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -80,7 +80,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     private final Property<RulesMode> rulesMode;
     private final Property<String> librariesExtensionName;
     private final Property<String> projectsExtensionName;
-    private final Map<String, DependenciesModelBuilderInternal> versionCatalogBuilders = Maps.newHashMap();
+    private final Map<String, VersionCatalogBuilderInternal> versionCatalogBuilders = Maps.newHashMap();
     private final ObjectFactory objects;
     private final ProviderFactory providers;
     private final Interner<String> strings = Interners.newStrongInterner();
@@ -145,7 +145,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     @Override
     public void versionCatalog(String name, Action<? super VersionCatalogBuilder> spec) {
         validateName(name);
-        DependenciesModelBuilderInternal model = versionCatalogBuilders.computeIfAbsent(name, n ->
+        VersionCatalogBuilderInternal model = versionCatalogBuilders.computeIfAbsent(name, n ->
             objects.newInstance(DefaultVersionCatalogBuilder.class, n, strings, versions, objects, providers, plugins, dependencyResolutionServices));
         UserCodeApplicationContext.Application current = context.current();
         model.withContext(current == null ? "Settings" : current.getDisplayName().getDisplayName(), () -> spec.execute(model));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DependenciesModelBuilderInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DependenciesModelBuilderInternal.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.internal.management;
 
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
-import org.gradle.api.internal.std.AllDependenciesModel;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
 
-public interface DependenciesModelBuilderInternal extends DependenciesModelBuilder {
-    AllDependenciesModel build();
+public interface DependenciesModelBuilderInternal extends VersionCatalogBuilder {
+    DefaultVersionCatalog build();
     void withContext(String context, Runnable action);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/VersionCatalogBuilderInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/VersionCatalogBuilderInternal.java
@@ -18,7 +18,7 @@ package org.gradle.internal.management;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.internal.std.DefaultVersionCatalog;
 
-public interface DependenciesModelBuilderInternal extends VersionCatalogBuilder {
+public interface VersionCatalogBuilderInternal extends VersionCatalogBuilder {
     DefaultVersionCatalog build();
     void withContext(String context, Runnable action);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultVersionCatalogBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DefaultVersionCatalogBuilderTest.groovy
@@ -29,10 +29,10 @@ import spock.lang.Unroll
 
 import java.util.function.Supplier
 
-class DefaultDependenciesModelBuilderTest extends Specification {
+class DefaultVersionCatalogBuilderTest extends Specification {
 
     @Subject
-    DefaultDependenciesModelBuilder builder = new DefaultDependenciesModelBuilder("libs", Interners.newStrongInterner(), Interners.newStrongInterner(), TestUtil.objectFactory(), TestUtil.providerFactory(), Stub(PluginDependenciesSpec), Stub(Supplier))
+    DefaultVersionCatalogBuilder builder = new DefaultVersionCatalogBuilder("libs", Interners.newStrongInterner(), Interners.newStrongInterner(), TestUtil.objectFactory(), TestUtil.providerFactory(), Stub(PluginDependenciesSpec), Stub(Supplier))
 
     @Unroll("#notation is an invalid notation")
     def "reasonable error message if notation is invalid"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -33,7 +33,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.isolation.TestIsolatableFactory
-import org.gradle.internal.management.DependenciesModelBuilderInternal
+import org.gradle.internal.management.VersionCatalogBuilderInternal
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -262,7 +262,7 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasDependencyAlias('other', 'getOther', "This dependency was declared in ${context}")
     }
 
-    private void generate(String className = 'Generated', @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = DependenciesModelBuilderInternal) Closure<Void> spec) {
+    private void generate(String className = 'Generated', @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = VersionCatalogBuilderInternal) Closure<Void> spec) {
         DefaultVersionCatalogBuilder builder = new DefaultVersionCatalogBuilder("lib", Interners.newStrongInterner(), Interners.newStrongInterner(), TestUtil.objectFactory(), TestUtil.providerFactory(), Stub(PluginDependenciesSpec), Stub(Supplier))
         spec.delegate = builder
         spec.resolveStrategy = Closure.DELEGATE_FIRST

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -263,7 +263,7 @@ class DependenciesSourceGeneratorTest extends Specification {
     }
 
     private void generate(String className = 'Generated', @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = DependenciesModelBuilderInternal) Closure<Void> spec) {
-        DefaultDependenciesModelBuilder builder = new DefaultDependenciesModelBuilder("lib", Interners.newStrongInterner(), Interners.newStrongInterner(), TestUtil.objectFactory(), TestUtil.providerFactory(), Stub(PluginDependenciesSpec), Stub(Supplier))
+        DefaultVersionCatalogBuilder builder = new DefaultVersionCatalogBuilder("lib", Interners.newStrongInterner(), Interners.newStrongInterner(), TestUtil.objectFactory(), TestUtil.providerFactory(), Stub(PluginDependenciesSpec), Stub(Supplier))
         spec.delegate = builder
         spec.resolveStrategy = Closure.DELEGATE_FIRST
         spec()
@@ -276,12 +276,12 @@ class DependenciesSourceGeneratorTest extends Specification {
     class GeneratedSource {
         final String className
         final String source
-        final AllDependenciesModel model
+        final DefaultVersionCatalog model
         final List<String> lines
 
         Class<? extends AbstractExternalDependencyFactory> factory
 
-        GeneratedSource(String className, String src, AllDependenciesModel model) {
+        GeneratedSource(String className, String src, DefaultVersionCatalog model) {
             this.className = className
             this.source = src
             this.model = model

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/SimpleGeneratedJavaClassCompilerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/SimpleGeneratedJavaClassCompilerTest.groovy
@@ -74,12 +74,12 @@ class SimpleGeneratedJavaClassCompilerTest extends Specification {
     def "compiler is isolated from the Gradle API"() {
         when:
         compile(source("A", """
-            import org.gradle.api.internal.std.AllDependenciesModel;
+            import org.gradle.api.internal.std.DefaultVersionCatalog;
 
             class A {
-                private final AllDependenciesModel model;
+                private final DefaultVersionCatalog model;
 
-                public A(AllDependenciesModel model) {
+                public A(DefaultVersionCatalog model) {
                     this.model = model;
                 }
             }
@@ -90,10 +90,10 @@ class SimpleGeneratedJavaClassCompilerTest extends Specification {
         normaliseLineSeparators(ex.message) == """Unable to compile generated sources:
   - File A.java, line: 3, package org.gradle.api.internal.std does not exist
   - File A.java, line: 6, cannot find symbol
-      symbol:   class AllDependenciesModel
+      symbol:   class DefaultVersionCatalog
       location: class org.test.A
   - File A.java, line: 8, cannot find symbol
-      symbol:   class AllDependenciesModel
+      symbol:   class DefaultVersionCatalog
       location: class org.test.A"""
     }
 
@@ -101,12 +101,12 @@ class SimpleGeneratedJavaClassCompilerTest extends Specification {
         classPath = classPathRegistry.getClassPath("DEPENDENCIES-EXTENSION-COMPILER")
         when:
         compile(source("A", """
-            import org.gradle.api.internal.std.AllDependenciesModel;
+            import org.gradle.api.internal.std.DefaultVersionCatalog;
 
             class A {
-                private final AllDependenciesModel model;
+                private final DefaultVersionCatalog model;
 
-                public A(AllDependenciesModel model) {
+                public A(DefaultVersionCatalog model) {
                     this.model = model;
                 }
             }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogIntegrationTest.groovy
@@ -35,7 +35,7 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
     }
 
     def "can generate a Gradle platform file"() {
-        withSamplePlatform()
+        withSampleCatalog()
 
         when:
         succeeds ':generateCatalogAsToml'
@@ -45,7 +45,7 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
     }
 
     def "can publish a Gradle platform"() {
-        withSamplePlatform()
+        withSampleCatalog()
         withPublishing()
 
         when:
@@ -91,8 +91,8 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can generate a Gradle platform file from a dependencies configuration and the extension"() {
         buildFile << """
-            versionCatalog {
-                dependenciesModel {
+            catalog {
+                versionCatalog {
                     bundle('my', ['foo', 'bar'])
                 }
             }
@@ -131,7 +131,7 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can declare a different alias in case of name clash"() {
         buildFile << """
-            versionCatalog {
+            catalog {
                configureExplicitAlias 'foo2', 'org2', 'foo'
             }
             dependencies {
@@ -149,7 +149,7 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can declare a explicit alias without name clash"() {
         buildFile << """
-            versionCatalog {
+            catalog {
                configureExplicitAlias 'other', 'org', 'bar'
             }
             dependencies {
@@ -210,7 +210,7 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can fix name clash between dependencies and constraints"() {
         buildFile << """
-            versionCatalog {
+            catalog {
                 configureExplicitAlias 'foo2', 'org2', 'foo'
             }
             dependencies {
@@ -234,9 +234,9 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can mix plugins, dependencies, constraints and model to create a platform"() {
         buildFile << """
-            versionCatalog {
+            catalog {
                 configureExplicitAlias 'foo2', 'org', 'foo'
-                dependenciesModel {
+                versionCatalog {
                     alias('foo').to('org:from-model:1.0')
                     bundle('my', ['foo', 'foo2', 'from-script'])
                 }
@@ -302,10 +302,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
         expectPlatformContents 'expected9'
     }
 
-    private void withSamplePlatform() {
+    private void withSampleCatalog() {
         buildFile << """
-            versionCatalog {
-                dependenciesModel {
+            catalog {
+                versionCatalog {
                     alias("my-lib").to("org:foo:1.0")
                     alias("junit4").to("junit", "junit").version {
                         require "[4.13.1, 5["

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -43,7 +43,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
 
     def "can consume versions from a published Gradle platform"() {
         def platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 alias('my-lib'). to 'org.test:lib:1.1'
             }
         '''
@@ -54,7 +54,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from("org.gradle.test:my-platform:1.0")
                 }
             }
@@ -76,7 +76,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
 
     def "can override versions defined in a Gradle platform"() {
         def platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 def v = version('lib', '1.0')
                 alias('my-lib').to('org.test', 'lib').versionRef(v)
                 alias('my-lib-json').to('org.test', 'lib-json').versionRef(v)
@@ -89,7 +89,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from("org.gradle.test:my-platform:1.0")
                     version('lib', '1.1') // override version declared in the platform, this is order sensitive
                 }
@@ -115,14 +115,14 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
     // This documents the existing behavior but it may change in the future
     def "can use dependency locking to resolve platform in settings"() {
         def platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 alias('my-lib').to('org.test:lib:1.0')
             }
         '''
         executer.inDirectory(platformProject).withTasks('publish').run()
 
         platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 alias('my-lib').to('org.test:lib:1.1')
             }
         ''', '1.1'
@@ -133,7 +133,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from("org.gradle.test:my-platform:+")
                 }
             }
@@ -163,7 +163,7 @@ unspecified:unspecified:unspecified
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from("org.gradle.test:my-platform:1.0")
                 }
             }
@@ -179,7 +179,7 @@ unspecified:unspecified:unspecified
     def "reasonable error message if a no repositories are defined in settings"() {
         settingsFile << """
             dependencyResolutionManagement {
-                dependenciesModel("libs") {
+                versionCatalog("libs") {
                     from("org.gradle.test:my-platform:1.0")
                 }
             }
@@ -197,7 +197,7 @@ unspecified:unspecified:unspecified
             .withModuleMetadata()
 
         def platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 alias('my-lib').to('org.test:lib:1.1')
             }
         '''
@@ -220,8 +220,8 @@ unspecified:unspecified:unspecified
             group = 'org.gradle.platform'
             version = '1.0'
 
-            versionCatalog {
-                dependenciesModel {
+            catalog {
+                versionCatalog {
                     from('org.gradle.test:my-platform:1.0')
                     alias('other').to('org:other:1.5')
                 }
@@ -265,7 +265,7 @@ unspecified:unspecified:unspecified
             .withModuleMetadata()
 
         def platformProject = preparePlatformProject '''
-            dependenciesModel {
+            versionCatalog {
                 alias('hello').to('org.test:hello:1.1')
                 alias('world').to('org.test:world:1.7')
                 alias('ignored').to('org.test:ignored:1.3')
@@ -297,8 +297,8 @@ unspecified:unspecified:unspecified
             group = 'org.gradle.platform'
             version = '1.0'
 
-            versionCatalog {
-                dependenciesModel {
+            catalog {
+                versionCatalog {
                     from('org.gradle.test:my-platform:1.0') {
                         includeDependency('hello')
                         excludePlugin('bof', 'not.interested')
@@ -373,7 +373,7 @@ unspecified:unspecified:unspecified
                 }
             }
 
-            versionCatalog {
+            catalog {
                 $platformSpec
             }
         """

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
@@ -17,7 +17,7 @@ package org.gradle.api.plugins.catalog;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.plugin.use.PluginDependenciesSpec;
 
@@ -28,12 +28,12 @@ import org.gradle.plugin.use.PluginDependenciesSpec;
  */
 @Incubating
 @HasInternalProtocol
-public interface VersionCatalogExtension {
+public interface CatalogPluginExtension {
     /**
-     * Configures the dependency model of this catalog.
+     * Configures the version catalog.
      * @param spec the spec used to configure the dependencies
      */
-    void dependenciesModel(Action<? super DependenciesModelBuilder> spec);
+    void versionCatalog(Action<? super VersionCatalogBuilder> spec);
 
     /**
      * Configures the plugins model of this catalog.

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
@@ -35,8 +35,8 @@ import org.gradle.api.tasks.TaskProvider;
 import javax.inject.Inject;
 
 /**
- * <p>A {@link Plugin} makes it possible to generate a version catalog, which is a set of recommendations
- * for dependency and plugin versions</p>
+ * <p>A {@link Plugin} makes it possible to generate a version catalog,  which is a set of versions and
+ * coordinates for dependencies and plugins to import in the settings of a Gradle build.</p>
  *
  * @since 6.8
  */

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
@@ -26,8 +26,8 @@ import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.catalog.internal.DefaultVersionCatalogExtension;
-import org.gradle.api.plugins.catalog.internal.VersionCatalogExtensionInternal;
+import org.gradle.api.plugins.catalog.internal.DefaultVersionCatalogPluginExtension;
+import org.gradle.api.plugins.catalog.internal.CatalogExtensionInternal;
 import org.gradle.api.plugins.catalog.internal.TomlFileGenerator;
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping;
 import org.gradle.api.tasks.TaskProvider;
@@ -35,7 +35,7 @@ import org.gradle.api.tasks.TaskProvider;
 import javax.inject.Inject;
 
 /**
- * <p>A {@link Plugin} makes it possible to generate a "Gradle platform", which is a set of recommendations
+ * <p>A {@link Plugin} makes it possible to generate a version catalog, which is a set of recommendations
  * for dependency and plugin versions</p>
  *
  * @since 6.8
@@ -58,7 +58,7 @@ public class VersionCatalogPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         Configuration dependenciesConfiguration = createDependenciesConfiguration(project);
-        VersionCatalogExtensionInternal extension = createExtension(project, dependenciesConfiguration);
+        CatalogExtensionInternal extension = createExtension(project, dependenciesConfiguration);
         TaskProvider<TomlFileGenerator> generator = createGenerator(project, extension);
         createPublication(project, generator);
     }
@@ -87,21 +87,21 @@ public class VersionCatalogPlugin implements Plugin<Project> {
         });
     }
 
-    private TaskProvider<TomlFileGenerator> createGenerator(Project project, VersionCatalogExtensionInternal extension) {
+    private TaskProvider<TomlFileGenerator> createGenerator(Project project, CatalogExtensionInternal extension) {
         return project.getTasks().register(GENERATE_CATALOG_FILE_TASKNAME, TomlFileGenerator.class, t -> configureTask(project, extension, t));
     }
 
-    private void configureTask(Project project, VersionCatalogExtensionInternal extension, TomlFileGenerator task) {
+    private void configureTask(Project project, CatalogExtensionInternal extension, TomlFileGenerator task) {
         task.setGroup(BasePlugin.BUILD_GROUP);
         task.setDescription("Generates a TOML file for a version catalog");
         task.getOutputFile().convention(project.getLayout().getBuildDirectory().file("version-catalog/dependencies.toml"));
-        task.getDependenciesModel().convention(extension.getDependenciesModel());
+        task.getDependenciesModel().convention(extension.getVersionCatalog());
         task.getPluginVersions().convention(extension.getPluginVersions());
     }
 
-    private VersionCatalogExtensionInternal createExtension(Project project, Configuration dependenciesConfiguration) {
-        return (VersionCatalogExtensionInternal) project.getExtensions()
-            .create(VersionCatalogExtension.class, "versionCatalog", DefaultVersionCatalogExtension.class, dependenciesConfiguration);
+    private CatalogExtensionInternal createExtension(Project project, Configuration dependenciesConfiguration) {
+        return (CatalogExtensionInternal) project.getExtensions()
+            .create(CatalogPluginExtension.class, "catalog", DefaultVersionCatalogPluginExtension.class, dependenciesConfiguration);
     }
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/CatalogExtensionInternal.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/CatalogExtensionInternal.java
@@ -15,13 +15,13 @@
  */
 package org.gradle.api.plugins.catalog.internal;
 
-import org.gradle.api.internal.std.AllDependenciesModel;
-import org.gradle.api.plugins.catalog.VersionCatalogExtension;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
+import org.gradle.api.plugins.catalog.CatalogPluginExtension;
 import org.gradle.api.provider.Provider;
 
 import java.util.Map;
 
-public interface VersionCatalogExtensionInternal extends VersionCatalogExtension {
-    Provider<AllDependenciesModel> getDependenciesModel();
+public interface CatalogExtensionInternal extends CatalogPluginExtension {
+    Provider<DefaultVersionCatalog> getVersionCatalog();
     Provider<Map<String, String>> getPluginVersions();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/DefaultVersionCatalogPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/DefaultVersionCatalogPluginExtension.java
@@ -21,10 +21,10 @@ import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.initialization.dsl.DependenciesModelBuilder;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
-import org.gradle.api.internal.std.AllDependenciesModel;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -36,16 +36,16 @@ import javax.inject.Inject;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class DefaultVersionCatalogExtension implements VersionCatalogExtensionInternal {
-    private final VersionCatalogDependenciesModelBuilder builder;
+public class DefaultVersionCatalogPluginExtension implements CatalogExtensionInternal {
+    private final DependenciesAwareVersionCatalogBuilder builder;
     private final SimplifiedPluginDependenciesSpec plugins;
-    private final Provider<AllDependenciesModel> model;
+    private final Provider<DefaultVersionCatalog> model;
     private final Provider<Map<String, String>> pluginsModel;
 
     @Inject
-    public DefaultVersionCatalogExtension(ObjectFactory objects, ProviderFactory providers, DependencyResolutionServices drs, Configuration dependenciesConfiguration) {
+    public DefaultVersionCatalogPluginExtension(ObjectFactory objects, ProviderFactory providers, DependencyResolutionServices drs, Configuration dependenciesConfiguration) {
         this.plugins = new SimplifiedPluginDependenciesSpec();
-        this.builder = objects.newInstance(VersionCatalogDependenciesModelBuilder.class,
+        this.builder = objects.newInstance(DependenciesAwareVersionCatalogBuilder.class,
             "versionCatalog",
             Interners.newStrongInterner(),
             Interners.newStrongInterner(),
@@ -60,7 +60,7 @@ public class DefaultVersionCatalogExtension implements VersionCatalogExtensionIn
     }
 
     @Override
-    public void dependenciesModel(Action<? super DependenciesModelBuilder> spec) {
+    public void versionCatalog(Action<? super VersionCatalogBuilder> spec) {
         spec.execute(builder);
     }
 
@@ -75,7 +75,7 @@ public class DefaultVersionCatalogExtension implements VersionCatalogExtensionIn
     }
 
     @Override
-    public Provider<AllDependenciesModel> getDependenciesModel() {
+    public Provider<DefaultVersionCatalog> getVersionCatalog() {
         return model;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/DependenciesAwareVersionCatalogBuilder.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/DependenciesAwareVersionCatalogBuilder.java
@@ -32,8 +32,8 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
-import org.gradle.api.internal.std.AllDependenciesModel;
-import org.gradle.api.internal.std.DefaultDependenciesModelBuilder;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
+import org.gradle.api.internal.std.DefaultVersionCatalogBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -47,15 +47,15 @@ import java.util.function.Supplier;
 
 import static org.gradle.api.internal.std.DependenciesModelHelper.ALIAS_PATTERN;
 
-public class VersionCatalogDependenciesModelBuilder extends DefaultDependenciesModelBuilder {
-    private final static Logger LOGGER = Logging.getLogger(VersionCatalogDependenciesModelBuilder.class);
+public class DependenciesAwareVersionCatalogBuilder extends DefaultVersionCatalogBuilder {
+    private final static Logger LOGGER = Logging.getLogger(DependenciesAwareVersionCatalogBuilder.class);
 
     private final Configuration dependenciesConfiguration;
     private final Map<ModuleIdentifier, String> explicitAliases = Maps.newHashMap();
     private boolean shouldAmendModel = true;
 
     @Inject
-    public VersionCatalogDependenciesModelBuilder(String name,
+    public DependenciesAwareVersionCatalogBuilder(String name,
                                                   Interner<String> strings,
                                                   Interner<ImmutableVersionConstraint> versionConstraintInterner,
                                                   ObjectFactory objects,
@@ -68,7 +68,7 @@ public class VersionCatalogDependenciesModelBuilder extends DefaultDependenciesM
     }
 
     @Override
-    public AllDependenciesModel build() {
+    public DefaultVersionCatalog build() {
         if (shouldAmendModel) {
             DependencySet allDependencies = dependenciesConfiguration.getAllDependencies();
             DependencyConstraintSet allDependencyConstraints = dependenciesConfiguration.getAllDependencyConstraints();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlFileGenerator.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlFileGenerator.java
@@ -18,7 +18,7 @@ package org.gradle.api.plugins.catalog.internal;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.std.AllDependenciesModel;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
@@ -36,7 +36,7 @@ import java.util.Map;
 @CacheableTask
 public abstract class TomlFileGenerator extends DefaultTask {
     @Input
-    public abstract Property<AllDependenciesModel> getDependenciesModel();
+    public abstract Property<DefaultVersionCatalog> getDependenciesModel();
 
     @Input
     public abstract MapProperty<String, String> getPluginVersions();
@@ -46,7 +46,7 @@ public abstract class TomlFileGenerator extends DefaultTask {
 
     @TaskAction
     void generateToml() throws IOException {
-        AllDependenciesModel model = getDependenciesModel().get();
+        DefaultVersionCatalog model = getDependenciesModel().get();
         Map<String, String> plugins = getPluginVersions().get();
         File outputFile = getOutputFile().getAsFile().get();
         File outputDir = outputFile.getParentFile();
@@ -57,7 +57,7 @@ public abstract class TomlFileGenerator extends DefaultTask {
         }
     }
 
-    private void doGenerate(AllDependenciesModel model, Map<String, String> plugins, File outputFile) throws FileNotFoundException, UnsupportedEncodingException {
+    private void doGenerate(DefaultVersionCatalog model, Map<String, String> plugins, File outputFile) throws FileNotFoundException, UnsupportedEncodingException {
         try (PrintWriter writer = new PrintWriter(outputFile, "UTF-8")) {
             TomlWriter ctx = new TomlWriter(writer);
             ctx.generate(model, plugins);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlWriter.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/internal/TomlWriter.java
@@ -17,7 +17,7 @@ package org.gradle.api.plugins.catalog.internal;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
-import org.gradle.api.internal.std.AllDependenciesModel;
+import org.gradle.api.internal.std.DefaultVersionCatalog;
 import org.gradle.api.internal.std.DependencyModel;
 
 import java.io.PrintWriter;
@@ -32,7 +32,7 @@ class TomlWriter {
         this.writer = writer;
     }
 
-    public void generate(AllDependenciesModel model, Map<String, String> plugins) {
+    public void generate(DefaultVersionCatalog model, Map<String, String> plugins) {
         writeHeader();
         writeVersions(model);
         writeLibraries(model);
@@ -40,7 +40,7 @@ class TomlWriter {
         writePlugins(plugins);
     }
 
-    private void writeVersions(AllDependenciesModel model) {
+    private void writeVersions(DefaultVersionCatalog model) {
         List<String> versions = model.getVersionAliases();
         if (versions.isEmpty()) {
             return;
@@ -53,7 +53,7 @@ class TomlWriter {
         writer.println();
     }
 
-    private void writeLibraries(AllDependenciesModel model) {
+    private void writeLibraries(DefaultVersionCatalog model) {
         List<String> aliases = model.getDependencyAliases();
         if (aliases.isEmpty()) {
             return;
@@ -83,7 +83,7 @@ class TomlWriter {
         writer.println();
     }
 
-    private void writeBundles(AllDependenciesModel model) {
+    private void writeBundles(DefaultVersionCatalog model) {
         List<String> aliases = model.getBundleAliases();
         if (aliases.isEmpty()) {
             return;

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/catalog/internal/TomlWriterTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/catalog/internal/TomlWriterTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.api.plugins.catalog.internal
 
 import com.google.common.collect.Interners
 import groovy.transform.Canonical
-import org.gradle.api.internal.std.AllDependenciesModel
-import org.gradle.api.internal.std.DefaultDependenciesModelBuilder
+import org.gradle.api.internal.std.DefaultVersionCatalog
+import org.gradle.api.internal.std.DefaultVersionCatalogBuilder
 import org.gradle.api.internal.std.ImportConfiguration
 import org.gradle.api.internal.std.TomlDependenciesFileParser
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -88,7 +88,7 @@ class TomlWriterTest extends Specification {
                 }
             }
         }
-        def builder = new DefaultDependenciesModelBuilder("libs",
+        def builder = new DefaultVersionCatalogBuilder("libs",
             Interners.newStrongInterner(),
             Interners.newStrongInterner(),
             TestUtil.objectFactory(),
@@ -103,7 +103,7 @@ class TomlWriterTest extends Specification {
 
     @Canonical
     private static class Model {
-        AllDependenciesModel deps
+        DefaultVersionCatalog deps
         Map<String, String> plugins
     }
 }


### PR DESCRIPTION
This commit renames the "dependencies model" into "version catalog" for consistency with the places where it's used.
The name is less abstract than "dependencies model". It does introduce some weirdness in the "versions catalog" plugin with a double "catalog" but it's clearer in other areas.