### PR TITLE
Deprecate special 'master' subdirectory treatment for multiproject roots

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -52,6 +52,9 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
                     file('root/gradle.properties').text = "systemProp.greeting=$greeting"
                     return configurationCacheRun('greet')
                 case SystemPropertySource.GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR:
+                    // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
+                    executer.noDeprecationChecks()
+
                     file('master/gradle.properties').text = "systemProp.greeting=$greeting"
                     file('master/settings.gradle').text = """
                         rootProject.projectDir = file('../root')
@@ -754,7 +757,7 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
 
         when:
         configurationCacheRun "help", "-Dorg.gradle.booleanProperty=true"
-        
+
         then:
         configurationCache.assertStateStored()
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -52,7 +52,7 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
                     file('root/gradle.properties').text = "systemProp.greeting=$greeting"
                     return configurationCacheRun('greet')
                 case SystemPropertySource.GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR:
-                    // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
+                    // because the 'master' directory special treatment deprecation message is not emitted when configuration is loaded form config cache
                     executer.noDeprecationChecks()
 
                     file('master/gradle.properties').text = "systemProp.greeting=$greeting"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -36,8 +36,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
     }
 
     def "settings with master folder are exposed"() {
-        // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
-        executer.noDeprecationChecks()
+        executer.expectDocumentedDeprecationWarning("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#master_subdirectory_root_build")
 
         def customSettingsFile = file("master/settings.gradle")
         customSettingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -36,6 +36,8 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
     }
 
     def "settings with master folder are exposed"() {
+        // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
+        executer.noDeprecationChecks()
 
         def customSettingsFile = file("master/settings.gradle")
         customSettingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -53,6 +53,8 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
     }
 
     def "settings with master folder are exposed correctly"() {
+        // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
+        executer.noDeprecationChecks()
 
         def customSettingsFile = file("master/settings.gradle")
         customSettingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -53,8 +53,7 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
     }
 
     def "settings with master folder are exposed correctly"() {
-        // because the 'master' directory special treatment deprecation message is emitted early in the build and only appears on warm daemons
-        executer.noDeprecationChecks()
+        executer.expectDocumentedDeprecationWarning("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#master_subdirectory_root_build")
 
         def customSettingsFile = file("master/settings.gradle")
         customSettingsFile << """

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.Path;
 
 /**
@@ -53,6 +54,12 @@ public class DefaultSettingsLoader implements SettingsLoader {
         StartParameter startParameter = gradle.getStartParameter();
 
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
+        if (settingsLocation.settingsLoadedFromDeprecatedMasterDirectory()) {
+            DeprecationLogger.deprecateBehaviour("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated.")
+                .willBeRemovedInGradle7()
+                .withUpgradeGuideSection(6, "master_subdirectory_root_build")
+                .nagUser();
+        }
         loadGradlePropertiesFrom(settingsLocation);
 
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter, settingsLocation, gradle.getClassLoaderScope());

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsLocation.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsLocation.java
@@ -23,6 +23,14 @@ public class SettingsLocation {
     @Nullable
     private final File settingsFile;
 
+    private boolean settingsLoadedFromDeprecatedMasterDirectory = false;
+
+    public SettingsLocation(File settingsDir, @Nullable File settingsFile, boolean settingsLoadedFromDeprecatedMasterDirectory) {
+        this.settingsDir = settingsDir;
+        this.settingsFile = settingsFile;
+        this.settingsLoadedFromDeprecatedMasterDirectory = settingsLoadedFromDeprecatedMasterDirectory;
+    }
+
     public SettingsLocation(File settingsDir, @Nullable File settingsFile) {
         this.settingsDir = settingsDir;
         this.settingsFile = settingsFile;
@@ -41,6 +49,10 @@ public class SettingsLocation {
     @Nullable
     public File getSettingsFile() {
         return settingsFile;
+    }
+
+    boolean settingsLoadedFromDeprecatedMasterDirectory() {
+        return settingsLoadedFromDeprecatedMasterDirectory;
     }
 }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
@@ -23,6 +23,11 @@ import java.io.File;
 public class BuildLayout extends SettingsLocation {
     private final File rootDirectory;
 
+    BuildLayout(File rootDirectory, File settingsDir, @Nullable File settingsFile, boolean settingsLoadedFromMasterDirectory) {
+        super(settingsDir, settingsFile, settingsLoadedFromMasterDirectory);
+        this.rootDirectory = rootDirectory;
+    }
+
     // Note: `null` for `settingsFile` means explicitly no settings
     //       A non null value can be a non existent file, which is semantically equivalent to an empty file
     public BuildLayout(File rootDirectory, File settingsDir, @Nullable File settingsFile) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -98,7 +98,7 @@ public class BuildLayoutFactory {
     }
 
     private static void deprecateMasterSubdirectoryForRootBuild() {
-        DeprecationLogger.deprecateBehaviour("Resolving root build in directory named 'master' from a sibling subproject has been deprecated.")
+        DeprecationLogger.deprecateBehaviour("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated.")
             .willBeRemovedInGradle7()
             .withUpgradeGuideSection(6, "master_subdirectory_root_build")
             .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -69,11 +69,12 @@ If you happen to have cross-build task ordering defined using above mentioned me
 [[master_subdirectory_root_build]]
 ==== Searching for settings files in 'master' directories
 
-Resolving root build in a directory named `master` when Gradle is invoked from a sibling subproject has been deprecated.
-If a build uses a directory named `master` to define the root build, and you want to keep the ability to invoke Gradle
-from its subprojects, then consider refactoring the build to have its root match the physical root of the subproject hierarchy.
-Alternatively, the tasks for such builds can still be invoked from the root project in `master` directory by their
-<<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,fully qualified names>>.
+Gradle will emit a deprecation warning when your build relies on finding the settings file in a directory named `master` in a sibling directory.
+
+If your build uses this feature, consider refactoring the build to have the root directory match the physical root of the project hierarchy.
+
+Alternatively, you can still run tasks in builds like this by invoking the build from the `master` directory only using a
+<<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,fully qualified path to the task>>.
 
 [[changes_6.7]]
 == Upgrading from 6.6

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -67,7 +67,7 @@ Task ordering using `mustRunAfter` and `shouldRunAfter` as well as finalizers sp
 If you happen to have cross-build task ordering defined using above mentioned methods, consider restructuring such builds and decoupling them from one another.
 
 [[master_subdirectory_root_build]]
-==== Resolving root build in 'master' from a sibling subproject
+==== Searching for settings files in 'master' directories
 
 Resolving root build in a directory named `master` when Gradle is invoked from a sibling subproject has been deprecated.
 If a build uses a directory named `master` to define the root build, and you want to keep the ability to invoke Gradle

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -66,6 +66,15 @@ Direct references to tasks from included builds in `mustRunAfter`, `shouldRunAft
 Task ordering using `mustRunAfter` and `shouldRunAfter` as well as finalizers specified by `finalizedBy` should be used for task ordering within a build.
 If you happen to have cross-build task ordering defined using above mentioned methods, consider restructuring such builds and decoupling them from one another.
 
+[[master_subdirectory_root_build]]
+==== Resolving root build in 'master' from a sibling subproject
+
+Resolving root build in a directory named `master` when Gradle is invoked from a sibling subproject has been deprecated.
+If a build uses a directory named `master` to define the root build, and you want to keep the ability to invoke Gradle
+from its subprojects, then consider refactoring the build to have its root match the physical root of the subproject hierarchy.
+Alternatively, the tasks for such builds can still be invoked from the root project in `master` directory by their
+<<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,fully qualified names>>.
+
 [[changes_6.7]]
 == Upgrading from 6.6
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/14398

This behaviour is no longer documented since Gradle 6.7.
