### PR TITLE
Allow toolchain to be matched by on its implementation

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -186,7 +186,7 @@ There are many options to configure this feature which are described in the [use
 [Java toolchain support](userguide/toolchains.html) provides an easy way to declare what Java version the project should be built with.
 By default, Gradle will [auto-detect installed JDKs](userguide/toolchains.html#sec:auto_detection) that can be used as toolchain.
 
-#### Selecting toolchain by vendor
+#### Selecting toolchain by vendor and implementation
 
 In case your build has specific requirements from the used JRE/JDK, you may want to define the vendor for the toolchain as well.
 `JvmVendorSpec` has a list of well-known JVM vendors recognized by Gradle. The advantage is that Gradle can handle any inconsistencies across JDK versions
@@ -200,6 +200,19 @@ java {
 
         // alternativly, use custom matching
         // vendor = JvmVendorSpec.matching("customString")
+    }
+}
+```
+
+If the vendor is not enough to select the appropriate toolchain, you may as well filter by the implementation of the virtual machine.
+For example, to use an [Open J9](https://www.eclipse.org/openj9/) JVM, distributed via [AdoptOpenJDK](https://adoptopenjdk.net/), you can filter by the implementation as shown in the example below. 
+
+```
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+        vendor = JvmVendorSpec.ADOPTOPENJDK
+        implementation = JvmImplementation.J9
     }
 }
 ```

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -74,8 +74,10 @@ include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradl
 If your project requires a specific implementation, you can filter based on the implementation as well.
 Currently available implementations to choose from are:
 
-- `VENDOR_SPECIFIC` - Acts as a placeholder and matches any implementation from any vendor (e.g. hotspot, zulu, ...)
-- `J9` - Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
+`VENDOR_SPECIFIC`::
+Acts as a placeholder and matches any implementation from any vendor (e.g. hotspot, zulu, ...)
+`J9`::
+Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
 
 For example, to use an https://www.eclipse.org/openj9/[Open J9] JVM, distributed via https://adoptopenjdk.net/[AdoptOpenJDK],
 you can specify the filter as shown in the example below.

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -72,7 +72,13 @@ include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradl
 === Selecting toolchains by their virtual machine implementation
 
 If your project requires a specific implementation, you can filter based on the implementation as well.
-For example, to use an [Open J9](https://www.eclipse.org/openj9/) JVM, distributed via [AdoptOpenJDK](https://adoptopenjdk.net/), you can specify the filter as shown in the example below.
+Currently available implementations to choose from are:
+
+- `VENDOR_SPECIFIC` - Acts as a placeholder and matches any implementation from any vendor (e.g. hotspot, zulu, ...)
+- `J9` - Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
+
+For example, to use an https://www.eclipse.org/openj9/[Open J9] JVM, distributed via https://adoptopenjdk.net/[AdoptOpenJDK],
+you can specify the filter as shown in the example below.
 
 ====
 include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-implementation]"]

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -69,6 +69,17 @@ include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradl
 include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-vendor]"]
 ====
 
+=== Selecting toolchains by their virtual machine implementation
+
+If your project requires a specific implementation, you can filter based on the implementation as well.
+For example, to use an [Open J9](https://www.eclipse.org/openj9/) JVM, distributed via [AdoptOpenJDK](https://adoptopenjdk.net/), you can specify the filter as shown in the example below.
+
+====
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-implementation]"]
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-implementation]"]
+====
+
+
 == Specify custom toolchains for individual tasks
 
 In case you want to tweak which toolchain is used for a specific task, you can specify the exact tool a task is using.

--- a/subprojects/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
@@ -20,3 +20,13 @@ java {
     }
 }
 // end::toolchain-matching-vendor[]
+
+// tag::toolchain-matching-implementation[]
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+        vendor = JvmVendorSpec.ADOPTOPENJDK
+        implementation = JvmImplementation.J9
+    }
+}
+// end::toolchain-matching-implementation[]

--- a/subprojects/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
@@ -20,3 +20,14 @@ java {
     }
 }
 // end::toolchain-matching-vendor[]
+
+
+// tag::toolchain-matching-implementation[]
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+        vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+        implementation.set(JvmImplementation.J9)
+    }
+}
+// end::toolchain-matching-implementation[]

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -24,13 +24,13 @@ import org.gradle.internal.os.OperatingSystem;
 import java.io.File;
 import java.nio.file.Path;
 import java.text.MessageFormat;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public interface JvmInstallationMetadata {
 
     enum JavaInstallationCapability {
-        JAVA_COMPILER
+        JAVA_COMPILER, J9_IMPLEMENTATION
     }
 
     static DefaultJvmInstallationMetadata from(File javaHome, String implementationVersion, String vendor, String implementationName) {
@@ -127,11 +127,16 @@ public interface JvmInstallationMetadata {
         }
 
         private Set<JavaInstallationCapability> gatherCapabilities() {
+            final Set<JavaInstallationCapability> capabilities = new HashSet<>(2);
             final File javaCompiler = new File(new File(javaHome.toFile(), "bin"), OperatingSystem.current().getExecutableName("javac"));
             if (javaCompiler.exists()) {
-                return Collections.singleton(JavaInstallationCapability.JAVA_COMPILER);
+                capabilities.add(JavaInstallationCapability.JAVA_COMPILER);
             }
-            return Collections.emptySet();
+            boolean isJ9vm = implementationName.contains("J9");
+            if(isJ9vm) {
+                capabilities.add(JavaInstallationCapability.J9_IMPLEMENTATION);
+            }
+            return capabilities;
         }
 
         @Override

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public interface JvmInstallationMetadata {
 
     enum JavaInstallationCapability {
-        JAVA_COMPILER, J9_IMPLEMENTATION
+        JAVA_COMPILER, J9_VIRTUAL_MACHINE
     }
 
     static DefaultJvmInstallationMetadata from(File javaHome, String implementationVersion, String vendor, String implementationName) {
@@ -134,7 +134,7 @@ public interface JvmInstallationMetadata {
             }
             boolean isJ9vm = implementationName.contains("J9");
             if(isJ9vm) {
-                capabilities.add(JavaInstallationCapability.J9_IMPLEMENTATION);
+                capabilities.add(JavaInstallationCapability.J9_VIRTUAL_MACHINE);
             }
             return capabilities;
         }

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
@@ -111,7 +111,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         def metadata = detector.getMetadata(javaHome)
 
         then:
-        assert metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_IMPLEMENTATION) == isJ9
+        assert metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_VIRTUAL_MACHINE) == isJ9
 
         where:
         jdk              | systemProperties         | isJ9

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
@@ -33,8 +33,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
     @Rule
     TemporaryFolder temporaryFolder
 
-    @Unroll("Can probe version of #jdk is #displayName")
-    def "probes java installation"() {
+    @Unroll
+    def "can detect metadata of #displayName"() {
         given:
         def execHandleFactory = createExecHandleFactory(systemProperties)
 
@@ -71,6 +71,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         'openJdk9'       | openJdkJvm('9')        | JavaVersion.VERSION_1_9 | 'OpenJDK JRE 9'            | true   | true
         'AdoptOpenJDK11' | adoptOpenJDK('11.0.3') | JavaVersion.VERSION_11  | 'AdoptOpenJDK 11'          | true   | false
         'AdoptOpenJDK11' | adoptOpenJDK('11.0.3') | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11'      | true   | true
+        'AdoptOpenJDKJ9' | adoptOpenJDKJ9('14.0.2') | JavaVersion.VERSION_14  | 'AdoptOpenJDK 14'      | true   | false
         'oracleJdk4'     | oracleJvm('4')         | JavaVersion.VERSION_1_4 | 'Oracle JDK 4'             | true   | false
         'oracleJre4'     | oracleJvm('4')         | JavaVersion.VERSION_1_4 | 'Oracle JRE 4'             | true   | true
         'oracleJdk5'     | oracleJvm('5')         | JavaVersion.VERSION_1_5 | 'Oracle JDK 5'             | true   | false
@@ -97,6 +98,34 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         'bellsoftjdk11'  | bellsoftJvm('15')      | JavaVersion.VERSION_15  | 'BellSoft Liberica JDK 15' | true   | false
         'bellsoftjre11'  | bellsoftJvm('15')      | JavaVersion.VERSION_15  | 'BellSoft Liberica JRE 15' | true   | true
         'whitespaces'    | whitespaces('11.0.3')  | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11'      | true   | true
+    }
+
+    @Unroll
+    def "probes whether #jdk is a j9 virtual machine"() {
+        given:
+        def execHandleFactory = createExecHandleFactory(systemProperties)
+
+        when:
+        def detector = new DefaultJvmMetadataDetector(execHandleFactory)
+        def javaHome = temporaryFolder.newFolder(jdk)
+        def metadata = detector.getMetadata(javaHome)
+
+        then:
+        assert metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_IMPLEMENTATION) == isJ9
+
+        where:
+        jdk              | systemProperties         | isJ9
+        'openJdk9'       | openJdkJvm('9')          | false
+        'AdoptOpenJDK11' | adoptOpenJDK('11.0.3')   | false
+        'AdoptOpenJDKJ9' | adoptOpenJDKJ9('14.0.2') | true
+        'oracleJdk4'     | oracleJvm('4')           | false
+        'ibmJdk4'        | ibmJvm('4')              | true
+        'ibmJre4'        | ibmJvm('4')              | true
+        'ibmJdk5'        | ibmJvm('5')              | true
+        'ibmJdk6'        | ibmJvm('6')              | true
+        'ibmJdk7'        | ibmJvm('7')              | true
+        'ibmJdk8'        | ibmJvm('8')              | true
+        'ibmJdk9'        | ibmJvm('9')              | true
     }
 
     @Unroll
@@ -169,6 +198,17 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "${version}+7",
+         'java.runtime.name': "OpenJDK Runtime Environment"
+        ]
+    }
+
+    private static Map<String, String> adoptOpenJDKJ9(String version) {
+        ['java.home': "java-home",
+         'java.version': version,
+         'java.vendor': "AdoptOpenJDK",
+         'os.arch': "x86_64",
+         'java.vm.name': "Eclipse OpenJ9 VM",
+         'java.vm.version': "openj9-0.21.0",
          'java.runtime.name': "OpenJDK Runtime Environment"
         ]
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -104,7 +104,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractPluginIntegrationTest 
             .runWithFailure()
 
         then:
-        failureHasCause('No compatible toolchains found for request filter: {languageVersion=99, vendor=any} (auto-detect true, auto-download false)')
+        failureHasCause('No compatible toolchains found for request filter: {languageVersion=99, vendor=any, implementation=vendor-specific} (auto-detect true, auto-download false)')
     }
 
     @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_7) != null })
@@ -201,7 +201,7 @@ public class Foo {
         fails("compileJava")
 
         then:
-        failureHasCause("No compatible toolchains found for request filter: {languageVersion=${Jvm.current().javaVersion.majorVersion}, vendor=AMAZON} (auto-detect false, auto-download false)")
+        failureHasCause("No compatible toolchains found for request filter: {languageVersion=${Jvm.current().javaVersion.majorVersion}, vendor=AMAZON, implementation=vendor-specific} (auto-detect false, auto-download false)")
     }
 
     @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8) != null })

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -47,7 +47,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any}")
+            .assertHasCause("Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any, implementation=vendor-specific}")
             .assertHasCause("Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.")
             .assertThatCause(CoreMatchers.startsWith("Could not read 'https://api.adoptopenjdk.net/v3/binary/latest/99/ga/"))
     }
@@ -80,7 +80,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("No compatible toolchains found for request filter: {languageVersion=14, vendor=any} (auto-detect false, auto-download false)")
+            .assertHasCause("No compatible toolchains found for request filter: {languageVersion=14, vendor=any, implementation=vendor-specific} (auto-detect false, auto-download false)")
     }
 
     @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
@@ -112,7 +112,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause('Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any}')
+            .assertHasCause('Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any, implementation=vendor-specific}')
             .assertThatCause(CoreMatchers.startsWith('Attempting to download a JDK from an insecure URI http://example.com'))
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -44,4 +44,12 @@ public interface JavaToolchainSpec extends Describable {
      */
     Property<JvmVendorSpec> getVendor();
 
+    /**
+     * The virtual machine implementation of the toolchain.
+     * <p>By default, any implementation (hotspot, j9, ...) is eligible.</p>
+     *
+     * @since 6.8
+     */
+    Property<JvmImplementation> getImplementation();
+
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
@@ -27,7 +27,19 @@ import org.gradle.api.Incubating;
 @Incubating
 public final class JvmImplementation {
 
+    /**
+     * Vendor-specific virtual machine implementation.
+     *
+     * Acts as a placeholder and matches any implementation from any vendor.
+     * Usually used to override specific implementation requests.
+     */
     public static final JvmImplementation VENDOR_SPECIFIC = new JvmImplementation("vendor-specific");
+
+    /**
+     * Eclipse OpenJ9 (previously known as IBM J9) virtual machine implementation.
+     *
+     * Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
+     */
     public static final JvmImplementation J9 = new JvmImplementation("J9");
 
     private final String displayName;

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
@@ -16,14 +16,23 @@
 
 package org.gradle.jvm.toolchain;
 
-public enum JvmImplementation {
 
-    VENDOR_SPECIFIC("vendor-specific"),
-    J9("J9");
+import org.gradle.api.Incubating;
+
+/**
+ * Represents a filter for a implementation of a Java Virtual Machine.
+ *
+ * @since 6.8
+ */
+@Incubating
+public final class JvmImplementation {
+
+    public static final JvmImplementation VENDOR_SPECIFIC = new JvmImplementation("vendor-specific");
+    public static final JvmImplementation J9 = new JvmImplementation("J9");
 
     private final String displayName;
 
-    JvmImplementation(String displayName) {
+    private JvmImplementation(String displayName) {
         this.displayName = displayName;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+public enum JvmImplementation {
+
+    VENDOR_SPECIFIC("vendor-specific"),
+    J9("J9");
+
+    private final String displayName;
+
+    JvmImplementation(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -23,6 +23,7 @@ import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmImplementation;
 import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 
 import javax.inject.Inject;
@@ -75,7 +76,14 @@ public class AdoptOpenJdkRemoteBinary {
             determineOs() +
             "/" +
             determineArch() +
-            "/jdk/hotspot/normal/adoptopenjdk");
+            "/jdk/" +
+            determineImplementation(spec) +
+            "/normal/adoptopenjdk");
+    }
+
+    private String determineImplementation(JavaToolchainSpec spec) {
+        final JvmImplementation implementation = spec.getImplementation().getOrNull();
+        return implementation == JvmImplementation.J9 ? "openj9" : "hotspot";
     }
 
     public String toFilename(JavaToolchainSpec spec) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -48,7 +48,7 @@ public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<Jav
 
     @Override
     public boolean test(JavaToolchain toolchain) {
-        final JvmVendor vendor = toolchain.getVendor();
+        final JvmVendor vendor = toolchain.getMetadata().getVendor();
         return test(vendor);
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -21,6 +21,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmImplementation;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import javax.inject.Inject;
@@ -29,11 +30,13 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
 
     private final Property<JavaLanguageVersion> languageVersion;
     private final Property<JvmVendorSpec> vendor;
+    private final Property<JvmImplementation> implementation;
 
     @Inject
     public DefaultToolchainSpec(ObjectFactory factory) {
         this.languageVersion = factory.property(JavaLanguageVersion.class);
         this.vendor = factory.property(JvmVendorSpec.class).convention(DefaultJvmVendorSpec.any());
+        this.implementation = factory.property(JvmImplementation.class).convention(JvmImplementation.VENDOR_SPECIFIC);
     }
 
     @Override
@@ -46,6 +49,11 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
         return vendor;
     }
 
+    @Override
+    public Property<JvmImplementation> getImplementation() {
+        return implementation;
+    }
+
     public boolean isConfigured() {
         return languageVersion.isPresent();
     }
@@ -56,6 +64,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
         builder.omitNullValues();
         builder.add("languageVersion", languageVersion.map(JavaLanguageVersion::toString).getOrElse("unspecified"));
         builder.add("vendor", vendor.map(JvmVendorSpec::toString).getOrNull());
+        builder.add("implementation", implementation.map(JvmImplementation::toString).getOrNull());
         return builder.toString();
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
-import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
@@ -37,23 +36,21 @@ import java.nio.file.Path;
 
 public class JavaToolchain implements Describable, JavaInstallationMetadata {
 
-    private final boolean isJdk;
     private final JavaCompilerFactory compilerFactory;
     private final ToolchainToolFactory toolFactory;
     private final Directory javaHome;
     private final VersionNumber implementationVersion;
     private final JavaLanguageVersion javaVersion;
-    private final JvmVendor vendor;
+    private final JvmInstallationMetadata metadata;
 
     @Inject
     public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory) {
         this.javaHome = fileFactory.dir(computeEnclosingJavaHome(metadata.getJavaHome()).toFile());
         this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
-        this.isJdk = metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.JAVA_COMPILER);
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
         this.implementationVersion = VersionNumber.parse(metadata.getImplementationVersion());
-        this.vendor = metadata.getVendor();
+        this.metadata = metadata;
     }
 
     @Internal
@@ -88,12 +85,12 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
 
     @Internal
     public boolean isJdk() {
-        return isJdk;
+        return metadata.hasCapability(JvmInstallationMetadata.JavaInstallationCapability.JAVA_COMPILER);
     }
 
     @Internal
-    JvmVendor getVendor() {
-        return vendor;
+    public JvmInstallationMetadata getMetadata() {
+        return metadata;
     }
 
     @Internal

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
@@ -16,6 +16,8 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import org.gradle.internal.jvm.inspection.JvmVendor;
+
 import java.util.Comparator;
 
 public class JavaToolchainComparator implements Comparator<JavaToolchain> {
@@ -23,10 +25,15 @@ public class JavaToolchainComparator implements Comparator<JavaToolchain> {
     @Override
     public int compare(JavaToolchain o1, JavaToolchain o2) {
         return Comparator
-            .comparing(JavaToolchain::getToolVersion)
-            .thenComparing(JavaToolchain::isJdk)
+            .comparing(JavaToolchain::isJdk)
+            .thenComparing(this::extractVendor, Comparator.reverseOrder())
+            .thenComparing(JavaToolchain::getToolVersion)
             .reversed()
             .compare(o1, o2);
+    }
+
+    private JvmVendor.KnownJvmVendor extractVendor(JavaToolchain toolchain) {
+        return toolchain.getMetadata().getVendor().getKnownVendor();
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmImplementation;
+
+import java.util.function.Predicate;
+
+public class ToolchainMatcher implements Predicate<JavaToolchain> {
+
+    private final JavaToolchainSpec filter;
+
+    public ToolchainMatcher(JavaToolchainSpec filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean test(JavaToolchain toolchain) {
+        return languagePredicate().and(vendorPredicate()).and(implementationPredicate()).test(toolchain);
+    }
+
+    private Predicate<JavaToolchain> languagePredicate() {
+        return toolchain -> toolchain.getLanguageVersion().equals(filter.getLanguageVersion().get());
+    }
+
+    private Predicate<? super JavaToolchain> implementationPredicate() {
+        return toolchain -> {
+            final boolean isJ9Vm = toolchain.getMetadata().hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_VIRTUAL_MACHINE);
+            final boolean j9Requested = filter.getImplementation().get() == JvmImplementation.J9;
+            return !j9Requested || isJ9Vm;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Predicate<? super JavaToolchain> vendorPredicate() {
+        return (Predicate<? super JavaToolchain>) filter.getVendor().get();
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpecTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpecTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain.internal
 
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.jvm.inspection.JvmVendor
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import spock.lang.Specification
@@ -27,7 +28,9 @@ class DefaultJvmVendorSpecTest extends Specification {
     def "unknown does not match known vendor"() {
         given:
         def toolchain = Mock(JavaToolchain) {
-            getVendor() >> JvmVendor.fromString("some unknown")
+            getMetadata() >> Mock(JvmInstallationMetadata) {
+                getVendor() >> JvmVendor.fromString("some unknown")
+            }
         }
 
         when:
@@ -40,7 +43,9 @@ class DefaultJvmVendorSpecTest extends Specification {
     def "matches known vendors"() {
         given:
         def toolchain = Mock(JavaToolchain) {
-            getVendor() >> JvmVendor.fromString("bellsoft")
+            getMetadata() >> Mock(JvmInstallationMetadata) {
+                getVendor() >> JvmVendor.fromString("bellsoft")
+            }
         }
 
         expect:
@@ -51,7 +56,9 @@ class DefaultJvmVendorSpecTest extends Specification {
     def "matches by raw string"() {
         given:
         def toolchain = Mock(JavaToolchain) {
-            getVendor() >> JvmVendor.fromString("someCustomJdk")
+            getMetadata() >> Mock(JvmInstallationMetadata) {
+                getVendor() >> JvmVendor.fromString("someCustomJdk")
+            }
         }
 
         expect:


### PR DESCRIPTION
As we decided to not encode information about the implementation (hotspot, j9, etc) into the vendor, this introduces a separate `implementation` filter. 

```
java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(11)
        vendor = JvmVendorSpec.ADOPTOPENJDK
        implementation = JvmImplementation.J9
    }
}
```
