### PR TITLE
Store daemon logs for performance test failures as well

### DIFF
--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -60,6 +60,7 @@ const val individualPerformanceTestArtifactRules = """
 subprojects/*/build/test-results-*.zip => results
 subprojects/*/build/tmp/**/log.txt => failure-logs
 subprojects/*/build/tmp/**/profile.log => failure-logs
+subprojects/*/build/tmp/**/daemon-*.out.log => failure-logs
 """
 
 fun BuildSteps.killGradleProcessesStep(os: Os) {


### PR DESCRIPTION
So it is easier to diagnose problems with file system watching between builds.