### PR TITLE
Expose the Java software component name as a constant

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.FeaturePreviews;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorDescription;
@@ -65,7 +66,7 @@ class IvyPluginPublishingPlugin implements Plugin<Project> {
                 if (!pluginDevelopment.isAutomatedPublishing()) {
                     return;
                 }
-                SoftwareComponent mainComponent = project.getComponents().getByName("java");
+                SoftwareComponent mainComponent = project.getComponents().getByName(JavaPlugin.SOFTWARE_COMPONENT_NAME);
                 IvyPublication mainPublication = addMainPublication(publishing, mainComponent);
                 addMarkerPublications(mainPublication, publishing, pluginDevelopment);
             }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -62,7 +62,7 @@ class MavenPluginPublishPlugin implements Plugin<Project> {
                 if (!pluginDevelopment.isAutomatedPublishing()) {
                     return;
                 }
-                SoftwareComponent mainComponent = project.getComponents().getByName("java");
+                SoftwareComponent mainComponent = project.getComponents().getByName(JavaPlugin.SOFTWARE_COMPONENT_NAME);
                 MavenPublication mainPublication = addMainPublication(publishing, mainComponent);
                 addMarkerPublications(mainPublication, publishing, pluginDevelopment);
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -32,6 +32,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.AdhocComponentWithVariants;
+import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
@@ -282,6 +283,13 @@ public class JavaPlugin implements Plugin<Project> {
      */
     public static final String TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "testRuntimeClasspath";
 
+    /**
+     * The name of the Java {@link SoftwareComponent}.
+     *
+     * @since TODO
+     */
+    public static final String SOFTWARE_COMPONENT_NAME = "java";
+
     private final ObjectFactory objectFactory;
     private final SoftwareComponentFactory softwareComponentFactory;
     private final JvmPluginServices jvmServices;
@@ -376,7 +384,7 @@ public class JavaPlugin implements Plugin<Project> {
     private void registerSoftwareComponents(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         // the main "Java" component
-        AdhocComponentWithVariants java = softwareComponentFactory.adhoc("java");
+        AdhocComponentWithVariants java = softwareComponentFactory.adhoc(SOFTWARE_COMPONENT_NAME);
         java.addVariantsFromConfiguration(configurations.getByName(API_ELEMENTS_CONFIGURATION_NAME), new JavaConfigurationVariantMapping("compile", false));
         java.addVariantsFromConfiguration(configurations.getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME), new JavaConfigurationVariantMapping("runtime", false));
         project.getComponents().add(java);


### PR DESCRIPTION
### Context
A simple change to expose the Java software component name ("java") as a constant allowing plugins (and/or build-scripts) to use it, as has been done with many other plugin/task/etc names already.

A few notes:
- I have left the `@since` as `TODO` as I do not know which version this would appear in.
- I have left the last four items in the contributor checklist unchecked, as I am not sure which (if any) apply to this pull request due to how minor the changes are - please correct me if wrong.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes