### PR TITLE
Add “mergeReruns” option to JUnit XML report generation

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -223,7 +223,7 @@ same way it works for other Gradle API classes.
 
 ### Test re-run JUnit XML reporting enhancements
 
-The [`Test` task](dsl/org.gradle.api.tasks.testing.Test.html), used for executing JVM tests, reports the test results as HTML and as a set of XML files in the “JUnit XML” pseudo standard.
+The [`Test` task](dsl/org.gradle.api.tasks.testing.Test.html), used for [executing JVM tests](userguide/java_testing.html#test_reporting), reports test results as HTML and as a set of XML files in the “JUnit XML” pseudo standard.
 It is common for CI servers and other tooling to observe test results via the XML files.
 A new [`mergeReruns` option](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html#getMergeReruns--) has been added that changes how tests that are executed more than once are reported in the XML files.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -223,8 +223,9 @@ same way it works for other Gradle API classes.
 
 ### Test re-run JUnit XML reporting enhancements
 
-A new opt-in [`mergeReruns` option](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html#getMergeReruns--) has been added that changes the “JUnit XML” produced by test tasks.
-When enabled, the XML output will be very similar to [the surefire plugin of Apache Maven™](https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html) when enabling reruns.
+The [`Test` task](dsl/org.gradle.api.tasks.testing.Test.html), used for executing JVM tests, reports the test results as HTML and as a set of XML files in the “JUnit XML” pseudo standard.
+It is common for CI servers and other tooling to observe test results via the XML files.
+A new [`mergeReruns` option](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html#getMergeReruns--) has been added that changes how tests that are executed more than once are reported in the XML files.
 
 ```
 test {
@@ -232,12 +233,26 @@ test {
 }
 ```
 
-If a test fails but is then retried and succeeds, its failures will be recorded as `<flakyFailure>` instead of `<failure>`, within one `<testcase>`. 
-This can be important for build tooling that uses this XML to understand test results, and where distinguishing such passed-on-retry outcomes is important.
-This is the case for the Jenkins CI server and its [Flaky Test Handler plugin](https://plugins.jenkins.io/flaky-test-handler).
+This option is `false` by default, causing each test execution to be listed as a separate `<testcase>` in the XML.
+This means that a test that is executed multiple times, due to a retry-on-failure mechanism for example, is listed multiple times.
+This is also the behavior for all previous Gradle versions.
 
-This does not add any retry/rerun functionality in and of itself.
-The retry can be performed by the test execution framework, 
+When this new option is enabled, if a test fails but is then retried and succeeds, its failures will be recorded as `<flakyFailure>` instead of `<failure>`, within one `<testcase>`.
+This is effectively the reporting produced by the [surefire plugin of Apache Maven™](https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html) when enabling reruns.
+If your CI server understands this format, it will indicate that the test was flaky.
+If it does not, it will indicate that the test succeeded as it will ignore the `<flakyFailure>` information.
+If the test does not succeed (i.e. it fails for every retry), it will be indicated as having failed whether your tool understands this format or not.
+ 
+This new option is useful when using a CI tool that uses the XML test reports to determine build failure instead of relying on Gradle's determination of whether
+the build failed or not, and you wish to not consider the build failed if all failed tests passed when retried.
+This is the case for the Jenkins CI server and its [JUnit plugin](https://plugins.jenkins.io/junit/).
+With `mergeReruns` enabled, tests that pass-on-retry will no longer cause this Jenkins plugin to consider the build to have failed.
+However, failed test executions will be omitted from the Jenkins test result visualizations as it does not consider `<flakyFailure>` information.   
+The separate [Flaky Test Handler Jenkins plugin](https://plugins.jenkins.io/flaky-test-handler) can be used in addition to the JUnit Jenkins plugin to have
+such “flaky failures” also be visualized.
+ 
+Note that enabling the new `mergeReruns` option does not add any retry/rerun functionality to test execution.
+Rerunning can be enabled by the test execution framework (e.g. JUnit's [`@RepeatedTest`](https://junit.org/junit5/docs/current/user-guide/#writing-tests-repeated-tests)), 
 or generically via the separate [Test Retry Gradle plugin](https://github.com/gradle/test-retry-gradle-plugin).
 
 ## Security Improvements

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -221,6 +221,25 @@ See the [toolchain documentation](userguide/toolchains.html) for more in-depth i
 When using [dependency injection](userguide/custom_gradle_types.html#service_injection) when developing plugins, tasks or project extensions, it is now possible to use the `@Inject` annotation without explicitly importing it into your build scripts the
 same way it works for other Gradle API classes.
 
+### Test re-run JUnit XML reporting enhancements
+
+A new opt-in [`mergeReruns` option](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html#getMergeReruns--) has been added that changes the “JUnit XML” produced by test tasks.
+When enabled, the XML output will be very similar to [the surefire plugin of Apache Maven™](https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html) when enabling reruns.
+
+```
+test {
+    reporting.junitXml.mergeReruns = true
+}
+```
+
+If a test fails but is then retried and succeeds, its failures will be recorded as `<flakyFailure>` instead of `<failure>`, within one `<testcase>`. 
+This can be important for build tooling that uses this XML to understand test results, and where distinguishing such passed-on-retry outcomes is important.
+This is the case for the Jenkins CI server and its [Flaky Test Handler plugin](https://plugins.jenkins.io/flaky-test-handler).
+
+This does not add any retry/rerun functionality in and of itself.
+The retry can be performed by the test execution framework, 
+or generically via the separate [Test Retry Gradle plugin](https://github.com/gradle/test-retry-gradle-plugin).
+
 ## Security Improvements
 
 ### Outdated TLS versions are no longer enabled by default

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -70,6 +70,10 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         return testClassNode.@tests.toInteger()
     }
 
+    int getTestCasesCount() {
+        return testClassNode.testcase.size()
+    }
+
     TestClassExecutionResult withResult(Closure action) {
         action(testClassNode)
         this

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -18,8 +18,8 @@ package org.gradle.integtests.fixtures
 
 import groovy.util.slurpersupport.GPathResult
 import groovy.util.slurpersupport.NodeChild
-import org.hamcrest.Matcher
 import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
 import org.junit.Assert
 
 import static org.gradle.integtests.fixtures.DefaultTestExecutionResult.removeParentheses
@@ -227,13 +227,10 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
                     Assert.assertThat(failure.@type.text(), CoreMatchers.not(CoreMatchers.equalTo('')))
                     Assert.assertThat(failure.text(), CoreMatchers.not(CoreMatchers.equalTo('')))
                 }
-                def matcher = CoreMatchers.equalTo(outputAssociation == TestResultOutputAssociation.WITH_TESTCASE ? 1 : 0)
-                Assert.assertThat(node.'system-err'.size(), matcher)
-                Assert.assertThat(node.'system-out'.size(), matcher)
-            }
-            if (outputAssociation == TestResultOutputAssociation.WITH_SUITE) {
-                Assert.assertThat(testClassNode.'system-out'.size(), CoreMatchers.equalTo(1))
-                Assert.assertThat(testClassNode.'system-err'.size(), CoreMatchers.equalTo(1))
+                if (outputAssociation == TestResultOutputAssociation.WITH_SUITE) {
+                    Assert.assertThat(node.'system-out'.size(), CoreMatchers.equalTo(0))
+                    Assert.assertThat(node.'system-err'.size(), CoreMatchers.equalTo(0))
+                }
             }
             checked = true
         }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
@@ -17,15 +17,19 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Task;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleDirectoryReport;
 import org.gradle.api.tasks.testing.JUnitXmlReport;
 
 public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectoryReport implements JUnitXmlReport {
 
     private boolean outputPerTestCase;
+    private final Property<Boolean> mergeReruns;
 
-    public DefaultJUnitXmlReport(String name, Task task) {
+    public DefaultJUnitXmlReport(String name, Task task, ObjectFactory objectFactory) {
         super(name, task, null);
+        this.mergeReruns = objectFactory.property(Boolean.class).convention(false);
     }
 
     @Override
@@ -38,4 +42,8 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
         this.outputPerTestCase = outputPerTestCase;
     }
 
+    @Override
+    public Property<Boolean> getMergeReruns() {
+        return mergeReruns;
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestTaskReports.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestTaskReports.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.reporting.ConfigurableReport;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Report;
@@ -31,10 +32,10 @@ import javax.inject.Inject;
 public class DefaultTestTaskReports extends TaskReportContainer<Report> implements TestTaskReports {
 
     @Inject
-    public DefaultTestTaskReports(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+    public DefaultTestTaskReports(Task task, ObjectFactory objectFactory, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(ConfigurableReport.class, task, callbackActionDecorator);
 
-        add(DefaultJUnitXmlReport.class, "junitXml", task);
+        add(DefaultJUnitXmlReport.class, "junitXml", task, objectFactory);
         add(TaskGeneratedSingleDirectoryReport.class, "html", task, "index.html");
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
@@ -99,20 +99,33 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
     }
 
     @Override
-    public boolean hasOutput(long id, final TestOutputEvent.Destination destination) {
+    public boolean hasOutput(long classId, final TestOutputEvent.Destination destination) {
         return Iterables.any(
-                classOutputProviders.get(id),
-                new Predicate<DelegateProvider>() {
-                    @Override
-                    public boolean apply(DelegateProvider delegateProvider) {
-                        return delegateProvider.provider.hasOutput(delegateProvider.id, destination);
-                    }
-                });
+            classOutputProviders.get(classId),
+            new Predicate<DelegateProvider>() {
+                @Override
+                public boolean apply(DelegateProvider delegateProvider) {
+                    return delegateProvider.provider.hasOutput(delegateProvider.id, destination);
+                }
+            });
     }
 
     @Override
-    public void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
-        for (DelegateProvider delegateProvider : classOutputProviders.get(id)) {
+    public boolean hasOutput(long classId, final long testId, final TestOutputEvent.Destination destination) {
+        return Iterables.any(
+            classOutputProviders.get(classId),
+            new Predicate<DelegateProvider>() {
+                @Override
+                public boolean apply(DelegateProvider delegateProvider) {
+                    return delegateProvider.provider.hasOutput(delegateProvider.id, testId, destination);
+                }
+            });
+
+    }
+
+    @Override
+    public void writeAllOutput(long classId, TestOutputEvent.Destination destination, Writer writer) {
+        for (DelegateProvider delegateProvider : classOutputProviders.get(classId)) {
             delegateProvider.provider.writeAllOutput(delegateProvider.id, destination, writer);
         }
     }
@@ -128,8 +141,8 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
     }
 
     @Override
-    public void writeNonTestOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
-        for (DelegateProvider delegateProvider : classOutputProviders.get(id)) {
+    public void writeNonTestOutput(long classId, TestOutputEvent.Destination destination, Writer writer) {
+        for (DelegateProvider delegateProvider : classOutputProviders.get(classId)) {
             delegateProvider.provider.writeNonTestOutput(delegateProvider.id, destination, writer);
         }
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit.result;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
@@ -39,14 +40,17 @@ public class Binary2JUnitXmlReportGenerator {
 
     private final File testResultsDir;
     private final TestResultsProvider testResultsProvider;
-    private JUnitXmlResultWriter xmlWriter;
+
+    @VisibleForTesting
+    JUnitXmlResultWriter xmlWriter;
+
     private final BuildOperationExecutor buildOperationExecutor;
     private final static Logger LOG = Logging.getLogger(Binary2JUnitXmlReportGenerator.class);
 
-    public Binary2JUnitXmlReportGenerator(File testResultsDir, TestResultsProvider testResultsProvider, TestOutputAssociation outputAssociation, BuildOperationExecutor buildOperationExecutor, String hostName) {
+    public Binary2JUnitXmlReportGenerator(File testResultsDir, TestResultsProvider testResultsProvider, JUnitXmlResultOptions options, BuildOperationExecutor buildOperationExecutor, String hostName) {
         this.testResultsDir = testResultsDir;
         this.testResultsProvider = testResultsProvider;
-        this.xmlWriter = new JUnitXmlResultWriter(hostName, testResultsProvider, outputAssociation);
+        this.xmlWriter = new JUnitXmlResultWriter(hostName, testResultsProvider, options);
         this.buildOperationExecutor = buildOperationExecutor;
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
@@ -31,23 +31,28 @@ public class BinaryResultBackedTestResultsProvider extends TestOutputStoreBacked
     }
 
     @Override
-    public boolean hasOutput(final long id, final TestOutputEvent.Destination destination) {
+    public boolean hasOutput(final long classId, final TestOutputEvent.Destination destination) {
         final boolean[] hasOutput = new boolean[1];
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                hasOutput[0] = reader.hasOutput(id, destination);
+                hasOutput[0] = reader.hasOutput(classId, destination);
             }
         });
         return hasOutput[0];
     }
 
     @Override
-    public void writeAllOutput(final long id, final TestOutputEvent.Destination destination, final Writer writer) {
+    public boolean hasOutput(long classId, long testId, TestOutputEvent.Destination destination) {
+        return false;
+    }
+
+    @Override
+    public void writeAllOutput(final long classId, final TestOutputEvent.Destination destination, final Writer writer) {
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                reader.writeAllOutput(id, destination, writer);
+                reader.writeAllOutput(classId, destination, writer);
             }
         });
     }
@@ -58,11 +63,11 @@ public class BinaryResultBackedTestResultsProvider extends TestOutputStoreBacked
     }
 
     @Override
-    public void writeNonTestOutput(final long id, final TestOutputEvent.Destination destination, final Writer writer) {
+    public void writeNonTestOutput(final long classId, final TestOutputEvent.Destination destination, final Writer writer) {
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                reader.writeNonTestOutput(id, destination, writer);
+                reader.writeNonTestOutput(classId, destination, writer);
             }
         });
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
@@ -30,33 +30,45 @@ public class InMemoryTestResultsProvider extends TestOutputStoreBackedResultsPro
     }
 
     @Override
-    public boolean hasOutput(final long id, final TestOutputEvent.Destination destination) {
+    public boolean hasOutput(final long classId, final TestOutputEvent.Destination destination) {
         final boolean[] hasOutput = new boolean[1];
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                hasOutput[0] = reader.hasOutput(id, destination);
+                hasOutput[0] = reader.hasOutput(classId, destination);
             }
         });
         return hasOutput[0];
     }
 
     @Override
-    public void writeAllOutput(final long id, final TestOutputEvent.Destination destination, final Writer writer) {
+    public boolean hasOutput(final long classId, final long testId, final TestOutputEvent.Destination destination) {
+        final boolean[] hasOutput = new boolean[1];
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                reader.writeAllOutput(id, destination, writer);
+                hasOutput[0] = reader.hasOutput(classId, testId, destination);
+            }
+        });
+        return hasOutput[0];
+    }
+
+    @Override
+    public void writeAllOutput(final long classId, final TestOutputEvent.Destination destination, final Writer writer) {
+        withReader(new Action<TestOutputStore.Reader>() {
+            @Override
+            public void execute(TestOutputStore.Reader reader) {
+                reader.writeAllOutput(classId, destination, writer);
             }
         });
     }
 
     @Override
-    public void writeNonTestOutput(final long id, final TestOutputEvent.Destination destination, final Writer writer) {
+    public void writeNonTestOutput(final long classId, final TestOutputEvent.Destination destination, final Writer writer) {
         withReader(new Action<TestOutputStore.Reader>() {
             @Override
             public void execute(TestOutputStore.Reader reader) {
-                reader.writeNonTestOutput(id, destination, writer);
+                reader.writeNonTestOutput(classId, destination, writer);
             }
         });
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit.result;
+
+public class JUnitXmlResultOptions {
+
+    public final boolean outputPerTestCase;
+    public final boolean mergeReruns;
+
+    public JUnitXmlResultOptions(boolean outputPerTestCase, boolean mergeReruns) {
+        this.outputPerTestCase = outputPerTestCase;
+        this.mergeReruns = mergeReruns;
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -16,55 +16,70 @@
 
 package org.gradle.api.internal.tasks.testing.junit.result;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
 import org.apache.tools.ant.util.DateUtils;
-import org.gradle.internal.xml.SimpleXmlWriter;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.xml.SimpleXmlWriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class JUnitXmlResultWriter {
 
     private final String hostName;
     private final TestResultsProvider testResultsProvider;
-    private final TestOutputAssociation outputAssociation;
+    private final JUnitXmlResultOptions options;
 
-    public JUnitXmlResultWriter(String hostName, TestResultsProvider testResultsProvider, TestOutputAssociation outputAssociation) {
+    public JUnitXmlResultWriter(String hostName, TestResultsProvider testResultsProvider, JUnitXmlResultOptions options) {
         this.hostName = hostName;
         this.testResultsProvider = testResultsProvider;
-        this.outputAssociation = outputAssociation;
+        this.options = options;
     }
 
-    /**
-     * @param output The destination, unbuffered
-     */
     public void write(TestClassResult result, OutputStream output) {
         long classId = result.getId();
 
         try {
             SimpleXmlWriter writer = new SimpleXmlWriter(output, "  ");
             writer.startElement("testsuite")
-                    .attribute("name", result.getXmlTestSuiteName())
-                    .attribute("tests", String.valueOf(result.getTestsCount()))
-                    .attribute("skipped", String.valueOf(result.getSkippedCount()))
-                    .attribute("failures", String.valueOf(result.getFailuresCount()))
-                    .attribute("errors", "0")
-                    .attribute("timestamp", DateUtils.format(result.getStartTime(), DateUtils.ISO8601_DATETIME_PATTERN))
-                    .attribute("hostname", hostName)
-                    .attribute("time", String.valueOf(result.getDuration() / 1000.0));
+                .attribute("name", result.getXmlTestSuiteName())
+
+                // NOTE: these totals are unaffected by “merge reruns” with Surefire, so we do the same
+                .attribute("tests", String.valueOf(result.getTestsCount()))
+                .attribute("skipped", String.valueOf(result.getSkippedCount()))
+                .attribute("failures", String.valueOf(result.getFailuresCount()))
+                .attribute("errors", "0")
+
+                .attribute("timestamp", DateUtils.format(result.getStartTime(), DateUtils.ISO8601_DATETIME_PATTERN))
+                .attribute("hostname", hostName)
+                .attribute("time", String.valueOf(result.getDuration() / 1000.0));
 
             writer.startElement("properties");
             writer.endElement();
 
-            writeTests(writer, result.getResults(), result.getClassName(), classId);
+            Iterable<TestMethodResult> methodResults = result.getResults();
+            String className = result.getClassName();
+
+            if (options.mergeReruns) {
+                writeTestCasesWithMergeRerunHandling(writer, methodResults, className, classId);
+            } else {
+                writeTestCasesWithDiscreteRerunHandling(writer, methodResults, className, classId);
+            }
 
             writer.startElement("system-out");
-            writeOutputs(writer, classId, outputAssociation.equals(TestOutputAssociation.WITH_SUITE), TestOutputEvent.Destination.StdOut);
+            writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdOut);
             writer.endElement();
             writer.startElement("system-err");
-            writeOutputs(writer, classId, outputAssociation.equals(TestOutputAssociation.WITH_SUITE), TestOutputEvent.Destination.StdErr);
+            writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdErr);
             writer.endElement();
 
             writer.endElement();
@@ -83,44 +98,313 @@ public class JUnitXmlResultWriter {
         writer.endCDATA();
     }
 
-    private void writeOutputs(SimpleXmlWriter writer, long classId, long testId, TestOutputEvent.Destination destination) throws IOException {
-        writer.startCDATA();
-        testResultsProvider.writeTestOutput(classId, testId, destination, writer);
-        writer.endCDATA();
-    }
+    /**
+     * Output in the format the Surefire uses when enabling retries.
+     *
+     * - https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html
+     * - https://github.com/apache/maven-surefire/blob/edb3b71b95db98eef6a8e4fa98d376fd3512b05a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report-3.0.xsd
+     * - https://plugins.jenkins.io/flaky-test-handler/
+     *
+     * We deviate from Maven's behaviour when there are any skipped executions, or when there are multiple successful executions.
+     * The “standard” does not specify the behaviour in this circumstance.
+     *
+     * There's no way to convey multiple successful “executions” of a test case in the XML structure.
+     * If this happens, Maven just omits any information about successful executions if they were not the last.
+     * We break the executions up into multiple testcases, which each successful execution being the last execution
+     * of the test case, so as to not drop information.
+     */
+    private void writeTestCasesWithMergeRerunHandling(SimpleXmlWriter writer, final Iterable<TestMethodResult> methodResults, final String className, final long classId) throws IOException {
+        List<List<TestMethodResult>> groupedExecutions = groupExecutions(methodResults);
 
-    private void writeTests(SimpleXmlWriter writer, Iterable<TestMethodResult> methodResults, String className, long classId) throws IOException {
-        for (TestMethodResult methodResult : methodResults) {
-            writer.startElement("testcase")
-                    .attribute("name", methodResult.getDisplayName())
-                    .attribute("classname", className)
-                    .attribute("time", String.valueOf(methodResult.getDuration() / 1000.0));
-
-            if (methodResult.getResultType() == TestResult.ResultType.SKIPPED) {
-                writer.startElement("skipped");
-                writer.endElement();
+        for (final List<TestMethodResult> groupedExecution : groupedExecutions) {
+            if (groupedExecution.size() == 1) {
+                writeTestCase(writer, discreteTestCase(className, classId, groupedExecution.get(0)));
             } else {
-                for (TestFailure failure : methodResult.getFailures()) {
-                    writer.startElement("failure")
-                            .attribute("message", failure.getMessage())
-                            .attribute("type", failure.getExceptionType());
+                final TestMethodResult firstExecution = groupedExecution.get(0);
+                final TestMethodResult lastExecution = groupedExecution.get(groupedExecution.size() - 1);
+                final boolean allFailed = lastExecution.getResultType() == TestResult.ResultType.FAILURE;
 
-                    writer.characters(failure.getStackTrace());
+                // https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html
+                // (if) The test passes in one of its re-runs […] the running time of a flaky test will be the running time of the last successful run.
+                // (if) The test fails in all of the re-runs […] the running time of a failing test with re-runs will be the running time of the first failing run.
+                long duration = allFailed ? firstExecution.getDuration() : lastExecution.getDuration();
 
-                    writer.endElement();
-                }
+                writeTestCase(writer, new TestCase(
+                    firstExecution.getDisplayName(),
+                    className,
+                    duration,
+                    mergeRerunExecutions(allFailed, groupedExecution, firstExecution, classId)
+                ));
             }
-
-            if (outputAssociation.equals(TestOutputAssociation.WITH_TESTCASE)) {
-                writer.startElement("system-out");
-                writeOutputs(writer, classId, methodResult.getId(), TestOutputEvent.Destination.StdOut);
-                writer.endElement();
-                writer.startElement("system-err");
-                writeOutputs(writer, classId, methodResult.getId(), TestOutputEvent.Destination.StdErr);
-                writer.endElement();
-            }
-
-            writer.endElement();
         }
     }
+
+    private Iterable<TestCaseExecution> mergeRerunExecutions(final boolean allFailed, final List<TestMethodResult> groupedExecution, final TestMethodResult firstExecution, final long classId) {
+        return Iterables.concat(Iterables.transform(groupedExecution, new Function<TestMethodResult, Iterable<? extends TestCaseExecution>>() {
+            @Override
+            public Iterable<? extends TestCaseExecution> apply(final TestMethodResult execution) {
+                switch (execution.getResultType()) {
+                    case SUCCESS:
+                        return Collections.singleton(success(classId, execution.getId()));
+                    case SKIPPED:
+                        return Collections.singleton(skipped(classId, execution.getId()));
+                    case FAILURE:
+                        return failures(classId, execution, allFailed
+                            ? execution == firstExecution ? FailureType.FAILURE : FailureType.RERUN_FAILURE
+                            : FailureType.FLAKY_FAILURE
+                        );
+                    default:
+                        throw new IllegalStateException("unhandled type: " + execution.getResultType());
+                }
+            }
+        }));
+    }
+
+    /**
+     * Group the method results into sequences of executions, where each group shares the same display name.
+     *
+     * Each group can only have one successful execution, which must be the last.
+     * On each successful execution, a new group is started.
+     *
+     * The methodResults are assumed to be in execution order.
+     */
+    private List<List<TestMethodResult>> groupExecutions(Iterable<TestMethodResult> methodResults) {
+        List<List<TestMethodResult>> groupedExecutions = new ArrayList<List<TestMethodResult>>();
+        Map<String, Integer> latestGroupForName = new HashMap<String, Integer>();
+
+        for (TestMethodResult methodResult : methodResults) {
+            String name = methodResult.getDisplayName();
+            Integer index = latestGroupForName.get(name);
+            if (index == null) {
+                List<TestMethodResult> executions = Collections.singletonList(methodResult);
+                groupedExecutions.add(executions);
+                if (methodResult.getResultType() == TestResult.ResultType.FAILURE) {
+                    latestGroupForName.put(name, groupedExecutions.size() - 1);
+                }
+            } else {
+                List<TestMethodResult> executions = groupedExecutions.get(index);
+                if (executions.size() == 1) {
+                    executions = new ArrayList<TestMethodResult>(executions);
+                    groupedExecutions.set(index, executions);
+                }
+                executions.add(methodResult);
+                if (methodResult.getResultType() != TestResult.ResultType.FAILURE) {
+                    latestGroupForName.remove(name);
+                }
+            }
+        }
+
+        return groupedExecutions;
+    }
+
+    private void writeTestCasesWithDiscreteRerunHandling(SimpleXmlWriter writer, final Iterable<TestMethodResult> methodResults, final String className, final long classId) throws IOException {
+        for (TestMethodResult methodResult : methodResults) {
+            writeTestCase(writer, discreteTestCase(className, classId, methodResult));
+        }
+    }
+
+    private TestCase discreteTestCase(String className, long classId, TestMethodResult methodResult) {
+        return new TestCase(methodResult.getDisplayName(), className, methodResult.getDuration(), discreteTestCaseExecutions(classId, methodResult));
+    }
+
+    private Iterable<? extends TestCaseExecution> discreteTestCaseExecutions(final long classId, final TestMethodResult methodResult) {
+        switch (methodResult.getResultType()) {
+            case FAILURE:
+                return failures(classId, methodResult, FailureType.FAILURE);
+            case SKIPPED:
+                return Collections.singleton(skipped(classId, methodResult.getId()));
+            case SUCCESS:
+                return Collections.singleton(success(classId, methodResult.getId()));
+            default:
+                throw new IllegalStateException("Unexpected result type: " + methodResult.getResultType());
+        }
+    }
+
+
+    private void writeTestCase(SimpleXmlWriter writer, TestCase testCase) throws IOException {
+        writer.startElement("testcase")
+            .attribute("name", testCase.name)
+            .attribute("classname", testCase.className)
+            .attribute("time", String.valueOf(testCase.duration / 1000.0));
+
+        for (TestCaseExecution execution : testCase.executions) {
+            execution.write(writer);
+        }
+
+        writer.endElement();
+    }
+
+    abstract static class TestCaseExecution {
+
+        private final OutputProvider outputProvider;
+
+        TestCaseExecution(OutputProvider outputProvider) {
+            this.outputProvider = outputProvider;
+        }
+
+        abstract void write(SimpleXmlWriter writer) throws IOException;
+
+        protected void writeOutput(SimpleXmlWriter writer) throws IOException {
+            if (outputProvider.has(TestOutputEvent.Destination.StdOut)) {
+                writer.startElement("system-out");
+                writer.startCDATA();
+                outputProvider.write(TestOutputEvent.Destination.StdOut, writer);
+                writer.endCDATA();
+                writer.endElement();
+            }
+
+            if (outputProvider.has(TestOutputEvent.Destination.StdErr)) {
+                writer.startElement("system-err");
+                writer.startCDATA();
+                outputProvider.write(TestOutputEvent.Destination.StdErr, writer);
+                writer.endCDATA();
+                writer.endElement();
+            }
+        }
+    }
+
+    private static class TestCase {
+        final String name;
+        final String className;
+        final long duration;
+        final Iterable<? extends TestCaseExecution> executions;
+
+        TestCase(String name, String className, long duration, Iterable<? extends TestCaseExecution> executions) {
+            this.name = name;
+            this.className = className;
+            this.duration = duration;
+            this.executions = executions;
+        }
+    }
+
+    private static class TestCaseExecutionSuccess extends TestCaseExecution {
+        TestCaseExecutionSuccess(OutputProvider outputProvider) {
+            super(outputProvider);
+        }
+
+        public void write(SimpleXmlWriter writer) throws IOException {
+            writeOutput(writer);
+        }
+    }
+
+
+    private static class TestCaseExecutionSkipped extends TestCaseExecution {
+        TestCaseExecutionSkipped(OutputProvider outputProvider) {
+            super(outputProvider);
+        }
+
+        public void write(SimpleXmlWriter writer) throws IOException {
+            writer.startElement("skipped").endElement();
+            writeOutput(writer);
+        }
+    }
+
+    enum FailureType {
+        FAILURE("failure", false),
+        FLAKY_FAILURE("flakyFailure", true),
+        RERUN_FAILURE("rerunFailure", true);
+
+        private final String elementName;
+        private final boolean useStacktraceElementAndNestedOutput;
+
+        FailureType(String elementName, boolean useStacktraceElementAndNestedOutput) {
+            this.elementName = elementName;
+            this.useStacktraceElementAndNestedOutput = useStacktraceElementAndNestedOutput;
+        }
+    }
+
+    private static class TestCaseExecutionFailure extends TestCaseExecution {
+        private final TestFailure failure;
+        private final FailureType type;
+
+        TestCaseExecutionFailure(OutputProvider outputProvider, FailureType type, TestFailure failure) {
+            super(outputProvider);
+            this.failure = failure;
+            this.type = type;
+        }
+
+        public void write(SimpleXmlWriter writer) throws IOException {
+            writer.startElement(type.elementName)
+                .attribute("message", failure.getMessage())
+                .attribute("type", failure.getExceptionType());
+
+            if (type.useStacktraceElementAndNestedOutput) {
+                writer.startElement("stackTrace")
+                    .characters(failure.getStackTrace())
+                    .endElement();
+                writeOutput(writer);
+                writer.endElement();
+            } else {
+                writer.characters(failure.getStackTrace());
+                writer.endElement();
+                writeOutput(writer);
+            }
+        }
+    }
+
+    private TestCaseExecution success(long classId, long id) {
+        return new TestCaseExecutionSuccess(outputProvider(classId, id));
+    }
+
+    private TestCaseExecution skipped(long classId, long id) {
+        return new TestCaseExecutionSkipped(outputProvider(classId, id));
+    }
+
+    private Iterable<TestCaseExecution> failures(final long classId, final TestMethodResult methodResult, final FailureType failureType) {
+        List<TestFailure> failures = methodResult.getFailures();
+        final TestFailure firstFailure = failures.get(0);
+        return Iterables.transform(failures, new Function<TestFailure, TestCaseExecution>() {
+            @Override
+            public TestCaseExecution apply(final TestFailure failure) {
+                boolean isFirst = failure == firstFailure;
+                OutputProvider outputProvider = isFirst ? outputProvider(classId, methodResult.getId()) : NullOutputProvider.INSTANCE;
+                return new TestCaseExecutionFailure(outputProvider, failureType, failure);
+            }
+        });
+    }
+
+    private OutputProvider outputProvider(long classId, long id) {
+        return options.outputPerTestCase ? new BackedOutputProvider(classId, id) : NullOutputProvider.INSTANCE;
+    }
+
+    interface OutputProvider {
+        boolean has(TestOutputEvent.Destination destination);
+
+        void write(TestOutputEvent.Destination destination, Writer writer);
+    }
+
+    class BackedOutputProvider implements OutputProvider {
+        private final long classId;
+        private final long testId;
+
+        public BackedOutputProvider(long classId, long testId) {
+            this.classId = classId;
+            this.testId = testId;
+        }
+
+        @Override
+        public boolean has(TestOutputEvent.Destination destination) {
+            return testResultsProvider.hasOutput(classId, testId, destination);
+        }
+
+        @Override
+        public void write(TestOutputEvent.Destination destination, Writer writer) {
+            testResultsProvider.writeTestOutput(classId, testId, destination, writer);
+        }
+    }
+
+    static class NullOutputProvider implements OutputProvider {
+        static final OutputProvider INSTANCE = new NullOutputProvider();
+
+        @Override
+        public boolean has(TestOutputEvent.Destination destination) {
+            return false;
+        }
+
+        @Override
+        public void write(TestOutputEvent.Destination destination, Writer writer) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestCaseRerunHandling.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestCaseRerunHandling.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit.result;
 
-public enum TestOutputAssociation {
-    WITH_SUITE,
-    WITH_TESTCASE
+public enum TestCaseRerunHandling {
+    DISCRETE,
+    SUREFIRE_FORMAT
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
@@ -84,7 +84,6 @@ public class TestClassResult {
         return failuresCount;
     }
 
-
     public int getSkippedCount() {
         return skippedCount;
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
@@ -28,7 +28,7 @@ public class TestMethodResult {
     private TestResult.ResultType resultType;
     private long duration;
     private long endTime;
-    private List<TestFailure> failures = new ArrayList<TestFailure>();
+    private final List<TestFailure> failures = new ArrayList<TestFailure>();
 
     public TestMethodResult(long id, String name) {
         this(id, name, name);

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestOutputStoreBackedResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestOutputStoreBackedResultsProvider.java
@@ -50,4 +50,5 @@ public abstract class TestOutputStoreBackedResultsProvider implements TestResult
     public void close() throws IOException {
         CompositeStoppable.stoppable(readers.values()).stop();
     }
+
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestResultsProvider.java
@@ -28,9 +28,9 @@ public interface TestResultsProvider extends Closeable {
      *
      * Writes all output for the test class.
      */
-    void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer);
+    void writeAllOutput(long classId, TestOutputEvent.Destination destination, Writer writer);
 
-    void writeNonTestOutput(long id, TestOutputEvent.Destination destination, Writer writer);
+    void writeNonTestOutput(long classId, TestOutputEvent.Destination destination, Writer writer);
 
     /**
      * Writes the output of the given test to the given writer. This method must be called only after {@link #visitClasses(org.gradle.api.Action)}.
@@ -44,7 +44,9 @@ public interface TestResultsProvider extends Closeable {
      */
     void visitClasses(Action<? super TestClassResult> visitor);
 
-    boolean hasOutput(long id, TestOutputEvent.Destination destination);
+    boolean hasOutput(long classId, TestOutputEvent.Destination destination);
+
+    boolean hasOutput(long classId, long testId, TestOutputEvent.Destination destination);
 
     boolean isHasResults();
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -34,8 +34,8 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 import org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator;
 import org.gradle.api.internal.tasks.testing.junit.result.InMemoryTestResultsProvider;
+import org.gradle.api.internal.tasks.testing.junit.result.JUnitXmlResultOptions;
 import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult;
-import org.gradle.api.internal.tasks.testing.junit.result.TestOutputAssociation;
 import org.gradle.api.internal.tasks.testing.junit.result.TestOutputStore;
 import org.gradle.api.internal.tasks.testing.junit.result.TestReportDataCollector;
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultSerializer;
@@ -537,10 +537,11 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
             JUnitXmlReport junitXml = reports.getJunitXml();
             if (junitXml.isEnabled()) {
-                TestOutputAssociation outputAssociation = junitXml.isOutputPerTestCase()
-                    ? TestOutputAssociation.WITH_TESTCASE
-                    : TestOutputAssociation.WITH_SUITE;
-                Binary2JUnitXmlReportGenerator binary2JUnitXmlReportGenerator = new Binary2JUnitXmlReportGenerator(junitXml.getDestination(), testResultsProvider, outputAssociation, getBuildOperationExecutor(), getHostnameLookup().getHostname());
+                JUnitXmlResultOptions xmlResultOptions = new JUnitXmlResultOptions(
+                    junitXml.isOutputPerTestCase(),
+                    junitXml.getMergeReruns().get()
+                );
+                Binary2JUnitXmlReportGenerator binary2JUnitXmlReportGenerator = new Binary2JUnitXmlReportGenerator(junitXml.getDestination(), testResultsProvider, xmlResultOptions, getBuildOperationExecutor(), getHostnameLookup().getHostname());
                 binary2JUnitXmlReportGenerator.generate();
             }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
@@ -16,11 +16,15 @@
 
 package org.gradle.api.tasks.testing;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.tasks.Input;
 
 /**
  * The JUnit XML files, commonly used to communicate results to CI servers.
+ *
+ * @see TestTaskReports#getJunitXml()
  */
 public interface JUnitXmlReport extends DirectoryReport {
 
@@ -34,5 +38,25 @@ public interface JUnitXmlReport extends DirectoryReport {
      * Should the output be associated with individual test cases instead of at the suite level.
      */
     void setOutputPerTestCase(boolean outputPerTestCase);
+
+    /**
+     * Whether reruns or retries of a test should be merged into a combined testcase.
+     *
+     * When enabled, the XML output will be very similar to the surefire plugin of Apache Maven™ when enabling reruns.
+     * If a test fails but is then retried and succeeds, its failures will be recorded as {@code <flakyFailure>}
+     * instead of {@code <failure>}, within one {@code <testcase>}.
+     * This can be important for build tooling that uses this XML to understand test results,
+     * and where distinguishing such passed-on-retry outcomes is important.
+     * This is the case for the Jenkins CI server and its Flaky Test Handler plugin.
+     *
+     * This value defaults to {@code false}, causing each test execution to be a discrete {@code <testcase>}.
+     *
+     * @see <a href="https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html">https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html</a>
+     * @see <a href="https://plugins.jenkins.io/flaky-test-handler">https://plugins.jenkins.io/flaky-test-handler</a>
+     * @since 6.8
+     */
+    @Input
+    @Incubating
+    Property<Boolean> getMergeReruns();
 
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -36,7 +36,8 @@ import spock.lang.Unroll
 
 class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
-    @Rule private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
+    @Rule
+    private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     private resultsProvider = Mock(TestResultsProvider)
     BuildOperationExecutor buildOperationExecutor
     Binary2JUnitXmlReportGenerator generator
@@ -47,7 +48,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(Clock), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), parallelismConfiguration, new DefaultBuildOperationIdFactory())
-        Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, TestOutputAssociation.WITH_SUITE, buildOperationExecutor, "localhost")
+        Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, new JUnitXmlResultOptions(false, false), buildOperationExecutor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)
         return reportGenerator
     }
@@ -77,14 +78,14 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
         0 * generator.xmlWriter._
 
         where:
-        numThreads << [ 1, 4 ]
+        numThreads << [1, 4]
     }
 
     def "adds context information to the failure if something goes wrong"() {
         generator = generatorWithMaxThreads(1)
 
         def fooTest = new TestClassResult(1, 'FooTest', 100)
-                .add(new TestMethodResult(1, "foo"))
+            .add(new TestMethodResult(1, "foo"))
 
         resultsProvider.visitClasses(_) >> { Action action ->
             action.execute(fooTest)

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit.result
+
+import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
+import org.gradle.internal.SystemProperties
+import spock.lang.Specification
+
+class JUnitXmlResultWriterMergeRerunSpec extends Specification {
+
+    def provider = new BuildableTestResultsProvider()
+    def outputPerTestCase = true
+
+    protected JUnitXmlResultWriter getGenerator() {
+        new JUnitXmlResultWriter("localhost", provider, new JUnitXmlResultOptions(outputPerTestCase, true))
+    }
+
+    def "merges for simple case - output per testcase"() {
+        when:
+        def testClass = provider.testClassResult("com.Flaky") {
+            stdout "class-out"
+            stderr "class-err"
+            testcase("m1") {
+                stderr "m1-err-1"
+                stdout "m1-out-1"
+                failure "m1-message-1", "m1-stackTrace-1"
+            }
+            testcase("m1") {
+                stdout "m1-out-2"
+                stderr "m1-err-2"
+            }
+            testcase("m2") {
+                stderr "m2-err-1"
+                stdout "m2-out-1"
+                failure "m2-message-1", "m2-stackTrace-1"
+            }
+            testcase("m2") {
+                stderr "m2-err-2"
+                stdout "m2-out-2"
+                failure "m2-message-2", "m2-stackTrace-2"
+            }
+        }
+
+        then:
+        getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.Flaky" tests="4" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+  <properties/>
+  <testcase name="m1" classname="com.Flaky" time="2.0">
+    <flakyFailure message="m1-message-1" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1</stackTrace>
+      <system-out><![CDATA[m1-out-1]]></system-out>
+      <system-err><![CDATA[m1-err-1]]></system-err>
+    </flakyFailure>
+    <system-out><![CDATA[m1-out-2]]></system-out>
+    <system-err><![CDATA[m1-err-2]]></system-err>
+  </testcase>
+  <testcase name="m2" classname="com.Flaky" time="1.0">
+    <failure message="m2-message-1" type="ExceptionType">m2-stackTrace-1</failure>
+    <system-out><![CDATA[m2-out-1]]></system-out>
+    <system-err><![CDATA[m2-err-1]]></system-err>
+    <rerunFailure message="m2-message-2" type="ExceptionType">
+      <stackTrace>m2-stackTrace-2</stackTrace>
+      <system-out><![CDATA[m2-out-2]]></system-out>
+      <system-err><![CDATA[m2-err-2]]></system-err>
+    </rerunFailure>
+  </testcase>
+  <system-out><![CDATA[class-out]]></system-out>
+  <system-err><![CDATA[class-err]]></system-err>
+</testsuite>
+"""
+    }
+
+    def "merges for simple case - output at suite"() {
+        when:
+        outputPerTestCase = false
+        def testClass = provider.testClassResult("com.Flaky") {
+            stdout "class-out"
+            stderr "class-err"
+            testcase("m1") {
+                stderr "m1-err-1"
+                stdout "m1-out-1"
+                failure "m1-message-1", "m1-stackTrace-1"
+            }
+            testcase("m1") {
+                stdout "m1-out-2"
+                stderr "m1-err-2"
+            }
+            testcase("m2") {
+                stderr "m2-err-1"
+                stdout "m2-out-1"
+                failure "m2-message-1", "m2-stackTrace-1"
+            }
+            testcase("m2") {
+                stderr "m2-err-2"
+                stdout "m2-out-2"
+                failure "m2-message-2", "m2-stackTrace-2"
+            }
+        }
+
+        then:
+        getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.Flaky" tests="4" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+  <properties/>
+  <testcase name="m1" classname="com.Flaky" time="2.0">
+    <flakyFailure message="m1-message-1" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1</stackTrace>
+    </flakyFailure>
+  </testcase>
+  <testcase name="m2" classname="com.Flaky" time="1.0">
+    <failure message="m2-message-1" type="ExceptionType">m2-stackTrace-1</failure>
+    <rerunFailure message="m2-message-2" type="ExceptionType">
+      <stackTrace>m2-stackTrace-2</stackTrace>
+    </rerunFailure>
+  </testcase>
+  <system-out><![CDATA[class-outm1-out-1m1-out-2m2-out-1m2-out-2]]></system-out>
+  <system-err><![CDATA[class-errm1-err-1m1-err-2m2-err-1m2-err-2]]></system-err>
+</testsuite>
+"""
+    }
+
+    def "can have many failing executions"() {
+        when:
+        def testClass = provider.testClassResult("com.Flaky") {
+            stdout "class-out"
+            stderr "class-err"
+            testcase("m1") {
+                stderr "m1-err-1"
+                stdout "m1-out-1"
+                failure "m1-message-1", "m1-stackTrace-1"
+            }
+            testcase("m2") {
+                stderr "m2-err-1"
+                stdout "m2-out-1"
+                failure "m2-message-1", "m2-stackTrace-1"
+            }
+            testcase("m1") {
+                stderr "m1-err-2"
+                stdout "m1-out-2"
+                failure "m1-message-2", "m1-stackTrace-2"
+            }
+            testcase("m2") {
+                stderr "m2-err-2"
+                stdout "m2-out-2"
+                failure "m2-message-2", "m2-stackTrace-2"
+            }
+            testcase("m1") {
+                stdout "m1-out-3"
+                stderr "m1-err-3"
+            }
+            testcase("m2") {
+                stderr "m2-err-3"
+                stdout "m2-out-3"
+                failure "m2-message-3", "m2-stackTrace-3"
+            }
+        }
+
+        then:
+        getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.Flaky" tests="6" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+  <properties/>
+  <testcase name="m1" classname="com.Flaky" time="3.0">
+    <flakyFailure message="m1-message-1" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1</stackTrace>
+      <system-out><![CDATA[m1-out-1]]></system-out>
+      <system-err><![CDATA[m1-err-1]]></system-err>
+    </flakyFailure>
+    <flakyFailure message="m1-message-2" type="ExceptionType">
+      <stackTrace>m1-stackTrace-2</stackTrace>
+      <system-out><![CDATA[m1-out-2]]></system-out>
+      <system-err><![CDATA[m1-err-2]]></system-err>
+    </flakyFailure>
+    <system-out><![CDATA[m1-out-3]]></system-out>
+    <system-err><![CDATA[m1-err-3]]></system-err>
+  </testcase>
+  <testcase name="m2" classname="com.Flaky" time="1.0">
+    <failure message="m2-message-1" type="ExceptionType">m2-stackTrace-1</failure>
+    <system-out><![CDATA[m2-out-1]]></system-out>
+    <system-err><![CDATA[m2-err-1]]></system-err>
+    <rerunFailure message="m2-message-2" type="ExceptionType">
+      <stackTrace>m2-stackTrace-2</stackTrace>
+      <system-out><![CDATA[m2-out-2]]></system-out>
+      <system-err><![CDATA[m2-err-2]]></system-err>
+    </rerunFailure>
+    <rerunFailure message="m2-message-3" type="ExceptionType">
+      <stackTrace>m2-stackTrace-3</stackTrace>
+      <system-out><![CDATA[m2-out-3]]></system-out>
+      <system-err><![CDATA[m2-err-3]]></system-err>
+    </rerunFailure>
+  </testcase>
+  <system-out><![CDATA[class-out]]></system-out>
+  <system-err><![CDATA[class-err]]></system-err>
+</testsuite>
+"""
+    }
+
+    def "breaks up into testcases terminated by non failed results"() {
+        when:
+        def testClass = provider.testClassResult("com.Flaky") {
+            testcase("m1") {
+                failure "m1-message-1", "m1-stackTrace-1"
+            }
+            testcase("m1") {
+                failure "m1-message-2", "m1-stackTrace-2"
+            }
+            testcase("m1") {
+
+            }
+            testcase("m1") {
+                failure "m1-message-3", "m1-stackTrace-3"
+            }
+            testcase("m1") {
+                ignore()
+            }
+            testcase("m1") {
+                failure "m1-message-4", "m1-stackTrace-4"
+            }
+            testcase("m1") {
+                failure "m1-message-5", "m1-stackTrace-5"
+            }
+        }
+
+        then:
+        getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.Flaky" tests="7" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+  <properties/>
+  <testcase name="m1" classname="com.Flaky" time="3.0">
+    <flakyFailure message="m1-message-1" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1</stackTrace>
+    </flakyFailure>
+    <flakyFailure message="m1-message-2" type="ExceptionType">
+      <stackTrace>m1-stackTrace-2</stackTrace>
+    </flakyFailure>
+  </testcase>
+  <testcase name="m1" classname="com.Flaky" time="5.0">
+    <flakyFailure message="m1-message-3" type="ExceptionType">
+      <stackTrace>m1-stackTrace-3</stackTrace>
+    </flakyFailure>
+    <skipped/>
+  </testcase>
+  <testcase name="m1" classname="com.Flaky" time="6.0">
+    <failure message="m1-message-4" type="ExceptionType">m1-stackTrace-4</failure>
+    <rerunFailure message="m1-message-5" type="ExceptionType">
+      <stackTrace>m1-stackTrace-5</stackTrace>
+    </rerunFailure>
+  </testcase>
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>
+"""
+    }
+
+    def "unpacks multiple failures"() {
+        when:
+        def testClass = provider.testClassResult("com.Flaky") {
+            stdout "class-out"
+            stderr "class-err"
+            testcase("m1") {
+                stderr "m1-err-1"
+                stdout "m1-out-1"
+                failure "m1-message-1.1", "m1-stackTrace-1.1"
+                failure "m1-message-1.2", "m1-stackTrace-1.2"
+            }
+            testcase("m1") {
+                stdout "m1-out-2"
+                stderr "m1-err-2"
+            }
+            testcase("m2") {
+                stderr "m2-err-1"
+                stdout "m2-out-1"
+                failure "m2-message-1.1", "m2-stackTrace-1.1"
+                failure "m2-message-1.2", "m2-stackTrace-1.2"
+            }
+            testcase("m2") {
+                stderr "m2-err-2"
+                stdout "m2-out-2"
+                failure "m2-message-2.1", "m2-stackTrace-2.1"
+                failure "m2-message-2.2", "m2-stackTrace-2.2"
+            }
+        }
+
+        then:
+        getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.Flaky" tests="4" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+  <properties/>
+  <testcase name="m1" classname="com.Flaky" time="2.0">
+    <flakyFailure message="m1-message-1.1" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1.1</stackTrace>
+      <system-out><![CDATA[m1-out-1]]></system-out>
+      <system-err><![CDATA[m1-err-1]]></system-err>
+    </flakyFailure>
+    <flakyFailure message="m1-message-1.2" type="ExceptionType">
+      <stackTrace>m1-stackTrace-1.2</stackTrace>
+    </flakyFailure>
+    <system-out><![CDATA[m1-out-2]]></system-out>
+    <system-err><![CDATA[m1-err-2]]></system-err>
+  </testcase>
+  <testcase name="m2" classname="com.Flaky" time="1.0">
+    <failure message="m2-message-1.1" type="ExceptionType">m2-stackTrace-1.1</failure>
+    <system-out><![CDATA[m2-out-1]]></system-out>
+    <system-err><![CDATA[m2-err-1]]></system-err>
+    <failure message="m2-message-1.2" type="ExceptionType">m2-stackTrace-1.2</failure>
+    <rerunFailure message="m2-message-2.1" type="ExceptionType">
+      <stackTrace>m2-stackTrace-2.1</stackTrace>
+      <system-out><![CDATA[m2-out-2]]></system-out>
+      <system-err><![CDATA[m2-err-2]]></system-err>
+    </rerunFailure>
+    <rerunFailure message="m2-message-2.2" type="ExceptionType">
+      <stackTrace>m2-stackTrace-2.2</stackTrace>
+    </rerunFailure>
+  </testcase>
+  <system-out><![CDATA[class-out]]></system-out>
+  <system-err><![CDATA[class-err]]></system-err>
+</testsuite>
+"""
+    }
+
+    def getXml(TestClassResult result) {
+        def text = new ByteArrayOutputStream()
+        generator.write(result, text)
+        return text.toString("UTF-8").replace(SystemProperties.instance.lineSeparator, "\n")
+    }
+}

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
@@ -144,10 +144,9 @@ class JUnitXmlResultWriterSpec extends Specification {
         given:
         options = new JUnitXmlResultOptions(true, false)
         provider = new BuildableTestResultsProvider()
-        def testClass = provider.testClassResult("com.Foo")
 
         when:
-        testClass {
+        def testClass = provider.testClassResult("com.Foo") {
             stdout "class-out"
             stderr "class-err"
             testcase("m1") {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
@@ -25,21 +25,21 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static TestOutputAssociation.WITH_SUITE
-import static TestOutputAssociation.WITH_TESTCASE
 import static java.util.Collections.emptyList
 import static org.gradle.api.tasks.testing.TestOutputEvent.Destination.StdErr
 import static org.gradle.api.tasks.testing.TestOutputEvent.Destination.StdOut
-import static org.gradle.api.tasks.testing.TestResult.ResultType.*
+import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SUCCESS
 import static org.hamcrest.CoreMatchers.equalTo
 
 class JUnitXmlResultWriterSpec extends Specification {
 
     private provider = Mock(TestResultsProvider)
-    private mode = WITH_SUITE
+    private options = new JUnitXmlResultOptions(false, false)
 
     protected JUnitXmlResultWriter getGenerator() {
-        new JUnitXmlResultWriter("localhost", provider, mode)
+        new JUnitXmlResultWriter("localhost", provider, options)
     }
 
     private startTime = 1353344968049
@@ -59,14 +59,14 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         then:
         new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", "com.foo.FooTest", TestResultOutputAssociation.WITH_SUITE)
-                .assertTestCount(4, 1, 1, 0)
-                .assertTestFailed("some failing test", equalTo('failure message'))
-                .assertTestsSkipped("some skipped test")
-                .assertTestsExecuted("some test", "some test two", "some failing test")
-                .assertStdout(equalTo("""1st output message
+            .assertTestCount(4, 1, 1, 0)
+            .assertTestFailed("some failing test", equalTo('failure message'))
+            .assertTestsSkipped("some skipped test")
+            .assertTestsExecuted("some test", "some test two", "some failing test")
+            .assertStdout(equalTo("""1st output message
 2nd output message
 """))
-                .assertStderr(equalTo("err"))
+            .assertStderr(equalTo("err"))
 
         and:
         xml == """<?xml version="1.0" encoding="UTF-8"?>
@@ -142,21 +142,21 @@ class JUnitXmlResultWriterSpec extends Specification {
 
     def "can generate with output per test"() {
         given:
-        mode = WITH_TESTCASE
+        options = new JUnitXmlResultOptions(true, false)
         provider = new BuildableTestResultsProvider()
         def testClass = provider.testClassResult("com.Foo")
 
         when:
-        testClass.with {
+        testClass {
             stdout "class-out"
             stderr "class-err"
-            testcase("m1").with {
+            testcase("m1") {
                 stderr " m1-err-1"
                 stdout " m1-out-1"
                 stdout " m1-out-2"
                 stderr " m1-err-2"
             }
-            testcase("m2").with {
+            testcase("m2") {
                 stderr " m2-err-1"
                 stdout " m2-out-1"
                 stdout " m2-out-2"
@@ -168,11 +168,11 @@ class JUnitXmlResultWriterSpec extends Specification {
         getXml(testClass) == """<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="com.Foo" tests="2" skipped="0" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
   <properties/>
-  <testcase name="m1" classname="com.Foo" time="0.1">
+  <testcase name="m1" classname="com.Foo" time="1.0">
     <system-out><![CDATA[ m1-out-1 m1-out-2]]></system-out>
     <system-err><![CDATA[ m1-err-1 m1-err-2]]></system-err>
   </testcase>
-  <testcase name="m2" classname="com.Foo" time="0.1">
+  <testcase name="m2" classname="com.Foo" time="1.0">
     <system-out><![CDATA[ m2-out-1 m2-out-2]]></system-out>
     <system-err><![CDATA[ m2-err-1 m2-err-2]]></system-err>
   </testcase>

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -18,11 +18,14 @@ package org.gradle.testing
 
 
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
+import org.gradle.integtests.fixtures.JUnitTestClassExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
+import org.hamcrest.CoreMatchers
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -359,6 +362,73 @@ public class SubClassTests extends SuperClassTests {
 
         then:
         executedAndNotSkipped(":test")
+    }
+
+    def "can enable merge rerun in xml report"() {
+        when:
+        buildScript """
+            $junitSetup
+            test.reports.junitXml.mergeReruns = true
+        """
+        rerunningTest("SomeTest")
+        fails "test"
+
+        then:
+        def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
+        def clazz = xmlReport.testClass("SomeTest")
+        clazz.testCount == 6
+        (clazz as JUnitTestClassExecutionResult).testCasesCount == 2
+        clazz.assertTestPassed("testFlaky[]")
+        clazz.assertTestFailed("testFailing[]", CoreMatchers.anything())
+    }
+
+    def "merge rerun defaults to false"() {
+        when:
+        buildScript """
+            $junitSetup
+        """
+        rerunningTest("SomeTest")
+        fails "test"
+
+        then:
+        def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
+        def clazz = xmlReport.testClass("SomeTest")
+        clazz.testCount == 6
+        (clazz as JUnitTestClassExecutionResult).testCasesCount == 6
+    }
+
+    private TestFile rerunningTest(String className) {
+        file("src/test/java/${className}.java") << """
+            import org.junit.Assert;
+            import org.junit.Test;
+
+            @org.junit.runner.RunWith(org.junit.runners.Parameterized.class)
+            public class $className {
+
+                @org.junit.runners.Parameterized.Parameters(name = "")
+                public static Object[] data() {
+                    return new Object[] { 1, 2, 3 };
+                }
+
+                private final int i;
+
+                public SomeTest(int i) {
+                    this.i = i;
+                }
+
+                @Test
+                public void testFlaky() {
+                    System.out.println("execution " + i);
+                    Assert.assertTrue(i == 3);
+                }
+
+                @Test
+                public void testFailing() {
+                    System.out.println("execution " + i);
+                    Assert.assertTrue(false);
+                }
+            }
+        """
     }
 
     def "outputs over lifecycle"() {


### PR DESCRIPTION
When enabled, the XML output will be very similar to Apache Maven's surefire plugin when enabling reruns.
Most notably, if a test fails but is then retried and succeeds, its failures will be recorded as `<flakyFailure>` instead of `<failure>`, within a single `<testcase>`.
This can be important for build tooling that uses this XML to understand test results, and where distinguishing such passed-on-retry outcomes is important.
This is the case for the Jenkins CI server and its Flaky Test Handler plugin.

This does not add any retry/rerun functionality.
It just changes the reporting if such a mechanism is separately in place.

### Notes:

I tried the produced XML output manually with the latest Jenkins. I was unable to test with the Jenkins flaky test plugin as currently there's no version of it that works with a recent Jenkins version, though it looks like there has been some recent activity towards making it work.

Without the plugin installed, Jenkins effectively ignores `<flakyFailure>` and `<rerunFailure>`. This produces the behaviour of tests passing after retry _not_ causing the build to fail, which was one of the goals of this change.

I reverse engineered the code of the flaky test handling plugin, and am confident that the output we produce would be successfully interpreted by that plugin, in that `<flakyFailure>` would be treated as a “flake”.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
