### PR TITLE
Add API to configure variants for libraries extension sources

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
@@ -581,4 +582,39 @@ public interface DependencyHandler extends ExtensionAware {
      */
     @Incubating
     Dependency testFixtures(Object notation, Action<? super Dependency> configureAction);
+
+    /**
+     * Allows fine tuning what variant to select for the target dependency. This can be used to
+     * specify a classifier, for example.
+     *
+     * @param dependencyProvider the dependency provider
+     * @param variantSpec the variant specification
+     * @return a new dependency provider targetting the configured variant
+     * @since 6.8
+     */
+    @Incubating
+    Provider<MinimalExternalModuleDependency> variantOf(Provider<MinimalExternalModuleDependency> dependencyProvider, Action<? super ExternalModuleDependencyVariantSpec> variantSpec);
+
+    /**
+     * Configures this dependency provider to select the platform variant of the target component
+     * @param dependencyProvider the dependency provider
+     * @return a new dependency provider targetting the platform variant of the component
+     * @since 6.8
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> platform(Provider<MinimalExternalModuleDependency> dependencyProvider) {
+        return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::platform);
+    }
+
+    /**
+     * Configures this dependency provider to select the test fixtures of the target component
+     * @param dependencyProvider the dependency provider
+     * @return a new dependency provider targetting the test fixtures of the component
+     * @since 6.8
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> testFixtures(Provider<MinimalExternalModuleDependency> dependencyProvider) {
+        return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::testFixtures);
+    }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.dsl;
+
+import org.gradle.api.Incubating;
+
+/**
+ * The specification of a dependency variant. Some dependencies can be fined tuned
+ * to select a particular variant. For example, one might want to select the test
+ * fixtures of a target component, or a specific classifier.
+ *
+ * @since 6.8
+ */
+@Incubating
+public interface ExternalModuleDependencyVariantSpec {
+    /**
+     * Configures the dependency to select the "platform" variant.
+     */
+    void platform();
+
+    /**
+     * Configures the dependency to select the test fixtures capability.
+     */
+    void testFixtures();
+
+    /**
+     * Configures the classifier of this dependency
+     */
+    void classifier(String classifier);
+
+    /**
+     * Configures the artifact type of this dependency
+     */
+    void artifactType(String artifactType);
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -313,8 +313,8 @@ class DependencyManagementBuildScopeServices {
         ProjectDependencyFactory projectDependencyFactory = new ProjectDependencyFactory(factory);
 
         return new DefaultDependencyFactory(
-            DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
-            DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
+            DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner, attributesFactory, capabilityNotationParser),
+            DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner, attributesFactory),
             new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
             capabilityNotationParser, projectDependencyFactory,
             attributesFactory);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMinimalDependencyVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMinimalDependencyVariant.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.internal.Actions;
+
+import javax.annotation.Nullable;
+
+public class DefaultMinimalDependencyVariant implements MinimalExternalModuleDependency, DependencyVariant {
+    private final MinimalExternalModuleDependency delegate;
+    private final Action<? super AttributeContainer> attributesMutator;
+    private final Action<? super ModuleDependencyCapabilitiesHandler> capabilitiesMutator;
+    private final String classifier;
+    private final String artifactType;
+
+    public DefaultMinimalDependencyVariant(MinimalExternalModuleDependency delegate,
+                                           @Nullable Action<? super AttributeContainer> attributesMutator,
+                                           @Nullable Action<? super ModuleDependencyCapabilitiesHandler> capabilitiesMutator,
+                                           @Nullable String classifier,
+                                           @Nullable String artifactType) {
+        this.delegate = delegate;
+        boolean delegateIsVariant = delegate instanceof DefaultMinimalDependencyVariant;
+        this.attributesMutator = delegateIsVariant ? Actions.composite(((DefaultMinimalDependencyVariant) delegate).attributesMutator, attributesMutator == null ? Actions.doNothing() : attributesMutator) : attributesMutator;
+        this.capabilitiesMutator = delegateIsVariant ? Actions.composite(((DefaultMinimalDependencyVariant) delegate).capabilitiesMutator, capabilitiesMutator == null ? Actions.doNothing() : capabilitiesMutator) : capabilitiesMutator;
+        if (classifier == null && delegateIsVariant) {
+            classifier = ((DefaultMinimalDependencyVariant) delegate).getClassifier();
+        }
+        if (artifactType == null && delegateIsVariant) {
+            artifactType = ((DefaultMinimalDependencyVariant) delegate).getArtifactType();
+        }
+        this.classifier = classifier;
+        this.artifactType = artifactType;
+    }
+
+    @Override
+    public ModuleIdentifier getModule() {
+        return delegate.getModule();
+    }
+
+    @Override
+    public VersionConstraint getVersionConstraint() {
+        return delegate.getVersionConstraint();
+    }
+
+    @Override
+    public void mutateAttributes(AttributeContainer attributes) {
+        if (attributesMutator!= null) {
+            attributesMutator.execute(attributes);
+        }
+    }
+
+    @Override
+    public void mutateCapabilities(ModuleDependencyCapabilitiesHandler capabilitiesHandler) {
+        if (capabilitiesMutator != null) {
+            capabilitiesMutator.execute(capabilitiesHandler);
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Nullable
+    @Override
+    public String getArtifactType() {
+        return artifactType;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyVariant.java
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.artifacts;
+package org.gradle.api.internal.artifacts.dependencies;
 
-import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
+import org.gradle.api.attributes.AttributeContainer;
 
-/**
- * The minimal information Gradle needs to address an external module.
- *
- * @since 6.8
- */
-@Incubating
-@HasInternalProtocol
-public interface MinimalExternalModuleDependency {
-    ModuleIdentifier getModule();
-    VersionConstraint getVersionConstraint();
+import javax.annotation.Nullable;
+
+public interface DependencyVariant {
+    void mutateAttributes(AttributeContainer attributes);
+    void mutateCapabilities(ModuleDependencyCapabilitiesHandler capabilitiesHandler);
+
+    @Nullable
+    String getClassifier();
+
+    @Nullable
+    String getArtifactType();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -26,20 +26,24 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.dsl.ExternalModuleDependencyVariantSpec;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
+import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependencyVariant;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.internal.std.DependencyBundleValueSource;
@@ -57,6 +61,7 @@ import org.gradle.internal.metaobject.MethodMixIn;
 import org.gradle.util.ConfigureUtil;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -388,6 +393,15 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         return testFixturesDependency;
     }
 
+    @Override
+    public Provider<MinimalExternalModuleDependency> variantOf(Provider<MinimalExternalModuleDependency> dependencyProvider, Action<? super ExternalModuleDependencyVariantSpec> variantSpec) {
+        return dependencyProvider.map(dep -> {
+            DefaultExternalModuleDependencyVariantSpec spec = objects.newInstance(DefaultExternalModuleDependencyVariantSpec.class, objects, dep);
+            variantSpec.execute(spec);
+            return new DefaultMinimalDependencyVariant(dep, spec.attributesAction, spec.capabilitiesMutator, spec.classifier, spec.artifactType);
+        });
+    }
+
     private Category toCategory(String category) {
         return objects.named(Category.class, category);
     }
@@ -398,6 +412,42 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         @SuppressWarnings("rawtypes")
         public Dependency add(Configuration configuration, Object dependencyNotation, @Nullable Closure configureAction) {
             return doAdd(configuration, dependencyNotation, configureAction);
+        }
+    }
+
+    public static class DefaultExternalModuleDependencyVariantSpec implements ExternalModuleDependencyVariantSpec {
+
+        private final ObjectFactory objects;
+        private final MinimalExternalModuleDependency dep;
+        private Action<? super AttributeContainer> attributesAction = null;
+        private Action<ModuleDependencyCapabilitiesHandler> capabilitiesMutator = null;
+        private String classifier;
+        private String artifactType;
+
+        @Inject
+        public DefaultExternalModuleDependencyVariantSpec(ObjectFactory objects, MinimalExternalModuleDependency dep) {
+            this.objects = objects;
+            this.dep = dep;
+        }
+
+        @Override
+        public void platform() {
+            this.attributesAction = attrs -> attrs.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.REGULAR_PLATFORM));
+        }
+
+        @Override
+        public void testFixtures() {
+            this.capabilitiesMutator = capabilities -> capabilities.requireCapability(new ImmutableCapability(dep.getModule().getGroup(), dep.getModule().getName() + TEST_FIXTURES_CAPABILITY_APPENDIX, null));
+        }
+
+        @Override
+        public void classifier(String classifier) {
+            this.classifier = classifier;
+        }
+
+        @Override
+        public void artifactType(String artifactType) {
+            this.artifactType = artifactType;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
@@ -17,13 +17,17 @@
 package org.gradle.api.internal.notations;
 
 import com.google.common.collect.Interner;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DependencyVariant;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationConvertResult;
@@ -34,10 +38,10 @@ import org.gradle.internal.typeconversion.TypeConversionException;
 import org.gradle.internal.typeconversion.TypedNotationConverter;
 
 public class DependencyConstraintNotationParser {
-    public static NotationParser<Object, DependencyConstraint> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, Interner<String> stringInterner) {
+    public static NotationParser<Object, DependencyConstraint> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, Interner<String> stringInterner, ImmutableAttributesFactory attributesFactory) {
         return NotationParserBuilder
             .toType(DependencyConstraint.class)
-            .fromType(MinimalExternalModuleDependency.class, new MinimalExternalDependencyNotationConverter(instantiator))
+            .fromType(MinimalExternalModuleDependency.class, new MinimalExternalDependencyNotationConverter(instantiator, attributesFactory))
             .fromCharSequence(new DependencyStringNotationConverter<>(instantiator, DefaultDependencyConstraint.class, stringInterner))
             .converter(new DependencyMapNotationConverter<>(instantiator, DefaultDependencyConstraint.class))
             .fromType(Project.class, new DependencyConstraintProjectNotationConverter(dependencyFactory))
@@ -60,18 +64,46 @@ public class DependencyConstraintNotationParser {
 
     private static class MinimalExternalDependencyNotationConverter implements NotationConverter<MinimalExternalModuleDependency, DefaultDependencyConstraint> {
         private final Instantiator instantiator;
+        private final ImmutableAttributesFactory attributesFactory;
 
-        public MinimalExternalDependencyNotationConverter(Instantiator instantiator) {
+        public MinimalExternalDependencyNotationConverter(Instantiator instantiator, ImmutableAttributesFactory attributesFactory) {
             this.instantiator = instantiator;
+            this.attributesFactory = attributesFactory;
         }
 
         @Override
         public void convert(MinimalExternalModuleDependency notation, NotationConvertResult<? super DefaultDependencyConstraint> result) throws TypeConversionException {
-            result.converted(instantiator.newInstance(DefaultDependencyConstraint.class, notation.getModule(), notation.getVersionConstraint()));
+            DefaultDependencyConstraint dependencyConstraint = instantiator.newInstance(DefaultDependencyConstraint.class, notation.getModule(), notation.getVersionConstraint());
+            if (notation instanceof DependencyVariant) {
+                dependencyConstraint.setAttributesFactory(attributesFactory);
+                DependencyVariant dependencyVariant = (DependencyVariant) notation;
+                dependencyConstraint.attributes(dependencyVariant::mutateAttributes);
+                dependencyVariant.mutateCapabilities(UnsupportedCapabilitiesHandler.INSTANCE);
+                String classifier = dependencyVariant.getClassifier();
+                String artifactType = dependencyVariant.getArtifactType();
+                if (classifier != null || artifactType != null) {
+                    throw new InvalidUserDataException("Classifier and artifact types aren't supported by dependency constraints");
+                }
+            }
+            result.converted(dependencyConstraint);
         }
 
         @Override
         public void describe(DiagnosticsVisitor visitor) {
+        }
+    }
+
+    private final static class UnsupportedCapabilitiesHandler implements ModuleDependencyCapabilitiesHandler {
+        private final static UnsupportedCapabilitiesHandler INSTANCE = new UnsupportedCapabilitiesHandler();
+
+        @Override
+        public void requireCapability(Object capabilityNotation) {
+            throw new InvalidUserDataException("Capabilies are not supported by dependency constraints");
+        }
+
+        @Override
+        public void requireCapabilities(Object... capabilityNotations) {
+            throw new InvalidUserDataException("Capabilies are not supported by dependency constraints");
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -20,11 +20,15 @@ import com.google.common.collect.Interner;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.internal.artifacts.dependencies.DependencyVariant;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryHelper;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
@@ -37,11 +41,19 @@ import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
 public class DependencyNotationParser {
-    public static NotationParser<Object, Dependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileCollectionFactory fileCollectionFactory, RuntimeShadedJarFactory runtimeShadedJarFactory, CurrentGradleInstallation currentGradleInstallation, Interner<String> stringInterner) {
+    public static NotationParser<Object, Dependency> parser(Instantiator instantiator,
+                                                            DefaultProjectDependencyFactory dependencyFactory,
+                                                            ClassPathRegistry classPathRegistry,
+                                                            FileCollectionFactory fileCollectionFactory,
+                                                            RuntimeShadedJarFactory runtimeShadedJarFactory,
+                                                            CurrentGradleInstallation currentGradleInstallation,
+                                                            Interner<String> stringInterner,
+                                                            ImmutableAttributesFactory attributesFactory,
+                                                            NotationParser<Object, Capability> capabilityNotationParser) {
         return NotationParserBuilder
             .toType(Dependency.class)
             .fromCharSequence(new DependencyStringNotationConverter<>(instantiator, DefaultExternalModuleDependency.class, stringInterner))
-            .fromType(MinimalExternalModuleDependency.class, new MinimalExternalDependencyNotationConverter(instantiator))
+            .fromType(MinimalExternalModuleDependency.class, new MinimalExternalDependencyNotationConverter(instantiator, attributesFactory, capabilityNotationParser))
             .converter(new DependencyMapNotationConverter<>(instantiator, DefaultExternalModuleDependency.class))
             .fromType(FileCollection.class, new DependencyFilesNotationConverter(instantiator))
             .fromType(Project.class, new DependencyProjectNotationConverter(dependencyFactory))
@@ -52,14 +64,31 @@ public class DependencyNotationParser {
 
     private static class MinimalExternalDependencyNotationConverter implements NotationConverter<MinimalExternalModuleDependency, DefaultExternalModuleDependency> {
         private final Instantiator instantiator;
+        private final ImmutableAttributesFactory attributesFactory;
+        private final NotationParser<Object, Capability> capabilityNotationParser;
 
-        public MinimalExternalDependencyNotationConverter(Instantiator instantiator) {
+        public MinimalExternalDependencyNotationConverter(Instantiator instantiator, ImmutableAttributesFactory attributesFactory, NotationParser<Object, Capability> capabilityNotationParser) {
             this.instantiator = instantiator;
+            this.attributesFactory = attributesFactory;
+            this.capabilityNotationParser = capabilityNotationParser;
         }
 
         @Override
         public void convert(MinimalExternalModuleDependency notation, NotationConvertResult<? super DefaultExternalModuleDependency> result) throws TypeConversionException {
-            result.converted(instantiator.newInstance(DefaultExternalModuleDependency.class, notation.getModule(), notation.getVersionConstraint()));
+            DefaultExternalModuleDependency moduleDependency = instantiator.newInstance(DefaultExternalModuleDependency.class, notation.getModule(), notation.getVersionConstraint());
+            if (notation instanceof DependencyVariant) {
+                moduleDependency.setAttributesFactory(attributesFactory);
+                moduleDependency.setCapabilityNotationParser(capabilityNotationParser);
+                DependencyVariant dependencyVariant = (DependencyVariant) notation;
+                moduleDependency.attributes(dependencyVariant::mutateAttributes);
+                moduleDependency.capabilities(dependencyVariant::mutateCapabilities);
+                String classifier = dependencyVariant.getClassifier();
+                String artifactType = dependencyVariant.getArtifactType();
+                if (classifier != null || artifactType != null) {
+                    ModuleFactoryHelper.addExplicitArtifactsIfDefined(moduleDependency, artifactType, classifier);
+                }
+            }
+            result.converted(moduleDependency);
         }
 
         @Override

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -21,10 +21,12 @@ import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.ExternalModuleDependencyVariantSpec
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformParameters
@@ -138,4 +140,7 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
 
     override fun testFixtures(notation: Any, configureAction: Action<in Dependency>): Dependency =
         delegate.testFixtures(notation, configureAction)
+
+    override fun variantOf(dependencyProvider: Provider<MinimalExternalModuleDependency>, variantSpec: Action<in ExternalModuleDependencyVariantSpec>): Provider<MinimalExternalModuleDependency> =
+        delegate.variantOf(dependencyProvider, variantSpec)
 }


### PR DESCRIPTION
This commit fixes a hole in the implementation: for dependencies
issued from a dependency catalog there was no easy way to depend
on the platform variant, the test fixtures variant, or an artifact
notation (classifier or artifact type).
