### PR TITLE
Use separate table to store experiment names to avoid slow queries

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -100,11 +100,9 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
         return withConnection("load test history", connection -> {
             Set<PerformanceExperiment> testNames = Sets.newLinkedHashSet();
             try (PreparedStatement testIdsStatement = connection.prepareStatement(
-                "select distinct testClass, testId, testProject" +
-                    "   from testExecution" +
+                "select testClass, testId, testProject" +
+                    "   from testExecutionExperiment" +
                     "  where resultType = ?" +
-                    "    and testClass is not null" +
-                    "    and starttime > NOW() - INTERVAL 7 DAY" +
                     "  order by testClass, testId, testProject")
             ) {
                 testIdsStatement.setString(1, resultType);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -193,10 +193,8 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
             try (
                 Statement statement = connection.createStatement();
                 ResultSet testExecutions = statement.executeQuery(
-                    "select distinct testClass, testId, testProject" +
-                        "   from testExecution" +
-                        "  where testclass is not null" +
-                        "    and starttime > NOW() - INTERVAL 7 DAY" +
+                    "select testClass, testId, testProject" +
+                        "   from testExecutionExperiment" +
                         "  order by testClass, testId, testProject"
                 )
             ) {


### PR DESCRIPTION
### Context

Previously we use `select distinct` from a million-row-table to get all experiment name, which can result in 10+ min slow queries. Now we put it into a separate table.