### PR TITLE
Only use the identity name of an included build in the IDEA module name if there is a conflict

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/DefaultUniqueProjectNameProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/DefaultUniqueProjectNameProvider.java
@@ -36,7 +36,7 @@ public class DefaultUniqueProjectNameProvider implements UniqueProjectNameProvid
         if (uniqueName != null) {
             return uniqueName;
         }
-        return getUniqueProjectName(projectState);
+        return project.getName();
     }
 
     private synchronized Map<ProjectState, String> getDeduplicatedNames() {
@@ -47,15 +47,16 @@ public class DefaultUniqueProjectNameProvider implements UniqueProjectNameProvid
         return deduplicated;
     }
 
-    private static String getUniqueProjectName(ProjectState projectState) {
-        String identityName = projectState.getIdentityPath().getName();
-        return identityName != null ? identityName : projectState.getName();
-    }
-
     private static class ProjectPathDeduplicationAdapter implements HierarchicalElementAdapter<ProjectState> {
         @Override
         public String getName(ProjectState element) {
-            return getUniqueProjectName(element);
+            return element.getName();
+        }
+
+        @Override
+        public String getIdentityName(ProjectState element) {
+            String identityName = element.getIdentityPath().getName();
+            return identityName != null ? identityName : element.getName();
         }
 
         @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
@@ -118,6 +118,11 @@ public class EclipseModelAwareUniqueProjectNameProvider implements UniqueProject
         }
 
         @Override
+        public String getIdentityName(ProjectStateWrapper element) {
+            return element.name;
+        }
+
+        @Override
         public ProjectStateWrapper getParent(ProjectStateWrapper element) {
             return projectToInformationMap.get(element.parent);
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/HierarchicalElementAdapter.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/HierarchicalElementAdapter.java
@@ -32,6 +32,16 @@ public interface HierarchicalElementAdapter<T> {
     String getName(T element);
 
     /**
+     * Returns the original identity name of the given element which
+     * may be used to uniquely identify the element if the name returned
+     * by getName() is not unique in the hierarchy.
+     *
+     * @param element the element, cannot be null
+     * @return the identity name of the element, never null
+     */
+    String getIdentityName(T element);
+
+    /**
      * Returns the parent in this element's hierarchy.
      *
      * @param element the child element, cannot be null


### PR DESCRIPTION
This is a follow up to #14671 to preserver the previous behaviour for projects that already work in the IDE.

Theoretically, it should not matter what the name of the IDE project/module is as long as it is unique for each one.
Still, currently some of the IDEA Sync code depends on the previous behaviour to setup dependencies between included builds correctly.

#14671 changed the behaviour to always use the 'identity name' if available. We now revert to the previous behaviour of using the normal projects name. Instead, when we reach a point in the de-duplicator where we still have conflicts but cannot find a solution by adding more prefixes, we then change to use the identity name instead of the project name.
