### PR TITLE
Remove unnecessary calls to 'configure' on lazy tasks API

### DIFF
--- a/subprojects/distributions-integ-tests/build.gradle.kts
+++ b/subprojects/distributions-integ-tests/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 }
 
-tasks.forkingIntegTest.configure {
+tasks.forkingIntegTest {
     systemProperty("gradleBuildBranch", moduleIdentity.gradleBuildBranch.get())
     systemProperty("gradleBuildCommitId", moduleIdentity.gradleBuildCommitId.get())
 }

--- a/subprojects/docs/src/samples/build-organization/gradle-plugin/kotlin/greeting-plugin/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/gradle-plugin/kotlin/greeting-plugin/build.gradle.kts
@@ -34,7 +34,7 @@ val functionalTestTask = tasks.register<Test>("functionalTest") {
     classpath = configurations[functionalTest.runtimeClasspathConfigurationName] + functionalTest.output
 }
 
-tasks.check.configure {
+tasks.check {
     // Run the functional tests as part of `check`
     dependsOn(functionalTestTask)
 }

--- a/subprojects/docs/src/snippets/providers/implicitTaskInputFileDependency/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/providers/implicitTaskInputFileDependency/kotlin/build.gradle.kts
@@ -26,13 +26,13 @@ open class Consumer : DefaultTask() {
 val producer by tasks.registering(Producer::class)
 val consumer by tasks.registering(Consumer::class)
 
-consumer.configure {
+consumer {
     // Connect the producer task output to the consumer task input
     // Don't need to add a task dependency to the consumer task. This is automatically added
     inputFile.set(producer.flatMap { it.outputFile })
 }
 
-producer.configure {
+producer {
     // Set values for the producer lazily
     // Don't need to update the consumer.inputFile property. This is automatically updated as producer.outputFile changes
     outputFile.set(layout.buildDirectory.file("file.txt"))

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -112,7 +112,7 @@ pluginPublish {
 
 // TODO:kotlin-dsl investigate
 // See https://builds.gradle.org/viewLog.html?buildId=19024848&problemId=23230
-tasks.noDaemonIntegTest.configure {
+tasks.noDaemonIntegTest {
     enabled = false
 }
 

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -77,7 +77,7 @@ classycle {
     excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }
 
-tasks.named<Test>("test").configure {
+tasks.test {
     exclude("org/gradle/api/internal/tasks/testing/junit/AJunit*.*")
     exclude("org/gradle/api/internal/tasks/testing/junit/BJunit*.*")
     exclude("org/gradle/api/internal/tasks/testing/junit/ATestClass*.*")

--- a/subprojects/wrapper/build.gradle.kts
+++ b/subprojects/wrapper/build.gradle.kts
@@ -58,12 +58,12 @@ val executableJar by tasks.registering(Jar::class) {
     }.files)
 }
 
-tasks.jar.configure {
+tasks.jar {
     from(executableJar)
 }
 
 // === TODO remove and address the following when we have a good reason to change the wrapper jar
-executableJar.configure {
+executableJar {
     val cliClasspath = layout.buildDirectory.file("gradle-cli-classpath.properties") // This file was accidentally included into the gradle-wrapper.jar
     val cliParameterNames = layout.buildDirectory.file("gradle-cli-parameter-names.properties")  // This file was accidentally included into the gradle-wrapper.jar
     doFirst {


### PR DESCRIPTION
In Kotlin DSL, it is never necessary to use configure.
