### PR TITLE
Make catalogs support nested catalogs

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -58,7 +58,7 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
             }
 
             dependencies {
-                implementation(libs.myLib) {
+                implementation(libs.my.lib) {
                     version {
                         strictly("1.1")
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/TomlDependenciesExtensionIntegrationTest.groovy
@@ -98,7 +98,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
             }
         """
 
@@ -126,7 +126,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(libs.myLib) {
+                implementation(libs.my.lib) {
                     version {
                         require '1.1'
                     }
@@ -332,7 +332,7 @@ build-src-lib="org.gradle.test:buildsrc-lib:1.0"
             }
 
             dependencies {
-                implementation libs.buildSrcLib
+                implementation libs.build.src.lib
             }
         """
         buildFile << """
@@ -372,7 +372,7 @@ build-src-lib="org.gradle.test:buildsrc-lib:1.0"
             version = 'zloubi'
 
             dependencies {
-                implementation libs.fromIncluded
+                implementation libs.from.included
             }
         """
         file("included/gradle/dependencies.toml") << """[dependencies]
@@ -428,7 +428,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
                 implementation libs.other
             }
         """
@@ -469,7 +469,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.1"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
             }
         """
         settingsFile << """
@@ -534,7 +534,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
             }
 
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
             }
 
             tasks.register("checkDeps", CheckDeps) {
@@ -596,7 +596,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libraries.myLib
+                implementation libraries.my.lib
             }
         """
 
@@ -630,8 +630,8 @@ my-other-lib = {group = "org.gradle.test", name="lib2", version.ref="rich"}
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libs.myLib
-                implementation libs.myOtherLib
+                implementation libs.my.lib
+                implementation libs.my.other.lib
             }
         """
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractExternalDependencyFactory.java
@@ -27,6 +27,12 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
     private final DefaultVersionCatalog config;
     private final ProviderFactory providers;
 
+    protected abstract class SubDependencyFactory implements ExternalModuleDependencyFactory {
+        protected Provider<MinimalExternalModuleDependency> create(String alias) {
+            return AbstractExternalDependencyFactory.this.create(alias);
+        }
+    }
+
     @Inject
     protected AbstractExternalDependencyFactory(DefaultVersionCatalog config,
                                                 ProviderFactory providers) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractSourceGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/AbstractSourceGenerator.java
@@ -33,11 +33,15 @@ public abstract class AbstractSourceGenerator {
     }
 
     static String toJavaName(String alias) {
-        return Splitter.on(SEPARATOR_PATTERN)
+        return nameSplitter()
             .splitToList(alias)
             .stream()
             .map(StringUtils::capitalize)
             .collect(Collectors.joining());
+    }
+
+    protected static Splitter nameSplitter() {
+        return Splitter.on(SEPARATOR_PATTERN);
     }
 
     protected void addImport(String clazz) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/DefaultDependenciesAccessors.java
@@ -39,6 +39,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.execution.ExecutionEngine;
+import org.gradle.internal.execution.ExecutionResult;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.workspace.WorkspaceProvider;
 import org.gradle.internal.file.TreeType;
@@ -142,15 +143,13 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     }
 
     private void executeWork(UnitOfWork work) {
-        engine.execute(work)
-            .getExecutionResult()
-            .ifSuccessful(er -> {
-                GeneratedAccessors accessors = (GeneratedAccessors) er.getOutput();
-                ClassPath generatedClasses = DefaultClassPath.of(accessors.classesDir);
-                sources = sources.plus(DefaultClassPath.of(accessors.sourcesDir));
-                classes = classes.plus(generatedClasses);
-                classLoaderScope.export(generatedClasses);
-            });
+        ExecutionEngine.Result result = engine.execute(work);
+        ExecutionResult er = result.getExecutionResult().get();
+        GeneratedAccessors accessors = (GeneratedAccessors) er.getOutput();
+        ClassPath generatedClasses = DefaultClassPath.of(accessors.classesDir);
+        sources = sources.plus(DefaultClassPath.of(accessors.sourcesDir));
+        classes = classes.plus(generatedClasses);
+        classLoaderScope.export(generatedClasses);
     }
 
     private static boolean assertCanGenerateAccessors(ProjectRegistry<? extends ProjectDescriptor> projectRegistry) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/std/DependenciesSourceGeneratorTest.groovy
@@ -90,12 +90,13 @@ class DependenciesSourceGeneratorTest extends Specification {
         sources.hasDependencyAlias(name, method)
 
         where:
-        name          | method
-        'groovy'      | 'getGroovy'
-        'groovy-json' | 'getGroovyJson'
-        'groovy.json' | 'getGroovyJson'
-        'groovyJson'  | 'getGroovyJson'
-        'lang3'       | 'getLang3'
+        name                  | method
+        'groovy'              | 'getGroovy'
+        'groovy-json'         | 'getJson'
+        'groovy.json'         | 'getJson'
+        'groovyJson'          | 'getGroovyJson'
+        'lang3'               | 'getLang3'
+        'kotlinx.awesome.lib' | 'getLib'
     }
 
     @Unroll
@@ -256,7 +257,7 @@ class DependenciesSourceGeneratorTest extends Specification {
 
         then:
         sources.assertClass('Generated', 'Some description for tests')
-        sources.hasDependencyAlias('some-alias', 'getSomeAlias', "This dependency was declared in ${context}")
+        sources.hasDependencyAlias('some-alias', 'getAlias', "This dependency was declared in ${context}")
         sources.hasBundle('b0Bundle', 'getB0Bundle', "This bundle was declared in ${context}")
         sources.hasVersion('v0Version', 'getV0Version', "This version was declared in ${innerContext}")
         sources.hasDependencyAlias('other', 'getOther', "This dependency was declared in ${context}")

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -42,6 +42,40 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",fil
 include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="settings.gradle.kts[tags=simple_catalog]"]
 ====
 
+[NOTE]
+.Mapping of aliases to type-safe accessors
+====
+Aliases must consist of a series of identifiers separated by a dash (`-`, recommended), an underscore (`_`) or a dot (`.`).
+Identifiers themselves must consist of ascii characters, preferably lowercase, eventually followed by numbers.
+
+For example:
+
+- `guava` is a valid alias
+- `groovy-core` is a valid alias
+- `commons-lang3` is a valid alias
+- `androidx.awesome.lib` is also a valid alias
+- but `this.#is.not!`
+
+Then type safe accessors are generated for _each subgroup_.
+For example, given the following aliases:
+
+`guava`, `groovy-core`, `groovy-xml`, `groovy-json`, `androidx.awesome.lib`
+
+We would generate the following type-safe accessors:
+
+- `libs.guava`
+- `libs.groovy.core`
+- `libs.groovy.xml`
+- `libs.groovy.json`
+- `libs.androidx.awesome.lib`
+
+It is illegal to have an alias to a dependency which happens to also belong to a nested group.
+For example `commons` and `commons-core` is illegal.
+
+In case you want to avoid the generation of a subgroup accessor, we recommend to rely on case to differentiate.
+For example the aliases `groovyCore`, `groovyJson` and `groovyXml` would be mapped to the `libs.groovyCore`, `libs.groovyJson` and `libs.groovyXml` accessors respectively.
+====
+
 [[sec:common-version-numbers]]
 ==== Dependencies with same version numbers
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/build.gradle
@@ -21,7 +21,7 @@ plugins {
 
 // tag::simple_dependency_use[]
 dependencies {
-    implementation(libs.groovy)
+    implementation(libs.groovy.core)
 }
 // end::simple_dependency_use[]
 
@@ -34,9 +34,9 @@ checkstyle {
 
 // tag::use_catalog[]
 dependencies {
-    implementation libs.groovy
-    implementation libs.groovyJson
-    implementation libs.groovyNio
+    implementation libs.groovy.core
+    implementation libs.groovy.json
+    implementation libs.groovy.nio
 }
 // end::use_catalog[]
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            alias('groovy').to('org.codehaus.groovy:groovy:3.0.5')
+            alias('groovy-core').to('org.codehaus.groovy:groovy:3.0.5')
             alias('groovy-json').to('org.codehaus.groovy:groovy-json:3.0.5')
             alias('groovy-nio').to('org.codehaus.groovy:groovy-nio:3.0.5')
             alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
@@ -44,7 +44,7 @@ dependencyResolutionManagement {
         libs {
             version('groovy', '3.0.5')
             version('checkstyle', '8.37')
-            alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
+            alias('groovy-core').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
             alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
             alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
             alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
@@ -62,14 +62,14 @@ dependencyResolutionManagement {
         libs {
             version('groovy', '3.0.5')
             version('checkstyle', '8.37')
-            alias('groovy').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
+            alias('groovy-core').to('org.codehaus.groovy', 'groovy').versionRef('groovy')
             alias('groovy-json').to('org.codehaus.groovy', 'groovy-json').versionRef('groovy')
             alias('groovy-nio').to('org.codehaus.groovy', 'groovy-nio').versionRef('groovy')
             alias('commons-lang3').to('org.apache.commons', 'commons-lang3').version {
                 strictly '[3.8, 4.0['
                 prefer '3.9'
             }
-            bundle('groovy', ['groovy', 'groovy-json', 'groovy-nio'])
+            bundle('groovy', ['groovy-core', 'groovy-json', 'groovy-nio'])
         }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 // tag::simple_dependency_use[]
 dependencies {
-    implementation(libs.groovy)
+    implementation(libs.groovy.core)
 }
 // end::simple_dependency_use[]
 
@@ -34,9 +34,9 @@ checkstyle {
 
 // tag::use_catalog[]
 dependencies {
-    implementation(libs.groovy)
-    implementation(libs.groovyJson)
-    implementation(libs.groovyNio)
+    implementation(libs.groovy.core)
+    implementation(libs.groovy.json)
+    implementation(libs.groovy.nio)
 }
 // end::use_catalog[]
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -27,7 +27,7 @@ if (providers.systemProperty("create1").forUseAtConfigurationTime().getOrNull() 
     dependencyResolutionManagement {
         versionCatalogs {
             create("libs") {
-                alias("groovy").to("org.codehaus.groovy:groovy:3.0.5")
+                alias("groovy-core").to("org.codehaus.groovy:groovy:3.0.5")
                 alias("groovy-json").to("org.codehaus.groovy:groovy-json:3.0.5")
                 alias("groovy-nio").to("org.codehaus.groovy:groovy-nio:3.0.5")
                 alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
@@ -47,7 +47,7 @@ if (providers.systemProperty("create2").forUseAtConfigurationTime().getOrNull() 
             create("libs") {
                 version("groovy", "3.0.5")
                 version("checkstyle", "8.37")
-                alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
+                alias("groovy-core").to("org.codehaus.groovy", "groovy").versionRef("groovy")
                 alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
                 alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
                 alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
@@ -67,14 +67,14 @@ if (providers.systemProperty("create3").forUseAtConfigurationTime().getOrNull() 
             create("libs") {
                 version("groovy", "3.0.5")
                 version("checkstyle", "8.37")
-                alias("groovy").to("org.codehaus.groovy", "groovy").versionRef("groovy")
+                alias("groovy-core").to("org.codehaus.groovy", "groovy").versionRef("groovy")
                 alias("groovy-json").to("org.codehaus.groovy", "groovy-json").versionRef("groovy")
                 alias("groovy-nio").to("org.codehaus.groovy", "groovy-nio").versionRef("groovy")
                 alias("commons-lang3").to("org.apache.commons", "commons-lang3").version {
                     strictly("[3.8, 4.0[")
                     prefer("3.9")
                 }
-                bundle("groovy", listOf("groovy", "groovy-json", "groovy-nio"))
+                bundle("groovy", listOf("groovy-core", "groovy-json", "groovy-nio"))
             }
         }
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/dependencies.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/dependencies.toml
@@ -3,13 +3,13 @@ groovy = "3.0.5"
 checkstyle = "8.37"
 
 [dependencies]
-groovy = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
 groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
 groovy-nio = { module = "org.codehaus.groovy:groovy-nio", version.ref = "groovy" }
 commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version = { strictly = "[3.8, 4.0[", prefer="3.9" } }
 
 [bundles]
-groovy = ["groovy", "groovy-json", "groovy-nio"]
+groovy = ["groovy-core", "groovy-json", "groovy-nio"]
 
 [plugins]
 my.awesome.plugin = "1.4"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/test-dependencies.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/test-dependencies.toml
@@ -2,4 +2,4 @@
 my-lib = "com.mycompany:mylib:1.4"
 my-other-lib = { module = "com.mycompany:other", version="1.4" }
 my-other-lib2 = { group = "com.mycompany", name="alternate", version="1.4" }
-my-lib-full-format = { group = "com.mycompany", name="alternate", version={ require = "1.4" } }
+mylib-full-format = { group = "com.mycompany", name="alternate", version={ require = "1.4" } }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/dependencies.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/dependencies.toml
@@ -3,13 +3,13 @@ groovy = "3.0.5"
 checkstyle = "8.37"
 
 [dependencies]
-groovy = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
 groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
 groovy-nio = { module = "org.codehaus.groovy:groovy-nio", version.ref = "groovy" }
 commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version = { strictly = "[3.8, 4.0[", prefer="3.9" } }
 
 [bundles]
-groovy = ["groovy", "groovy-json", "groovy-nio"]
+groovy = ["groovy-core", "groovy-json", "groovy-nio"]
 
 [plugins]
 my.awesome.plugin = "1.4"

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/test-dependencies.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/test-dependencies.toml
@@ -2,4 +2,4 @@
 my-lib = "com.mycompany:mylib:1.4"
 my-other-lib = { module = "com.mycompany:other", version="1.4" }
 my-other-lib2 = { group = "com.mycompany", name="alternate", version="1.4" }
-my-lib-full-format = { group = "com.mycompany", name="alternate", version={ require = "1.4" } }
+mylib-full-format = { group = "com.mycompany", name="alternate", version={ require = "1.4" } }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -64,7 +64,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
 
         buildFile << """
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
             }
         """
 
@@ -80,7 +80,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
         def platformProject = preparePlatformProject '''
             versionCatalog {
                 def v = version('lib', '1.0')
-                alias('my-lib').to('org.test', 'lib').versionRef(v)
+                alias('my-lib-core').to('org.test', 'lib').versionRef(v)
                 alias('my-lib-json').to('org.test', 'lib-json').versionRef(v)
             }
         '''
@@ -102,8 +102,8 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
 
         buildFile << """
             dependencies {
-                implementation libs.myLib
-                implementation libs.myLibJson
+                implementation libs.my.lib.core
+                implementation libs.my.lib.json
             }
         """
 
@@ -150,7 +150,7 @@ org.gradle.test:my-platform:1.0
 
         buildFile << """
             dependencies {
-                implementation libs.myLib
+                implementation libs.my.lib
             }
         """
 


### PR DESCRIPTION
### Context

Previously a catalog was a flat list of dependencies. With this change, a catalog consists of nested accessors, based on the alias.
For example "my-lib" would generate the accessor `libs.my.lib`, instead of `libs.myLib` previously.

This fixes an issue reported by a large customer wanting to migrate to native catalogs, but without this feature it would mean rewriting a lot of build scripts.
