### PR TITLE
Improve reporting for single-use daemon

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -49,20 +49,14 @@ Currently, a given Gradle version can only connect to daemons of the same versio
 [[sec:disabling_the_daemon]]
 == Disabling the Daemon
 
-The Gradle Daemon is enabled by default, and we recommend always enabling it. There are several ways to disable the Daemon, but the most common one is to add the line
+The Gradle Daemon is enabled by default, and we recommend always enabling it. You can disable the long-lived Gradle daemon via the `--no-daemon` command-line option, or by adding `org.gradle.daemon=false` to your `gradle.properties` file. You can find details of other ways to disable (and enable) the Daemon in <<#daemon_faq,Daemon FAQ>> further down.
 
-[source]
-----
-org.gradle.daemon=false
-----
+[NOTE]
+====
 
-to the file `«USER_HOME»/.gradle/gradle.properties`, where `«USER_HOME»` is your home directory. That’s typically one of the following, depending on your platform:
+In order to honour the required JVM options for your build, Gradle will normally spawn a separate process for build invocation, even when the Daemon is disabled. You can prevent this "single-use Daemon" by ensuring that the JVM settings for the client VM match those required for the build VM. See <<build_environment.adoc#sec:configuring_jvm_memory,Configuring JVM Memory>> for more details.
 
-* `C:\Users\<username>` (Windows Vista & 7+)
-* `/Users/<username>` (macOS)
-* `/home/<username>` (Linux)
-
-If that file doesn’t exist, just create it using a text editor. You can find details of other ways to disable (and enable) the Daemon in <<#daemon_faq,Daemon FAQ>> further down. That section also contains more detailed information on how the Daemon works.
+====
 
 Note that having the Daemon enabled, all your builds will take advantage of the speed boost, regardless of the version of Gradle a particular build uses.
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/SingleUseDaemonClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/SingleUseDaemonClient.java
@@ -35,7 +35,7 @@ import java.io.InputStream;
 import java.util.UUID;
 
 public class SingleUseDaemonClient extends DaemonClient {
-    public static final String MESSAGE = "To honour the JVM settings for this build a new JVM will be forked.";
+    public static final String MESSAGE = "To honour the JVM settings for this build a single-use Daemon process will be forked.";
     private static final Logger LOGGER = Logging.getLogger(SingleUseDaemonClient.class);
     private final DocumentationRegistry documentationRegistry;
 
@@ -46,7 +46,7 @@ public class SingleUseDaemonClient extends DaemonClient {
 
     @Override
     public BuildActionResult execute(BuildAction action, BuildActionParameters parameters, BuildRequestContext buildRequestContext) {
-        LOGGER.lifecycle("{} Please consider using the daemon: {}.", MESSAGE, documentationRegistry.getDocumentationFor("gradle_daemon"));
+        LOGGER.lifecycle(MESSAGE + " See {}.", documentationRegistry.getDocumentationFor("gradle_daemon", "sec:disabling_the_daemon"));
 
         DaemonClientConnection daemonConnection = getConnector().startSingleUseDaemon();
         Build build = new Build(getIdGenerator().generateId(), daemonConnection.getDaemon().getToken(), action, buildRequestContext.getClient(), buildRequestContext.getStartTime(), buildRequestContext.isInteractive(), parameters);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/RequestStopIfSingleUsedDaemon.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/RequestStopIfSingleUsedDaemon.java
@@ -30,7 +30,7 @@ public class RequestStopIfSingleUsedDaemon implements DaemonCommandAction {
         if (execution.isSingleUseDaemon()) {
             LOGGER.debug("Requesting daemon stop after processing {}", execution.getCommand());
             // Does not take effect until after execution has completed
-            execution.getDaemonStateControl().requestStop("stopping after processing");
+            execution.getDaemonStateControl().requestStop("");
         }
         execution.proceed();
     }


### PR DESCRIPTION
With the Daemon enabled by default, the log messages can be confusing for users that explicitly disable the daemon.

Before this change, a user would see:
```
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/6.7/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
```

With this change, the message is:
```
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/6.7/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build
```

The `Disabling the Daemon` docs have been updated to include why we start a separate process even when the daemon is disabled.
