### PR TITLE
Improve handling of enforced platforms

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -58,7 +58,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{strictly 15}' because of the following reason: what not""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{strictly 15}' because of the following reason: what not""")
 
     }
 
@@ -254,7 +254,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{require 1.0; reject 1.1}'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject 1.1}'""")
     }
 
     @Unroll
@@ -291,7 +291,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
 
         where:
         rejects << [
@@ -334,7 +334,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
    Dependency path ':test:unspecified' --> 'org:foo:1.0'
-   Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{reject all versions}'""")
+   Constraint path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{reject all versions}'""")
 
     }
 
@@ -390,8 +390,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
+   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
         failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
@@ -450,8 +450,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
+   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
         failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -478,7 +478,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo:{strictly 15}'""")
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' (conf) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -564,7 +564,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'org:bar:1' --> 'org:foo:{strictly 15}'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1' (runtime) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -794,9 +794,10 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         fails ':checkDeps'
 
         then:
+        def selected = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo:{require 1.0; reject 1.1}'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
     }
 
     def "can reject a version range"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -160,7 +160,7 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:databind:{strictly 2.7.9}'
-   Constraint path ':test:unspecified' --> 'org:platform:2.9.4' --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Constraint path ':test:unspecified' --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {
@@ -208,9 +208,10 @@ include 'other'
         fails ':checkDeps'
 
         then:
+        def coreVariant = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:databind:{strictly 2.7.9}'
-   Constraint path ':test:unspecified' --> 'test:other:unspecified' --> 'org:core:2.9.4' --> 'org:platform:2.9.4' --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Constraint path ':test:unspecified' --> 'test:other:unspecified' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "succeeds if forcing a virtual platform version by forcing multiple leaves with same version"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -123,7 +123,7 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:1.1'
    Constraint path ':test:unspecified' --> 'org:foo:{reject all versions}'""")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -857,7 +857,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB:{strictly 1.0}'"""
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{strictly 1.0}'"""
 
         where:
         thing                    | defineAsConstraint
@@ -930,7 +930,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
 
         where:
         thing                    | defineAsConstraint

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -190,8 +190,8 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:foo'
-   Constraint path ':test:unspecified' --> 'org:platform-a:1.0' --> 'org:foo:{strictly 1.0}'
-   Constraint path ':test:unspecified' --> 'org:platform-b:1.0' --> 'org:foo:{strictly 2.0}'"""
+   Constraint path ':test:unspecified' --> 'org:platform-a:1.0' (runtime) --> 'org:foo:{strictly 1.0}'
+   Constraint path ':test:unspecified' --> 'org:platform-b:1.0' (runtime) --> 'org:foo:{strictly 2.0}'"""
     }
 
     @ToBeFixedForConfigurationCache

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -236,7 +236,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:bar' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'test:foo:unspecified' --> 'org:bar:2.0'
+   Dependency path ':test:unspecified' --> 'test:foo:unspecified' (conf) --> 'org:bar:2.0'
    Constraint path ':test:unspecified' --> 'org:bar:{strictly 1.0}'"""
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -271,8 +271,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         then:
         failure.assertHasCause """Cannot find a version of 'org:c' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:c:2.0'
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:c:{strictly 1.0}'
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b:1.0' --> 'org:c:2.0'"""
+   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:c:{strictly 1.0}'
+   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:1.0' (runtime) --> 'org:c:2.0'"""
     }
 
     def "strict from selected and later evicted modules are ignored"() {
@@ -547,8 +547,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:x1:1.0' --> 'org:bar:1.0' --> 'org:foo:2.0'
-   Constraint path ':test:unspecified' --> 'org:x1:1.0' --> 'org:foo:{strictly 1.0}'"""
+   Dependency path ':test:unspecified' --> 'org:x1:1.0' (runtime) --> 'org:bar:1.0' (runtime) --> 'org:foo:2.0'
+   Constraint path ':test:unspecified' --> 'org:x1:1.0' (runtime) --> 'org:foo:{strictly 1.0}'"""
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -317,10 +317,11 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
             fails ':checkDeps'
         }
         then:
+        def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
         (platformType == ENFORCED_PLATFORM && !failure) || failure.assertHasCause(
             """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'org:platform:1.1' --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
+   Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
    Constraint path ':test:unspecified' --> 'org:foo:3.2'""")
 
         where:
@@ -382,8 +383,8 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         then:
         if (platformType == ENFORCED_PLATFORM) {
             failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
+   Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
    Constraint path ':test:unspecified' --> 'org:foo:{strictly 3.2}'"""
         } else {
             resolve.expectGraph {
@@ -469,15 +470,16 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         then:
         if (platformType == ENFORCED_PLATFORM) {
             failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:foo:{strictly 3.2}'"""
+   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:foo:{strictly 3.2}'"""
         } else {
+            def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
             failure.assertHasCause(
                 """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:platform:1.1' --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:foo:{strictly 3.2}'""")
+   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:foo:{strictly 3.2}'""")
         }
 
         where:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -365,20 +365,17 @@ class EdgeState implements DependencyGraphEdge {
         return selectedComponent != null && selectedComponent.getModule().isVirtualPlatform();
     }
 
+    boolean hasSelectedVariant() {
+        return resolvedVariant != null || !findTargetNodes().isEmpty();
+    }
+
     @Override
     @Nullable
     public ResolvedVariantResult getSelectedVariant() {
         if (resolvedVariant != null) {
             return resolvedVariant;
         }
-        List<NodeState> targetNodes = this.targetNodes;
-        if (targetNodes.isEmpty()) {
-            // happens for substituted dependencies
-            ComponentState targetComponent = getTargetComponent();
-            if (targetComponent != null) {
-                targetNodes = targetComponent.getNodes();
-            }
-        }
+        List<NodeState> targetNodes = findTargetNodes();
         assert !targetNodes.isEmpty();
         for (NodeState targetNode : targetNodes) {
             if (targetNode.isSelected()) {
@@ -387,6 +384,18 @@ class EdgeState implements DependencyGraphEdge {
             }
         }
         return null;
+    }
+
+    private List<NodeState> findTargetNodes() {
+        List<NodeState> targetNodes = this.targetNodes;
+        if (targetNodes.isEmpty()) {
+            // happens for substituted dependencies
+            ComponentState targetComponent = getTargetComponent();
+            if (targetComponent != null) {
+                targetNodes = targetComponent.getNodes();
+            }
+        }
+        return targetNodes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -20,12 +20,20 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.ForcingDependencyMetadata;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 abstract class MessageBuilderHelper {
+    private static boolean isDependencyForced(DependencyMetadata dependency) {
+        return dependency instanceof ForcingDependencyMetadata && ((ForcingDependencyMetadata) dependency).isForce();
+    }
+
     static Collection<String> pathTo(EdgeState edge) {
         return pathTo(edge, true);
     }
@@ -43,6 +51,7 @@ abstract class MessageBuilderHelper {
                 sb.append("Dependency path ");
             }
             boolean first = true;
+            String variantDetails = null;
             for (EdgeState e : path) {
                 if (!first) {
                     sb.append(" --> ");
@@ -50,15 +59,32 @@ abstract class MessageBuilderHelper {
                 first = false;
                 ModuleVersionIdentifier id = e.getFrom().getResolvedConfigurationId().getId();
                 sb.append('\'').append(id).append('\'');
+                if (variantDetails != null) {
+                    sb.append(variantDetails);
+                }
+                variantDetails = variantDetails(e);
             }
             if (includeLast) {
                 sb.append(" --> ");
-                ModuleIdentifier moduleId = edge.getSelector().getTargetModule().getId();
+                SelectorState selector = edge.getSelector();
+                ModuleIdentifier moduleId = selector.getTargetModule().getId();
                 sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName()).append('\'');
+                if (variantDetails != null) {
+                    sb.append(variantDetails);
+                }
             }
             result.add(sb.toString());
         }
         return result;
+    }
+
+    @Nullable
+    private static String variantDetails(EdgeState e) {
+        ResolvedVariantResult selectedVariant = e.hasSelectedVariant() ? e.getSelectedVariant() : null;
+        if (selectedVariant != null) {
+            return " (" + selectedVariant.getDisplayName() + ")";
+        }
+        return null;
     }
 
     static void pathTo(EdgeState component, List<EdgeState> currentPath, List<List<EdgeState>> accumulator, Set<NodeState> alreadySeen) {

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
@@ -106,3 +106,16 @@ There are differences between the two types of repository, particularly around t
 ====
 
 That's everything for the basic use case. However, many projects need more control over what gets published, so we look at several common scenarios in the following sections.
+
+[[sec:suppressing_validation_errors]]
+== Suppressing validation errors
+
+Gradle performs validation of generated module metadata.
+In some cases, validation can fail, indicating that you most likely have an error to fix, but you may have done something intentionally.
+If this is the case, Gradle will indicate the name of the validation error you can disable on the `GenerateModuleMetadata` tasks:
+
+.Disabling some validation errors
+====
+include::sample[dir="snippets/publishing/javaLibrary/groovy",files="build.gradle[tags=disable_validation]"]
+include::sample[dir="snippets/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=disable_validation]"]
+====

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
@@ -52,3 +52,11 @@ publishing {
     }
 }
 // end::disable-build-id[]
+
+// tag::disable_validation[]
+tasks.withType(GenerateModuleMetadata).configureEach {
+    // The value 'enforced_platform' is provided in the validation
+    // error message you got
+    suppressedValidationErrors.add('enforced_platform')
+}
+// end::disable_validation[]

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
@@ -52,3 +52,11 @@ publishing {
     }
 }
 // end::disable-build-id[]
+
+// tag::disable_validation[]
+tasks.withType<GenerateModuleMetadata> {
+    // The value 'enforced_platform' is provided in the validation
+    // error message you got
+    suppressedValidationErrors.add("enforced_platform")
+}
+// end::disable_validation[]

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
@@ -18,6 +18,7 @@
 package org.gradle.api.publish.ivy
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import spock.lang.Issue
 
 class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
 
@@ -239,4 +240,82 @@ class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
         outputContains("Publication ignores 'transitive = false' at configuration level.")
     }
 
+    @ToBeFixedForConfigurationCache(because = "configuration cache doesn't support task failures")
+    @Issue("https://github.com/gradle/gradle/issues/15009")
+    def "fails publishing if a variant contains a dependency on an enforced platform"() {
+        settingsFile << """
+            rootProject.name = 'publish'
+        """
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'ivy-publish'
+            }
+
+            dependencies {
+                implementation enforcedPlatform('org:platform:1.0')
+            }
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        when:
+        fails ':publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - Variant 'runtimeElements' contains a dependency on enforced platform 'org:platform'
+In general publishing dependencies to enforced platforms is a mistake: enforced platforms shouldn't be used for published components because they behave like forced dependencies and leak to consumers. This can result in hard to diagnose dependency resolution errors. If you did this intentionally you can disable this check by adding 'enforced-platform' to the suppressed validations of the :generateMetadataFileForIvyPublication task."""
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/15009")
+    @ToBeFixedForConfigurationCache(because = "configuration cache doesn't support task failures")
+    def "can disable validation of publication of dependencies on enforced platforms"() {
+        settingsFile << """
+            rootProject.name = 'publish'
+        """
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'ivy-publish'
+            }
+
+            group = 'com.acme'
+            version = '0.999'
+
+            dependencies {
+                implementation enforcedPlatform('org:platform:1.0')
+            }
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+
+            tasks.named('generateMetadataFileForIvyPublication') {
+                suppressedValidationErrors.add('enforced-platform')
+            }
+        """
+
+        when:
+        succeeds ':publish'
+
+        then:
+        executedAndNotSkipped ':generateMetadataFileForIvyPublication', ':publishIvyPublicationToIvyRepository'
+    }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/DependencyAttributesValidator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/DependencyAttributesValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.internal.metadata;
+
+import org.gradle.api.attributes.AttributeContainer;
+
+import java.util.Optional;
+
+public interface DependencyAttributesValidator {
+    String getSuppressor();
+    String getExplanation();
+
+    Optional<String> validationErrorFor(String group, String name, AttributeContainer attributes);
+}

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/EnforcedPlatformPublicationValidator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/EnforcedPlatformPublicationValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.internal.metadata;
+
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Category;
+
+import java.util.Optional;
+
+public class EnforcedPlatformPublicationValidator implements DependencyAttributesValidator {
+    private final static String SUPPRESSION = "enforced-platform";
+    private final static String LONG_EXPLANATION = "In general publishing dependencies to enforced platforms is a mistake: " +
+        "enforced platforms shouldn't be used for published components because they behave like forced dependencies and leak to consumers. " +
+        "This can result in hard to diagnose dependency resolution errors.";
+
+    @Override
+    public String getSuppressor() {
+        return SUPPRESSION;
+    }
+
+    @Override
+    public String getExplanation() {
+        return LONG_EXPLANATION;
+    }
+
+    @Override
+    public Optional<String> validationErrorFor(String group, String name, AttributeContainer attributes) {
+        Category category = attributes.getAttribute(Category.CATEGORY_ATTRIBUTE);
+        if (category != null) {
+            if (Category.ENFORCED_PLATFORM.equals(category.getName())) {
+                return Optional.of("contains a dependency on enforced platform '" + group + ":" + name + "'");
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriter.java
@@ -26,6 +26,7 @@ import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * <p>The Gradle module metadata file generator is responsible for generating a JSON file
@@ -45,11 +46,19 @@ public class GradleModuleMetadataWriter {
     private final BuildInvocationScopeId buildInvocationScopeId;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final ChecksumService checksumService;
+    private final String taskPath;
+    private final List<DependencyAttributesValidator> dependencyAttributeValidators;
 
-    public GradleModuleMetadataWriter(BuildInvocationScopeId buildInvocationScopeId, ProjectDependencyPublicationResolver projectDependencyResolver, ChecksumService checksumService) {
+    public GradleModuleMetadataWriter(BuildInvocationScopeId buildInvocationScopeId,
+                                      ProjectDependencyPublicationResolver projectDependencyResolver,
+                                      ChecksumService checksumService,
+                                      String taskPath,
+                                      List<DependencyAttributesValidator> dependencyAttributeValidators) {
         this.buildInvocationScopeId = buildInvocationScopeId;
         this.projectDependencyResolver = projectDependencyResolver;
         this.checksumService = checksumService;
+        this.taskPath = taskPath;
+        this.dependencyAttributeValidators = dependencyAttributeValidators;
     }
 
     public void writeTo(Writer writer, PublicationInternal<?> publication, Collection<? extends PublicationInternal<?>> publications) throws IOException {
@@ -75,13 +84,13 @@ public class GradleModuleMetadataWriter {
     }
 
     public ModuleMetadataSpec moduleMetadataSpecFor(PublicationInternal<?> publication, Collection<? extends PublicationInternal<?>> publications) {
-        InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName());
+        InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName(), taskPath);
         ModuleMetadataSpec spec = new ModuleMetadataSpecBuilder(
             publication,
             publications,
             checker,
-            projectDependencyResolver
-        ).build();
+            projectDependencyResolver,
+            dependencyAttributeValidators).build();
         checker.validate();
         return spec;
     }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -73,7 +73,7 @@ class GradleModuleMetadataWriterTest extends Specification {
 
     private writeTo(Writer writer, PublicationInternal publication, List<PublicationInternal> publications) {
         new GradleModuleMetadataWriter(
-            new BuildInvocationScopeId(buildId), projectDependencyResolver, TestUtil.checksumService
+            new BuildInvocationScopeId(buildId), projectDependencyResolver, TestUtil.checksumService, ':task', []
         ).writeTo(
             writer, publication, publications
         )


### PR DESCRIPTION
### Context

This pull request improves the handling of "enforced platforms" in two cases:

- if Gradle is consuming an enforced platform transitively and that a strict dependency conflicts with what the platform declared, it was very hard to figure out from the error message. This is improved by adding the selected variant to the error message, so that we have a clue.
- when publishing, Gradle will by default disallow generation of Gradle module metadata referencing an enforced platform, as it would generally be an error to do so. It is however possible to disable validation.

