### PR TITLE
Ensure all toolchain requirements are used as task inputs

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -214,7 +214,7 @@ public abstract class AvailableJavaHomes {
             .map(InstallationLocation::getLocation)
             .map(metadataDetector::getMetadata)
             .filter(JvmInstallationMetadata::isValidInstallation)
-            .sorted(Comparator.comparing(JvmInstallationMetadata::getLanguageVersion))
+            .sorted(Comparator.comparing(JvmInstallationMetadata::getDisplayName).thenComparing(JvmInstallationMetadata::getLanguageVersion))
             .collect(Collectors.toList());
 
         System.out.println("Found the following JVMs:");

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
@@ -41,6 +41,15 @@ public interface JavaInstallationMetadata {
     JavaLanguageVersion getLanguageVersion();
 
     /**
+     * Returns a human-readable string for the vendor of the JVM.
+     *
+     * @return the vendor
+     * @since 6.8
+     */
+    @Internal
+    String getVendor();
+
+    /**
      * The path to installation this tool belongs to.
      * <p>
      * This value matches what would be the content of {@code JAVA_HOME} for the given installation.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -28,7 +28,6 @@ import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JavadocTool;
 import org.gradle.util.VersionNumber;
 
@@ -44,14 +43,14 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     private final JvmInstallationMetadata metadata;
     private final JavaToolchainInput input;
 
-    public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory, JavaToolchainSpec spec) {
+    public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory, JavaToolchainInput input) {
         this.javaHome = fileFactory.dir(computeEnclosingJavaHome(metadata.getJavaHome()).toFile());
         this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
         this.implementationVersion = VersionNumber.parse(metadata.getImplementationVersion());
         this.metadata = metadata;
-        this.input = new JavaToolchainInput(spec);
+        this.input = input;
     }
 
     @Nested

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -93,6 +93,11 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
         return metadata;
     }
 
+    @Override
+    public String getVendor() {
+        return metadata.getVendor().getDisplayName();
+    }
+
     @Internal
     @Override
     public String getDisplayName() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -20,18 +20,18 @@ import org.gradle.api.Describable;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.file.FileFactory;
-import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JavadocTool;
 import org.gradle.util.VersionNumber;
 
-import javax.inject.Inject;
 import java.nio.file.Path;
 
 public class JavaToolchain implements Describable, JavaInstallationMetadata {
@@ -42,15 +42,21 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     private final VersionNumber implementationVersion;
     private final JavaLanguageVersion javaVersion;
     private final JvmInstallationMetadata metadata;
+    private final JavaToolchainInput input;
 
-    @Inject
-    public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory) {
+    public JavaToolchain(JvmInstallationMetadata metadata, JavaCompilerFactory compilerFactory, ToolchainToolFactory toolFactory, FileFactory fileFactory, JavaToolchainSpec spec) {
         this.javaHome = fileFactory.dir(computeEnclosingJavaHome(metadata.getJavaHome()).toFile());
         this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
         this.implementationVersion = VersionNumber.parse(metadata.getImplementationVersion());
         this.metadata = metadata;
+        this.input = new JavaToolchainInput(spec);
+    }
+
+    @Nested
+    protected JavaToolchainInput getTaskInputs() {
+        return input;
     }
 
     @Internal
@@ -68,7 +74,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
         return toolFactory.create(JavadocTool.class, this);
     }
 
-    @Input
+    @Internal
     public JavaLanguageVersion getLanguageVersion() {
         return javaVersion;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
@@ -19,7 +19,6 @@ package org.gradle.jvm.toolchain.internal;
 import org.gradle.api.internal.file.FileFactory;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -40,10 +39,10 @@ public class JavaToolchainFactory {
         this.fileFactory = fileFactory;
     }
 
-    public Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
+    public Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainInput input) {
         final JvmInstallationMetadata metadata = detector.getMetadata(javaHome);
         if(metadata.isValidInstallation()) {
-            final JavaToolchain toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, fileFactory, spec);
+            final JavaToolchain toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, fileFactory, input);
             return Optional.of(toolchain);
         }
         return Optional.empty();

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainFactory.java
@@ -19,6 +19,7 @@ package org.gradle.jvm.toolchain.internal;
 import org.gradle.api.internal.file.FileFactory;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -39,10 +40,10 @@ public class JavaToolchainFactory {
         this.fileFactory = fileFactory;
     }
 
-    public Optional<JavaToolchain> newInstance(File javaHome) {
+    public Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
         final JvmInstallationMetadata metadata = detector.getMetadata(javaHome);
         if(metadata.isValidInstallation()) {
-            final JavaToolchain toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, fileFactory);
+            final JavaToolchain toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, fileFactory, spec);
             return Optional.of(toolchain);
         }
         return Optional.empty();

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainInput.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainInput.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.gradle.api.tasks.Input;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+
+public class JavaToolchainInput {
+
+    private final JavaToolchainSpec spec;
+
+    public JavaToolchainInput(JavaToolchainSpec spec) {
+        this.spec = spec;
+    }
+
+    @Input
+    JavaLanguageVersion getLanguageVersion() {
+        return spec.getLanguageVersion().get();
+    }
+
+    @Input
+    String getVendor() {
+        return spec.getVendor().get().toString();
+    }
+
+    @Input
+    String getImplementation() {
+        return spec.getImplementation().get().toString();
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainInput.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainInput.java
@@ -22,25 +22,29 @@ import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 public class JavaToolchainInput {
 
-    private final JavaToolchainSpec spec;
+    private final JavaLanguageVersion javaLanguageVersion;
+    private final String vendor;
+    private final String implementation;
 
     public JavaToolchainInput(JavaToolchainSpec spec) {
-        this.spec = spec;
+        this.javaLanguageVersion = spec.getLanguageVersion().get();
+        this.vendor = spec.getVendor().get().toString();
+        this.implementation = spec.getImplementation().get().toString();
     }
 
     @Input
     JavaLanguageVersion getLanguageVersion() {
-        return spec.getLanguageVersion().get();
+        return javaLanguageVersion;
     }
 
     @Input
     String getVendor() {
-        return spec.getVendor().get().toString();
+        return vendor;
     }
 
     @Input
     String getImplementation() {
-        return spec.getImplementation().get().toString();
+        return implementation;
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -64,7 +64,7 @@ public class JavaToolchainQueryService {
     private JavaToolchain query(JavaToolchainSpec filter) {
         return registry.listInstallations().stream()
             .map(InstallationLocation::getLocation)
-            .map(this::asToolchain)
+            .map(javaHome -> asToolchain(javaHome, filter))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .filter(new ToolchainMatcher(filter))
@@ -76,7 +76,7 @@ public class JavaToolchainQueryService {
     private JavaToolchain downloadToolchain(JavaToolchainSpec spec) {
         final Optional<File> installation = installService.tryInstall(spec);
         final Optional<JavaToolchain> toolchain = installation
-            .map(this::asToolchain)
+            .map(home -> asToolchain(home, spec))
             .orElseThrow(noToolchainAvailable(spec));
         return toolchain.orElseThrow(provisionedToolchainIsInvalid(installation::get));
     }
@@ -89,7 +89,7 @@ public class JavaToolchainQueryService {
         return () -> new GradleException("Provisioned toolchain '" + javaHome.get() + "' could not be probed.");
     }
 
-    private Optional<JavaToolchain> asToolchain(File javaHome) {
-        return toolchainFactory.newInstance(javaHome);
+    private Optional<JavaToolchain> asToolchain(File javaHome, JavaToolchainSpec spec) {
+        return toolchainFactory.newInstance(javaHome, spec);
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -90,6 +90,6 @@ public class JavaToolchainQueryService {
     }
 
     private Optional<JavaToolchain> asToolchain(File javaHome, JavaToolchainSpec spec) {
-        return toolchainFactory.newInstance(javaHome, spec);
+        return toolchainFactory.newInstance(javaHome, new JavaToolchainInput(spec));
     }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainInputTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainInputTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmImplementation
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class JavaToolchainInputTest extends Specification {
+
+    def "optional properties are using defaults"() {
+        given:
+        def baseSpec = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def diffSpec = new DefaultToolchainSpec(TestUtil.objectFactory())
+        baseSpec.languageVersion.set(JavaLanguageVersion.of(11))
+        diffSpec.languageVersion.set(JavaLanguageVersion.of(11))
+        def base = new JavaToolchainInput(baseSpec)
+        def diff = new JavaToolchainInput(diffSpec)
+
+        expect:
+        base.languageVersion == diff.languageVersion
+        base.vendor == diff.vendor
+        base.implementation == diff.implementation
+    }
+
+    def "language version is stable"() {
+        given:
+        def base = new JavaToolchainInput(newSpec(11))
+        def diff = new JavaToolchainInput(newSpec(11))
+
+        expect:
+        base.languageVersion == diff.languageVersion
+        base.vendor == diff.vendor
+        base.implementation == diff.implementation
+    }
+
+    def "change in language version is a different input"() {
+        given:
+        def base = new JavaToolchainInput(newSpec(11))
+        def diff = new JavaToolchainInput(newSpec(14))
+
+        expect:
+        base.languageVersion != diff.languageVersion
+        base.vendor == diff.vendor
+        base.implementation == diff.implementation
+    }
+
+    def "change in vendor is a different input"() {
+        given:
+        def base = new JavaToolchainInput(newSpec(11, "adoptopenjdk"))
+        def diff = new JavaToolchainInput(newSpec(11, "amazon"))
+
+        expect:
+        base.languageVersion == diff.languageVersion
+        base.vendor != diff.vendor
+        base.implementation == diff.implementation
+    }
+
+    def "change in implementation is a different input"() {
+        given:
+        def base = new JavaToolchainInput(newSpec(11, "adoptopenjdk", JvmImplementation.VENDOR_SPECIFIC))
+        def diff = new JavaToolchainInput(newSpec(11, "adoptopenjdk", JvmImplementation.J9))
+
+        expect:
+        base.languageVersion == diff.languageVersion
+        base.vendor == diff.vendor
+        base.implementation != diff.implementation
+    }
+
+    def newSpec(int languageVersion, String vendor = "ibm", JvmImplementation impl = JvmImplementation.VENDOR_SPECIFIC) {
+        def spec = new DefaultToolchainSpec(TestUtil.objectFactory())
+        spec.languageVersion.set(JavaLanguageVersion.of(languageVersion))
+        spec.vendor.set(JvmVendorSpec.matching(vendor))
+        spec.implementation.set(impl)
+        spec
+    }
+}

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -158,10 +158,10 @@ class JavaToolchainQueryServiceTest extends Specification {
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
         def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
-            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
+            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainInput input) {
                 def vendor = vendors[Integer.valueOf(javaHome.name.substring(2))]
                 def metadata = newMetadata(new File("/path/8"), vendor)
-                return Optional.of(new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), spec))
+                return Optional.of(new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), input))
             }
         }
         def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), createProviderFactory())
@@ -229,10 +229,10 @@ class JavaToolchainQueryServiceTest extends Specification {
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
         def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
-            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
+            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainInput input) {
                 def metadata = newMetadata(javaHome)
                 if(metadata.isValidInstallation()) {
-                    def toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), spec)
+                    def toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), input)
                     return Optional.of(toolchain)
                 }
                 return Optional.empty()

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -175,6 +175,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         then:
         toolchain.isPresent()
         toolchain.get().metadata.vendor.knownVendor == JvmVendor.KnownJvmVendor.BELLSOFT
+        toolchain.get().vendor == "BellSoft Liberica"
     }
 
     def "install toolchain if no matching toolchain found"() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -158,10 +158,10 @@ class JavaToolchainQueryServiceTest extends Specification {
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
         def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
-            Optional<JavaToolchain> newInstance(File javaHome) {
+            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
                 def vendor = vendors[Integer.valueOf(javaHome.name.substring(2))]
                 def metadata = newMetadata(new File("/path/8"), vendor)
-                return Optional.of(new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory()))
+                return Optional.of(new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), spec))
             }
         }
         def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), createProviderFactory())
@@ -229,10 +229,10 @@ class JavaToolchainQueryServiceTest extends Specification {
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
         def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
-            Optional<JavaToolchain> newInstance(File javaHome) {
+            Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainSpec spec) {
                 def metadata = newMetadata(javaHome)
                 if(metadata.isValidInstallation()) {
-                    def toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory())
+                    def toolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), spec)
                     return Optional.of(toolchain)
                 }
                 return Optional.empty()

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -40,10 +40,10 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.jvm.toolchain.JavaLauncher
-import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaLauncher
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory
 import org.gradle.jvm.toolchain.internal.JavaToolchain
+import org.gradle.jvm.toolchain.internal.JavaToolchainInput
 import org.gradle.jvm.toolchain.internal.ToolchainToolFactory
 import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.internal.worker.WorkerProcessBuilder
@@ -289,7 +289,7 @@ class TestTest extends AbstractConventionTaskTest {
         metadata.getLanguageVersion() >> Jvm.current().javaVersion
         metadata.getCapabilities() >> Collections.emptySet()
         metadata.getJavaHome() >> Jvm.current().javaHome.toPath()
-        def toolchain = new JavaToolchain(metadata, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory), TestFiles.fileFactory(), Mock(JavaToolchainSpec))
+        def toolchain = new JavaToolchain(metadata, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory), TestFiles.fileFactory(), Mock(JavaToolchainInput))
         def launcher = new DefaultToolchainJavaLauncher(toolchain)
 
         when:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -40,6 +40,7 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaLauncher
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory
 import org.gradle.jvm.toolchain.internal.JavaToolchain
@@ -288,7 +289,7 @@ class TestTest extends AbstractConventionTaskTest {
         metadata.getLanguageVersion() >> Jvm.current().javaVersion
         metadata.getCapabilities() >> Collections.emptySet()
         metadata.getJavaHome() >> Jvm.current().javaHome.toPath()
-        def toolchain = new JavaToolchain(metadata, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory), TestFiles.fileFactory())
+        def toolchain = new JavaToolchain(metadata, Mock(JavaCompilerFactory), Mock(ToolchainToolFactory), TestFiles.fileFactory(), Mock(JavaToolchainSpec))
         def launcher = new DefaultToolchainJavaLauncher(toolchain)
 
         when:


### PR DESCRIPTION
Fixes #13970

As discussed, we now consider vendor and implementation as well as task inputs but only if they've been specified as toolchain requirements. 