### PR TITLE
Only expire on full metaspace if GC rate is high

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
@@ -40,6 +40,11 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
     def setup() {
         executer.withBuildJvmOpts(garbageCollector.configuration.jvmArgs.split(" "))
         executer.withEnvironmentVars(JAVA_TOOL_OPTIONS: "-D${DefaultGarbageCollectionMonitor.DISABLE_POLLING_SYSTEM_PROPERTY}=true -D${DaemonMemoryStatus.ENABLE_PERFORMANCE_MONITORING}=true")
+        buildFile << """
+            ${injectionImports}
+
+            task injectEvents()
+        """
     }
 
     def "expires daemon when heap leaks slowly"() {
@@ -65,7 +70,7 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
         fails "injectEvents"
 
         then:
-        failure.assertHasDescription("Gradle build daemon has been stopped: JVM garbage collector thrashing and after running out of JVM memory")
+        failure.assertHasDescription("Gradle build daemon has been stopped: JVM garbage collector thrashing and after running out of JVM heap space")
 
         and:
         daemons.daemon.stops()
@@ -105,6 +110,7 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
 
     def "expires daemon when metaspace leaks"() {
         given:
+        configureGarbageCollectionHeapEventsFor(256, 512, 0, garbageCollector.monitoringStrategy.gcRateThreshold + 0.2)
         configureGarbageCollectionNonHeapEventsFor(256, 512, 35, 0)
 
         when:
@@ -141,6 +147,7 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
 
     def "does not expire daemon when leak does not consume metaspace threshold"() {
         given:
+        configureGarbageCollectionHeapEventsFor(256, 512, 0, garbageCollector.monitoringStrategy.gcRateThreshold + 0.2)
         configureGarbageCollectionNonHeapEventsFor(256, 512, 5, 0)
 
         when:
@@ -161,12 +168,8 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
     void configureGarbageCollectionEvents(String type, long initial, long max, leakRate, gcRate) {
         def events = eventsFor(initial, max, leakRate, gcRate)
         buildFile << """
-            ${injectionImports}
-
-            task injectEvents {
-                doLast {
-                    ${eventInjectionConfiguration(type, events, initial, max)}
-                }
+            injectEvents.doLast {
+                ${eventInjectionConfiguration(type, events, initial, max)}
             }
         """
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonMemoryStatus.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonMemoryStatus.java
@@ -32,14 +32,14 @@ public class DaemonMemoryStatus {
 
     private final DaemonHealthStats stats;
     private final int heapUsageThreshold;
-    private final double heapRateThreshold;
+    private final double gcRateThreshold;
     private final int nonHeapUsageThreshold;
     private final double thrashingThreshold;
 
-    public DaemonMemoryStatus(DaemonHealthStats stats, int heapUsageThreshold, double heapRateThreshold, int nonHeapUsageThreshold, double thrashingThreshold) {
+    public DaemonMemoryStatus(DaemonHealthStats stats, int heapUsageThreshold, double gcRateThreshold, int nonHeapUsageThreshold, double thrashingThreshold) {
         this.stats = stats;
         this.heapUsageThreshold = heapUsageThreshold;
-        this.heapRateThreshold = heapRateThreshold;
+        this.gcRateThreshold = gcRateThreshold;
         this.nonHeapUsageThreshold = nonHeapUsageThreshold;
         this.thrashingThreshold = thrashingThreshold;
     }
@@ -51,23 +51,28 @@ public class DaemonMemoryStatus {
             @Override
             public boolean isSatisfiedBy(GarbageCollectionStats gcStats) {
                 return heapUsageThreshold != 0
-                    && heapRateThreshold != 0
+                    && gcRateThreshold != 0
                     && gcStats.isValid()
                     && gcStats.getUsedPercent() >= heapUsageThreshold
-                    && gcStats.getGcRate() >= heapRateThreshold;
+                    && gcStats.getGcRate() >= gcRateThreshold;
             }
         });
     }
 
     public boolean isNonHeapSpaceExhausted() {
-        GarbageCollectionStats gcStats = stats.getNonHeapStats();
-
-        return exceedsThreshold(NON_HEAP, gcStats, new Spec<GarbageCollectionStats>() {
+        return exceedsThreshold(NON_HEAP, stats.getNonHeapStats(), new Spec<GarbageCollectionStats>() {
             @Override
             public boolean isSatisfiedBy(GarbageCollectionStats gcStats) {
                 return nonHeapUsageThreshold != 0
                     && gcStats.isValid()
                     && gcStats.getUsedPercent() >= nonHeapUsageThreshold;
+            }
+        }) && exceedsThreshold(HEAP, stats.getHeapStats(), new Spec<GarbageCollectionStats>() {
+            @Override
+            public boolean isSatisfiedBy(GarbageCollectionStats gcStats) {
+                return gcRateThreshold != 0
+                    && gcStats.isValid()
+                    && gcStats.getGcRate() >= gcRateThreshold;
             }
         });
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategy.java
@@ -27,7 +27,7 @@ public class LowHeapSpaceDaemonExpirationStrategy implements DaemonExpirationStr
     private final DaemonMemoryStatus status;
     private static final Logger LOG = Logging.getLogger(LowHeapSpaceDaemonExpirationStrategy.class);
 
-    public static final String EXPIRATION_REASON = "after running out of JVM memory";
+    public static final String EXPIRATION_REASON = "after running out of JVM heap space";
     public static final String EXPIRE_DAEMON_MESSAGE = "Expiring Daemon because JVM heap space is exhausted";
 
     public LowHeapSpaceDaemonExpirationStrategy(DaemonMemoryStatus status) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategy.java
@@ -27,7 +27,7 @@ public class LowNonHeapDaemonExpirationStrategy implements DaemonExpirationStrat
     private final DaemonMemoryStatus status;
     private static final Logger LOG = Logging.getLogger(LowNonHeapDaemonExpirationStrategy.class);
 
-    public static final String EXPIRATION_REASON = "after running out of JVM memory";
+    public static final String EXPIRATION_REASON = "after running out of JVM metaspace";
 
     public LowNonHeapDaemonExpirationStrategy(DaemonMemoryStatus status) {
         this.status = status;

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -18,7 +18,10 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.android.AndroidHome
+import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
+import org.gradle.testkit.runner.internal.ToolingApiGradleExecutor
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -47,7 +50,8 @@ class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
         }
 
         when:
-        def result = useAgpVersion(androidPluginVersion, runner(workers, 'clean', ':app:testDebugUnitTestCoverage')).build()
+        def runner = runner(workers, 'clean', ':app:testDebugUnitTestCoverage') as DefaultGradleRunner
+        def result = useAgpVersion(androidPluginVersion, runner).build()
 
         then:
         result.task(':app:testDebugUnitTestCoverage').outcome == SUCCESS
@@ -57,6 +61,9 @@ class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
             // TODO: re-enable once the Kotlin plugin fixes how it extends configurations
             // expectNoDeprecationWarnings(result)
         }
+
+        cleanup:
+        DaemonLogsAnalyzer.newAnalyzer(new File(runner.testKitDirProvider.getDir(), ToolingApiGradleExecutor.TEST_KIT_DAEMON_DIR_NAME)).killAll()
 
         where:
 // To run a specific combination, set the values here, uncomment the following four lines

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -18,7 +18,10 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.android.AndroidHome
+import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
+import org.gradle.testkit.runner.internal.ToolingApiGradleExecutor
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -47,7 +50,8 @@ class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
         }
 
         when:
-        def result = useAgpVersion(androidPluginVersion, runner(workers, 'clean', ':app:testDebugUnitTestCoverage')).build()
+        def runner = runner(workers, 'clean', ':app:testDebugUnitTestCoverage') as DefaultGradleRunner
+        def result = useAgpVersion(androidPluginVersion, runner).build()
 
         then:
         result.task(':app:testDebugUnitTestCoverage').outcome == SUCCESS
@@ -57,6 +61,9 @@ class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
             // TODO: re-enable once the Kotlin plugin fixes how it extends configurations
             // expectNoDeprecationWarnings(result)
         }
+
+        cleanup:
+        DaemonLogsAnalyzer.newAnalyzer(new File(runner.testKitDirProvider.getDir(), ToolingApiGradleExecutor.TEST_KIT_DAEMON_DIR_NAME)).killAll()
 
         where:
 // To run a specific combination, set the values here, uncomment the following four lines

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringCoverage.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringCoverage.groovy
@@ -25,7 +25,8 @@ import static org.gradle.integtests.fixtures.daemon.JavaGarbageCollector.ORACLE_
 
 class DaemonPerformanceMonitoringCoverage {
     static final def ALL_VERSIONS = [
+        new FullyQualifiedGarbageCollector(vendor: JvmVendor.KnownJvmVendor.ADOPTOPENJDK, version: JavaVersion.VERSION_15, gc: ORACLE_G1),
         new FullyQualifiedGarbageCollector(vendor: JvmVendor.KnownJvmVendor.IBM, version: JavaVersion.VERSION_1_8, gc: ORACLE_PARALLEL_CMS),
-        new FullyQualifiedGarbageCollector(vendor: JvmVendor.KnownJvmVendor.ORACLE, version: JavaVersion.VERSION_1_8, gc: ORACLE_G1)
+        new FullyQualifiedGarbageCollector(vendor: JvmVendor.KnownJvmVendor.ORACLE, version: JavaVersion.VERSION_1_8, gc: ORACLE_G1),
     ]
 }

--- a/subprojects/soak/src/testFixtures/groovy/org/gradle/launcher/daemon/fixtures/DaemonMultiJdkIntegrationTest.groovy
+++ b/subprojects/soak/src/testFixtures/groovy/org/gradle/launcher/daemon/fixtures/DaemonMultiJdkIntegrationTest.groovy
@@ -16,14 +16,13 @@
 
 package org.gradle.launcher.daemon.fixtures
 
-
 import org.gradle.api.specs.Spec
 import org.gradle.integtests.fixtures.MultiVersionSpecRunner
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
-import org.gradle.util.EmptyStatement
 import org.gradle.util.VersionNumber
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -35,7 +34,8 @@ import static org.gradle.integtests.fixtures.AvailableJavaHomes.getAvailableJdk
 @RunWith(MultiVersionSpecRunner)
 class DaemonMultiJdkIntegrationTest extends DaemonIntegrationSpec {
     static def version
-    @Rule IgnoreIfJdkNotFound ignoreRule = new IgnoreIfJdkNotFound()
+    @Rule
+    IgnoreIfJdkNotFound ignoreRule = new IgnoreIfJdkNotFound()
 
     JavaInfo jdk
 
@@ -50,18 +50,21 @@ class DaemonMultiJdkIntegrationTest extends DaemonIntegrationSpec {
                 @Override
                 boolean isSatisfiedBy(JvmInstallationMetadata install) {
                     if (version.hasProperty("vendor")) {
-                        if(install.getVendor().getKnownVendor() != version.vendor) {
+                        def actualVendor = install.getVendor().getKnownVendor()
+                        def expectedVendor = version.vendor
+                        if (actualVendor != expectedVendor) {
                             return false
                         }
                     }
-                    return install.languageVersion == version.version
+                    def actualVersion = install.languageVersion.majorVersion
+                    def expectedVersion = version.version
+                    return actualVersion == expectedVersion
                 }
             })
 
-            if (jdk != null) {
-                return base
-            } else {
-                return EmptyStatement.INSTANCE
+            return {
+                Assume.assumeTrue("$version.vendor JDK $version.version not found.", jdk != null)
+                base.evaluate()
             }
         }
     }


### PR DESCRIPTION
The metaspace expiration strategy expired daemons too eagerly.
It only looked at the space, but not whether the GC was busy.
A full metaspace alone is no big problem and happens very easily
with Gradle due to the many soft reference caches. These soft refs
are only cleaned up when the JVM runs out of memory.

The strategy will now only expire the daemon if metaspace is full
and the GC fails to free up memory (i.e. there is a real leak).

I noticed this when switching tasks to the worker API with classloader
isolation. Information about the classes is saved in the cross build cache
and only cleaned up when the JVM is about to run out of memory. This
lead to perfectly healthy daemons being expired because metaspace went
over the 80% threshold. After this fix, Gradle lets the JVM do the soft ref GC
and metaspace is freed up. The daemon can live to die another day.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
