### PR TITLE
Improve database interaction of performance tests

### DIFF
--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -63,7 +63,7 @@ class AbstractBuildScanPluginPerformanceTest extends Specification {
         assert buildStampJsonData.commitId
         def pluginCommitId = buildStampJsonData.commitId as String
         def gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
-        runner = new BuildScanPerformanceTestRunner(new GradleBuildExperimentRunner(gradleProfilerReporter), resultStore, resultStore, pluginCommitId, buildContext) {
+        runner = new BuildScanPerformanceTestRunner(new GradleBuildExperimentRunner(gradleProfilerReporter), resultStore, pluginCommitId, buildContext) {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {
                 super.defaultSpec(builder)

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
@@ -22,7 +22,6 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.DataReporter
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.util.Git
 import org.gradle.util.GradleVersion
 
@@ -30,8 +29,8 @@ import org.gradle.util.GradleVersion
 class BuildScanPerformanceTestRunner extends AbstractCrossBuildPerformanceTestRunner<CrossBuildPerformanceResults> {
     private final String pluginCommitSha
 
-    BuildScanPerformanceTestRunner(GradleBuildExperimentRunner experimentRunner, ResultsStore resultsStore, DataReporter<CrossBuildPerformanceResults> dataReporter, String pluginCommitSha, IntegrationTestBuildContext buildContext) {
-        super(experimentRunner, resultsStore, dataReporter, buildContext)
+    BuildScanPerformanceTestRunner(GradleBuildExperimentRunner experimentRunner, DataReporter<CrossBuildPerformanceResults> dataReporter, String pluginCommitSha, IntegrationTestBuildContext buildContext) {
+        super(experimentRunner, dataReporter, buildContext)
         this.pluginCommitSha = pluginCommitSha
         this.testGroup = "build scan plugin"
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
@@ -55,10 +55,9 @@ class AbstractCrossBuildPerformanceTest extends Specification {
     def setup() {
         def gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
         runner = new CrossBuildPerformanceTestRunner(
-            new GradleBuildExperimentRunner(gradleProfilerReporter),
-            RESULTS_STORE,
-            RESULTS_STORE.reportAlso(gradleProfilerReporter),
-            buildContext
+                new GradleBuildExperimentRunner(gradleProfilerReporter),
+                RESULTS_STORE.reportAlso(gradleProfilerReporter),
+                buildContext
         ) {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
@@ -57,11 +57,10 @@ class AbstractCrossVersionPerformanceTest extends Specification {
     def setup() {
         def gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
         runner = new CrossVersionPerformanceTestRunner(
-            new GradleBuildExperimentRunner(gradleProfilerReporter),
-            RESULTS_STORE,
-            RESULTS_STORE.reportAlso(gradleProfilerReporter),
-            new ReleasedVersionDistributions(buildContext),
-            buildContext
+                new GradleBuildExperimentRunner(gradleProfilerReporter),
+                RESULTS_STORE.reportAlso(gradleProfilerReporter),
+                new ReleasedVersionDistributions(buildContext),
+                buildContext
         )
         runner.workingDir = temporaryFolder.testDirectory
         runner.current = new UnderDevelopmentGradleDistribution(buildContext)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
@@ -45,11 +45,10 @@ class AbstractGradleVsMavenPerformanceTest extends Specification {
 
     GradleProfilerReporter gradleProfilerReporter = new GradleProfilerReporter(temporaryFolder.testDirectory)
     GradleVsMavenPerformanceTestRunner runner = new GradleVsMavenPerformanceTestRunner(
-        temporaryFolder,
-        new GradleVsMavenBuildExperimentRunner(gradleProfilerReporter),
-        RESULT_STORE,
-        RESULT_STORE.reportAlso(gradleProfilerReporter),
-        buildContext
+            temporaryFolder,
+            new GradleVsMavenBuildExperimentRunner(gradleProfilerReporter),
+            RESULT_STORE.reportAlso(gradleProfilerReporter),
+            buildContext
     ) {
         @Override
         protected void defaultSpec(BuildExperimentSpec.Builder builder) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
@@ -24,7 +24,6 @@ import org.gradle.internal.time.Clock
 import org.gradle.internal.time.Time
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.DataReporter
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.results.ResultsStoreHelper
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
@@ -50,11 +49,9 @@ abstract class AbstractCrossBuildPerformanceTestRunner<R extends CrossBuildPerfo
     boolean measureGarbageCollection = true
 
     final DataReporter<R> reporter
-    final ResultsStore resultsStore
 
-    AbstractCrossBuildPerformanceTestRunner(BuildExperimentRunner experimentRunner, ResultsStore resultsStore, DataReporter<R> dataReporter, IntegrationTestBuildContext buildContext) {
+    AbstractCrossBuildPerformanceTestRunner(BuildExperimentRunner experimentRunner, DataReporter<R> dataReporter, IntegrationTestBuildContext buildContext) {
         this.reporter = dataReporter
-        this.resultsStore = resultsStore
         this.experimentRunner = experimentRunner
         this.buildContext = buildContext
         this.gradleDistribution = new UnderDevelopmentGradleDistribution(buildContext)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
@@ -22,14 +22,13 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.DataReporter
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.util.Git
 import org.gradle.util.GradleVersion
 
 @CompileStatic
 class CrossBuildPerformanceTestRunner extends AbstractCrossBuildPerformanceTestRunner<CrossBuildPerformanceResults> {
-    CrossBuildPerformanceTestRunner(AbstractBuildExperimentRunner experimentRunner, ResultsStore resultsStore, DataReporter<CrossBuildPerformanceResults> dataReporter, IntegrationTestBuildContext buildContext) {
-        super(experimentRunner, resultsStore, dataReporter, buildContext)
+    CrossBuildPerformanceTestRunner(AbstractBuildExperimentRunner experimentRunner, DataReporter<CrossBuildPerformanceResults> dataReporter, IntegrationTestBuildContext buildContext) {
+        super(experimentRunner, dataReporter, buildContext)
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -32,7 +32,6 @@ import org.gradle.internal.time.Time
 import org.gradle.performance.results.CrossVersionPerformanceResults
 import org.gradle.performance.results.DataReporter
 import org.gradle.performance.results.MeasuredOperationList
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.results.ResultsStoreHelper
 import org.gradle.performance.util.Git
 import org.gradle.profiler.BuildAction
@@ -61,7 +60,6 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
     private static final Pattern COMMA_OR_SEMICOLON = Pattern.compile('[;,]')
 
     private final IntegrationTestBuildContext buildContext
-    private final ResultsStore resultsStore
     private final DataReporter<CrossVersionPerformanceResults> reporter
     private final ReleasedVersionDistributions releases
     private final Clock clock = Time.clock()
@@ -91,8 +89,7 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
     private final List<String> measuredBuildOperations = []
     private BuildAction buildAction
 
-    CrossVersionPerformanceTestRunner(BuildExperimentRunner experimentRunner, ResultsStore resultsStore, DataReporter<CrossVersionPerformanceResults> reporter, ReleasedVersionDistributions releases, IntegrationTestBuildContext buildContext) {
-        this.resultsStore = resultsStore
+    CrossVersionPerformanceTestRunner(BuildExperimentRunner experimentRunner, DataReporter<CrossVersionPerformanceResults> reporter, ReleasedVersionDistributions releases, IntegrationTestBuildContext buildContext) {
         this.reporter = reporter
         this.experimentRunner = experimentRunner
         this.releases = releases

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -21,7 +21,6 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.results.DataReporter
 import org.gradle.performance.results.GradleVsMavenBuildPerformanceResults
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.util.Git
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.maven.M2Installation
@@ -42,10 +41,9 @@ class GradleVsMavenPerformanceTestRunner extends AbstractCrossBuildPerformanceTe
 
     GradleVsMavenPerformanceTestRunner(TestDirectoryProvider testDirectoryProvider,
                                        GradleVsMavenBuildExperimentRunner experimentRunner,
-                                       ResultsStore resultsStore,
                                        DataReporter<GradleVsMavenBuildPerformanceResults> dataReporter,
                                        IntegrationTestBuildContext buildContext) {
-        super(experimentRunner, resultsStore, dataReporter, buildContext)
+        super(experimentRunner, dataReporter, buildContext)
         m2 = new M2Installation(testDirectoryProvider)
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
@@ -98,6 +98,14 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
         return db.withConnection(actionName, action)
     }
 
+    protected <RESULT> RESULT withConnectionClosingDb(String actionName, ConnectionAction<RESULT> action) {
+        try {
+            return db.withConnection(actionName, action)
+        } finally {
+            db.close()
+        }
+    }
+
 
     @Override
     void close() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -48,7 +48,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
 
     @Override
     public void report(final R results) {
-        withConnection("write results", (ConnectionAction<Void>) connection -> {
+        withConnectionClosingDb("write results", (ConnectionAction<Void>) connection -> {
             long executionId;
             try (PreparedStatement statement = connection.prepareStatement("insert into testExecution(testClass, testId, testProject, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, resultType, channel, host, teamCityBuildId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
                 statement.setString(1, results.getTestClass());

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -99,7 +99,14 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
     public List<PerformanceExperiment> getPerformanceExperiments() {
         return withConnection("load test history", connection -> {
             Set<PerformanceExperiment> testNames = Sets.newLinkedHashSet();
-            try (PreparedStatement testIdsStatement = connection.prepareStatement("select distinct testClass, testId, testProject from testExecution where resultType = ? order by testClass, testId, testProject")) {
+            try (PreparedStatement testIdsStatement = connection.prepareStatement(
+                "select distinct testClass, testId, testProject" +
+                    "   from testExecution" +
+                    "  where resultType = ?" +
+                    "    and testClass is not null" +
+                    "    and starttime > NOW() - INTERVAL 7 DAY" +
+                    "  order by testClass, testId, testProject")
+            ) {
                 testIdsStatement.setString(1, resultType);
                 try (ResultSet testExecutions = testIdsStatement.executeQuery()) {
                     while (testExecutions.next()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -192,7 +192,13 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
         return withConnection("load test history", connection -> {
             try (
                 Statement statement = connection.createStatement();
-                ResultSet testExecutions = statement.executeQuery("select distinct testClass, testId, testProject from testExecution order by testClass, testId, testProject")
+                ResultSet testExecutions = statement.executeQuery(
+                    "select distinct testClass, testId, testProject" +
+                        "   from testExecution" +
+                        "  where testclass is not null" +
+                        "    and starttime > NOW() - INTERVAL 7 DAY" +
+                        "  order by testClass, testId, testProject"
+                )
             ) {
                 List<PerformanceExperiment> testNames = new ArrayList<>();
                 while (testExecutions.next()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -92,7 +92,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
 
     @Override
     public void report(final CrossVersionPerformanceResults results) {
-        withConnection("write results", (ConnectionAction<Void>) connection -> {
+        withConnectionClosingDb("write results", (ConnectionAction<Void>) connection -> {
             long testId = insertExecution(connection, results);
             batchInsertOperation(connection, results, testId);
             updatePreviousTestId(connection, results);


### PR DESCRIPTION
- Close the results store after writing the results of a single test to it
- Only take tests of the last week into account for the `AllResultsStore`.