### PR TITLE
Select vendor-specific toolchains over specific implemementation

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
@@ -43,7 +43,7 @@ public class ToolchainMatcher implements Predicate<JavaToolchain> {
         return toolchain -> {
             final boolean isJ9Vm = toolchain.getMetadata().hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_VIRTUAL_MACHINE);
             final boolean j9Requested = filter.getImplementation().get() == JvmImplementation.J9;
-            return !j9Requested || isJ9Vm;
+            return j9Requested == isJ9Vm;
         };
     }
 


### PR DESCRIPTION
Despite having a higher version, we want to select a `vendor-specific`
toolchain over a specific implementation when selecting toolchains.

