### PR TITLE
Improve task timeout reliability and diagnostics

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.timeout.impl;
 
+import com.google.common.io.CharStreams;
 import org.gradle.api.Describable;
 import org.gradle.internal.concurrent.ManagedScheduledExecutor;
 import org.gradle.internal.concurrent.Stoppable;
@@ -23,12 +24,16 @@ import org.gradle.internal.execution.timeout.Timeout;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
+import org.gradle.internal.time.CountdownTimer;
+import org.gradle.internal.time.Time;
 import org.gradle.internal.time.TimeFormatting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.PrintWriter;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +43,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
 
     // Only intended to be used for integration testing
     public static final String POST_TIMEOUT_CHECK_FREQUENCY_PROPERTY = DefaultTimeoutHandler.class.getName() + ".postTimeoutCheckFrequency";
+    public static final String SLOW_STOP_LOG_STACKTRACE_FREQUENCY_PROPERTY = DefaultTimeoutHandler.class.getName() + ".slowStopLogStacktraceFrequency";
 
     private final ManagedScheduledExecutor executor;
     private final CurrentBuildOperationRef currentBuildOperationRef;
@@ -62,6 +68,11 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
         return Integer.parseInt(System.getProperty(POST_TIMEOUT_CHECK_FREQUENCY_PROPERTY, "3000"));
     }
 
+    // Value is queried “dynamically” to support testing
+    private static long slowStopLogStacktraceFrequency() {
+        return Integer.parseInt(System.getProperty(SLOW_STOP_LOG_STACKTRACE_FREQUENCY_PROPERTY, "10000"));
+    }
+
     private final class DefaultTimeout implements Timeout {
 
         private final Thread thread;
@@ -76,6 +87,10 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
         private boolean slowStop;
         private boolean stopped;
         private boolean interrupted;
+
+        private StackTraceElement[] lastStacktrace;
+        private CountdownTimer logStacktraceTimer;
+
         private ScheduledFuture<?> scheduledFuture;
 
         private DefaultTimeout(Thread thread, Duration timeout, Describable workUnitDescription, @Nullable BuildOperationRef buildOperationRef) {
@@ -92,6 +107,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
                     interrupted = true;
                     doAsPartOfBuildOperation(() -> LOGGER.warn("Requesting stop of {} as it has exceeded its configured timeout of {}.", workUnitDescription.getDisplayName(), TimeFormatting.formatDurationTerse(timeout.toMillis())));
                     thread.interrupt();
+                    logStacktraceTimer = Time.startCountdownTimer(slowStopLogStacktraceFrequency());
                     scheduledFuture = executor.schedule(this::onAfterTimeoutCheck, postTimeoutCheckFrequency(), TimeUnit.MILLISECONDS);
                 }
             }
@@ -101,13 +117,39 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
             synchronized (lock) {
                 if (!stopped) {
                     slowStop = true;
-                    doAsPartOfBuildOperation(() -> LOGGER.warn("Timed out {} has not yet stopped.", workUnitDescription.getDisplayName()));
+                    doAsPartOfBuildOperation(() -> {
+                        LOGGER.warn("Timed out {} has not yet stopped.", workUnitDescription.getDisplayName());
 
-                    // Interrupt again in case the work unit cleared the interrupt.
-                    thread.interrupt();
+                        if (logStacktraceTimer.hasExpired()) {
+                            StackTraceElement[] currentStackTrace = thread.getStackTrace();
+                            if (currentStackTrace.length > 0 && !Arrays.equals(lastStacktrace, currentStackTrace)) {
+                                lastStacktrace = currentStackTrace;
+                                logStacktrace(currentStackTrace);
+                            }
+                            logStacktraceTimer.reset();
+                        }
+                    });
+
+                    thread.interrupt(); // interrupt again in case the work unit cleared the interrupt.
 
                     scheduledFuture = executor.schedule(this::onAfterTimeoutCheck, postTimeoutCheckFrequency(), TimeUnit.MILLISECONDS);
                 }
+            }
+        }
+
+        private void logStacktrace(StackTraceElement[] currentStackTrace) {
+            if (LOGGER.isWarnEnabled()) {
+                // Assemble string this way so it is logged atomically, and with platform line endings
+                StringBuilder logMessageBuilder = new StringBuilder();
+                try (PrintWriter logMessageWriter = new PrintWriter(CharStreams.asWriter(logMessageBuilder))) {
+                    logMessageWriter.print("Current stacktrace of timed out but not yet stopped ");
+                    logMessageWriter.print(workUnitDescription.getDisplayName());
+                    logMessageWriter.println(":");
+                    for (StackTraceElement traceElement : currentStackTrace) {
+                        logMessageWriter.println("  at " + traceElement);
+                    }
+                }
+                LOGGER.warn(logMessageBuilder.toString());
             }
         }
 


### PR DESCRIPTION
This has two functional changes:

1. When a work unit times out, we know continue to interrupt it until it stops. Previously we did this only once.
2. When a work unit is slow to stop, we now log its stack trace every 10s if it has changed since last being logged

Here's an example of the output for part 2:


```

> Task :block
Requesting stop of task ':block' as it has exceeded its configured timeout of 500ms.
Timed out task ':block' has not yet stopped.
Current stacktrace of timed out but not yet stopped task ':block':
  at build_67ste90xdw0dy37opt2wkr8tj.checkpoint1(/Users/ld/Projects/gradle/subprojects/core/build/tmp/test files/TaskTimeout.Test/e9z0g/build.gradle:5)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Current stacktrace of timed out but not yet stopped task ':block':
  at build_67ste90xdw0dy37opt2wkr8tj.checkpoint2(/Users/ld/Projects/gradle/subprojects/core/build/tmp/test files/TaskTimeout.Test/e9z0g/build.gradle:10)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Current stacktrace of timed out but not yet stopped task ':block':
  at build_67ste90xdw0dy37opt2wkr8tj.checkpoint3(/Users/ld/Projects/gradle/subprojects/core/build/tmp/test files/TaskTimeout.Test/e9z0g/build.gradle:15)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base@11.0.4/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

Timed out task ':block' has not yet stopped.
Timed out task ':block' has not yet stopped.
Timed out task ':block' has stopped.

> Task :block FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':block'.
> Timeout has been exceeded
```