### PR TITLE
Only run a small set of performance tests per commit

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -65,7 +65,7 @@ data class CIBuildModel(
                 TestCoverage(3, TestType.platform, Os.LINUX, JvmCategory.MIN_VERSION),
                 TestCoverage(4, TestType.platform, Os.WINDOWS, JvmCategory.MAX_VERSION),
                 TestCoverage(20, TestType.configCache, Os.LINUX, JvmCategory.MIN_VERSION)),
-            performanceTests = listOf(PerformanceTestCoverage(1, PerformanceTestType.test, Os.LINUX, numberOfBuckets = 40, oldUuid = "PerformanceTestTestLinux")),
+            performanceTests = listOf(PerformanceTestCoverage(1, PerformanceTestType.per_commit, Os.LINUX, numberOfBuckets = 40, oldUuid = "PerformanceTestTestLinux")),
             omitsSlowProjects = true),
         Stage(StageNames.READY_FOR_NIGHTLY,
             trigger = Trigger.eachCommit,
@@ -77,8 +77,8 @@ data class CIBuildModel(
                 TestCoverage(6, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION),
                 TestCoverage(28, TestType.watchFs, Os.LINUX, JvmCategory.MAX_VERSION)),
             performanceTests = listOf(
-                PerformanceTestCoverage(6, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5, failsStage = false),
-                PerformanceTestCoverage(7, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5, failsStage = false)
+                PerformanceTestCoverage(6, PerformanceTestType.per_commit, Os.WINDOWS, numberOfBuckets = 5, failsStage = false),
+                PerformanceTestCoverage(7, PerformanceTestType.per_commit, Os.MACOS, numberOfBuckets = 5, failsStage = false)
             )
         ),
         Stage(StageNames.READY_FOR_RELEASE,
@@ -102,7 +102,7 @@ data class CIBuildModel(
                 TestCoverage(31, TestType.watchFs, Os.MACOS, JvmCategory.MIN_VERSION),
                 TestCoverage(30, TestType.watchFs, Os.WINDOWS, JvmCategory.MAX_VERSION)),
             performanceTests = listOf(
-                PerformanceTestCoverage(2, PerformanceTestType.slow, Os.LINUX, numberOfBuckets = 30, oldUuid = "PerformanceTestSlowLinux")
+                PerformanceTestCoverage(2, PerformanceTestType.per_day, Os.LINUX, numberOfBuckets = 30, oldUuid = "PerformanceTestSlowLinux")
             )),
         Stage(StageNames.HISTORICAL_PERFORMANCE,
             trigger = Trigger.weekly,
@@ -111,9 +111,9 @@ data class CIBuildModel(
                 PerformanceTestCoverage(4, PerformanceTestType.flakinessDetection, Os.LINUX, numberOfBuckets = 60, oldUuid = "PerformanceTestFlakinessDetectionLinux"),
                 PerformanceTestCoverage(15, PerformanceTestType.flakinessDetection, Os.WINDOWS, numberOfBuckets = 10),
                 PerformanceTestCoverage(16, PerformanceTestType.flakinessDetection, Os.MACOS, numberOfBuckets = 10),
-                PerformanceTestCoverage(5, PerformanceTestType.experiment, Os.LINUX, numberOfBuckets = 20, oldUuid = "PerformanceTestExperimentLinux"),
-                PerformanceTestCoverage(8, PerformanceTestType.experiment, Os.WINDOWS, numberOfBuckets = 5),
-                PerformanceTestCoverage(9, PerformanceTestType.experiment, Os.MACOS, numberOfBuckets = 5)
+                PerformanceTestCoverage(5, PerformanceTestType.per_week, Os.LINUX, numberOfBuckets = 20, oldUuid = "PerformanceTestExperimentLinux"),
+                PerformanceTestCoverage(8, PerformanceTestType.per_week, Os.WINDOWS, numberOfBuckets = 5),
+                PerformanceTestCoverage(9, PerformanceTestType.per_week, Os.MACOS, numberOfBuckets = 5)
             )),
         Stage(StageNames.EXPERIMENTAL,
             trigger = Trigger.never,
@@ -168,10 +168,10 @@ data class CIBuildModel(
             trigger = Trigger.never,
             runsIndependent = true,
             performanceTests = listOf(
-                PerformanceTestCoverage(10, PerformanceTestType.test, Os.LINUX, numberOfBuckets = 40, withoutDependencies = true),
-                PerformanceTestCoverage(11, PerformanceTestType.test, Os.WINDOWS, numberOfBuckets = 5, withoutDependencies = true),
-                PerformanceTestCoverage(12, PerformanceTestType.test, Os.MACOS, numberOfBuckets = 5, withoutDependencies = true),
-                PerformanceTestCoverage(13, PerformanceTestType.slow, Os.LINUX, numberOfBuckets = 30, withoutDependencies = true)
+                PerformanceTestCoverage(10, PerformanceTestType.per_commit, Os.LINUX, numberOfBuckets = 40, withoutDependencies = true),
+                PerformanceTestCoverage(11, PerformanceTestType.per_commit, Os.WINDOWS, numberOfBuckets = 5, withoutDependencies = true),
+                PerformanceTestCoverage(12, PerformanceTestType.per_commit, Os.MACOS, numberOfBuckets = 5, withoutDependencies = true),
+                PerformanceTestCoverage(13, PerformanceTestType.per_day, Os.LINUX, numberOfBuckets = 30, withoutDependencies = true)
             )
         )
     ),
@@ -306,19 +306,19 @@ enum class PerformanceTestType(
     val channel: String,
     val extraParameters: String = ""
 ) {
-    test(
+    per_commit(
         displayName = "Performance Regression Test",
         timeout = 420,
         defaultBaselines = "defaults",
         channel = "commits"
     ),
-    slow(
+    per_day(
         displayName = "Slow Performance Regression Test",
         timeout = 420,
         defaultBaselines = "defaults",
         channel = "commits"
     ),
-    experiment(
+    per_week(
         displayName = "Performance Experiment",
         timeout = 420,
         defaultBaselines = "defaults",

--- a/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/PerformanceTestBucketProvider.kt
@@ -142,7 +142,7 @@ fun determineScenarioTestDurations(os: Os, performanceTestDurations: OperatingSy
 
 fun determineScenariosFor(performanceTestSpec: PerformanceTestSpec, performanceTestConfigurations: List<PerformanceTestConfiguration>): List<PerformanceScenario> {
     val performanceTestTypes = if (performanceTestSpec.performanceTestType in setOf(PerformanceTestType.historical, PerformanceTestType.flakinessDetection)) {
-        listOf(PerformanceTestType.test, PerformanceTestType.slow)
+        listOf(PerformanceTestType.per_commit, PerformanceTestType.per_day)
     } else {
         listOf(performanceTestSpec.performanceTestType)
     }

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -4,12 +4,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -17,7 +17,7 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux", "windows" ]
+        "per_day" : [ "linux", "windows" ]
       }
     } ]
   }, {
@@ -25,12 +25,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -38,12 +38,12 @@
     "groups" : [ {
       "testProject" : "mediumJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -51,12 +51,12 @@
     "groups" : [ {
       "testProject" : "mediumJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -64,12 +64,12 @@
     "groups" : [ {
       "testProject" : "mediumJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -77,12 +77,12 @@
     "groups" : [ {
       "testProject" : "mediumJavaMultiProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -90,22 +90,22 @@
     "groups" : [ {
       "testProject" : "bigNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "multiNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "smallNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -113,17 +113,17 @@
     "groups" : [ {
       "testProject" : "bigPCHNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumPCHNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "smallPCHNative",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -131,12 +131,12 @@
     "groups" : [ {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidJavaBuild",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -144,12 +144,12 @@
     "groups" : [ {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidJavaBuild",
       "coverage" : {
-        "experiment" : [ "linux" ]
+        "per_week" : [ "linux" ]
       }
     } ]
   }, {
@@ -157,7 +157,7 @@
     "groups" : [ {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "experiment" : [ "linux", "macOs", "windows" ]
+        "per_week" : [ "linux", "macOs", "windows" ]
       }
     } ]
   }, {
@@ -165,7 +165,7 @@
     "groups" : [ {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -173,7 +173,7 @@
     "groups" : [ {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -181,12 +181,12 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -194,7 +194,7 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -202,12 +202,7 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
-      "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -215,12 +210,12 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -228,7 +223,7 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -236,12 +231,12 @@
     "groups" : [ {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -250,7 +245,7 @@
       "testProject" : "largeJavaMultiProject",
       "comment" : "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -259,7 +254,7 @@
       "testProject" : "largeJavaMultiProject",
       "comment" : "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation.",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -267,12 +262,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -280,12 +275,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -293,12 +288,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -306,12 +301,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -319,12 +314,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -332,17 +327,17 @@
     "groups" : [ {
       "testProject" : "bigCppApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigCppMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigNative",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -350,12 +345,12 @@
     "groups" : [ {
       "testProject" : "bigSwiftApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumSwiftMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -363,7 +358,7 @@
     "groups" : [ {
       "testProject" : "archivePerformanceProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -371,7 +366,7 @@
     "groups" : [ {
       "testProject" : "archivePerformanceProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -379,7 +374,7 @@
     "groups" : [ {
       "testProject" : "archivePerformanceProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -387,7 +382,7 @@
     "groups" : [ {
       "testProject" : "generateLotsOfDeprecationWarnings",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -395,7 +390,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -403,7 +398,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -411,12 +406,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     } ]
   }, {
@@ -424,12 +419,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     } ]
   }, {
@@ -437,12 +432,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     } ]
   }, {
@@ -450,12 +445,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     }, {
       "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
-        "test" : [ "linux", "windows", "macOs" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     } ]
   }, {
@@ -463,12 +458,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -476,12 +471,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -489,7 +484,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -497,7 +492,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -505,7 +500,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -513,7 +508,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -521,7 +516,7 @@
     "groups" : [ {
       "testProject" : "excludeRuleMergingBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -529,7 +524,7 @@
     "groups" : [ {
       "testProject" : "springBootApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -537,7 +532,7 @@
     "groups" : [ {
       "testProject" : "springBootApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -545,17 +540,17 @@
     "groups" : [ {
       "testProject" : "bigNative",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -563,7 +558,7 @@
     "groups" : [ {
       "testProject" : "withVerboseJUnit",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -571,12 +566,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -584,7 +579,7 @@
     "groups" : [ {
       "testProject" : "createLotsOfTasks",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -592,12 +587,12 @@
     "groups" : [ {
       "testProject" : "withVerboseJUnit",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "withVerboseTestNG",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -605,17 +600,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -623,17 +618,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -641,22 +636,22 @@
     "groups" : [ {
       "testProject" : "largeGroovyMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicGroovyProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -664,22 +659,22 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumJavaCompositeBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumJavaPredefinedCompositeBuild",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -687,7 +682,7 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProjectNoBuildSrc",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -695,12 +690,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProjectNoBuildSrc",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "smallJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -708,7 +703,7 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProjectNoBuildSrc",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -716,12 +711,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProjectNoBuildSrc",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "smallJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -729,17 +724,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -747,12 +742,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -760,17 +755,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -778,17 +773,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -796,17 +791,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProjectKotlinDsl",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -814,12 +809,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -827,12 +822,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -840,22 +835,22 @@
     "groups" : [ {
       "testProject" : "largeGroovyMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicGroovyProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -863,12 +858,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -876,12 +871,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -889,17 +884,17 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumJavaMultiProjectWithTestNG",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -907,12 +902,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -920,7 +915,7 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux", "windows" ]
+        "per_commit" : [ "linux", "windows" ]
       }
     } ]
   }, {
@@ -928,12 +923,12 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -941,7 +936,7 @@
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -949,7 +944,7 @@
     "groups" : [ {
       "testProject" : "nativeDependents",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -957,7 +952,7 @@
     "groups" : [ {
       "testProject" : "nativeDependents",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -965,12 +960,12 @@
     "groups" : [ {
       "testProject" : "bigCppApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigCppMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -978,12 +973,12 @@
     "groups" : [ {
       "testProject" : "bigCppApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigCppMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -991,12 +986,12 @@
     "groups" : [ {
       "testProject" : "bigCppApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigCppMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1004,62 +999,62 @@
     "groups" : [ {
       "testProject" : "bigCppApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigCppMulti",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "bigNative",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumCppApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumCppAppWithMacroIncludes",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumCppMulti",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumCppMultiWithMacroIncludes",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumNative",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "multiNative",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "smallCppApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "smallCppMulti",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "smallNative",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -1067,7 +1062,7 @@
     "groups" : [ {
       "testProject" : "manyProjectsNative",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -1075,12 +1070,12 @@
     "groups" : [ {
       "testProject" : "nativeMonolithic",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "nativeMonolithicOverlapping",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1088,12 +1083,12 @@
     "groups" : [ {
       "testProject" : "nativeMonolithic",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     }, {
       "testProject" : "nativeMonolithicOverlapping",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1101,7 +1096,7 @@
     "groups" : [ {
       "testProject" : "smallNativeMonolithic",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1109,7 +1104,7 @@
     "groups" : [ {
       "testProject" : "mediumNativeMonolithic",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1117,7 +1112,7 @@
     "groups" : [ {
       "testProject" : "mediumNativeMonolithic",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_commit" : [ "linux" ]
       }
     } ]
   }, {
@@ -1125,12 +1120,12 @@
     "groups" : [ {
       "testProject" : "bigSwiftApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumSwiftMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -1138,12 +1133,12 @@
     "groups" : [ {
       "testProject" : "bigSwiftApp",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumSwiftMulti",
       "coverage" : {
-        "test" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   }, {
@@ -1151,12 +1146,12 @@
     "groups" : [ {
       "testProject" : "bigSwiftApp",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     }, {
       "testProject" : "mediumSwiftMulti",
       "coverage" : {
-        "slow" : [ "linux" ]
+        "per_day" : [ "linux" ]
       }
     } ]
   } ]

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -48,9 +48,9 @@ class PerformanceTestBuildTypeTest {
                 functionalTests = listOf(
                     TestCoverage(1, TestType.platform, Os.LINUX, JvmVersion.java8),
                     TestCoverage(2, TestType.platform, Os.WINDOWS, JvmVersion.java11, vendor = JvmVendor.openjdk)),
-                performanceTests = listOf(PerformanceTestCoverage(1, PerformanceTestType.test, Os.LINUX)),
+                performanceTests = listOf(PerformanceTestCoverage(1, PerformanceTestType.per_commit, Os.LINUX)),
                 omitsSlowProjects = true),
-            PerformanceTestCoverage(1, PerformanceTestType.test, Os.LINUX),
+            PerformanceTestCoverage(1, PerformanceTestType.per_commit, Os.LINUX),
             "Description",
             "performance",
             listOf("largeTestProject", "smallTestProject"),

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/RunFor.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/RunFor.groovy
@@ -72,9 +72,9 @@ import static org.gradle.performance.fixture.PerformanceTestScenarioDefinition.P
 }
 
 enum ScenarioType {
-    TEST,
-    SLOW,
-    EXPERIMENT
+    PER_COMMIT,
+    PER_DAY,
+    PER_WEEK
 }
 
 @CompileStatic

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/buildcache/LocalTaskOutputCacheCrossBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/buildcache/LocalTaskOutputCacheCrossBuildPerformanceTest.groovy
@@ -25,11 +25,11 @@ import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearBuildCacheMutator
 
 import static org.gradle.integtests.tooling.fixture.TextUtil.escapeString
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor([
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
 ])
 class LocalTaskOutputCacheCrossBuildPerformanceTest extends AbstractCrossBuildPerformanceTest {
     def "assemble with local cache (build comparison)"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -23,12 +23,12 @@ import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.results.BaselineVersion
 import org.gradle.performance.results.CrossBuildPerformanceResults
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX, WINDOWS], testProjects = ["largeJavaMultiProject"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX, WINDOWS], testProjects = ["largeJavaMultiProject"])
 )
 class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
 )
 class ParallelBuildPerformanceTest extends AbstractCrossBuildPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.performance.fixture.JavaTestProject
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 /**
@@ -31,7 +31,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
  * sure we are always faster than Maven.
  */
 @RunFor(
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects =  ["mediumMonolithicJavaProject", "mediumJavaMultiProject"])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects =  ["mediumMonolithicJavaProject", "mediumJavaMultiProject"])
 )
 class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/nativeplatform/NativeParallelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/nativeplatform/NativeParallelPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects = ['smallNative', 'mediumNative', 'bigNative', 'multiNative'])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects = ['smallNative', 'mediumNative', 'bigNative', 'multiNative'])
 )
 class NativeParallelPerformanceTest extends AbstractCrossBuildPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/nativeplatform/NativePreCompiledHeaderPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/nativeplatform/NativePreCompiledHeaderPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects = ["smallPCHNative", "mediumPCHNative", "bigPCHNative"])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects = ["smallPCHNative", "mediumPCHNative", "bigPCHNative"])
 )
 class NativePreCompiledHeaderPerformanceTest extends AbstractCrossBuildPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -37,13 +37,13 @@ import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearConfigurationCacheStateMutator
 import org.gradle.profiler.mutations.ClearProjectCacheMutator
 
-import static org.gradle.performance.annotations.ScenarioType.EXPERIMENT
+import static org.gradle.performance.annotations.ScenarioType.PER_WEEK
 import static org.gradle.performance.results.OperatingSystem.LINUX
 import static org.gradle.performance.results.OperatingSystem.MAC_OS
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 @RunFor(
-    @Scenario(type = EXPERIMENT, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild", "santaTrackerAndroidJavaBuild"])
+    @Scenario(type = PER_WEEK, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild", "santaTrackerAndroidJavaBuild"])
 )
 class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPerformanceTest {
     private static final String AGP_TARGET_VERSION = "4.2"
@@ -79,7 +79,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     @RunFor([
-        @Scenario(type = EXPERIMENT, operatingSystems = [LINUX, MAC_OS, WINDOWS], testProjects = ["santaTrackerAndroidBuild"])
+        @Scenario(type = PER_WEEK, operatingSystems = [LINUX, MAC_OS, WINDOWS], testProjects = ["santaTrackerAndroidBuild"])
     ])
     def "file system watching baseline non-abi change (build comparison)"() {
         given:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -22,19 +22,15 @@ import org.gradle.performance.fixture.AndroidTestProject
 import org.gradle.performance.fixture.IncrementalAndroidTestProject
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild"])
-)
 class RealLifeAndroidBuildPerformanceTest extends AbstractRealLifeAndroidBuildPerformanceTest {
-
     @Unroll
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild", "largeAndroidBuild"], iterationMatcher = "run help"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "run assembleDebug"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = ".*phthalic.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = "run help"),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "run assembleDebug"),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = ".*phthalic.*")
     ])
     def "run #tasks"() {
         given:
@@ -64,6 +60,9 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractRealLifeAndroidBuildPe
         'clean phthalic:assembleDebug' | 2          | 8
     }
 
+    @RunFor(
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild"])
+    )
     def "abi change"() {
         given:
         def testProject = androidTestProject as IncrementalAndroidTestProject
@@ -79,6 +78,9 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractRealLifeAndroidBuildPe
         result.assertCurrentVersionHasNotRegressed()
     }
 
+    @RunFor(
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild"])
+    )
     def "non-abi change"() {
         given:
         def testProject = androidTestProject as IncrementalAndroidTestProject

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildSlowPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildSlowPerformanceTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearArtifactTransformCacheMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.fixture.AndroidTestProject.LARGE_ANDROID_BUILD
 import static org.gradle.performance.fixture.IncrementalAndroidTestProject.SANTA_TRACKER_KOTLIN
 import static org.gradle.performance.results.OperatingSystem.LINUX
@@ -31,8 +31,8 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class RealLifeAndroidBuildSlowPerformanceTest extends AbstractRealLifeAndroidBuildPerformanceTest {
 
     @RunFor([
-        @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "clean assemble.*"),
-        @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = "clean phthalic.*")
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "clean assemble.*"),
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = "clean phthalic.*")
     ])
     @Unroll
     def "clean #tasks with clean transforms cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -23,11 +23,11 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.AndroidTestProject
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"])
 )
 class RealLifeAndroidStudioMockupPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -24,12 +24,12 @@ import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.test.fixtures.keystore.TestKeyStore
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
 )
 class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
@@ -111,7 +111,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     }
 
     @RunFor(
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
     )
     def "clean assemble with local cache"() {
         given:
@@ -127,7 +127,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"],
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"],
             comment = "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation."
         )
     ])
@@ -147,7 +147,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"],
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"],
             comment = "We only test the multi-project here since for the monolithic project we would have no cache hits. This would mean we actually would test incremental compilation."
         )
     ])

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
@@ -19,12 +19,12 @@ package org.gradle.performance.regression.buildcache
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 // TODO: Merge with TaskOutputCachingJavaPerformanceTest
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["bigCppApp", "bigCppMulti", "bigNative"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["bigCppApp", "bigCppMulti", "bigNative"])
 )
 class TaskOutputCachingNativePerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -19,11 +19,11 @@ package org.gradle.performance.regression.buildcache
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["mediumSwiftMulti", "bigSwiftApp"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["mediumSwiftMulti", "bigSwiftApp"])
 )
 class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
     def setup() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -20,17 +20,19 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
-)
+
 class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.targetVersions = ["6.8-20201028230040+0000"]
     }
 
+    @RunFor(
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
+    )
     def "visiting zip trees"() {
         given:
         runner.tasksToRun = ['visitZip']
@@ -42,6 +44,9 @@ class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
     }
 
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
+    )
     def "visiting tar trees"() {
         given:
         runner.tasksToRun = ['visitTar']
@@ -53,6 +58,9 @@ class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
     }
 
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
+    )
     def "visiting gzip tar trees"() {
         given:
         runner.tasksToRun = ['visitTarGz']

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["generateLotsOfDeprecationWarnings"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["generateLotsOfDeprecationWarnings"])
 )
 class DeprecationCreationPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def "create many deprecation warnings"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.performance.WithExternalRepository
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["excludeRuleMergingBuild"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["excludeRuleMergingBuild"])
 )
 class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -28,14 +28,14 @@ import org.gradle.performance.fixture.TestProjects
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 import static org.gradle.performance.results.OperatingSystem.MAC_OS
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 @Unroll
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = ["santaTrackerAndroidBuild", "largeJavaMultiProject"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = ["santaTrackerAndroidBuild", "largeJavaMultiProject"])
 )
 @LeaksFileHandles("The TAPI keeps handles to the distribution it starts open in the test JVM")
 class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceTest {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
@@ -20,14 +20,14 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject"])
-)
 class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject"])
+    )
     def "eclipse"() {
         given:
         runner.tasksToRun = ['eclipse']
@@ -40,6 +40,9 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         result.assertCurrentVersionHasNotRegressed()
     }
 
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject"])
+    )
     def "idea"() {
         given:
         runner.tasksToRun = ['idea']

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -23,11 +23,11 @@ import org.gradle.performance.annotations.Scenario
 import spock.lang.Ignore
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["excludeRuleMergingBuild"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["excludeRuleMergingBuild"])
 )
 class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -34,11 +34,11 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import java.util.concurrent.atomic.AtomicInteger
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ["springBootApp"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["springBootApp"])
 )
 class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
     File tmpRepoDir = temporaryFolder.createDir('repository')

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
@@ -21,7 +21,8 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class RichConsolePerformanceTest extends AbstractCrossVersionPerformanceTest {
@@ -31,10 +32,9 @@ class RichConsolePerformanceTest extends AbstractCrossVersionPerformanceTest {
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject", "bigNative"],
-            iterationMatcher = "^clean assemble.*"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["withVerboseJUnit"],
-            iterationMatcher = "^cleanTest.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject"], iterationMatcher = "^clean assemble.*"),
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "bigNative"], iterationMatcher = "^clean assemble.*"),
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["withVerboseJUnit"], iterationMatcher = "^cleanTest.*")
     ])
     @Unroll
     def "#tasks with rich console"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskAvoidancePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskAvoidancePerformanceTest.groovy
@@ -21,10 +21,10 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(@Scenario(type = TEST, operatingSystems = [LINUX], testProjects =  ["largeJavaMultiProject", "largeMonolithicJavaProject"]))
+@RunFor(@Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects =  ["largeJavaMultiProject", "largeMonolithicJavaProject"]))
 class TaskAvoidancePerformanceTest extends AbstractCrossBuildPerformanceTest {
 
     def "help with lazy and eager tasks"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["createLotsOfTasks"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["createLotsOfTasks"])
 )
 class TaskCreationPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["withVerboseTestNG", "withVerboseJUnit"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["withVerboseTestNG", "withVerboseJUnit"])
 )
 class VerboseTestOutputPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/BuildSrcApiChangePerformanceTest.groovy
@@ -25,11 +25,11 @@ import org.gradle.performance.mutator.ApplyNonAbiChangeToGroovySourceFileMutator
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX],
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX],
         testProjects = ["mediumMonolithicJavaProject", "largeJavaMultiProject", "largeJavaMultiProjectKotlinDsl"])
 )
 class BuildSrcApiChangePerformanceTest extends AbstractCrossVersionPerformanceTest {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -23,12 +23,14 @@ import org.gradle.performance.fixture.JavaTestProject
 import org.gradle.performance.mutator.ApplyAbiChangeToGroovySourceFileMutator
 import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "largeMonolithicGroovyProject", "largeGroovyMultiProject"])
-)
+@RunFor([
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeGroovyMultiProject"]),
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeMonolithicGroovyProject", "largeMonolithicJavaProject"])
+])
 class JavaABIChangePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def "assemble for abi change"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -20,12 +20,14 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "mediumJavaCompositeBuild", "mediumJavaPredefinedCompositeBuild"])
-)
+@RunFor([
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "mediumJavaCompositeBuild"]),
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["mediumJavaPredefinedCompositeBuild"])
+])
 class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def "clean assemble"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -27,7 +27,8 @@ import spock.lang.Unroll
 
 import java.nio.file.Files
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 import static org.junit.Assert.assertTrue
 
@@ -39,9 +40,11 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc", "smallJavaMultiProject"],
-            iterationMatcher = ".*with hot.*"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc"], iterationMatcher = ".*with cold.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["smallJavaMultiProject"], iterationMatcher = ".*with hot.*"),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc"], iterationMatcher = "assemble loading configuration cache state with cold daemon"),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc"], iterationMatcher = "assemble storing configuration cache state with hot daemon"),
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc"], iterationMatcher = "assemble storing configuration cache state with cold daemon"),
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProjectNoBuildSrc"], iterationMatcher = "assemble loading configuration cache state with hot daemon")
     ])
     @Unroll
     def "assemble #action configuration cache state with #daemon daemon"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "largeJavaMultiProjectKotlinDsl"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "largeJavaMultiProjectKotlinDsl"])
 )
 class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
@@ -21,12 +21,12 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.generator.JavaTestProjectGenerator.LARGE_JAVA_MULTI_PROJECT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
 )
 class JavaDependencyReportPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -23,12 +23,12 @@ import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearGradleUserHomeMutator
 import org.gradle.profiler.mutations.ClearProjectCacheMutator
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.generator.JavaTestProjectGenerator.LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject", "largeJavaMultiProjectKotlinDsl"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeMonolithicJavaProject", "largeJavaMultiProject", "largeJavaMultiProjectKotlinDsl"])
 )
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -23,12 +23,12 @@ import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaProject
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.generator.JavaTestProjectGenerator.LARGE_MONOLITHIC_JAVA_PROJECT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
 )
 class JavaIDEModelPerformanceTest extends AbstractCrossVersionPerformanceTest {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -24,11 +24,11 @@ import org.gradle.performance.mutator.ApplyNonAbiChangeToGroovySourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor([
-    @Scenario(type = TEST, operatingSystems = [LINUX],
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX],
         testProjects = ["largeJavaMultiProject", "largeGroovyMultiProject", "largeMonolithicJavaProject", "largeMonolithicGroovyProject"])
 ])
 class JavaNonABIChangePerformanceTest extends AbstractCrossVersionPerformanceTest {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
@@ -20,17 +20,18 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
-)
 class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.targetVersions = ["6.8-20201117230037+0000"]
     }
 
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    )
     def "tasks"() {
         given:
         runner.tasksToRun = ['tasks']
@@ -42,6 +43,9 @@ class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
     }
 
+    @RunFor(
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"])
+    )
     def "tasks --all"() {
         given:
         runner.tasksToRun = ['tasks', '--all']

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
@@ -22,11 +22,11 @@ import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.JavaTestProject
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "mediumJavaMultiProjectWithTestNG", "largeMonolithicJavaProject"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "mediumJavaMultiProjectWithTestNG", "largeMonolithicJavaProject"])
 )
 class JavaTestChangePerformanceTest extends AbstractCrossVersionPerformanceTest {
     def "test for non-abi change"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -24,14 +24,14 @@ import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearBuildCacheMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX, WINDOWS], testProjects = ["largeJavaMultiProject"], iterationMatcher = '.*parallel true.*'),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS], testProjects = ["largeJavaMultiProject"], iterationMatcher = '.*parallel true.*'),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
     ])
     @Unroll
     def "up-to-date assemble (parallel #parallel)"() {
@@ -51,8 +51,8 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"], iterationMatcher = '.*parallel true.*'),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject"], iterationMatcher = '.*parallel true.*'),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
     ])
     @Unroll
     def "up-to-date assemble with local build cache enabled (parallel #parallel)"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerformanceTest {
@@ -32,7 +32,7 @@ class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerforman
     }
 
     @RunFor(
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["nativeDependents"], iterationMatcher = ".*libA0.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["nativeDependents"], iterationMatcher = ".*libA0.*")
     )
     @Unroll
     def "run #task"() {
@@ -55,7 +55,7 @@ class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerforman
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["nativeDependents"], iterationMatcher = ".*libA0.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["nativeDependents"], iterationMatcher = ".*libA0.*")
     ])
     @Unroll
     def "run #subprojectPath:dependentComponents"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -22,12 +22,14 @@ import org.gradle.performance.annotations.Scenario
 import org.gradle.profiler.mutations.ApplyChangeToNativeSourceFileMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
-@RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["bigCppApp", "bigCppMulti"])
-)
+@RunFor([
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["bigCppMulti"]),
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["bigCppApp"])
+])
 class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class NativeCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
@@ -30,7 +30,7 @@ class NativeCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTes
     }
 
     @RunFor([
-        @Scenario(type = SLOW, operatingSystems = [LINUX],
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX],
             testProjects =  [
                 'smallNative',
                 'mediumNative',
@@ -62,7 +62,7 @@ class NativeCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTes
     }
 
     @RunFor([
-        @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects =  ['manyProjectsNative'])
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects =  ['manyProjectsNative'])
     ])
     def "clean assemble (native, parallel)"() {
         given:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -24,11 +24,11 @@ import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildMutator
 import spock.lang.Unroll
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["nativeMonolithic", "nativeMonolithicOverlapping"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["nativeMonolithic", "nativeMonolithicOverlapping"])
 )
 class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
@@ -60,8 +60,8 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
     }
 
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["mediumNativeMonolithic"], iterationMatcher = ".*(header|source) file.*"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["smallNativeMonolithic"], iterationMatcher = ".*build file.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["mediumNativeMonolithic"], iterationMatcher = ".*(header|source) file.*"),
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["smallNativeMonolithic"], iterationMatcher = ".*build file.*")
     ])
     @Unroll
     def "build with #changeType file change"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
@@ -22,11 +22,11 @@ import org.gradle.performance.annotations.Scenario
 import org.gradle.profiler.BuildContext
 import org.gradle.profiler.mutations.AbstractFileChangeMutator
 
-import static org.gradle.performance.annotations.ScenarioType.TEST
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["mediumSwiftMulti", "bigSwiftApp"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["mediumSwiftMulti", "bigSwiftApp"])
 )
 class SwiftBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 
-import static org.gradle.performance.annotations.ScenarioType.SLOW
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = SLOW, operatingSystems = [LINUX], testProjects = ['mediumSwiftMulti', 'bigSwiftApp'])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ['mediumSwiftMulti', 'bigSwiftApp'])
 )
 class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
 


### PR DESCRIPTION
### Context

There's a huge size of performance test set run per commit. Let's keep only core set of performance tests running in `ReadyForMerge` and `ReadyForNightly` phase to improve feedback time.