### PR TITLE
Remove unused code for handling public inline functions in Kotlin compile avoidance

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
@@ -34,20 +34,12 @@ import org.gradle.internal.normalization.java.impl.MethodStubbingApiMemberAdapte
 import org.gradle.internal.normalization.java.impl.SimpleAnnotationValue
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes
 import java.util.Optional
 
 
 class KotlinApiClassExtractor : ApiClassExtractor(
     emptySet(),
-    { classReader, classWriter ->
-        KotlinApiMemberWriter(
-            MethodStubbingApiMemberAdapter(classWriter),
-            MethodCopyingApiMemberAdapter(classReader, classWriter)
-        )
-    }
+    { classWriter -> KotlinApiMemberWriter(MethodStubbingApiMemberAdapter(classWriter)) }
 ) {
 
     override fun extractApiClassFrom(originalClassReader: ClassReader): Optional<ByteArray> {
@@ -62,7 +54,7 @@ class KotlinApiClassExtractor : ApiClassExtractor(
 
 
 private
-class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor, val inlineMethodWriter: MethodCopyingApiMemberAdapter) : ApiMemberWriter(apiMemberAdapter) {
+class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor) : ApiMemberWriter(apiMemberAdapter) {
 
     val kotlinMetadataAnnotationSignature = "Lkotlin/Metadata;"
 
@@ -100,7 +92,6 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor, val inlineMethodWrit
     override fun writeMethod(method: MethodMember) {
         when {
             method.isInternal() -> return
-            // TODO: detect lambdas in public inline methods and treat them as ABI, then inlineMethodWriter.writeMethod(method)
             method.isInline() -> throw CompileAvoidanceException("Can not use compile avoidance with public inline function: $method")
             else -> super.writeMethod(method)
         }
@@ -170,26 +161,6 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor, val inlineMethodWrit
 
     private
     fun MethodMember.isInline() = inlineFunctions.contains(this.binarySignature())
-}
-
-
-private
-class MethodCopyingApiMemberAdapter(val classReader: ClassReader, val classWriter: ClassWriter) {
-    fun writeMethod(method: MethodMember) {
-        classReader.accept(MethodCopyingVisitor(method, classWriter), ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES)
-    }
-}
-
-
-private
-class MethodCopyingVisitor(val method: MethodMember, val classWriter: ClassWriter) : ClassVisitor(Opcodes.ASM7) {
-
-    override fun visitMethod(access: Int, name: String?, descriptor: String?, signature: String?, exceptions: Array<out String>?): MethodVisitor? {
-        if (method.access == access && method.name == name && method.typeDesc == descriptor && method.signature == signature) {
-            return classWriter.visitMethod(access, name, descriptor, signature, exceptions)
-        }
-        return super.visitMethod(access, name, descriptor, signature, exceptions)
-    }
 }
 
 

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiClassExtractor.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiClassExtractor.java
@@ -38,7 +38,7 @@ public class ApiClassExtractor {
     private final ApiMemberWriterFactory apiMemberWriterFactory;
 
     public ApiClassExtractor(Set<String> exportedPackages) {
-        this(exportedPackages, (classReader, classWriter) -> new ApiMemberWriter(new MethodStubbingApiMemberAdapter(classWriter)));
+        this(exportedPackages, classWriter -> new ApiMemberWriter(new MethodStubbingApiMemberAdapter(classWriter)));
     }
 
     public ApiClassExtractor(Set<String> exportedPackages, ApiMemberWriterFactory apiMemberWriterFactory) {
@@ -78,7 +78,7 @@ public class ApiClassExtractor {
             return Optional.empty();
         }
         ClassWriter apiClassWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        ApiMemberSelector visitor = new ApiMemberSelector(originalClassReader.getClassName(), apiMemberWriterFactory.makeApiMemberWriter(originalClassReader, apiClassWriter), apiIncludesPackagePrivateMembers);
+        ApiMemberSelector visitor = new ApiMemberSelector(originalClassReader.getClassName(), apiMemberWriterFactory.makeApiMemberWriter(apiClassWriter), apiIncludesPackagePrivateMembers);
         originalClassReader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
         if (visitor.isPrivateInnerClass()) {
             return Optional.empty();

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiMemberWriterFactory.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiMemberWriterFactory.java
@@ -17,9 +17,8 @@
 package org.gradle.internal.normalization.java;
 
 import org.gradle.internal.normalization.java.impl.ApiMemberWriter;
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
 public interface ApiMemberWriterFactory {
-    ApiMemberWriter makeApiMemberWriter(ClassReader classReader, ClassWriter classWriter);
+    ApiMemberWriter makeApiMemberWriter(ClassWriter classWriter);
 }


### PR DESCRIPTION
Compile avoidance is not supported for public inline functions - we fall back to using the full hash of the jar upon encountering a public inline function. This change removes previously added code that attempted to make public inline functions part of the ABI for compile avoidance. This code is no longer used.
