### PR TITLE
Restore included build service listener subscription correctly

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -17,14 +17,12 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrationTest {
     def setup() {
         buildTestFixture.withBuildInSubDir()
     }
 
-    @ToBeFixedForConfigurationCache(because = "composite build / build services")
     def "will rebuild on input change for included build task dependency"() {
         def outputFile = file("included/build/output.txt")
         def inputFile = file("included/inputs/input.txt")
@@ -67,7 +65,6 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         outputFile.text == "second"
     }
 
-    @ToBeFixedForConfigurationCache(because = "composite build / build services")
     def "will rebuild on change for included build library dependency"() {
         def includedLibrary = singleProjectBuild("library") {
             buildFile << """
@@ -185,7 +182,6 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         stopGradle()
     }
 
-    @ToBeFixedForConfigurationCache(because = "composite build / build services")
     def "will rebuild on change for build included into a multi-project build"() {
         def includedLibrary = singleProjectBuild("library") {
             buildFile << """

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -167,7 +167,6 @@ class ConfigurationCacheIO internal constructor(
             classLoaderHierarchyHasher = service(),
             isolatableFactory = service(),
             valueSnapshotter = service(),
-            buildServiceRegistry = service(),
             managedFactoryRegistry = service(),
             parameterScheme = service(),
             actionScheme = service(),
@@ -177,7 +176,8 @@ class ConfigurationCacheIO internal constructor(
             patternSetFactory = factory(),
             fileOperations = service(),
             fileFactory = service(),
-            includedTaskGraph = service()
+            includedTaskGraph = service(),
+            buildStateRegistry = service()
         )
 
     private

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -165,7 +165,6 @@ abstract class AbstractUserTypeCodecTest {
         classLoaderHierarchyHasher = mock(),
         isolatableFactory = mock(),
         valueSnapshotter = mock(),
-        buildServiceRegistry = mock(),
         managedFactoryRegistry = mock(),
         parameterScheme = mock(),
         actionScheme = mock(),
@@ -175,6 +174,7 @@ abstract class AbstractUserTypeCodecTest {
         patternSetFactory = mock(),
         fileOperations = mock(),
         fileFactory = mock(),
-        includedTaskGraph = mock()
+        includedTaskGraph = mock(),
+        buildStateRegistry = mock()
     )
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.services.internal;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
 import org.gradle.api.logging.LoggingOutput;
 import org.gradle.api.services.BuildService;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 
 // TODO - complain when used at configuration time, except when opted in to this
 public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends AbstractMinimalProvider<T> implements Managed {
+    private final BuildIdentifier buildIdentifier;
     private final String name;
     private final Class<T> implementationType;
     private final IsolationScheme<BuildService, BuildServiceParameters> isolationScheme;
@@ -42,7 +44,8 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     private final P parameters;
     private Try<T> instance;
 
-    public BuildServiceProvider(String name, Class<T> implementationType, @Nullable P parameters, IsolationScheme<BuildService, BuildServiceParameters> isolationScheme, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory, ServiceRegistry internalServices) {
+    public BuildServiceProvider(BuildIdentifier buildIdentifier, String name, Class<T> implementationType, @Nullable P parameters, IsolationScheme<BuildService, BuildServiceParameters> isolationScheme, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory, ServiceRegistry internalServices) {
+        this.buildIdentifier = buildIdentifier;
         this.name = name;
         this.implementationType = implementationType;
         this.parameters = parameters;
@@ -50,6 +53,13 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
         this.instantiationScheme = instantiationScheme;
         this.isolatableFactory = isolatableFactory;
         this.internalServices = internalServices;
+    }
+
+    /**
+     * Returns the identifier for the build that owns this service.
+     */
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
     }
 
     public String getName() {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -21,7 +21,10 @@ import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.internal.resources.SharedResource;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scopes.Gradle.class)
 public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
     /**
      * @param maxUsages Same semantics as {@link SharedResource#getMaxUsages()}.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -81,6 +81,7 @@ import org.gradle.initialization.BuildOperationFiringTaskExecutionPreparer;
 import org.gradle.initialization.DefaultTaskExecutionPreparer;
 import org.gradle.initialization.TaskExecutionPreparer;
 import org.gradle.internal.Factory;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.cleanup.DefaultBuildOutputCleanupRegistry;
@@ -297,8 +298,26 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         );
     }
 
-    BuildServiceRegistryInternal createSharedServiceRegistry(Instantiator instantiator, DomainObjectCollectionFactory factory, InstantiatorFactory instantiatorFactory, ServiceRegistry services, ListenerManager listenerManager, IsolatableFactory isolatableFactory, SharedResourceLeaseRegistry sharedResourceLeaseRegistry) {
-        return instantiator.newInstance(DefaultBuildServicesRegistry.class, factory, instantiatorFactory, services, listenerManager, isolatableFactory, sharedResourceLeaseRegistry);
+    BuildServiceRegistryInternal createSharedServiceRegistry(
+        BuildState buildState,
+        Instantiator instantiator,
+        DomainObjectCollectionFactory factory,
+        InstantiatorFactory instantiatorFactory,
+        ServiceRegistry services,
+        ListenerManager listenerManager,
+        IsolatableFactory isolatableFactory,
+        SharedResourceLeaseRegistry sharedResourceLeaseRegistry
+    ) {
+        return instantiator.newInstance(
+            DefaultBuildServicesRegistry.class,
+            buildState.getBuildIdentifier(),
+            factory,
+            instantiatorFactory,
+            services,
+            listenerManager,
+            isolatableFactory,
+            sharedResourceLeaseRegistry
+        );
     }
 
     protected BuildOutputCleanupRegistry createBuildOutputCleanupRegistry(FileCollectionFactory fileCollectionFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.BuildListener
 import org.gradle.BuildResult
 import org.gradle.api.Action
 import org.gradle.api.GradleException
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.internal.event.DefaultListenerManager
@@ -33,7 +34,8 @@ class DefaultBuildServicesRegistryTest extends Specification {
     def listenerManager = new DefaultListenerManager(Scopes.Build)
     def isolatableFactory = new DefaultValueSnapshotter(null, TestUtil.managedFactoryRegistry())
     def leaseRegistry = Stub(SharedResourceLeaseRegistry)
-    def registry = new DefaultBuildServicesRegistry(TestUtil.domainObjectCollectionFactory(), TestUtil.instantiatorFactory(), TestUtil.services(), listenerManager, isolatableFactory, leaseRegistry)
+    def buildIdentifier = Mock(BuildIdentifier)
+    def registry = new DefaultBuildServicesRegistry(buildIdentifier, TestUtil.domainObjectCollectionFactory(), TestUtil.instantiatorFactory(), TestUtil.services(), listenerManager, isolatableFactory, leaseRegistry)
 
     def setup() {
         ServiceImpl.reset()


### PR DESCRIPTION
By remembering which build a build service belongs to and registering it with the correct `BuildServiceRegistry` upon loading.

There are still a few problems to be addressed in subsequent PRs:
- the build service class might not be present in the root build classloader hierarchy but all listener subscriptions are currently stored as part of the root build state (and that will include build service registrations);
- build service registrations might be stored more than once when tasks from different included builds reference the same build service;