### PR TITLE
Use a named object container for the catalogs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
@@ -17,9 +17,10 @@ package org.gradle.api.initialization.dsl;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.Named;
 import org.gradle.api.artifacts.MutableVersionConstraint;
-import org.gradle.internal.Actions;
 import org.gradle.api.provider.Property;
+import org.gradle.internal.Actions;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.List;
  */
 @Incubating
 @HasInternalProtocol
-public interface VersionCatalogBuilder {
+public interface VersionCatalogBuilder extends Named {
 
     /**
      * A description for the dependencies model, which will be used in

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -20,7 +20,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.provider.Property;
-import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -54,13 +53,12 @@ public interface DependencyResolutionManagement {
     ComponentMetadataHandler getComponents();
 
     /**
-     * Configures a version catalog which will be used to generate type safe accessors for dependencies.
-     * @param name the name of the extension which is going to be generated for this model
+     * Configures the version catalogs which will be used to generate type safe accessors for dependencies.
      * @param spec the spec to configure the dependencies
      *
      * @since 6.9
      */
-    void versionCatalog(String name, Action<? super VersionCatalogBuilder> spec);
+    void versionCatalogs(Action<? super VersionCatalogContainer> spec);
 
     /**
      * Returns the name of the extension generated for type-safe project accessors.

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/VersionCatalogContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/VersionCatalogContainer.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.gradle.api.initialization.resolve;
 
-// tag::import_main_catalog[]
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("lib") {
-            from(files("../gradle/dependencies.toml"))
-        }
-    }
+import org.gradle.api.Incubating;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
+
+/**
+ * The container for declaring version catalogs
+ *
+ * @since 6.9
+ */
+@Incubating
+public interface VersionCatalogContainer extends NamedDomainObjectContainer<VersionCatalogBuilder> {
 }
-// end::import_main_catalog[]

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.configuration;
 
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -80,7 +81,13 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         String defaultLibrary = dm.getDefaultLibrariesExtensionName().get();
         File dependenciesFile = new File(settings.getSettingsDir(), "gradle/dependencies.toml");
         if (dependenciesFile.exists()) {
-            dm.versionCatalog(defaultLibrary, builder -> builder.from(services.get(FileCollectionFactory.class).fixed(dependenciesFile)));
+            dm.versionCatalogs(catalogs -> {
+                VersionCatalogBuilder builder = catalogs.findByName(defaultLibrary);
+                if (builder == null) {
+                    builder = catalogs.create(defaultLibrary);
+                }
+                builder.from(services.get(FileCollectionFactory.class).fixed(dependenciesFile));
+            });
         }
         accessors.generateAccessors(dm.getDependenciesModelBuilders(), classLoaderScope, settings);
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/DependenciesExtensionIntegrationTest.groovy
@@ -26,8 +26,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "dependencies declared in settings trigger the creation of an extension (notation=#notation)"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    $notation
+                versionCatalogs {
+                    libs {
+                        $notation
+                    }
                 }
             }
         """
@@ -63,8 +65,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         when: "adding a library to the model"
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("bar") to "org.gradle.test:bar:1.0"
+                versionCatalogs {
+                    libs {
+                        alias("bar") to "org.gradle.test:bar:1.0"
+                    }
                 }
             }
         """
@@ -91,9 +95,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -125,9 +131,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency constraint"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -163,9 +171,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency and override the version"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -201,9 +211,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to declare a dependency constraint and override the version"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -243,12 +255,14 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     void "can add several dependencies at once using a bundle"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("lib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("lib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
+                        alias("lib2").to("org.gradle.test:lib2:1.0")
+                        bundle("myBundle", ["lib", "lib2"])
                     }
-                    alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -283,12 +297,14 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     void "overriding the version of a bundle overrides the version of all dependencies of the bundle"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("lib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libs {
+                        alias("lib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
+                        alias("lib2").to("org.gradle.test:lib2:1.0")
+                        bundle("myBundle", ["lib", "lib2"])
                     }
-                    alias("lib2").to("org.gradle.test:lib2:1.0")
-                    bundle("myBundle", ["lib", "lib2"])
                 }
             }
         """
@@ -327,9 +343,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure a different libraries extension"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libraries") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libraries {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -361,14 +379,16 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure multiple libraries extension"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libraries") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libraries {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
-                }
-                versionCatalog("other") {
-                    alias("great").to("org.gradle.test", "lib2").version {
-                        require "1.1"
+                    other {
+                        alias("great").to("org.gradle.test", "lib2").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
@@ -407,14 +427,16 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can configure multiple libraries extension with same contents"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libraries") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                versionCatalogs {
+                    libraries {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
-                }
-                versionCatalog("other") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.0"
+                    other {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
                     }
                 }
             }
@@ -447,8 +469,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "extension can be used in any subproject"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("lib").to("org.gradle.test:lib:1.0")
+                versionCatalogs {
+                    libs {
+                        alias("lib").to("org.gradle.test:lib:1.0")
+                    }
                 }
             }
             include 'other'
@@ -492,8 +516,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "libraries extension is not visible in buildSrc"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("lib").to("org.gradle.test:lib:1.0")
+                versionCatalogs {
+                    libs {
+                        alias("lib").to("org.gradle.test:lib:1.0")
+                    }
                 }
             }
         """
@@ -513,8 +539,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "buildSrc and main project have different libraries extensions"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("lib").to("org.gradle.test:lib:1.0")
+                versionCatalogs {
+                    libs {
+                        alias("lib").to("org.gradle.test:lib:1.0")
+                    }
                 }
             }
         """
@@ -529,8 +557,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
         """
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("build-src-lib").to("org.gradle.test:buildsrc-lib:1.0")
+                versionCatalogs {
+                    libs {
+                        alias("build-src-lib").to("org.gradle.test:buildsrc-lib:1.0")
+                    }
                 }
             }
         """
@@ -581,8 +611,10 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
                 repositories {
                     maven { url "${mavenHttpRepo.uri}" }
                 }
-                versionCatalog("libs") {
-                    alias('from-included').to('org.gradle.test:other:1.1')
+                versionCatalogs {
+                    libs {
+                        alias('from-included').to('org.gradle.test:other:1.1')
+                    }
                 }
             }
         """
@@ -620,15 +652,17 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can declare a version with a name and reference it"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    version("myVersion") {
-                        require "1.0"
-                    }
-                    alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
-                    alias("myOtherLib").to("org.gradle.test", "lib2").versionRef("myOtherVersion")
-                    version("myOtherVersion") {
-                        // intentionnally declared AFTER
-                        strictly "1.1"
+                versionCatalogs {
+                    libs {
+                        version("myVersion") {
+                            require "1.0"
+                        }
+                        alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
+                        alias("myOtherLib").to("org.gradle.test", "lib2").versionRef("myOtherVersion")
+                        version("myOtherVersion") {
+                            // intentionnally declared AFTER
+                            strictly "1.1"
+                        }
                     }
                 }
             }
@@ -665,12 +699,14 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "multiple libraries can use the same version reference"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    def myVersion = version("myVersion") {
-                        require "1.0"
+                versionCatalogs {
+                        libs {
+                        def myVersion = version("myVersion") {
+                            require "1.0"
+                        }
+                        alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
+                        alias("myOtherLib").to("org.gradle.test", "lib2").versionRef(myVersion)
                     }
-                    alias("myLib").to("org.gradle.test", "lib").versionRef("myVersion")
-                    alias("myOtherLib").to("org.gradle.test", "lib2").versionRef(myVersion)
                 }
             }
         """
@@ -707,9 +743,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can generate a version accessor and use it in a build script"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    version("libVersion") {
-                        $notation
+                versionCatalogs {
+                    libs {
+                        version("libVersion") {
+                            $notation
+                        }
                     }
                 }
             }
@@ -750,9 +788,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to select the test fixtures of a dependency"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.1"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
@@ -801,9 +841,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to select the platform variant of a dependency"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.1"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
@@ -841,9 +883,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to select a classified dependency"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.1"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
@@ -881,9 +925,11 @@ class DependenciesExtensionIntegrationTest extends AbstractCentralDependenciesIn
     def "can use the generated extension to select an artifact with different type"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("myLib").to("org.gradle.test", "lib").version {
-                        require "1.1"
+                versionCatalogs {
+                    libs {
+                        alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -45,8 +45,10 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
         def lib = mavenHttpRepo.module('org.gradle.test', 'lib', '1.1').publish()
         settingsKotlinFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias("my-lib").to("org.gradle.test:lib:1.0")
+                versionCatalogs {
+                    create("libs") {
+                        alias("my-lib").to("org.gradle.test:lib:1.0")
+                    }
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -294,8 +294,10 @@ lib = "org.gradle.test:lib:1.0"
 """
         file("buildSrc/settings.gradle") << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    from(files("../gradle/dependencies.toml"))
+                versionCatalogs {
+                    libs {
+                        from(files("../gradle/dependencies.toml"))
+                    }
                 }
             }
         """
@@ -432,8 +434,10 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
         """
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias('other').to('org.gradle.test:other:1.0')
+                versionCatalogs {
+                    libs {
+                        alias('other').to('org.gradle.test:other:1.0')
+                    }
                 }
             }
         """
@@ -470,8 +474,10 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.1"}
         """
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    alias('my-lib').to('org.gradle.test:lib:1.0')
+                versionCatalogs {
+                    libs {
+                        alias('my-lib').to('org.gradle.test:lib:1.0')
+                    }
                 }
             }
         """
@@ -653,8 +659,10 @@ my-other-lib = {group = "org.gradle.test", name="lib2", version.ref="rich"}
         def path = file("missing.toml").absolutePath
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog('libs') {
-                    from(files("missing.toml"))
+                versionCatalogs {
+                    libs {
+                        from(files("missing.toml"))
+                    }
                 }
             }
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -25,6 +25,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.ClassPathRegistry;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.GradleInternal;
@@ -260,7 +261,8 @@ class DependencyManagementBuildScopeServices {
                                                                                     FileCollectionFactory fileCollectionFactory,
                                                                                     DependencyMetaDataProvider dependencyMetaDataProvider,
                                                                                     ObjectFactory objects,
-                                                                                    ProviderFactory providers) {
+                                                                                    ProviderFactory providers,
+                                                                                    CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         return instantiator.newInstance(DefaultDependencyResolutionManagement.class,
             context,
             dependencyManagementServices,
@@ -268,7 +270,8 @@ class DependencyManagementBuildScopeServices {
             fileCollectionFactory,
             dependencyMetaDataProvider,
             objects,
-            providers
+            providers,
+            collectionCallbackActionDecorator
         );
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalogBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultVersionCatalogBuilder.java
@@ -317,6 +317,11 @@ public class DefaultVersionCatalogBuilder implements VersionCatalogBuilderIntern
         return dependencies.containsKey(name);
     }
 
+    @Override
+    public String getName() {
+        return name;
+    }
+
     private class VersionReferencingDependencyModel implements Supplier<DependencyModel> {
         private final String group;
         private final String name;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -16,15 +16,11 @@
 package org.gradle.internal.management;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Interner;
-import com.google.common.collect.Interners;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
@@ -36,9 +32,10 @@ import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.initialization.resolve.RulesMode;
+import org.gradle.api.initialization.resolve.VersionCatalogContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
-import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
@@ -47,7 +44,6 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.std.DefaultVersionCatalogBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -58,17 +54,11 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.plugin.management.PluginManagementSpec;
-import org.gradle.plugin.use.PluginDependenciesSpec;
 
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 
 @NonNullApi
 public class DefaultDependencyResolutionManagement implements DependencyResolutionManagementInternal {
-    private static final String VALID_EXTENSION_NAME = "[a-z]([a-zA-Z0-9])+";
-    private static final Pattern VALID_EXTENSION_PATTERN = Pattern.compile(VALID_EXTENSION_NAME);
-
     private static final DisplayName UNKNOWN_CODE = Describables.of("unknown code");
     private static final Logger LOGGER = Logging.getLogger(DependencyResolutionManagement.class);
     private final List<Action<? super ComponentMetadataHandler>> componentMetadataRulesActions = Lists.newArrayList();
@@ -80,12 +70,8 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     private final Property<RulesMode> rulesMode;
     private final Property<String> librariesExtensionName;
     private final Property<String> projectsExtensionName;
-    private final Map<String, VersionCatalogBuilderInternal> versionCatalogBuilders = Maps.newHashMap();
-    private final ObjectFactory objects;
-    private final ProviderFactory providers;
-    private final Interner<String> strings = Interners.newStrongInterner();
-    private final Interner<ImmutableVersionConstraint> versions = Interners.newStrongInterner();
-    private PluginDependenciesSpec plugins;
+    private final DefaultVersionCatalogBuilderContainer versionCatalogs;
+
     private boolean mutable = true;
 
     public DefaultDependencyResolutionManagement(UserCodeApplicationContext context,
@@ -94,15 +80,15 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
                                                  FileCollectionFactory fileCollectionFactory,
                                                  DependencyMetaDataProvider dependencyMetaDataProvider,
                                                  ObjectFactory objects,
-                                                 ProviderFactory providers) {
+                                                 ProviderFactory providers,
+                                                 CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
         this.rulesMode = objects.property(RulesMode.class).convention(RulesMode.PREFER_PROJECT);
-        this.objects = objects;
-        this.providers = providers;
         this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.INSTANCE));
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
+        this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, providers, dependencyResolutionServices, context);
     }
 
     @Override
@@ -143,18 +129,8 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     }
 
     @Override
-    public void versionCatalog(String name, Action<? super VersionCatalogBuilder> spec) {
-        validateName(name);
-        VersionCatalogBuilderInternal model = versionCatalogBuilders.computeIfAbsent(name, n ->
-            objects.newInstance(DefaultVersionCatalogBuilder.class, n, strings, versions, objects, providers, plugins, dependencyResolutionServices));
-        UserCodeApplicationContext.Application current = context.current();
-        model.withContext(current == null ? "Settings" : current.getDisplayName().getDisplayName(), () -> spec.execute(model));
-    }
-
-    private static void validateName(String name) {
-        if (!VALID_EXTENSION_PATTERN.matcher(name).matches()) {
-            throw new InvalidUserDataException("Invalid model name '" + name + "': it must match the following regular expression: " + VALID_EXTENSION_NAME);
-        }
+    public void versionCatalogs(Action<? super VersionCatalogContainer> spec) {
+        spec.execute(versionCatalogs);
     }
 
     @Override
@@ -175,7 +151,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
 
     @Override
     public List<VersionCatalogBuilder> getDependenciesModelBuilders() {
-        return ImmutableList.copyOf(versionCatalogBuilders.values());
+        return ImmutableList.copyOf(versionCatalogs);
     }
 
     @Override
@@ -245,7 +221,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
 
     @Override
     public void setPluginsSpec(PluginManagementSpec pluginManagementSpec) {
-        this.plugins = pluginManagementSpec.getPlugins();
+        this.versionCatalogs.setPlugins(pluginManagementSpec.getPlugins());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.management;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
+import org.gradle.api.initialization.resolve.VersionCatalogContainer;
+import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.artifacts.DependencyResolutionServices;
+import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
+import org.gradle.api.internal.std.DefaultVersionCatalogBuilder;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.configuration.internal.UserCodeApplicationContext;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.plugin.use.PluginDependenciesSpec;
+
+import javax.inject.Inject;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import static org.gradle.api.reflect.TypeOf.typeOf;
+
+public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainObjectContainer<VersionCatalogBuilder> implements VersionCatalogContainer {
+    private static final String VALID_EXTENSION_NAME = "[a-z]([a-zA-Z0-9])+";
+    private static final Pattern VALID_EXTENSION_PATTERN = Pattern.compile(VALID_EXTENSION_NAME);
+
+    private final Interner<String> strings = Interners.newStrongInterner();
+    private final Interner<ImmutableVersionConstraint> versions = Interners.newStrongInterner();
+    private final Supplier<DependencyResolutionServices> dependencyResolutionServices;
+
+    private final ObjectFactory objects;
+    private final ProviderFactory providers;
+    private final UserCodeApplicationContext context;
+
+    private PluginDependenciesSpec plugins;
+
+    @Inject
+    public DefaultVersionCatalogBuilderContainer(Instantiator instantiator,
+                                                 CollectionCallbackActionDecorator callbackActionDecorator,
+                                                 ObjectFactory objects,
+                                                 ProviderFactory providers,
+                                                 Supplier<DependencyResolutionServices> dependencyResolutionServices,
+                                                 UserCodeApplicationContext context) {
+        super(VersionCatalogBuilder.class, instantiator, callbackActionDecorator);
+        this.objects = objects;
+        this.providers = providers;
+        this.context = context;
+        this.dependencyResolutionServices = dependencyResolutionServices;
+    }
+
+    private static void validateName(String name) {
+        if (!VALID_EXTENSION_PATTERN.matcher(name).matches()) {
+            throw new InvalidUserDataException("Invalid model name '" + name + "': it must match the following regular expression: " + VALID_EXTENSION_NAME);
+        }
+    }
+
+    @Override
+    public VersionCatalogBuilder create(String name, Action<? super VersionCatalogBuilder> configureAction) throws InvalidUserDataException {
+        validateName(name);
+        return super.create(name, model -> {
+            UserCodeApplicationContext.Application current = context.current();
+            DefaultVersionCatalogBuilder builder = (DefaultVersionCatalogBuilder) model;
+            builder.withContext(current == null ? "Settings" : current.getDisplayName().getDisplayName(), () -> configureAction.execute(model));
+        });
+    }
+
+    private static ProjectFinder makeUnknownProjectFinder() {
+        return new UnknownProjectFinder("Project dependencies are not allowed in shared dependency resolution services");
+    }
+
+    @Override
+    protected VersionCatalogBuilder doCreate(String name) {
+        return objects.newInstance(DefaultVersionCatalogBuilder.class, name, strings, versions, objects, providers, plugins, dependencyResolutionServices);
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return typeOf(VersionCatalogContainer.class);
+    }
+
+    void setPlugins(PluginDependenciesSpec plugins) {
+        this.plugins = plugins;
+    }
+}

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
@@ -27,18 +27,22 @@ dependencyResolutionManagement {
 
 // tag::consume_catalog[]
 dependencyResolutionManagement {
-    versionCatalog("libs") {
-        from("com.mycompany:catalog:1.0")
+    versionCatalogs {
+        libs {
+            from("com.mycompany:catalog:1.0")
+        }
     }
 }
 // end::consume_catalog[]
 
 // tag::overwrite_version[]
 dependencyResolutionManagement {
-    versionCatalog("libs") {
-        from("com.mycompany:catalog:1.0")
-        // overwrite the "groovy" version declared in the imported catalog
-        version("groovy", "3.0.6")
+    versionCatalogs {
+        libs {
+            from("com.mycompany:catalog:1.0")
+            // overwrite the "groovy" version declared in the imported catalog
+            version("groovy", "3.0.6")
+        }
     }
 }
 // end::overwrite_version[]
@@ -46,28 +50,32 @@ dependencyResolutionManagement {
 if (providers.systemProperty("compose").forUseAtConfigurationTime().getOrNull()) {
     // tag::compose_catalog[]
     dependencyResolutionManagement {
-        versionCatalog("libs") {
-            from("com.mycompany:catalog:1.0")
-            from("com.other:catalog:1.1")
-            // and add explicit dependencies
-            alias("my-alias").to("my.own:lib:1.2")
+        versionCatalogs {
+            libs {
+                from("com.mycompany:catalog:1.0")
+                from("com.other:catalog:1.1")
+                // and add explicit dependencies
+                alias("my-alias").to("my.own:lib:1.2")
+            }
         }
     }
     // end::compose_catalog[]
 
     // tag::compose_catalog_filtering[]
     dependencyResolutionManagement {
-        versionCatalog("libs") {
-            from("com.mycompany:catalog:1.0") {
-                // import everything, excluding the following dependency
-                excludeDependency 'some-alias'
+        versionCatalogs {
+            libs {
+                from("com.mycompany:catalog:1.0") {
+                    // import everything, excluding the following dependency
+                    excludeDependency 'some-alias'
+                }
+                from("com.other:catalog:1.1") {
+                    // exclude everything but this dependency
+                    includeDependency 'some-dep'
+                }
+                // and add explicit dependencies
+                alias("some-alias").to("my.own:lib:1.2")
             }
-            from("com.other:catalog:1.1") {
-                // exclude everything but this dependency
-                includeDependency 'some-dep'
-            }
-            // and add explicit dependencies
-            alias("some-alias").to("my.own:lib:1.2")
         }
     }
     // end::compose_catalog_filtering[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
@@ -25,51 +25,64 @@ dependencyResolutionManagement {
     }
 }
 
-// tag::consume_catalog[]
-dependencyResolutionManagement {
-    versionCatalog("libs") {
-        from("com.mycompany:catalog:1.0")
+if (providers.systemProperty("create1").forUseAtConfigurationTime().getOrNull() != null) {
+    // tag::consume_catalog[]
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                from("com.mycompany:catalog:1.0")
+            }
+        }
     }
+    // end::consume_catalog[]
 }
-// end::consume_catalog[]
 
-// tag::overwrite_version[]
-dependencyResolutionManagement {
-    versionCatalog("libs") {
-        from("com.mycompany:catalog:1.0")
-        // overwrite the "groovy" version declared in the imported catalog
-        version("groovy", "3.0.6")
+if (providers.systemProperty("create2").forUseAtConfigurationTime().getOrNull() != null) {
+    // tag::overwrite_version[]
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                from("com.mycompany:catalog:1.0")
+                // overwrite the "groovy" version declared in the imported catalog
+                version("groovy", "3.0.6")
+            }
+        }
     }
+    // end::overwrite_version[]
 }
-// end::overwrite_version[]
 
-if (providers.systemProperty("compose").forUseAtConfigurationTime().getOrNull() != null) {
+if (providers.systemProperty("compose1").forUseAtConfigurationTime().getOrNull() != null) {
     // tag::compose_catalog[]
     dependencyResolutionManagement {
-        versionCatalog("libs") {
-            from("com.mycompany:catalog:1.0")
-            from("com.other:catalog:1.1")
-            // and add explicit dependencies
-            alias("my-alias").to("my.own:lib:1.2")
+        versionCatalogs {
+            create("libs") {
+                from("com.mycompany:catalog:1.0")
+                from("com.other:catalog:1.1")
+                // and add explicit dependencies
+                alias("my-alias").to("my.own:lib:1.2")
+            }
         }
     }
     // end::compose_catalog[]
+}
 
+if (providers.systemProperty("compose2").forUseAtConfigurationTime().getOrNull() != null) {
     // tag::compose_catalog_filtering[]
     dependencyResolutionManagement {
-        versionCatalog("libs") {
-            from("com.mycompany:catalog:1.0") {
-                // import everything, excluding the following dependency
-                excludeDependency("some-alias")
+        versionCatalogs {
+            create("libs") {
+                from("com.mycompany:catalog:1.0") {
+                    // import everything, excluding the following dependency
+                    excludeDependency("some-alias")
+                }
+                from("com.other:catalog:1.1") {
+                    // exclude everything but this dependency
+                    includeDependency("some-dep")
+                }
+                // and add explicit dependencies
+                alias("some-alias").to("my.own:lib:1.2")
             }
-            from("com.other:catalog:1.1") {
-                // exclude everything but this dependency
-                includeDependency("some-dep")
-            }
-            // and add explicit dependencies
-            alias("some-alias").to("my.own:lib:1.2")
         }
     }
     // end::compose_catalog_filtering[]
-
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/tests/resolve.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/tests/resolve.sample.conf
@@ -1,3 +1,3 @@
 execution-subdirectory: consumer
 executable: gradle
-args: dependencies --configuration compileClasspath
+args: "dependencies --configuration compileClasspath -Dcreate1=true"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/tests/sanityCheck.sample.conf
@@ -1,3 +1,3 @@
 execution-subdirectory: consumer
 executable: gradle
-args: help -q
+args: "help -q -Dcreate1=true"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/groovy/settings.gradle
@@ -16,7 +16,9 @@
 rootProject.name = 'platform'
 
 dependencyResolutionManagement {
-    versionCatalog('libs') {
-        alias('mylib').to('org:mylib:1.0')
+    versionCatalogs {
+        libs {
+            alias('mylib').to('org:mylib:1.0')
+        }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/kotlin/settings.gradle.kts
@@ -16,7 +16,9 @@
 rootProject.name = "platform"
 
 dependencyResolutionManagement {
-    versionCatalog("libs") {
-        alias("mylib").to("org:mylib:1.0")
+    versionCatalogs {
+        create("libs") {
+            alias("mylib").to("org:mylib:1.0")
+        }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -24,8 +24,8 @@ dependencyResolutionManagement {
 
 // tag::simple_catalog[]
 dependencyResolutionManagement {
-    dependencyResolutionManagement {
-        versionCatalog('libs') {
+    versionCatalogs {
+        libs {
             alias('groovy').to('org.codehaus.groovy:groovy:3.0.5')
             alias('groovy-json').to('org.codehaus.groovy:groovy-json:3.0.5')
             alias('groovy-nio').to('org.codehaus.groovy:groovy-nio:3.0.5')
@@ -40,15 +40,17 @@ dependencyResolutionManagement {
 
 // tag::catalog_with_versions[]
 dependencyResolutionManagement {
-    versionCatalog('libs') {
-        version('groovy', '3.0.5')
-        version('checkstyle', '8.37')
-        alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
-        alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
-        alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
-        alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
-            strictly '[3.8, 4.0['
-            prefer '3.9'
+    versionCatalogs {
+        libs {
+            version('groovy', '3.0.5')
+            version('checkstyle', '8.37')
+            alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
+            alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
+            alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
+            alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
+                strictly '[3.8, 4.0['
+                prefer '3.9'
+            }
         }
     }
 }
@@ -56,17 +58,19 @@ dependencyResolutionManagement {
 
 // tag::catalog_with_bundle[]
 dependencyResolutionManagement {
-    versionCatalog('libs') {
-        version('groovy', '3.0.5')
-        version('checkstyle', '8.37')
-        alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
-        alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
-        alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
-        alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
-            strictly '[3.8, 4.0['
-            prefer '3.9'
+    versionCatalogs {
+        libs {
+            version('groovy', '3.0.5')
+            version('checkstyle', '8.37')
+            alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
+            alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
+            alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
+            alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
+                strictly '[3.8, 4.0['
+                prefer '3.9'
+            }
+            bundle('groovy', ['groovy', 'groovy-json', 'groovy-nio'])
         }
-        bundle('groovy', ['groovy', 'groovy-json', 'groovy-nio'])
     }
 }
 // end::catalog_with_bundle[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -22,51 +22,61 @@ dependencyResolutionManagement {
     }
 }
 
-// tag::simple_catalog[]
-dependencyResolutionManagement {
+if (providers.systemProperty("create1").forUseAtConfigurationTime().getOrNull() != null) {
+    // tag::simple_catalog[]
     dependencyResolutionManagement {
-        versionCatalog("libs") {
-            alias("groovy").to("org.codehaus.groovy:groovy:3.0.5")
-            alias("groovy-json").to("org.codehaus.groovy:groovy-json:3.0.5")
-            alias("groovy-nio").to("org.codehaus.groovy:groovy-nio:3.0.5")
-            alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
-                strictly("[3.8, 4.0[")
-                prefer("3.9")
+        versionCatalogs {
+            create("libs") {
+                alias("groovy").to("org.codehaus.groovy:groovy:3.0.5")
+                alias("groovy-json").to("org.codehaus.groovy:groovy-json:3.0.5")
+                alias("groovy-nio").to("org.codehaus.groovy:groovy-nio:3.0.5")
+                alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
+                    strictly("[3.8, 4.0[")
+                    prefer("3.9")
+                }
             }
         }
     }
+    // end::simple_catalog[]
 }
-// end::simple_catalog[]
 
-// tag::catalog_with_versions[]
-dependencyResolutionManagement {
-    versionCatalog("libs") {
-        version("groovy", "3.0.5")
-        version("checkstyle", "8.37")
-        alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
-        alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
-        alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
-        alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
-            strictly("[3.8, 4.0[")
-            prefer("3.9")
+if (providers.systemProperty("create2").forUseAtConfigurationTime().getOrNull() != null) {
+    // tag::catalog_with_versions[]
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                version("groovy", "3.0.5")
+                version("checkstyle", "8.37")
+                alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
+                alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
+                alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
+                alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
+                    strictly("[3.8, 4.0[")
+                    prefer("3.9")
+                }
+            }
         }
     }
+    // end::catalog_with_versions[]
 }
-// end::catalog_with_versions[]
 
-// tag::catalog_with_bundle[]
-dependencyResolutionManagement {
-    versionCatalog("libs") {
-        version("groovy", "3.0.5")
-        version("checkstyle", "8.37")
-        alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
-        alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
-        alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
-        alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
-            strictly("[3.8, 4.0[")
-            prefer("3.9")
+if (providers.systemProperty("create3").forUseAtConfigurationTime().getOrNull() != null) {
+    // tag::catalog_with_bundle[]
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                version("groovy", "3.0.5")
+                version("checkstyle", "8.37")
+                alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
+                alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
+                alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
+                alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
+                    strictly("[3.8, 4.0[")
+                    prefer("3.9")
+                }
+                bundle("groovy", listOf("groovy", "groovy-json", "groovy-nio"))
+            }
         }
-        bundle("groovy", listOf("groovy", "groovy-json", "groovy-nio"))
     }
+    // end::catalog_with_bundle[]
 }
-// end::catalog_with_bundle[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/tests/resolve.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/tests/resolve.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: dependencies --configuration compileClasspath
+args: "dependencies --configuration compileClasspath -Dcreate3=true"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/tests/sanityCheck.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: "help -q -Dcreate3=true"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/buildSrc/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/buildSrc/settings.gradle
@@ -16,8 +16,10 @@
 
 // tag::import_main_catalog[]
 dependencyResolutionManagement {
-    versionCatalog('lib') {
-        from(files("../gradle/dependencies.toml"))
+    versionCatalogs {
+        lib {
+            from(files("../gradle/dependencies.toml"))
+        }
     }
 }
 // end::import_main_catalog[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
@@ -30,9 +30,11 @@ dependencyResolutionManagement {
 
 // tag::additional_catalog[]
 dependencyResolutionManagement {
-    // declares an additional catalog, named 'testLibs', from the 'test-dependencies.toml' file
-    versionCatalog('testLibs') {
-        from(files('gradle/test-dependencies.toml'))
+    versionCatalogs {
+        // declares an additional catalog, named 'testLibs', from the 'test-dependencies.toml' file
+        testLibs {
+            from(files('gradle/test-dependencies.toml'))
+        }
     }
 }
 // end::additional_catalog[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
@@ -30,9 +30,11 @@ dependencyResolutionManagement {
 
 // tag::additional_catalog[]
 dependencyResolutionManagement {
-    // declares an additional catalog, named 'testLibs', from the 'test-dependencies.toml' file
-    versionCatalog("testLibs") {
-        from(files("gradle/test-dependencies.toml"))
+    versionCatalogs {
+        // declares an additional catalog, named 'testLibs', from the 'test-dependencies.toml' file
+        create("testLibs") {
+            from(files("gradle/test-dependencies.toml"))
+        }
     }
 }
 // end::additional_catalog[]

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -54,8 +54,10 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                versionCatalog("libs") {
-                    from("org.gradle.test:my-platform:1.0")
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:1.0")
+                    }
                 }
             }
         """
@@ -89,9 +91,11 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                versionCatalog("libs") {
-                    from("org.gradle.test:my-platform:1.0")
-                    version('lib', '1.1') // override version declared in the platform, this is order sensitive
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:1.0")
+                        version('lib', '1.1') // override version declared in the platform, this is order sensitive
+                    }
                 }
             }
         """
@@ -133,8 +137,10 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                versionCatalog("libs") {
-                    from("org.gradle.test:my-platform:+")
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:+")
+                    }
                 }
             }
         """
@@ -162,8 +168,10 @@ org.gradle.test:my-platform:1.0
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
-                versionCatalog("libs") {
-                    from("org.gradle.test:my-platform:1.0")
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:1.0")
+                    }
                 }
             }
         """
@@ -178,8 +186,10 @@ org.gradle.test:my-platform:1.0
     def "reasonable error message if a no repositories are defined in settings"() {
         settingsFile << """
             dependencyResolutionManagement {
-                versionCatalog("libs") {
-                    from("org.gradle.test:my-platform:1.0")
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:1.0")
+                    }
                 }
             }
         """


### PR DESCRIPTION
### Context

Suggestion from @big-guy 

For consistency with other DSLs in Gradle, use a named object container
to declare catalogs. For the Groovy DSL it's actually a bit nicer. For
the Kotlin DSL unfortunately it makes things a bit more verbose.
