### PR TITLE
Backport toolchain bug fixes

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloader.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloader.java
@@ -17,6 +17,7 @@
 package org.gradle.jvm.toolchain.install.internal;
 
 import org.apache.commons.io.IOUtils;
+import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
@@ -35,6 +36,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 
 public class AdoptOpenJdkDownloader {
@@ -59,11 +63,27 @@ public class AdoptOpenJdkDownloader {
         }
     }
 
-    private void downloadResource(URI source, File tmpFile, ExternalResource resource) {
-        resource.withContent(inputStream -> {
-            LOGGER.info("Downloading {} to {}", resource.getDisplayName(), tmpFile);
-            copyIntoFile(source, inputStream, tmpFile);
-        });
+    private void downloadResource(URI source, File targetFile, ExternalResource resource) {
+        final File downloadFile = new File(targetFile.getAbsoluteFile() + ".part");
+        try {
+            resource.withContent(inputStream -> {
+                LOGGER.info("Downloading {} to {}", resource.getDisplayName(), targetFile);
+                copyIntoFile(source, inputStream, downloadFile);
+            });
+            moveFile(targetFile, downloadFile);
+        } catch (IOException e) {
+            throw new GradleException("Unable to move downloaded toolchain to target destination", e);
+        } finally {
+            downloadFile.delete();
+        }
+    }
+
+    private void moveFile(File targetFile, File downloadFile) throws IOException {
+        try {
+            Files.move(downloadFile.toPath(), targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(downloadFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 
     private void copyIntoFile(URI source, InputStream inputStream, File destination) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.file.FileFactory;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Optional;
 
 public class JavaToolchainFactory {
 
@@ -36,9 +37,15 @@ public class JavaToolchainFactory {
         this.fileFactory = fileFactory;
     }
 
-    public JavaToolchain newInstance(File javaHome) {
+    public Optional<JavaToolchain> newInstance(File javaHome) {
         final JavaInstallationProbe.ProbeResult probeResult = probeService.checkJdk(javaHome);
-        return new JavaToolchain(probeResult, compilerFactory, toolFactory, fileFactory);
+        final JavaInstallationProbe.InstallType type = probeResult.getInstallType();
+        if(type == JavaInstallationProbe.InstallType.IS_JRE || type == JavaInstallationProbe.InstallType.IS_JDK) {
+            JavaToolchain toolchain = new JavaToolchain(probeResult, compilerFactory, toolFactory, fileFactory);
+            return Optional.of(toolchain);
+        }
+        return Optional.empty();
+
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistry.java
@@ -79,10 +79,18 @@ public class SharedJavaInstallationRegistry {
 
     private File canonicalize(File file) {
         try {
-            return file.getCanonicalFile();
+            final File canonicalFile = file.getCanonicalFile();
+            return findJavaHome(canonicalFile);
         } catch (IOException e) {
             throw new GradleException(String.format("Could not canonicalize path to java installation: %s.", file), e);
         }
+    }
+
+    private File findJavaHome(File potentialHome) {
+        if (new File(potentialHome, "Contents/Home").exists()) {
+            return new File(potentialHome, "Contents/Home");
+        }
+        return potentialHome;
     }
 
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloaderTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloaderTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.install.internal
+
+import org.gradle.api.Action
+import org.gradle.api.BuildCancelledException
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.authentication.Authentication
+import org.gradle.internal.resource.ExternalResource
+import org.gradle.internal.resource.ExternalResourceName
+import org.gradle.internal.resource.ExternalResourceRepository
+import org.gradle.internal.verifier.HttpRedirectVerifier
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class AdoptOpenJdkDownloaderTest extends Specification {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "cancelled download does not leave destination file behind"() {
+        RepositoryTransportFactory transportFactory = newFailingTransportFactory()
+
+        given:
+        def downloader = new AdoptOpenJdkDownloader(transportFactory)
+        def destinationFile = new File(temporaryFolder.newFolder(), "target")
+
+        when:
+        downloader.download(URI.create("https://foo"), destinationFile)
+
+        then:
+        thrown(BuildCancelledException)
+        !destinationFile.exists()
+    }
+
+    private RepositoryTransportFactory newFailingTransportFactory() {
+        Mock(RepositoryTransportFactory) {
+            createTransport(_ as String, _ as String, _ as Collection<Authentication>, _ as HttpRedirectVerifier) >> Mock(RepositoryTransport) {
+                getRepository() >> Mock(ExternalResourceRepository) {
+                    withProgressLogging() >> Mock(ExternalResourceRepository) {
+                        resource(_ as ExternalResourceName) >> Mock(ExternalResource) {
+                            withContent(_ as Action<? super InputStream>) >> { Action<? super InputStream> readAction ->
+                                readAction.execute(new ByteArrayInputStream("foo".bytes))
+                                throw new BuildCancelledException()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/SharedJavaInstallationRegistryTest.groovy
@@ -75,6 +75,20 @@ class SharedJavaInstallationRegistryTest extends Specification {
         installations.is(installations2)
     }
 
+    def "normalize installations to account for macOS folder layout"() {
+        given:
+        def tmpWithMacOsLayout = createTempDir()
+        def expectedHome = new File(tmpWithMacOsLayout, "Contents/Home")
+        assert expectedHome.mkdirs()
+        def registry = newRegistry(tmpWithMacOsLayout)
+
+        when:
+        def installations = registry.listInstallations()
+
+        then:
+        installations.containsAll(expectedHome)
+    }
+
     @Unroll
     def "warns and filters invalid installations, exists: #exists, directory: #directory"() {
         given:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #15060

Backported the following fixes:
* Fix detecting installations using macos layout from 305191e
* Ensure that no partial toolchain is left behind from #14764
* Ignore invalid installation when querying toolchains from 1419f90
