### PR TITLE
Rebaseline `JavaConfigurationCachePerformanceTest`

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -46,7 +46,7 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
     @Unroll
     def "assemble #action configuration cache state with #daemon daemon"() {
         given:
-        runner.targetVersions = ["6.8-20201111230035+0000"]
+        runner.targetVersions = ["6.8-20201116162838+0000"]
         runner.minimumBaseVersion = "6.6"
         runner.tasksToRun = ["assemble"]
         runner.args = ["-D${ConfigurationCacheOption.PROPERTY_NAME}=true"]


### PR DESCRIPTION
Due to a regression (~1.8%) after:

- changing how listener subscriptions are stored
- storing build identifier information for build services

See ab241a7c8e0d7aa8f9ae16463e02faf4186c0c93