### PR TITLE
Add `:checkSubprojectsInfo` to sanity task to ensure up-to-date

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -140,6 +140,20 @@
     "crossVersionTests": false
   },
   {
+    "dirName": "configuration-cache",
+    "name": "configuration-cache",
+    "unitTests": true,
+    "functionalTests": true,
+    "crossVersionTests": true
+  },
+  {
+    "dirName": "configuration-cache-report",
+    "name": "configuration-cache-report",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
     "dirName": "core",
     "name": "core",
     "unitTests": true,
@@ -311,20 +325,6 @@
     "dirName": "installation-beacon",
     "name": "installation-beacon",
     "unitTests": false,
-    "functionalTests": false,
-    "crossVersionTests": false
-  },
-  {
-    "dirName": "configuration-cache",
-    "name": "configuration-cache",
-    "unitTests": true,
-    "functionalTests": true,
-    "crossVersionTests": true
-  },
-  {
-    "dirName": "configuration-cache-report",
-    "name": "configuration-cache-report",
-    "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },

--- a/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild.generate-subprojects-info.gradle.kts
+++ b/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild.generate-subprojects-info.gradle.kts
@@ -1,3 +1,5 @@
 import gradlebuild.buildutils.tasks.GenerateSubprojectsInfo
+import gradlebuild.buildutils.tasks.CheckSubprojectsInfo
 
-tasks.register<GenerateSubprojectsInfo>("generateSubprojectsInfo")
+tasks.register<GenerateSubprojectsInfo>(GenerateSubprojectsInfo.TASK_NAME)
+tasks.register<CheckSubprojectsInfo>("checkSubprojectsInfo")

--- a/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/CheckSubprojectsInfo.kt
+++ b/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/CheckSubprojectsInfo.kt
@@ -16,18 +16,18 @@
 
 package gradlebuild.buildutils.tasks
 
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
 
-abstract class GenerateSubprojectsInfo : SubprojectsInfo() {
+abstract class CheckSubprojectsInfo : SubprojectsInfo() {
 
     @TaskAction
-    fun generateSubprojectsInfo() {
-        subprojectsJson.asFile.writeText(generateSubprojectsJson())
-    }
-
-    companion object {
-        internal
-        const val TASK_NAME = "generateSubprojectsInfo"
+    fun checkSubprojectsInfo() {
+        if (subprojectsJson.asFile.readText() != generateSubprojectsJson()) {
+            throw GradleException(
+                "New project(s) added without updating subproject JSON. Please run `:${GenerateSubprojectsInfo.TASK_NAME}` task."
+            )
+        }
     }
 }

--- a/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
+++ b/buildSrc/subprojects/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.buildutils.tasks
+
+import com.google.gson.GsonBuilder
+import gradlebuild.buildutils.model.GradleSubproject
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
+import java.io.File
+
+
+open class SubprojectsInfo : DefaultTask() {
+
+    private
+    val subprojectsFolder = project.layout.projectDirectory.dir("subprojects")
+
+    @get:Internal
+    protected
+    val subprojectsJson = project.layout.projectDirectory.file(".teamcity/subprojects.json")
+
+    protected
+    fun generateSubprojectsJson(): String {
+        val subprojects = generateSubprojects()
+        val gson = GsonBuilder().setPrettyPrinting().create()
+        return gson.toJson(subprojects) + '\n'
+    }
+
+    private
+    fun generateSubprojects(): List<GradleSubproject> {
+        return subprojectsFolder.asFile.listFiles(File::isDirectory)!!
+            .filter {
+                File(it, "build.gradle.kts").exists() ||
+                    File(it, "build.gradle").exists()
+            }
+            .sorted()
+            .map(this::generateSubproject)
+    }
+
+
+    private
+    fun generateSubproject(subprojectDir: File): GradleSubproject {
+        return GradleSubproject(
+            subprojectDir.name,
+            subprojectDir.name,
+            subprojectDir.hasDescendantDir("src/test"),
+            if (subprojectDir.name == "docs") true else subprojectDir.hasDescendantDir("src/integTest"),
+            subprojectDir.hasDescendantDir("src/crossVersionTest")
+        )
+    }
+
+    private
+    fun File.hasDescendantDir(descendant: String) = resolve(descendant).isDirectory
+}

--- a/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/buildSrc/subprojects/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -103,10 +103,14 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
         description = "Run all basic checks (without tests) - to be run locally and on CI for early feedback"
         group = "verification"
         dependsOn(
-            ":docs:checkstyleApi", ":internal-build-reports:allIncubationReportsZip",
-            ":architecture-test:checkBinaryCompatibility", ":docs:javadocAll",
-            ":architecture-test:test", ":tooling-api:toolingApiShadedJar",
-            ":performance:verifyPerformanceScenarioDefinitions"
+            ":docs:checkstyleApi",
+            ":internal-build-reports:allIncubationReportsZip",
+            ":architecture-test:checkBinaryCompatibility",
+            ":docs:javadocAll",
+            ":architecture-test:test",
+            ":tooling-api:toolingApiShadedJar",
+            ":performance:verifyPerformanceScenarioDefinitions",
+            ":checkSubprojectsInfo"
         )
     }
 }


### PR DESCRIPTION
`:checkSubprojectsInfo` will now be run as a part of the sanity check task. This will verify that the `.teamcity/subprojects.json` file is always kept up-to-date for our CI builds.

This came out of this discussion with @lptr:

https://github.com/gradle/gradle/pull/15240#discussion_r528576053