### PR TITLE
Allow detecting standalone jres inside other installation locations

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
@@ -109,7 +109,15 @@ public class SharedJavaInstallationRegistry {
         if (os.isMacOsX() && new File(potentialHome, "Contents/Home").exists()) {
             return new File(potentialHome, "Contents/Home");
         }
+        final File standaloneJre = new File(potentialHome, "jre");
+        if(!hasJavaExecutable(potentialHome) && hasJavaExecutable(standaloneJre)) {
+            return standaloneJre;
+        }
         return potentialHome;
+    }
+
+    private boolean hasJavaExecutable(File potentialHome) {
+        return new File(potentialHome, os.getExecutableName("bin/java")).exists();
     }
 
     public static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
@@ -80,10 +80,26 @@ class SharedJavaInstallationRegistryTest extends Specification {
 
     def "normalize installations to account for macOS folder layout"() {
         given:
-        def tmpWithMacOsLayout = createTempDir()
-        def expectedHome = new File(tmpWithMacOsLayout, "Contents/Home")
+        def expectedHome = new File(tempFolder, "Contents/Home")
         assert expectedHome.mkdirs()
-        def registry = new SharedJavaInstallationRegistry([forDirectory(tmpWithMacOsLayout)], new TestBuildOperationExecutor(), OperatingSystem.MAC_OS)
+        def registry = new SharedJavaInstallationRegistry([forDirectory(tempFolder)], new TestBuildOperationExecutor(), OperatingSystem.MAC_OS)
+
+        when:
+        def installations = registry.listInstallations()
+
+        then:
+        installations*.location.contains(expectedHome)
+    }
+
+    def "normalize installations to account for standalone jre"() {
+        given:
+        def expectedHome = new File(tempFolder, "jre")
+        assert expectedHome.mkdirs()
+        def jreBinFolder = new File(expectedHome, "bin")
+        assert jreBinFolder.mkdir()
+        assert new File(jreBinFolder, OperatingSystem.current().getExecutableName( "java")).createNewFile()
+
+        def registry = new SharedJavaInstallationRegistry([forDirectory(tempFolder)], new TestBuildOperationExecutor(), OperatingSystem.current())
 
         when:
         def installations = registry.listInstallations()


### PR DESCRIPTION
Fixes #15094
