### PR TITLE
Fix file system watching soak test on macOS

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
@@ -79,6 +79,7 @@ class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSy
         long endOfDaemonLog = daemon.logLineCount
         50.times { iteration ->
             // when:
+            println("Running iteration ${iteration + 1}")
             changeSourceFiles(iteration, numberOfChangesBetweenBuilds)
             waitForChangesToBePickedUp()
             succeeds("assemble")

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
@@ -35,6 +35,7 @@ class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSy
     VerboseVfsLogAccessor vfsLogs
 
     def setup() {
+        buildTestFixture.withBuildInSubDir()
         def subprojects = (1..NUMBER_OF_SUBPROJECTS).collect { "project$it" }
         def rootProject = multiProjectBuild("javaProject", subprojects) {
             buildFile << """
@@ -60,6 +61,7 @@ class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSy
             // running in parallel, so the soak test doesn't take this long.
             withArgument("--parallel")
             vfsLogs = enableVerboseVfsLogs()
+            inDirectory(rootProject)
         }
     }
 

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
@@ -22,13 +22,8 @@ import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Assert
-import spock.lang.Issue
 
-@Issue("https://github.com/gradle/gradle-private/issues/3235")
-@Requires(TestPrecondition.NOT_MAC_OS_X)
 class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSystemWatchingFixture {
 
     private static final int NUMBER_OF_SUBPROJECTS = 50


### PR DESCRIPTION
We sometimes run into an overflow on macOS during the build in the soak test, and that causes the soak test to fail. When we detect that overflow, we now do not assert how many files have been invalidated between builds. At the end of the test we now also check that we didn't have too much overflows.

Fixes gradle/gradle-private#3235