### PR TITLE
Ignore empty directories in source tasks

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.plugins.antlr.internal.AntlrSpecFactory;
 import org.gradle.api.plugins.antlr.internal.AntlrWorkerManager;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -303,6 +304,7 @@ public class AntlrTask extends SourceTask {
      */
     @Incubating
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     protected FileCollection getStableSources() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -429,7 +429,6 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
 
         def stableInputsFingerprintLog = result.getOutputLineThatContains(sourcesDebugLogging)
         stableInputsFingerprintLog.contains("RELATIVE_PATH{${testDirectory.absolutePath}")
-        stableInputsFingerprintLog.contains("java=IGNORED / DIR")
         stableInputsFingerprintLog.contains("Hello.java='Hello.java' / ")
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -59,6 +59,7 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      */
     @InputFiles
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.ABSOLUTE)
     public FileTree getSource() {
         return sourceFiles.getAsFileTree().matching(patternSet);

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -50,6 +50,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -225,6 +226,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
      */
     @Incubating
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE) // Java source files are supported, too. Therefore we should care about the relative path.
     @InputFiles
     protected FileCollection getStableSources() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.util.Requires
 import org.gradle.util.Resources
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
-import org.gradle.util.ToBeImplemented
 import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -634,8 +633,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         executedAndNotSkipped ':compileJava'
     }
 
-    @ToBeImplemented
-    @Issue(["https://github.com/gradle/gradle/issues/2463", "https://github.com/gradle/gradle/issues/3444"])
+    @Issue("https://github.com/gradle/gradle/issues/2463")
     def "non-incremental java compilation ignores empty packages"() {
         given:
         buildFile << """
@@ -656,10 +654,9 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
 
         when:
         file('src/main/java/org/gradle/different').createDir()
-        run('compileJava', '--info')
+        run('compileJava')
         then:
-        // FIXME: should be skipped
-        executedAndNotSkipped(':compileJava')
+        skipped(':compileJava')
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -49,6 +49,7 @@ import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.LocalState;
@@ -466,6 +467,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      */
     @Incubating
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     protected FileCollection getStableSources() {


### PR DESCRIPTION
This PR is on top of #15147 to actually ignore empty directories in source tasks and our Java/Groovy compilation tasks.

Fixes #2463
