### PR TITLE
Store compiled Kotlin project scripts in the build cache

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -77,6 +77,7 @@ class Interpreter(val host: Host) {
         )
 
         fun cachedDirFor(
+            scriptHost: KotlinScriptHost<*>,
             templateId: String,
             sourceHash: HashCode,
             compilationClassPath: ClassPath,
@@ -249,6 +250,7 @@ class Interpreter(val host: Host) {
 
         val scriptPath = scriptHost.fileName
         val classesDir = compile(
+            scriptHost,
             templateId,
             scriptPath,
             scriptSource,
@@ -271,6 +273,7 @@ class Interpreter(val host: Host) {
 
     private
     fun compile(
+        scriptHost: KotlinScriptHost<*>,
         templateId: String,
         scriptPath: String,
         scriptSource: ScriptSource,
@@ -280,6 +283,7 @@ class Interpreter(val host: Host) {
         compilationClassPath: ClassPath,
         pluginAccessorsClassPath: ClassPath
     ): File = host.cachedDirFor(
+        scriptHost,
         templateId,
         sourceHash,
         compilationClassPath,
@@ -450,6 +454,7 @@ class Interpreter(val host: Host) {
 
             val cacheDir =
                 host.cachedDirFor(
+                    scriptHost,
                     scriptTemplateId,
                     sourceHash,
                     compilationClassPath,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -238,13 +238,14 @@ class StandardKotlinScriptEvaluator(
         }
 
         override fun cachedDirFor(
+            scriptHost: KotlinScriptHost<*>,
             templateId: String,
             sourceHash: HashCode,
             compilationClassPath: ClassPath,
             accessorsClassPath: ClassPath,
             initializer: (File) -> Unit
         ): File = try {
-            executionEngine.execute(
+            executionEngineFor(scriptHost).execute(
                 CompileKotlinScript(
                     templateId,
                     sourceHash,
@@ -277,6 +278,14 @@ class StandardKotlinScriptEvaluator(
 
         override val implicitImports: List<String>
             get() = this@StandardKotlinScriptEvaluator.implicitImports.list
+    }
+
+    private
+    fun executionEngineFor(scriptHost: KotlinScriptHost<*>): ExecutionEngine {
+        // get the ExecutionEngine from the closest available service scope
+        // for the global one has no support for the build cache
+        return (scriptHost.target as? Project)?.serviceOf()
+            ?: executionEngine
     }
 
     private

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -112,6 +112,7 @@ class InterpreterTest : TestWithTempFiles() {
 
             on {
                 cachedDirFor(
+                    any(),
                     eq(stage1TemplateId),
                     eq(sourceHash),
                     same(testRuntimeClassPath),
@@ -119,12 +120,13 @@ class InterpreterTest : TestWithTempFiles() {
                     any()
                 )
             } doAnswer {
-                it.getArgument<(File) -> Unit>(4).invoke(stage1CacheDir)
+                it.getArgument<(File) -> Unit>(5).invoke(stage1CacheDir)
                 stage1CacheDir
             }
 
             on {
                 cachedDirFor(
+                    any(),
                     eq(stage2TemplateId),
                     eq(sourceHash),
                     same(testRuntimeClassPath),
@@ -132,7 +134,7 @@ class InterpreterTest : TestWithTempFiles() {
                     any()
                 )
             } doAnswer {
-                it.getArgument<(File) -> Unit>(4).invoke(stage2CacheDir)
+                it.getArgument<(File) -> Unit>(5).invoke(stage2CacheDir)
                 stage2CacheDir
             }
 

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -128,6 +128,7 @@ class SimplifiedKotlinScriptEvaluator(
         override fun cache(specializedProgram: CompiledScript, programId: ProgramId) = Unit
 
         override fun cachedDirFor(
+            scriptHost: KotlinScriptHost<*>,
             templateId: String,
             sourceHash: HashCode,
             compilationClassPath: ClassPath,

--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
@@ -24,7 +24,6 @@ import org.gradle.kotlin.dsl.fixtures.normalisedPath
 
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 
 import org.junit.Test
 
@@ -60,7 +59,6 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
     }
 
     @Test
-    @Ignore("https://github.com/gradle/gradle-private/issues/3239")
     fun `build cache integration can be disabled via system property`() {
 
         val buildCacheDir = existing("build-cache")


### PR DESCRIPTION
By using an `ExecutionEngine` from the correct service scope.