### PR TITLE
Deprecate JavaInstallationRegistry

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheRecreateOption
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.event.ListenerManager
-import org.gradle.jvm.toolchain.JavaInstallationRegistry
 import org.gradle.process.ExecOperations
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.workers.WorkerExecutor
@@ -34,7 +33,6 @@ import org.slf4j.Logger
 import spock.lang.Unroll
 
 import javax.inject.Inject
-
 
 class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -560,7 +558,6 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         ArchiveOperations.name           | "project.services.get(${ArchiveOperations.name})"           | "toString()"
         ExecOperations.name              | "project.services.get(${ExecOperations.name})"              | "toString()"
         ListenerManager.name             | "project.services.get(${ListenerManager.name})"             | "toString()"
-        JavaInstallationRegistry.name    | "project.services.get(${JavaInstallationRegistry.name})"    | "installationForCurrentVirtualMachine"
     }
 
     @Unroll

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
@@ -46,18 +46,21 @@ class CrossCompilationIntegrationTest extends AbstractIntegrationSpec {
                 sourceCompatibility = JavaVersion.${version.name()}
             }
 
-            def javaInstallation = project.javaInstalls.installationForDirectory(project.layout.projectDirectory.dir("${jvm.javaHome.toURI()}"))
+            def launcher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(${version.majorVersion})
+            }.get()
+            def installationDirectory = launcher.metadata.installationPath
 
             tasks.named("compileJava") {
                 options.fork = true
-                options.forkOptions.javaHome = javaInstallation.get().installationDirectory.asFile
+                options.forkOptions.javaHome = installationDirectory.asFile
             }
             tasks.named("compileTestJava") {
                 options.fork = true
-                options.forkOptions.javaHome = javaInstallation.get().installationDirectory.asFile
+                options.forkOptions.javaHome = installationDirectory.asFile
             }
             tasks.named("test") {
-                executable = javaInstallation.get().javaExecutable.asFile
+                executable = launcher.executablePath.asFile
             }
         """
 
@@ -92,6 +95,9 @@ class CrossCompilationIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        executer.beforeExecute({
+            withToolchainDetectionEnabled()
+        })
         fails("build")
 
         then:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
@@ -96,7 +96,7 @@ class CrossCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.beforeExecute({
-            withToolchainDetectionEnabled()
+            withArgument("-Porg.gradle.java.installations.paths=" + jvm.getJavaHome().getAbsolutePath())
         })
         fails("build")
 

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.Requires
@@ -28,9 +29,16 @@ import org.junit.Assume
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-import javax.inject.Inject
-
 class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        expectDocumentedDeprecationWarning()
+    }
+
+    private GradleExecuter expectDocumentedDeprecationWarning() {
+        executer.expectDocumentedDeprecationWarning("Using JavaInstallationRegistry to detect Java installations has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using Java Toolchains instead. See https://docs.gradle.org/current/userguide/toolchains.html for more details.")
+    }
+
     def "plugin can query information about the current JVM"() {
         taskTypeShowsJavaInstallationDetails()
         pluginShowsCurrentJvm()
@@ -195,6 +203,7 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         javaHome.createLink(Jvm.current().javaHome)
+        expectDocumentedDeprecationWarning()
         run("show")
 
         then:
@@ -224,8 +233,6 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
 
     def pluginShowsCurrentJvm() {
         buildFile << """
-            import ${Inject.name}
-
             abstract class ShowPlugin implements Plugin<Project> {
                 @Inject
                 abstract JavaInstallationRegistry getRegistry()
@@ -243,8 +250,6 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
 
     def taskTypeShowsJavaInstallationDetails() {
         buildFile << """
-            import ${Inject.name}
-
             abstract class ShowTask extends DefaultTask {
                 @Internal
                 abstract Property<JavaInstallation> getInstallation()

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaDevelopmentKit.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaDevelopmentKit.java
@@ -24,8 +24,10 @@ import org.gradle.api.file.RegularFile;
  * Information about a Java development kit.
  *
  * @since 6.2
+ * @deprecated Use <a href="https://docs.gradle.org/current/userguide/toolchains.html">Java Toolchains</a> instead.
  */
 @Incubating
+@Deprecated
 public interface JavaDevelopmentKit {
     /**
      * Returns the java compiler executable for this JDK.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallation.java
@@ -29,8 +29,10 @@ import java.util.Optional;
  * <p>You can obtain an instance of this type using {@link JavaInstallationRegistry}.</p>
  *
  * @since 6.2
+ * @deprecated Use <a href="https://docs.gradle.org/current/userguide/toolchains.html">Java Toolchains</a> instead.
  */
 @Incubating
+@Deprecated
 public interface JavaInstallation {
     /**
      * Returns the Java version that this installation provides

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationRegistry.java
@@ -26,8 +26,10 @@ import org.gradle.api.provider.Provider;
  * <p>An instance of this service is available for injection into tasks, plugins and other types.
  *
  * @since 6.2
+ * @deprecated Use <a href="https://docs.gradle.org/current/userguide/toolchains.html">Java Toolchains</a> instead.
  */
 @Incubating
+@Deprecated
 public interface JavaInstallationRegistry {
     /**
      * Returns the Java installation for the current virtual machine.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
@@ -58,6 +59,7 @@ public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry
 
     @Override
     public Provider<JavaInstallation> getInstallationForCurrentVirtualMachine() {
+        warnAboutDeprecation();
         return Providers.of(new DefaultJavaInstallation(metadataDetector.getMetadata(Jvm.current().getJavaHome()), fileCollectionFactory, fileFactory));
     }
 
@@ -66,6 +68,7 @@ public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry
         // TODO - should be a value source and so a build input if queried during configuration time
         // TODO - provider should advertise the type of value it produces
         // TODO - display name
+        warnAboutDeprecation();
         return providerFactory.provider(new Callable<JavaInstallation>() {
             private DefaultJavaInstallation value;
 
@@ -88,7 +91,17 @@ public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry
 
     @Override
     public Provider<JavaInstallation> installationForDirectory(Provider<Directory> installationDirectory) {
+        warnAboutDeprecation();
         return installationDirectory.flatMap(this::installationForDirectory);
+    }
+
+    private void warnAboutDeprecation() {
+        DeprecationLogger
+            .deprecate("Using JavaInstallationRegistry to detect Java installations")
+            .withAdvice("Consider using Java Toolchains instead.")
+            .willBeRemovedInGradle7()
+            .withUserManual("toolchains")
+            .nagUser();
     }
 
     @Contextual


### PR DESCRIPTION
Given we have first-class support for toolchains now, we
should deprecate APIs that talk about specific java
installations.
