### PR TITLE
Improve diagnostic logging on work unit timeout

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -32,13 +32,13 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
     private static final TIMEOUT = 500
 
-    long checkSlowStopEveryMs
+    long warnIfNotStoppedFrequencyMs
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
     def setup() {
         executer.beforeExecute {
-            def checkTime = checkSlowStopEveryMs ?: Duration.ofMinutes(3).toMillis() // use long timeout to avoid test flakiness
-            executer.withArgument("-D${DefaultTimeoutHandler.SLOW_STOP_CHECK_FREQUENCY_PROPERTY}=$checkTime")
+            def checkTime = warnIfNotStoppedFrequencyMs ?: Duration.ofMinutes(3).toMillis() // use long timeout to avoid test flakiness
+            executer.withArgument("-D${DefaultTimeoutHandler.WARN_IF_NOT_STOPPED_FREQUENCY_PROPERTY}=$checkTime")
         }
     }
 
@@ -253,7 +253,7 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
     def "additional logging is emitted when task is slow to stop"() {
         given:
-        checkSlowStopEveryMs = 100
+        warnIfNotStoppedFrequencyMs = 100
         buildFile << """
             task block() {
                 doLast {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -70,6 +70,7 @@ import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.resources.SharedResourceLeaseRegistry;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
@@ -149,7 +150,8 @@ public class ExecutionGradleServices {
         OverlappingOutputDetector overlappingOutputDetector,
         TimeoutHandler timeoutHandler,
         ValidateStep.ValidationWarningReporter validationWarningReporter,
-        ValueSnapshotter valueSnapshotter
+        ValueSnapshotter valueSnapshotter,
+        CurrentBuildOperationRef currentBuildOperationRef
     ) {
         // @formatter:off
         return new DefaultExecutionEngine(
@@ -171,7 +173,7 @@ public class ExecutionGradleServices {
             new BroadcastChangingOutputsStep<>(outputChangeListener,
             new CaptureStateAfterExecutionStep<>(buildOperationExecutor, buildInvocationScopeId.getId(), outputSnapshotter,
             new CreateOutputsStep<>(
-            new TimeoutStep<>(timeoutHandler,
+            new TimeoutStep<>(timeoutHandler, currentBuildOperationRef,
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
             new RemovePreviousOutputsStep<>(deleter, outputChangeListener,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -67,6 +67,7 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.service.ServiceRegistration;
@@ -220,8 +221,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return new DefaultFileAccessTimeJournal(cacheRepository, cacheDecoratorFactory);
     }
 
-    TimeoutHandler createTimeoutHandler(ExecutorFactory executorFactory) {
-        return new DefaultTimeoutHandler(executorFactory.createScheduled("execution timeouts", 1));
+    TimeoutHandler createTimeoutHandler(ExecutorFactory executorFactory, CurrentBuildOperationRef currentBuildOperationRef) {
+        return new DefaultTimeoutHandler(executorFactory.createScheduled("execution timeouts", 1), currentBuildOperationRef);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -199,6 +199,7 @@ import org.gradle.internal.management.DefaultDependencyResolutionManagement;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
@@ -740,6 +741,7 @@ class DependencyManagementBuildScopeServices {
      */
     ExecutionEngine createExecutionEngine(
             BuildOperationExecutor buildOperationExecutor,
+            CurrentBuildOperationRef currentBuildOperationRef,
             ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
             Deleter deleter,
             ExecutionStateChangeDetector changeDetector,
@@ -768,7 +770,7 @@ class DependencyManagementBuildScopeServices {
             new StoreExecutionStateStep<>(
             new CaptureStateAfterExecutionStep<>(buildOperationExecutor, fixedUniqueId, outputSnapshotter,
             new CreateOutputsStep<>(
-            new TimeoutStep<>(timeoutHandler,
+            new TimeoutStep<>(timeoutHandler, currentBuildOperationRef,
             new ResolveInputChangesStep<>(
             new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(buildOperationExecutor

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -46,7 +46,6 @@ import org.gradle.internal.execution.history.OutputFilesRepository
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
 import org.gradle.internal.execution.history.impl.DefaultOverlappingOutputDetector
 import org.gradle.internal.execution.timeout.TimeoutHandler
-import org.gradle.internal.execution.timeout.impl.DefaultTimeoutHandler
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -45,6 +45,7 @@ import org.gradle.internal.execution.TestExecutionHistoryStore
 import org.gradle.internal.execution.history.OutputFilesRepository
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
 import org.gradle.internal.execution.history.impl.DefaultOverlappingOutputDetector
+import org.gradle.internal.execution.timeout.TimeoutHandler
 import org.gradle.internal.execution.timeout.impl.DefaultTimeoutHandler
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter
@@ -55,6 +56,7 @@ import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.id.UniqueId
+import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
 import org.gradle.internal.service.ServiceRegistry
@@ -133,14 +135,15 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         outputFilesRepository,
         outputSnapshotter,
         new DefaultOverlappingOutputDetector(),
-        new DefaultTimeoutHandler(null),
+        Mock(TimeoutHandler),
         { String behavior ->
             DeprecationLogger.deprecateBehaviour(behavior)
                 .willBeRemovedInGradle7()
                 .undocumented()
                 .nagUser()
         },
-        valueSnapshotter
+        valueSnapshotter,
+        new CurrentBuildOperationRef()
     )
 
     def invoker = new DefaultTransformerInvocationFactory(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
@@ -24,19 +24,24 @@ import org.gradle.internal.execution.Step;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.timeout.Timeout;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 
 import java.time.Duration;
 import java.util.Optional;
 
 public class TimeoutStep<C extends Context> implements Step<C, Result> {
+
     private final TimeoutHandler timeoutHandler;
+    private final CurrentBuildOperationRef currentBuildOperationRef;
     private final Step<? super C, ? extends Result> delegate;
 
     public TimeoutStep(
         TimeoutHandler timeoutHandler,
+        CurrentBuildOperationRef currentBuildOperationRef,
         Step<? super C, ? extends Result> delegate
     ) {
         this.timeoutHandler = timeoutHandler;
+        this.currentBuildOperationRef = currentBuildOperationRef;
         this.delegate = delegate;
     }
 
@@ -55,7 +60,7 @@ public class TimeoutStep<C extends Context> implements Step<C, Result> {
     }
 
     private Result executeWithTimeout(UnitOfWork work, C context, Duration timeout) {
-        Timeout taskTimeout = timeoutHandler.start(Thread.currentThread(), timeout);
+        Timeout taskTimeout = timeoutHandler.start(Thread.currentThread(), timeout, work, currentBuildOperationRef.get());
         try {
             return executeWithoutTimeout(work, context);
         } finally {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/TimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/TimeoutHandler.java
@@ -16,8 +16,11 @@
 
 package org.gradle.internal.execution.timeout;
 
+import org.gradle.api.Describable;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.operations.BuildOperationRef;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 
 /**
@@ -30,7 +33,7 @@ public interface TimeoutHandler extends Stoppable {
      * the work that this timeout was supposed to limit, otherwise it may be interrupted doing
      * some other work later.
      */
-    Timeout start(Thread taskExecutionThread, Duration timeoutInMillis);
+    Timeout start(Thread taskExecutionThread, Duration timeoutInMillis, Describable workUnitDescription, @Nullable BuildOperationRef buildOperationRef);
 
     /**
      * Stops all {@link Timeout}s created from this handler.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -102,7 +102,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
             synchronized (lock) {
                 if (!stopped) {
                     slowStop = true;
-                    doAsPartOfBuildOperation(() -> LOGGER.warn("Timed out " + workUnitDescription.getDisplayName() + " has not yet stopped."));
+                    doAsPartOfBuildOperation(() -> LOGGER.warn("Timed out {} has not yet stopped.", workUnitDescription.getDisplayName()));
                     scheduledFuture = executor.schedule(this::warnIfNotStopped, warnIfNotStoppedFrequency(), TimeUnit.MILLISECONDS);
                 }
             }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -91,7 +91,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
             synchronized (lock) {
                 if (!stopped) {
                     interrupted = true;
-                    doAsPartOfBuildOperation(() -> LOGGER.warn("Requesting stop of " + workUnitDescription.getDisplayName() + " as it has exceeded its configured timeout of " + TimeFormatting.formatDurationTerse(timeout.toMillis()) + "."));
+                    doAsPartOfBuildOperation(() -> LOGGER.warn("Requesting stop of {} as it has exceeded its configured timeout of {}.", workUnitDescription.getDisplayName(), TimeFormatting.formatDurationTerse(timeout.toMillis())));
                     thread.interrupt();
                     scheduledFuture = executor.schedule(this::warnIfNotStopped, warnIfNotStoppedFrequency(), TimeUnit.MILLISECONDS);
                 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -84,7 +84,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
             this.workUnitDescription = workUnitDescription;
             this.buildOperationRef = buildOperationRef;
 
-            scheduledFuture = executor.schedule(this::interrupt, timeout.toMillis(), TimeUnit.MILLISECONDS);
+            this.scheduledFuture = executor.schedule(this::interrupt, timeout.toMillis(), TimeUnit.MILLISECONDS);
         }
 
         private void interrupt() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -40,7 +40,6 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
     public static final String WARN_IF_NOT_STOPPED_FREQUENCY_PROPERTY = DefaultTimeoutHandler.class.getName() + ".warnIfNotStoppedFrequency";
 
     private final ManagedScheduledExecutor executor;
-
     private final CurrentBuildOperationRef currentBuildOperationRef;
 
     public DefaultTimeoutHandler(ManagedScheduledExecutor executor, CurrentBuildOperationRef currentBuildOperationRef) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -124,7 +124,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
                 scheduledFuture.cancel(true);
                 stopped = true;
                 if (slowStop) {
-                    LOGGER.warn("Timed out " + workUnitDescription.getDisplayName() + " has stopped.");
+                    LOGGER.warn("Timed out {} has stopped.", workUnitDescription.getDisplayName());
                 }
                 return interrupted;
             }


### PR DESCRIPTION
Previously, there was no indication in the logging output that a work unit (e.g. task) was being stopped due to timeout.
This made it hard to diagnose when the work unit failed to respond to the stop, as the build would appear to just hang with no indication as to why.

Now, a message is always logged when the timeout occurs and stop is requested.
If the work unit takes longer than 3s to stop, a message will be logged indicating that it has not yet stopped.
This message will be logged every 3s until the work unit stops.
If this occurs, an extra message will be logged when the work unit finally stops.

Fixes https://github.com/gradle/gradle/issues/14960.

Example output for a fast to stop task:

```
> Task :block
Requesting stop of task ':block' as it has exceeded its configured timeout of 500ms.

> Task :block FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':block'.
> Timeout has been exceeded
```

Slow to stop…

```
> Task :block
Requesting stop of task ':block' as it has exceeded its configured timeout of 500ms.
Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Timed out task ':block' has stopped.

> Task :block FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':block'.
> Timeout has been exceeded
```