### PR TITLE
Fix infinite recursion in findBuild() of TAPI build controller

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -44,7 +44,9 @@ import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 @SuppressWarnings("deprecation")
@@ -155,7 +157,8 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
     }
 
     private GradleInternal findBuild(GradleBuildIdentity buildIdentity) {
-        GradleInternal build = findBuild(gradle, buildIdentity);
+        Set<GradleInternal> visited = new HashSet<>();
+        GradleInternal build = findBuild(gradle, buildIdentity, visited);
         if (build != null) {
             return build;
         } else {
@@ -163,14 +166,20 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
         }
     }
 
-    private GradleInternal findBuild(GradleInternal rootBuild, GradleBuildIdentity buildIdentity) {
+    private GradleInternal findBuild(GradleInternal rootBuild, GradleBuildIdentity buildIdentity, Set<GradleInternal> visited) {
         if (rootBuild.getRootProject().getProjectDir().equals(buildIdentity.getRootDir())) {
             return rootBuild;
         }
         for (IncludedBuild includedBuild : rootBuild.getIncludedBuilds()) {
-            GradleInternal matchingBuild = findBuild(((IncludedBuildState) includedBuild).getConfiguredBuild(), buildIdentity);
-            if (matchingBuild != null) {
-                return matchingBuild;
+            if (includedBuild instanceof IncludedBuildState) {
+                GradleInternal build = ((IncludedBuildState) includedBuild).getConfiguredBuild();
+                if (!visited.contains(build)) {
+                    visited.add(build);
+                    GradleInternal matchingBuild = findBuild(build, buildIdentity, visited);
+                    if (matchingBuild != null) {
+                        return matchingBuild;
+                    }
+                }
             }
         }
         return null;

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/AccessIncludedBuildProjectBuildAction.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/AccessIncludedBuildProjectBuildAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r68;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessIncludedBuildProjectBuildAction implements BuildAction<List<String>> {
+    public List<String> execute(BuildController controller) {
+        List<String> model = new ArrayList<String>();
+        for (GradleBuild included: controller.getBuildModel().getIncludedBuilds()) {
+            EclipseProject project = controller.getModel(included.getRootProject(), EclipseProject.class);
+            model.add(project.getName());
+        }
+        return model;
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildIncludeCycleCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildIncludeCycleCrossVersionSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r68
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+
+@ToolingApiVersion(">=6.8")
+@TargetGradleVersion('>=6.8')
+class CompositeBuildIncludeCycleCrossVersionSpec extends ToolingApiSpecification {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'module-root'
+            includeBuild('module-a')
+            includeBuild('module-c')
+        """
+        file('module-a').mkdir()
+        file('module-b').mkdir()
+        file('module-c').mkdir()
+        file('module-a/settings.gradle') << """
+            includeBuild('../module-b')
+        """
+        file('module-b/settings.gradle') << """
+            includeBuild('../module-a')
+        """
+    }
+
+    def "can find a build for of included build project despite cyclic include"() {
+        when:
+
+        List<String> result = withConnection { connection ->
+            connection.action(new AccessIncludedBuildProjectBuildAction()).run() }
+
+        then:
+        result == ['module-a', 'module-c']
+    }
+
+}


### PR DESCRIPTION
In certain cases with cyclic build imports, it ran into an infinite recursion when attempting to find the build object for a project of an included build.

This is affecting the import of such projects in Eclipse (see also https://github.com/eclipse/buildship/pull/1036).

Follow up to: #15039