### PR TITLE
Allow task exclusion in included builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class CompositeBuildTaskExcludeIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include('sub')
+            includeBuild('included')
+        """
+        file('included/settings.gradle') << """
+            include('sub')
+        """
+        buildFile << """
+            def test = tasks.register('test') {
+                doLast {
+                     println 'test executed'
+                }
+            }
+
+            tasks.register('build') {
+                doLast {
+                     println 'build executed'
+                }
+                dependsOn test
+                dependsOn gradle.includedBuild('included').task(':build')
+            }
+
+            project(':sub') {
+                def subTest = tasks.register('test') {
+                    doLast {
+                         println 'sub test executed'
+                    }
+                }
+
+                tasks.register('build') {
+                    doLast {
+                        println 'sub build executed'
+                    }
+                    dependsOn subTest
+                    dependsOn gradle.includedBuild('included').task(':sub:build')
+                }
+            }
+        """
+        file('included/build.gradle') << """
+            def test = tasks.register('test') {
+                doLast {
+                     println 'included test executed'
+                }
+            }
+
+            tasks.register('build') {
+                doLast {
+                     println 'included build executed'
+                }
+                dependsOn test
+            }
+
+            project(':sub') {
+                def subTest = tasks.register('test') {
+                    doLast {
+                         println 'included sub test executed'
+                    }
+                }
+                tasks.register('build') {
+                    doLast {
+                         println 'included sub build executed'
+                    }
+                    dependsOn subTest
+                }
+            }
+        """
+    }
+
+    def "can exclude tasks from an included build"() {
+        when:
+        succeeds("build", "-x", ":included:sub:test")
+
+        then:
+        result.assertTasksExecuted(":test", ":build", ":sub:test", ":sub:build", ":included:test", ":included:build" , ":included:sub:build")
+        result.assertTaskNotExecuted(":included:sub:test")
+    }
+
+    def "excluding a task from a root project does not affect included task with same path"() {
+        when:
+        succeeds("build", "-x", ":sub:test")
+
+        then:
+        result.assertTasksExecuted(":test", ":build", ":sub:build", ":included:test", ":included:build", ":included:sub:test", ":included:sub:build")
+        result.assertTaskNotExecuted(":sub:test")
+    }
+
+    def "cannot use unqualified task paths to exclude tasks from included build roots"() {
+        when:
+        run("build", "-x", "test")
+
+        then:
+        result.assertTasksExecuted(":build", ":sub:build", ":included:build", ":included:sub:build", ":included:test", ":included:sub:test")
+        result.assertTaskNotExecuted(":test")
+        result.assertTaskNotExecuted(":sub:test")
+    }
+
+    def "cannot use unqualified absolute paths to to exclude task from included build root"() {
+        expect:
+        runAndFail("build", "-x", "included:test")
+    }
+
+    def "cannot use unqualified task paths to exclude tasks from included build subproject"() {
+        when:
+        run("build", "-x", "sub:test")
+
+        then:
+        result.assertTasksExecuted(":test", ":build", ":sub:build", ":included:test", ":included:build", ":included:sub:test", ":included:sub:build")
+        result.assertTaskNotExecuted(":sub:test")
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
@@ -193,10 +193,95 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
 
         where:
         args                                  | executed                                                                                                            | skipped
-        ["build", "-x", "test"]               | [":build", ":sub:build", ":included:build", ":included:sub:build"]                                                  | [":test", ":sub:test", ":included:test", ":included:sub:test"]
-        ["build", "-x", "sub:test"]           | [":test", ":build", ":sub:build", ":included:test", ":included:build", ":included:sub:build"]                       | [":sub:test", ":included:sub:test"]
         ["build", "-x", ":sub:test"]          | [":test", ":build", ":sub:build", ":included:test", ":included:build", ":included:sub:test", ":included:sub:build"] | [":sub:test"]
         ["build", "-x", ":included:sub:test"] | [":test", ":build", ":sub:test", ":sub:build", ":included:test", ":included:build" , ":included:sub:build"]         | [":included:sub:test"]
+    }
+
+    def "cannot use unqualified task paths  to exclude tasks from included builds"() {
+        setup:
+        settingsFile << """
+            rootProject.name = 'root'
+            include('sub')
+            includeBuild('included')
+        """
+        file('included/settings.gradle') << """
+            include('sub')
+        """
+        buildFile << """
+            def test = tasks.register('test')
+            tasks.register('build') {
+                dependsOn test
+                dependsOn gradle.includedBuild('included').task(':build')
+            }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') {
+                    dependsOn subTest
+                    dependsOn gradle.includedBuild('included').task(':sub:build')
+                }
+            }
+        """
+        file('included/build.gradle') << """
+            def test = tasks.register('test')
+            tasks.register('build') { dependsOn test }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') { dependsOn subTest }
+            }
+        """
+
+        when:
+        run(*args)
+
+        then:
+        result.assertTasksExecuted(executed)
+        if (!skipped.empty) { skipped.each { result.assertTaskNotExecuted(it) } }
+
+        where:
+        args                                  | executed                                                                                                                         | skipped
+        ["build", "-x", "test"]               | [":build", ":sub:build", ":included:build", ":included:sub:build", ":included:test", ":included:sub:test"]                       | [":test", ":sub:test"]
+        ["build", "-x", "sub:test"]           | [":test", ":build", ":sub:build", ":included:test", ":included:build", ":included:sub:test", ":included:sub:build"]              | [":sub:test"]
+    }
+
+    def "cannot use unqualified absolute paths to to exclude task from included build"() {
+        setup:
+        settingsFile << """
+            rootProject.name = 'root'
+            include('sub')
+            includeBuild('included')
+        """
+        file('included/settings.gradle') << """
+            include('sub')
+        """
+        buildFile << """
+            def test = tasks.register('test')
+            tasks.register('build') {
+                dependsOn test
+                dependsOn gradle.includedBuild('included').task(':build')
+            }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') {
+                    dependsOn subTest
+                    dependsOn gradle.includedBuild('included').task(':sub:build')
+                }
+            }
+        """
+        file('included/build.gradle') << """
+            def test = tasks.register('test')
+            tasks.register('build') { dependsOn test }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') { dependsOn subTest }
+            }
+        """
+
+        expect:
+        runAndFail("build", "-x", "included:test")
     }
 
     def "can pass options to task in included build"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
@@ -151,38 +151,7 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
 
     def "can exclude tasks coming from included builds"() {
         setup:
-        settingsFile << """
-            rootProject.name = 'root'
-            include('sub')
-            includeBuild('included')
-        """
-        file('included/settings.gradle') << """
-            include('sub')
-        """
-        buildFile << """
-            def test = tasks.register('test')
-            tasks.register('build') {
-                dependsOn test
-                dependsOn gradle.includedBuild('included').task(':build')
-            }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') {
-                    dependsOn subTest
-                    dependsOn gradle.includedBuild('included').task(':sub:build')
-                }
-            }
-        """
-        file('included/build.gradle') << """
-            def test = tasks.register('test')
-            tasks.register('build') { dependsOn test }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') { dependsOn subTest }
-            }
-        """
+        setupComplexExample()
 
         when:
         succeeds(*args)
@@ -199,38 +168,7 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
 
     def "cannot use unqualified task paths  to exclude tasks from included builds"() {
         setup:
-        settingsFile << """
-            rootProject.name = 'root'
-            include('sub')
-            includeBuild('included')
-        """
-        file('included/settings.gradle') << """
-            include('sub')
-        """
-        buildFile << """
-            def test = tasks.register('test')
-            tasks.register('build') {
-                dependsOn test
-                dependsOn gradle.includedBuild('included').task(':build')
-            }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') {
-                    dependsOn subTest
-                    dependsOn gradle.includedBuild('included').task(':sub:build')
-                }
-            }
-        """
-        file('included/build.gradle') << """
-            def test = tasks.register('test')
-            tasks.register('build') { dependsOn test }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') { dependsOn subTest }
-            }
-        """
+        setupComplexExample()
 
         when:
         run(*args)
@@ -247,38 +185,7 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
 
     def "cannot use unqualified absolute paths to to exclude task from included build"() {
         setup:
-        settingsFile << """
-            rootProject.name = 'root'
-            include('sub')
-            includeBuild('included')
-        """
-        file('included/settings.gradle') << """
-            include('sub')
-        """
-        buildFile << """
-            def test = tasks.register('test')
-            tasks.register('build') {
-                dependsOn test
-                dependsOn gradle.includedBuild('included').task(':build')
-            }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') {
-                    dependsOn subTest
-                    dependsOn gradle.includedBuild('included').task(':sub:build')
-                }
-            }
-        """
-        file('included/build.gradle') << """
-            def test = tasks.register('test')
-            tasks.register('build') { dependsOn test }
-
-            project(':sub') {
-                def subTest = tasks.register('test')
-                tasks.register('build') { dependsOn subTest }
-            }
-        """
+        setupComplexExample()
 
         expect:
         runAndFail("build", "-x", "included:test")
@@ -482,5 +389,40 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
         expect:
         succeeds("doSomething")
         outputContains("do something")
+    }
+
+    private def setupComplexExample() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include('sub')
+            includeBuild('included')
+        """
+        file('included/settings.gradle') << """
+            include('sub')
+        """
+        buildFile << """
+            def test = tasks.register('test')
+            tasks.register('build') {
+                dependsOn test
+                dependsOn gradle.includedBuild('included').task(':build')
+            }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') {
+                    dependsOn subTest
+                    dependsOn gradle.includedBuild('included').task(':sub:build')
+                }
+            }
+        """
+        file('included/build.gradle') << """
+            def test = tasks.register('test')
+            tasks.register('build') { dependsOn test }
+
+            project(':sub') {
+                def subTest = tasks.register('test')
+                tasks.register('build') { dependsOn subTest }
+            }
+        """
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
@@ -22,9 +22,12 @@ import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.internal.Actions;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.plugin.management.internal.PluginRequests;
+import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class BuildDefinition {
     @Nullable
@@ -120,6 +123,11 @@ public class BuildDefinition {
         ((StartParameterInternal) includedBuildStartParam).setSearchUpwardsWithoutDeprecationWarning(false);
         includedBuildStartParam.setConfigureOnDemand(false);
         includedBuildStartParam.setInitScripts(startParameter.getInitScripts());
+        List<String> taskNames = startParameter.getExcludedTaskNames().stream()
+            .map(name -> Path.path(name)).filter(p -> !p.isAbsolute() || (p.segmentCount() > 1 && p.segment(0).equals(buildRootDir.getName())))
+            .map(p -> { if (p.isAbsolute()) { return p.removeFirstSegments(1).toString(); } else { return p.toString(); } })
+            .collect(Collectors.toList());
+        includedBuildStartParam.setExcludedTaskNames(taskNames);
         return includedBuildStartParam;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
@@ -22,12 +22,9 @@ import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.internal.Actions;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.plugin.management.internal.PluginRequests;
-import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class BuildDefinition {
     @Nullable
@@ -123,11 +120,7 @@ public class BuildDefinition {
         ((StartParameterInternal) includedBuildStartParam).setSearchUpwardsWithoutDeprecationWarning(false);
         includedBuildStartParam.setConfigureOnDemand(false);
         includedBuildStartParam.setInitScripts(startParameter.getInitScripts());
-        List<String> taskNames = startParameter.getExcludedTaskNames().stream()
-            .map(name -> Path.path(name)).filter(p -> !p.isAbsolute() || (p.segmentCount() > 1 && p.segment(0).equals(buildRootDir.getName())))
-            .map(p -> { if (p.isAbsolute()) { return p.removeFirstSegments(1).toString(); } else { return p.toString(); } })
-            .collect(Collectors.toList());
-        includedBuildStartParam.setExcludedTaskNames(taskNames);
+        includedBuildStartParam.setExcludedTaskNames(startParameter.getExcludedTaskNames());
         return includedBuildStartParam;
     }
 


### PR DESCRIPTION
This PR allows users to exclude tasks from the included builds.

The implementation forwards the filters from the start parameters to all included builds and creates the filter objects on their respective task graphs.

Excluding tasks from included builds has some drawbacks: it's easier to mess up existing builds. For example, if the user executes `gradle checkDeps -x jar` then the jar task will be excluded from all task graphs, with ultimately breaks the build.