### PR TITLE
Notify busy daemons about file system changes

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/InvalidateVirtualFileSystemCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/InvalidateVirtualFileSystemCrossVersionSpec.groovy
@@ -83,8 +83,8 @@ class InvalidateVirtualFileSystemCrossVersionSpec extends ToolingApiSpecificatio
         pathsInvalidated()
     }
 
-    @TargetGradleVersion(">=6.1")
-    def "does not invalidate paths for single busy daemon"() {
+    @TargetGradleVersion(">=6.8")
+    def "invalidates paths for single busy daemon"() {
         server.start()
         buildFile << """
             task block {
@@ -94,7 +94,7 @@ class InvalidateVirtualFileSystemCrossVersionSpec extends ToolingApiSpecificatio
             }
         """
         def block = server.expectAndBlock("block")
-        def build = executer.withTasks("block").start()
+        def build = executer.withTasks("block", "--info").start()
         block.waitForAllPendingCalls()
         toolingApi.daemons.daemon.assertBusy()
 
@@ -106,7 +106,7 @@ class InvalidateVirtualFileSystemCrossVersionSpec extends ToolingApiSpecificatio
         then:
         block.releaseAll()
         build.waitForFinish()
-        !pathsInvalidated()
+        pathsInvalidated()
 
         cleanup:
         block?.releaseAll()
@@ -114,7 +114,7 @@ class InvalidateVirtualFileSystemCrossVersionSpec extends ToolingApiSpecificatio
     }
 
     @TargetGradleVersion(">=2.6 <6.1")
-    def "invalidating paths has no effect"() {
+    def "invalidating paths has no effect on older daemons"() {
         when:
         createIdleDaemon()
         def executedCommandCount = countExecutedCommands()


### PR DESCRIPTION
when using the notification API from the tooling API.

This change also removes a race condition for detecting
idle daemons, since we send the message to all daemons.