### PR TITLE
Restore build service listener subscription for build service from included build correctly

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -72,10 +72,10 @@ class ConfigurationCacheIO internal constructor(
     }
 
     internal
-    fun writeIncludedBuildStateTo(stateFile: ConfigurationCacheStateFile, storedBuilds: StoredBuilds) {
+    fun writeIncludedBuildStateTo(stateFile: ConfigurationCacheStateFile, buildTreeState: StoredBuildTreeState) {
         writeConfigurationCacheState(stateFile) { cacheState ->
             cacheState.run {
-                writeBuildState(host.currentBuild, storedBuilds)
+                writeBuildState(host.currentBuild, buildTreeState)
             }
         }
     }
@@ -187,7 +187,7 @@ class ConfigurationCacheIO internal constructor(
             fileOperations = service(),
             fileFactory = service(),
             includedTaskGraph = service(),
-            buildStateRegistry = service()
+            buildServiceRegistry = service()
         )
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
@@ -29,6 +29,7 @@ import org.gradle.configurationcache.serialization.beans.BeanStateReader
 import org.gradle.configurationcache.serialization.beans.BeanStateWriter
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
+import kotlin.reflect.KClass
 
 
 /**
@@ -97,6 +98,8 @@ interface IsolateContext {
     var trace: PropertyTrace
 
     fun onProblem(problem: PropertyProblem)
+
+    fun <T : Any> contextual(key: KClass<T>): T?
 }
 
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -16,36 +16,17 @@
 
 package org.gradle.configurationcache.serialization.codecs
 
-import org.gradle.api.internal.GradleInternal
-import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.readNonNull
-import org.gradle.configurationcache.serialization.withGradleIsolate
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.TaskInAnotherBuild
 import org.gradle.execution.plan.TaskNode
 
 
 internal
-class WorkNodeCodec(
-    private val owner: GradleInternal,
-    private val internalTypesCodec: Codec<Any?>
-) {
+class WorkNodeCodec {
 
-    suspend fun WriteContext.writeWork(nodes: List<Node>) {
-        // Share bean instances across all nodes (except tasks, which have their own isolate)
-        withGradleIsolate(owner, internalTypesCodec) {
-            writeNodes(nodes)
-        }
-    }
-
-    suspend fun ReadContext.readWork(): List<Node> =
-        withGradleIsolate(owner, internalTypesCodec) {
-            readNodes()
-        }
-
-    private
     suspend fun WriteContext.writeNodes(nodes: List<Node>) {
         val nodeCount = nodes.size
         writeSmallInt(nodeCount)
@@ -56,7 +37,6 @@ class WorkNodeCodec(
         }
     }
 
-    private
     suspend fun ReadContext.readNodes(): List<Node> {
         val nodeCount = readSmallInt()
         val nodes = ArrayList<Node>(nodeCount)

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -49,6 +49,7 @@ import org.junit.Test
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
+import kotlin.reflect.KClass
 
 
 class ConfigurationCacheFingerprintCheckerTest {
@@ -279,6 +280,9 @@ class ConfigurationCacheFingerprintCheckerTest {
         override val isolate: WriteIsolate
             get() = undefined()
 
+        override fun <T : Any> contextual(key: KClass<T>): T =
+            undefined()
+
         override fun beanStateWriterFor(beanType: Class<*>): BeanStateWriter =
             undefined()
 
@@ -390,6 +394,9 @@ class ConfigurationCacheFingerprintCheckerTest {
             set(_) {}
 
         override fun onProblem(problem: PropertyProblem): Unit =
+            undefined()
+
+        override fun <T : Any> contextual(key: KClass<T>): T? =
             undefined()
 
         override fun push(codec: Codec<Any?>): Unit =

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -175,6 +175,6 @@ abstract class AbstractUserTypeCodecTest {
         fileOperations = mock(),
         fileFactory = mock(),
         includedTaskGraph = mock(),
-        buildStateRegistry = mock()
+        buildServiceRegistry = mock()
     )
 }

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -177,3 +177,11 @@ tasks.compileTestGroovy {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+afterEvaluate {
+    // This is a workaround for the validate plugins task trying to inspect classes which have changed but are NOT tasks.
+    // For the current project, we exclude all internal packages, since there are no tasks in there.
+    tasks.withType<ValidatePlugins>().configureEach {
+        classes.setFrom(sourceSets.main.get().output.classesDirs.asFileTree.matching { exclude("**/internal/**") })
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -16,128 +16,21 @@
 
 package org.gradle.api.services.internal;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.provider.AbstractMinimalProvider;
-import org.gradle.api.logging.LoggingOutput;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.internal.Try;
-import org.gradle.internal.instantiation.InstantiationScheme;
-import org.gradle.internal.isolated.IsolationScheme;
-import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.service.ServiceLookup;
-import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.state.Managed;
 
 import javax.annotation.Nullable;
 
-// TODO - complain when used at configuration time, except when opted in to this
-public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends AbstractMinimalProvider<T> implements Managed {
-    private final BuildIdentifier buildIdentifier;
-    private final String name;
-    private final Class<T> implementationType;
-    private final IsolationScheme<BuildService, BuildServiceParameters> isolationScheme;
-    private final InstantiationScheme instantiationScheme;
-    private final IsolatableFactory isolatableFactory;
-    private final ServiceRegistry internalServices;
-    private final P parameters;
-    private Try<T> instance;
+public interface BuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends Provider<T> {
 
-    public BuildServiceProvider(BuildIdentifier buildIdentifier, String name, Class<T> implementationType, @Nullable P parameters, IsolationScheme<BuildService, BuildServiceParameters> isolationScheme, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory, ServiceRegistry internalServices) {
-        this.buildIdentifier = buildIdentifier;
-        this.name = name;
-        this.implementationType = implementationType;
-        this.parameters = parameters;
-        this.isolationScheme = isolationScheme;
-        this.instantiationScheme = instantiationScheme;
-        this.isolatableFactory = isolatableFactory;
-        this.internalServices = internalServices;
-    }
+    BuildIdentifier getBuildIdentifier();
 
-    /**
-     * Returns the identifier for the build that owns this service.
-     */
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
-    }
+    String getName();
 
-    public String getName() {
-        return name;
-    }
-
-    public Class<T> getImplementationType() {
-        return implementationType;
-    }
+    Class<T> getImplementationType();
 
     @Nullable
-    public P getParameters() {
-        return parameters;
-    }
-
-    @Nullable
-    @Override
-    public Class<T> getType() {
-        return implementationType;
-    }
-
-    @Override
-    public boolean calculatePresence(ValueConsumer consumer) {
-        return true;
-    }
-
-    @Override
-    public boolean isImmutable() {
-        return true;
-    }
-
-    @Override
-    public Object unpackState() {
-        throw new UnsupportedOperationException("Build services cannot be serialized.");
-    }
-
-    @Override
-    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        synchronized (this) {
-            if (instance == null) {
-                // TODO - extract some shared infrastructure to take care of instantiation (eg which services are visible, strict vs lenient, decorated or not?)
-                // TODO - should hold the project lock to do the isolation. Should work the same way as artifact transforms (a work node does the isolation, etc)
-                P isolatedParameters = isolatableFactory.isolate(parameters).isolate();
-                // TODO - reuse this in other places
-                ServiceLookup instantiationServices = isolationScheme.servicesForImplementation(
-                    isolatedParameters,
-                    internalServices,
-                    ImmutableList.of(LoggingOutput.class),
-                    serviceType -> false
-                );
-                try {
-                    instance = Try.successful(instantiationScheme.withServices(instantiationServices).instantiator().newInstance(implementationType));
-                } catch (Exception e) {
-                    instance = Try.failure(new ServiceLifecycleException("Failed to create service '" + name + "'.", e));
-                }
-            }
-            return Value.of(instance.get());
-        }
-    }
-
-    @Override
-    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        return ExecutionTimeValue.changingValue(this);
-    }
-
-    public void maybeStop() {
-        synchronized (this) {
-            if (instance != null) {
-                instance.ifSuccessful(t -> {
-                    if (t instanceof AutoCloseable) {
-                        try {
-                            ((AutoCloseable) t).close();
-                        } catch (Exception e) {
-                            throw new ServiceLifecycleException("Failed to stop service '" + name + "'.", e);
-                        }
-                    }
-                });
-            }
-        }
-    }
+    P getParameters();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServiceProvider.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.services.internal;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.provider.AbstractMinimalProvider;
+import org.gradle.api.logging.LoggingOutput;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.internal.Try;
+import org.gradle.internal.instantiation.InstantiationScheme;
+import org.gradle.internal.isolated.IsolationScheme;
+import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.service.ServiceLookup;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.state.Managed;
+
+import javax.annotation.Nullable;
+
+// TODO - complain when used at configuration time, except when opted in to this
+public class DefaultBuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends AbstractMinimalProvider<T> implements Managed, BuildServiceProvider<T, P> {
+    private final BuildIdentifier buildIdentifier;
+    private final String name;
+    private final Class<T> implementationType;
+    private final IsolationScheme<BuildService, BuildServiceParameters> isolationScheme;
+    private final InstantiationScheme instantiationScheme;
+    private final IsolatableFactory isolatableFactory;
+    private final ServiceRegistry internalServices;
+    private final P parameters;
+    private Try<T> instance;
+
+    public DefaultBuildServiceProvider(BuildIdentifier buildIdentifier, String name, Class<T> implementationType, @Nullable P parameters, IsolationScheme<BuildService, BuildServiceParameters> isolationScheme, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory, ServiceRegistry internalServices) {
+        this.buildIdentifier = buildIdentifier;
+        this.name = name;
+        this.implementationType = implementationType;
+        this.parameters = parameters;
+        this.isolationScheme = isolationScheme;
+        this.instantiationScheme = instantiationScheme;
+        this.isolatableFactory = isolatableFactory;
+        this.internalServices = internalServices;
+    }
+
+    /**
+     * Returns the identifier for the build that owns this service.
+     */
+    @Override
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Class<T> getImplementationType() {
+        return implementationType;
+    }
+
+    @Override
+    @Nullable
+    public P getParameters() {
+        return parameters;
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        return implementationType;
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return true;
+    }
+
+    @Override
+    public boolean isImmutable() {
+        return true;
+    }
+
+    @Override
+    public Object unpackState() {
+        throw new UnsupportedOperationException("Build services cannot be serialized.");
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        synchronized (this) {
+            if (instance == null) {
+                // TODO - extract some shared infrastructure to take care of instantiation (eg which services are visible, strict vs lenient, decorated or not?)
+                // TODO - should hold the project lock to do the isolation. Should work the same way as artifact transforms (a work node does the isolation, etc)
+                P isolatedParameters = isolatableFactory.isolate(parameters).isolate();
+                // TODO - reuse this in other places
+                ServiceLookup instantiationServices = isolationScheme.servicesForImplementation(
+                    isolatedParameters,
+                    internalServices,
+                    ImmutableList.of(LoggingOutput.class),
+                    serviceType -> false
+                );
+                try {
+                    instance = Try.successful(instantiationScheme.withServices(instantiationServices).instantiator().newInstance(implementationType));
+                } catch (Exception e) {
+                    instance = Try.failure(new ServiceLifecycleException("Failed to create service '" + name + "'.", e));
+                }
+            }
+            return Value.of(instance.get());
+        }
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        return ExecutionTimeValue.changingValue(this);
+    }
+
+    public void maybeStop() {
+        synchronized (this) {
+            if (instance != null) {
+                instance.ifSuccessful(t -> {
+                    if (t instanceof AutoCloseable) {
+                        try {
+                            ((AutoCloseable) t).close();
+                        } catch (Exception e) {
+                            throw new ServiceLifecycleException("Failed to stop service '" + name + "'.", e);
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -73,7 +73,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
 
     @Override
     public SharedResource forService(Provider<? extends BuildService<?>> service) {
-        if (!(service instanceof BuildServiceProvider)) {
+        if (!(service instanceof DefaultBuildServiceProvider)) {
             throw new IllegalArgumentException("The given provider is not a build service provider.");
         }
         BuildServiceProvider<?, ?> provider = (BuildServiceProvider<?, ?>) service;
@@ -134,7 +134,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         P parameters,
         @Nullable Integer maxParallelUsages
     ) {
-        BuildServiceProvider<T, P> provider = new BuildServiceProvider<>(
+        DefaultBuildServiceProvider<T, P> provider = new DefaultBuildServiceProvider<>(
             buildIdentifier,
             name,
             implementationType,
@@ -180,10 +180,10 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
     public static abstract class DefaultServiceRegistration<T extends BuildService<P>, P extends BuildServiceParameters> implements BuildServiceRegistration<T, P> {
         private final String name;
         private final P parameters;
-        private final BuildServiceProvider<T, P> provider;
+        private final DefaultBuildServiceProvider<T, P> provider;
         private SharedResource resourceWrapper;
 
-        public DefaultServiceRegistration(String name, P parameters, BuildServiceProvider<T, P> provider) {
+        public DefaultServiceRegistration(String name, P parameters, DefaultBuildServiceProvider<T, P> provider) {
             this.name = name;
             this.parameters = parameters;
             this.provider = provider;
@@ -232,9 +232,9 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
     }
 
     private static class ServiceCleanupListener extends BuildAdapter {
-        private final BuildServiceProvider<?, ?> provider;
+        private final DefaultBuildServiceProvider<?, ?> provider;
 
-        ServiceCleanupListener(BuildServiceProvider<?, ?> provider) {
+        ServiceCleanupListener(DefaultBuildServiceProvider<?, ?> provider) {
             this.provider = provider;
         }
 


### PR DESCRIPTION
Before this change, `BuildServiceProvider` instances would be written to the configuration cache in the context of the build in which they are referenced, no matter which build they were registered with. That has implications when build services are registered as build event listeners since event listener subscriptions are stored in the context of the root build.

After this change, `BuildServiceProvider` instances found while writing event listener subscriptions to the cache are simply marked as used and then later written to the cache in the context of the correct build.