### PR TITLE
 Test sources should be available via Eclipse project dependency when target project applies java-test-fixtures plugin

### DIFF
--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/ToolingApiEclipseProjectDependenciesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/ToolingApiEclipseProjectDependenciesCrossVersionSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/ToolingApiEclipseProjectDependenciesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r68/ToolingApiEclipseProjectDependenciesCrossVersionSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.tooling.r68
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+@ToolingApiVersion(">=6.8")
+@TargetGradleVersion(">=6.8")
+class ToolingApiEclipseProjectDependenciesCrossVersionSpec extends ToolingApiSpecification {
+
+    def "project dependency does not leak test sources"() {
+        setup:
+        settingsFile << "include 'a', 'b'"
+        file('a/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+        """
+        file('b/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation project(':a')
+            }
+        """
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject).children.find { it.gradleProject.path == ':b' }
+
+        then:
+        project.projectDependencies.size() == 1
+        project.projectDependencies[0].classpathAttributes.find { it.name == 'without_test_code' }.value == "true"
+    }
+
+    def "project dependency pointing to test fixture project exposes test sources"() {
+        setup:
+        settingsFile << "include 'a', 'b'"
+        file('a/build.gradle') << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+        """
+        file('b/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation project(':a')
+            }
+        """
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject).children.find { it.gradleProject.path == ':b' }
+
+        then:
+        project.projectDependencies.size() == 1
+        project.projectDependencies[0].classpathAttributes.find { it.name == 'without_test_code' }.value == "false"
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseTestDependenciesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseTestDependenciesIntegrationTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants
+
+class EclipseTestDependenciesIntegrationTest extends AbstractEclipseIntegrationSpec {
+
+    @ToBeFixedForConfigurationCache
+    def "project dependency does not leak test sources"() {
+        settingsFile << "include 'a', 'b'"
+        file('a/build.gradle') << """
+            plugins {
+                id 'eclipse'
+                id 'java-library'
+            }
+        """
+        file('b/build.gradle') << """
+            plugins {
+                id 'eclipse'
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation project(':a')
+            }
+        """
+
+        when:
+        run "eclipse"
+
+        then:
+        Node projectDependency = classpath('b').entries.find { it.attribute('path') == '/a'}
+        projectDependency.attributes.attribute.find { it.@name == EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY && it.@value == 'true' }
+    }
+
+    @ToBeFixedForConfigurationCache
+    def "project dependency pointing to test fixture project exposes test sources"() {
+        settingsFile << "include 'a', 'b'"
+        file('a/build.gradle') << """
+            plugins {
+                id 'eclipse'
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+        """
+        file('b/build.gradle') << """
+            plugins {
+                id 'eclipse'
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation project(':a')
+            }
+        """
+
+        when:
+        run "eclipse"
+
+        then:
+        Node projectDependency = classpath('b').entries.find { it.attribute('path') == '/a'}
+        !projectDependency.attributes.attribute.find { it.@name == EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY && it.@value == 'true' }
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -279,7 +279,7 @@ public class EclipsePlugin extends IdePlugin {
         project.getPlugins().withType(JavaTestFixturesPlugin.class, new Action<JavaTestFixturesPlugin>() {
             @Override
             public void execute(JavaTestFixturesPlugin javaTestFixturesPlugin) {
-                model.getClasspath().setContainsTestFixtures(true);
+                model.getClasspath().getContainsTestFixtures().convention(true);
             }
         });
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaTestFixturesPlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.SourceSet;
@@ -185,8 +186,7 @@ public class EclipsePlugin extends IdePlugin {
             }
 
         });
-
-        artifactRegistry.registerIdeProject(new EclipseProjectMetadata(projectModel, project.getProjectDir(), task));
+        artifactRegistry.registerIdeProject(new EclipseProjectMetadata(model, project.getProjectDir(), task));
     }
 
     private void configureEclipseClasspath(final Project project, final EclipseModel model) {
@@ -273,6 +273,13 @@ public class EclipsePlugin extends IdePlugin {
                         }
                     }
                 });
+            }
+        });
+
+        project.getPlugins().withType(JavaTestFixturesPlugin.class, new Action<JavaTestFixturesPlugin>() {
+            @Override
+            public void execute(JavaTestFixturesPlugin javaTestFixturesPlugin) {
+                model.getClasspath().setContainsTestFixtures(true);
             }
         });
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -186,6 +186,7 @@ public class EclipsePlugin extends IdePlugin {
             }
 
         });
+
         artifactRegistry.registerIdeProject(new EclipseProjectMetadata(model, project.getProjectDir(), task));
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
@@ -20,7 +20,7 @@ import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
-import org.gradle.plugins.ide.eclipse.model.EclipseProject;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.internal.IdeProjectMetadata;
 
 import java.io.File;
@@ -28,11 +28,11 @@ import java.util.Collections;
 import java.util.Set;
 
 public class EclipseProjectMetadata implements IdeProjectMetadata {
-    private final EclipseProject eclipseProject;
+    private final EclipseModel eclipseProject;
     private final File projectDir;
     private final TaskProvider<? extends Task> generatorTask;
 
-    public EclipseProjectMetadata(EclipseProject eclipseProject, File projectDir, TaskProvider<? extends Task> generatorTask) {
+    public EclipseProjectMetadata(EclipseModel eclipseProject, File projectDir, TaskProvider<? extends Task> generatorTask) {
         this.eclipseProject = eclipseProject;
         this.projectDir = projectDir;
         this.generatorTask = generatorTask;
@@ -40,11 +40,11 @@ public class EclipseProjectMetadata implements IdeProjectMetadata {
 
     @Override
     public DisplayName getDisplayName() {
-        return Describables.withTypeAndName("Eclipse project", eclipseProject.getName());
+        return Describables.withTypeAndName("Eclipse project", eclipseProject.getProject().getName());
     }
 
     public String getName() {
-        return eclipseProject.getName();
+        return eclipseProject.getProject().getName();
     }
 
     @Override
@@ -55,5 +55,9 @@ public class EclipseProjectMetadata implements IdeProjectMetadata {
     @Override
     public Set<? extends Task> getGeneratorTasks() {
         return Collections.singleton(generatorTask.get());
+    }
+
+    public boolean hasJavaTestFixtures() {
+        return eclipseProject.getClasspath().getContainsTestFixtures();
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
@@ -28,23 +28,23 @@ import java.util.Collections;
 import java.util.Set;
 
 public class EclipseProjectMetadata implements IdeProjectMetadata {
-    private final EclipseModel eclipseProject;
+    private final EclipseModel eclipseModel;
     private final File projectDir;
     private final TaskProvider<? extends Task> generatorTask;
 
-    public EclipseProjectMetadata(EclipseModel eclipseProject, File projectDir, TaskProvider<? extends Task> generatorTask) {
-        this.eclipseProject = eclipseProject;
+    public EclipseProjectMetadata(EclipseModel eclipseModel, File projectDir, TaskProvider<? extends Task> generatorTask) {
+        this.eclipseModel = eclipseModel;
         this.projectDir = projectDir;
         this.generatorTask = generatorTask;
     }
 
     @Override
     public DisplayName getDisplayName() {
-        return Describables.withTypeAndName("Eclipse project", eclipseProject.getProject().getName());
+        return Describables.withTypeAndName("Eclipse project", eclipseModel.getProject().getName());
     }
 
     public String getName() {
-        return eclipseProject.getProject().getName();
+        return eclipseModel.getProject().getName();
     }
 
     @Override
@@ -58,6 +58,6 @@ public class EclipseProjectMetadata implements IdeProjectMetadata {
     }
 
     public boolean hasJavaTestFixtures() {
-        return eclipseProject.getClasspath().getContainsTestFixtures();
+        return eclipseModel.getClasspath().getContainsTestFixtures();
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
@@ -58,6 +58,6 @@ public class EclipseProjectMetadata implements IdeProjectMetadata {
     }
 
     public boolean hasJavaTestFixtures() {
-        return eclipseModel.getClasspath().getContainsTestFixtures();
+        return eclipseModel.getClasspath().getContainsTestFixtures().getOrElse(false);
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
@@ -58,6 +58,6 @@ public class EclipseProjectMetadata implements IdeProjectMetadata {
     }
 
     public boolean hasJavaTestFixtures() {
-        return eclipseModel.getClasspath().getContainsTestFixtures().getOrElse(false);
+        return eclipseModel.getClasspath().getContainsTestFixtures().get();
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -371,6 +371,9 @@ public class EclipseClasspath {
     }
 
     /**
+     * Sets whether the current project contains test fixtures.
+     *
+     * @see #getContainsTestFixtures()
      * @since 6.8
      */
     @Incubating

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -85,6 +85,9 @@ import java.util.Set;
  *     //default settings for downloading sources and Javadoc:
  *     downloadSources = true
  *     downloadJavadoc = false
+ *
+ *     //if you want to expose test classes to dependent projects
+ *     containsTestFixtures = true
  *   }
  * }
  * </pre>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -152,6 +152,8 @@ public class EclipseClasspath {
 
     private final org.gradle.api.Project project;
 
+    private boolean containsTestFixtures;
+
     @Inject
     public EclipseClasspath(org.gradle.api.Project project) {
         this.project = project;
@@ -354,5 +356,18 @@ public class EclipseClasspath {
             referenceFactory.addPathVariable(entry.getKey(), entry.getValue());
         }
         return referenceFactory;
+    }
+
+    /**
+     * Returns {@code true} if the classpath contains test fixture classes that should be visible
+     * through incoming project dependencies.
+     *
+     */
+    public boolean getContainsTestFixtures() {
+        return containsTestFixtures;
+    }
+
+    public void setContainsTestFixtures(boolean containsTestFixtures) {
+        this.containsTestFixtures = containsTestFixtures;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.eclipse.model;
 import com.google.common.base.Preconditions;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -152,7 +153,7 @@ public class EclipseClasspath {
 
     private final org.gradle.api.Project project;
 
-    private boolean containsTestFixtures;
+    private boolean containsTestFixtures = false;
 
     @Inject
     public EclipseClasspath(org.gradle.api.Project project) {
@@ -362,11 +363,17 @@ public class EclipseClasspath {
      * Returns {@code true} if the classpath contains test fixture classes that should be visible
      * through incoming project dependencies.
      *
+     * @since 6.8
      */
+    @Incubating
     public boolean getContainsTestFixtures() {
         return containsTestFixtures;
     }
 
+    /**
+     * @since 6.8
+     */
+    @Incubating
     public void setContainsTestFixtures(boolean containsTestFixtures) {
         this.containsTestFixtures = containsTestFixtures;
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.xml.XmlTransformer;
@@ -156,11 +157,12 @@ public class EclipseClasspath {
 
     private final org.gradle.api.Project project;
 
-    private boolean containsTestFixtures = false;
+    private final Property<Boolean> containsTestFixtures;
 
     @Inject
     public EclipseClasspath(org.gradle.api.Project project) {
         this.project = project;
+        this.containsTestFixtures = project.getObjects().property(Boolean.class);
     }
 
     /**
@@ -367,20 +369,10 @@ public class EclipseClasspath {
      * through incoming project dependencies.
      *
      * @since 6.8
+     * @return
      */
     @Incubating
-    public boolean getContainsTestFixtures() {
+    public Property<Boolean> getContainsTestFixtures() {
         return containsTestFixtures;
-    }
-
-    /**
-     * Sets whether the current project contains test fixtures.
-     *
-     * @see #getContainsTestFixtures()
-     * @since 6.8
-     */
-    @Incubating
-    public void setContainsTestFixtures(boolean containsTestFixtures) {
-        this.containsTestFixtures = containsTestFixtures;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -162,7 +162,7 @@ public class EclipseClasspath {
     @Inject
     public EclipseClasspath(org.gradle.api.Project project) {
         this.project = project;
-        this.containsTestFixtures = project.getObjects().property(Boolean.class);
+        this.containsTestFixtures = project.getObjects().property(Boolean.class).convention(false);
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -40,7 +40,12 @@ public class ProjectDependencyBuilder {
         if (asJavaModule) {
             dependency.getEntryAttributes().put(EclipsePluginConstants.MODULE_ATTRIBUTE_KEY, EclipsePluginConstants.MODULE_ATTRIBUTE_VALUE);
         }
-        dependency.getEntryAttributes().put(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_VALUE);
+
+        if (containsTestFixtures(componentIdentifier)) {
+            dependency.getEntryAttributes().put(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, "false");
+        } else {
+            dependency.getEntryAttributes().put(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, "true");
+        }
         return dependency;
     }
 
@@ -51,6 +56,11 @@ public class ProjectDependencyBuilder {
     public String determineTargetProjectName(ProjectComponentIdentifier id) {
         EclipseProjectMetadata eclipseProject = ideArtifactRegistry.getIdeProject(EclipseProjectMetadata.class, id);
         return eclipseProject == null ? id.getProjectName() : eclipseProject.getName();
+    }
+
+    private boolean containsTestFixtures(ProjectComponentIdentifier id) {
+        EclipseProjectMetadata eclipseProject = ideArtifactRegistry.getIdeProject(EclipseProjectMetadata.class, id);
+        return eclipseProject != null ? eclipseProject.hasJavaTestFixtures() : false;
     }
 
     private ProjectDependency buildProjectDependency(String path) {


### PR DESCRIPTION
See description at https://github.com/gradle/gradle/issues/14932

The implementation introduces a new `EclipseClasspath.containsTestFixtures` configuration that lets users configure this behavior explicitly.