### PR TITLE
Explain binary compatibility in report

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/build.gradle.kts
+++ b/buildSrc/subprojects/binary-compatibility/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm")
     implementation(kotlin("compiler-embeddable"))
 
-    testImplementation("org.jsoup:jsoup")
+    implementation("org.jsoup:jsoup")
 }
 
 tasks.compileGroovy.configure {

--- a/buildSrc/subprojects/binary-compatibility/build.gradle.kts
+++ b/buildSrc/subprojects/binary-compatibility/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm")
     implementation(kotlin("compiler-embeddable"))
 
-    implementation("org.jsoup:jsoup")
+    testImplementation("org.jsoup:jsoup")
 }
 
 tasks.compileGroovy.configure {

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -162,7 +162,8 @@ gradle.taskGraph.afterTask {
 <p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">documentation</a> for more details.</p>
 <p>
 We check the binary compatibility by comparing the current code’s binary interfaces
-against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH AND LOWER THAN CURRENT BASE VERSION.
+against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH (from `released-version.json` on this branch)
+AND LOWER THAN CURRENT BASE VERSION (from `version.txt` on this branch).
 The difference must identically match `accepted-public-api-changes.json`, no more, no less - otherwise the task will fail.
 </p>
 """)

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -24,6 +24,9 @@ import gradlebuild.binarycompatibility.CleanAcceptedApiChanges
 import gradlebuild.binarycompatibility.transforms.ExplodeZipAndFindJars
 import gradlebuild.binarycompatibility.transforms.FindGradleClasspath
 import gradlebuild.binarycompatibility.transforms.FindGradleJars
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
 
 plugins {
     id("gradlebuild.module-identity")
@@ -105,6 +108,9 @@ dependencies {
     }
 }
 
+def binaryCompatibilityReportDir = file("$buildDir/reports/binary-compatibility")
+def binaryCompatibilityReport = "report.html"
+
 def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", JapicmpTask) {
     def baseVersion = moduleIdentity.version.map { it.baseVersion.version }
     def isSnapshot = moduleIdentity.snapshot
@@ -141,12 +147,29 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", Japicm
         excludedClasses = toPatterns(PublicApi.excludes + PublicKotlinDslApi.excludes)
 
         title = "Binary compatibility report for Gradle ${isSnapshot.get() ? "${baseVersion.get()}-SNAPSHOT" : version} since ${compatibilityBaselineVersion}"
-        destinationDir = file("$buildDir/reports/binary-compatibility")
-        reportName = "report.html"
+        destinationDir = binaryCompatibilityReportDir
+        reportName = binaryCompatibilityReport
     }
 
     BinaryCompatibilityHelper.setupJApiCmpRichReportRules(delegate, acceptedViolations, apiSourceFolders, baseVersion.get())
 }
+
+gradle.taskGraph.afterTask {
+    if (it.state.failure != null && it instanceof JapicmpTask) {
+        File report = new File(binaryCompatibilityReportDir, binaryCompatibilityReport)
+        Document doc = Jsoup.parse(report.text)
+        doc.select(".jumbotron").get(0).append("""
+<p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.tfvlgk4slzc9">documentation</a> for more details.</p>
+<p>
+We check the binary compatibility by comparing the current code’s binary interfaces
+against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH AND LOWER THAN CURRENT BASE VERSION.
+The difference must identically match `accepted-public-api-changes.json`, no more, no less - otherwise the task will fail.
+</p>
+""")
+        report.text = doc.outerHtml()
+    }
+}
+
 tasks.named("check").configure { dependsOn(checkBinaryCompatibility) }
 
 tasks.register("cleanAcceptedApiChanges", CleanAcceptedApiChanges) {

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -159,7 +159,7 @@ gradle.taskGraph.afterTask {
         File report = new File(binaryCompatibilityReportDir, binaryCompatibilityReport)
         Document doc = Jsoup.parse(report.text)
         doc.select(".jumbotron").get(0).append("""
-<p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.tfvlgk4slzc9">documentation</a> for more details.</p>
+<p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">documentation</a> for more details.</p>
 <p>
 We check the binary compatibility by comparing the current code’s binary interfaces
 against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH AND LOWER THAN CURRENT BASE VERSION.

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -24,9 +24,6 @@ import gradlebuild.binarycompatibility.CleanAcceptedApiChanges
 import gradlebuild.binarycompatibility.transforms.ExplodeZipAndFindJars
 import gradlebuild.binarycompatibility.transforms.FindGradleClasspath
 import gradlebuild.binarycompatibility.transforms.FindGradleJars
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-
 
 plugins {
     id("gradlebuild.module-identity")
@@ -108,9 +105,6 @@ dependencies {
     }
 }
 
-def binaryCompatibilityReportDir = file("$buildDir/reports/binary-compatibility")
-def binaryCompatibilityReport = "report.html"
-
 def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", JapicmpTask) {
     def baseVersion = moduleIdentity.version.map { it.baseVersion.version }
     def isSnapshot = moduleIdentity.snapshot
@@ -149,28 +143,19 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", Japicm
         title = "Binary compatibility report for Gradle ${isSnapshot.get() ? "${baseVersion.get()}-SNAPSHOT" : version} since ${compatibilityBaselineVersion}"
         destinationDir = binaryCompatibilityReportDir
         reportName = binaryCompatibilityReport
+        description = """
+            <p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">documentation</a> for more details.</p>
+            <p>
+            We check the binary compatibility by comparing the current code’s binary interfaces
+            against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH (from `released-version.json` on this branch)
+            AND LOWER THAN CURRENT BASE VERSION (from `version.txt` on this branch).
+            The difference must identically match `accepted-public-api-changes.json`, no more, no less - otherwise the task will fail.
+            </p>
+""".stripIndent()
     }
 
     BinaryCompatibilityHelper.setupJApiCmpRichReportRules(delegate, acceptedViolations, apiSourceFolders, baseVersion.get())
 }
-
-gradle.taskGraph.afterTask {
-    if (it.state.failure != null && it instanceof JapicmpTask) {
-        File report = new File(binaryCompatibilityReportDir, binaryCompatibilityReport)
-        Document doc = Jsoup.parse(report.text)
-        doc.select(".jumbotron").get(0).append("""
-<p>See the <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">documentation</a> for more details.</p>
-<p>
-We check the binary compatibility by comparing the current code’s binary interfaces
-against THE LATEST VERSION WHICH IS RELEASED FROM RELEASE BRANCH (from `released-version.json` on this branch)
-AND LOWER THAN CURRENT BASE VERSION (from `version.txt` on this branch).
-The difference must identically match `accepted-public-api-changes.json`, no more, no less - otherwise the task will fail.
-</p>
-""")
-        report.text = doc.outerHtml()
-    }
-}
-
 tasks.named("check").configure { dependsOn(checkBinaryCompatibility) }
 
 tasks.register("cleanAcceptedApiChanges", CleanAcceptedApiChanges) {

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -142,17 +142,29 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
             change.changes
         )
 
-        def id = "accept" + (change.type + change.member).replaceAll('[^a-zA-Z0-9]', '_')
+        def changeId = (change.type + change.member).replaceAll('[^a-zA-Z0-9]', '_')
         Violation violation = Violation.error(
             member,
             rejection.getHumanExplanation() + """. If you did this intentionally, please accept the change and provide an explanation:
-                <a class="btn btn-info" role="button" data-toggle="collapse" href="#${id}" aria-expanded="false" aria-controls="collapseExample">Accept this change</a>
-                <div class="collapse" id="${id}">
+                <a class="btn btn-info" role="button" data-toggle="collapse" href="#accept-${changeId}" aria-expanded="false" aria-controls="collapseExample">Accept this change</a>
+                <div class="collapse" id="accept-${changeId}">
                   <div class="well">
                       In order to accept this change add the following to <code>subprojects/architecture-test/src/changes/accepted-public-api-changes.json</code>:
                     <pre>${prettyPrintJson(acceptanceJson)}</pre>
                   </div>
-                </div>""".stripIndent()
+                </div>
+                <p>
+                Or update baseline version:
+                </p>
+                <a class="btn btn-info" role="button" data-toggle="collapse" href="#update-baseline-${changeId}" aria-expanded="false" aria-controls="collapseExample">Update baseline</a>
+                <div class="collapse" id="update-baseline-${changeId}">
+                  <div class="well">
+                      Sometimes, the change was made on the `release` branch but hasn't yet been published to the baseline version.
+                      In that case, you can publish a new snapshot from the release branch. This will update `released-versions.json` on `master`.
+                      See <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">the documentation</a> for more details.
+                  </div>
+                </div>
+                """.stripIndent()
         )
         return violation
     }

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -145,7 +145,11 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
         def changeId = (change.type + change.member).replaceAll('[^a-zA-Z0-9]', '_')
         Violation violation = Violation.error(
             member,
-            rejection.getHumanExplanation() + """. If you did this intentionally, please accept the change and provide an explanation:
+            rejection.getHumanExplanation() + """.
+                <br>
+                <p>
+                If you did this intentionally, please accept the change and provide an explanation:
+                </p>
                 <a class="btn btn-info" role="button" data-toggle="collapse" href="#accept-${changeId}" aria-expanded="false" aria-controls="collapseExample">Accept this change</a>
                 <div class="collapse" id="accept-${changeId}">
                   <div class="well">
@@ -154,7 +158,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                   </div>
                 </div>
                 <p>
-                Or update baseline version:
+                If change was made on the `release` branch but hasn't yet been published to the baseline version, update the baseline version:
                 </p>
                 <a class="btn btn-info" role="button" data-toggle="collapse" href="#update-baseline-${changeId}" aria-expanded="false" aria-controls="collapseExample">Update baseline</a>
                 <div class="collapse" id="update-baseline-${changeId}">
@@ -162,6 +166,16 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                       Sometimes, the change was made on the `release` branch but hasn't yet been published to the baseline version.
                       In that case, you can publish a new snapshot from the release branch. This will update `released-versions.json` on `master`.
                       See <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">the documentation</a> for more details.
+                  </div>
+                </div>
+                <p>
+                If change was made on the `release` branch but hasn't yet been merged to `master`, merge `release` to `master`:
+                </p>
+                <a class="btn btn-info" role="button" data-toggle="collapse" href="#merge-release-${changeId}" aria-expanded="false" aria-controls="collapseExample">Merge release to master</a>
+                <div class="collapse" id="merge-release-${changeId}">
+                  <div class="well">
+                      Merging `release` back to `master` is a regular operation you’re free to do, at any time. Usually, you will see conflicts in `notes.md` or `accepted-public-api-changes.json`.
+                      On `master` branch, these two files are usually reset (cleaned up), unless you have special reasons not to do so.
                   </div>
                 </div>
                 """.stripIndent()

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -149,7 +149,6 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                 <br>
                 <p>
                 If you did this intentionally, please accept the change and provide an explanation:
-                </p>
                 <a class="btn btn-info" role="button" data-toggle="collapse" href="#accept-${changeId}" aria-expanded="false" aria-controls="collapseExample">Accept this change</a>
                 <div class="collapse" id="accept-${changeId}">
                   <div class="well">
@@ -157,9 +156,9 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                     <pre>${prettyPrintJson(acceptanceJson)}</pre>
                   </div>
                 </div>
+                </p>
                 <p>
                 If change was made on the `release` branch but hasn't yet been published to the baseline version, update the baseline version:
-                </p>
                 <a class="btn btn-info" role="button" data-toggle="collapse" href="#update-baseline-${changeId}" aria-expanded="false" aria-controls="collapseExample">Update baseline</a>
                 <div class="collapse" id="update-baseline-${changeId}">
                   <div class="well">
@@ -168,9 +167,9 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                       See <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">the documentation</a> for more details.
                   </div>
                 </div>
+                </p>
                 <p>
                 If change was made on the `release` branch but hasn't yet been merged to `master`, merge `release` to `master`:
-                </p>
                 <a class="btn btn-info" role="button" data-toggle="collapse" href="#merge-release-${changeId}" aria-expanded="false" aria-controls="collapseExample">Merge release to master</a>
                 <div class="collapse" id="merge-release-${changeId}">
                   <div class="well">
@@ -178,6 +177,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                       On `master` branch, these two files are usually reset (cleaned up), unless you have special reasons not to do so.
                   </div>
                 </div>
+                </p>
                 """.stripIndent()
         )
         return violation


### PR DESCRIPTION
This PR adds an extra message in binary compatibility report to help
developers understand what's happening.

This is how it looks like now:

![image](https://user-images.githubusercontent.com/12689835/100198865-650d2880-2f37-11eb-97c0-b89805ce4291.png)
