### PR TITLE
Log problems when enabling FS watching on debug

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -291,7 +291,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                         return Optional.of(new LinuxFileWatcherRegistryFactory(watchFilter));
                     }
                 } catch (NativeIntegrationUnavailableException e) {
-                    LOGGER.info("Native file system watching is not available for this operating system.", e);
+                    LOGGER.debug("Native file system watching is not available for this operating system.", e);
                 }
             }
             return Optional.empty();

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -119,7 +119,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
                             try {
                                 FileEvents.init(nativeBaseDir);
                             } catch (NativeIntegrationUnavailableException ex) {
-                                LOGGER.info("Native file system watching is not available for this operating system.", ex);
+                                LOGGER.debug("Native file system watching is not available for this operating system.", ex);
                                 useFileSystemWatching = false;
                             }
                         }


### PR DESCRIPTION
and not on info, so there is no exception stack trace in the info log for unsupported operating systems.

Fixes #15086