### PR TITLE
Fix race condition on pre-resolve actions

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -461,16 +461,18 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public void runDependencyActions() {
-        defaultDependencyActions.execute(dependencies);
-        withDependencyActions.execute(dependencies);
+        owner.getModel().applyToMutableState(o -> {
+            defaultDependencyActions.execute(dependencies);
+            withDependencyActions.execute(dependencies);
 
-        // Discard actions after execution
-        defaultDependencyActions = ImmutableActionSet.empty();
-        withDependencyActions = ImmutableActionSet.empty();
+            // Discard actions after execution
+            defaultDependencyActions = ImmutableActionSet.empty();
+            withDependencyActions = ImmutableActionSet.empty();
 
-        for (Configuration superConfig : extendsFrom) {
-            ((ConfigurationInternal) superConfig).runDependencyActions();
-        }
+            for (Configuration superConfig : extendsFrom) {
+                ((ConfigurationInternal) superConfig).runDependencyActions();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
If a configuration is used in a task without being declared as an input,
there's a chance that the dependency actions are executed concurrently
by several threads.

This commit works around the problem by introducing locking around the
dependency actions.

Fixes #15120
