### PR TITLE
Remove optimistic caching of the component metadata handler

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -642,4 +642,61 @@ task res {
         then:
         succeeds 'resolve'
     }
+
+    // In theory we shouldn't allow this because it can lead to inconsistent dependency
+    // resolution: it means that two strictly equivalent configurations, with the same
+    // dependencies, could resolve differently in the same project, after some rules
+    // have been added. However, the Nebula Resolution Rules plugin depends on this
+    // behavior, because it downloads rules in a JSON format and applies them to the
+    // current project.
+    @Issue("https://github.com/gradle/gradle/issues/15312")
+    def "rules can be added after a first resolution happened in the project"() {
+        repository {
+            'org.test:projectA:1.0'()
+        }
+        buildFile << """
+
+class LoggingRule implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println "I am executed on \${context.details.id}"
+    }
+}
+
+configurations {
+    ruleDownloader.incoming.afterResolve {
+        println "Adding rules"
+        dependencies {
+            components {
+                all(LoggingRule)
+            }
+        }
+    }
+}
+
+dependencies {
+    ruleDownloader files('rules.json')
+    conf 'org.test:projectA:1.0'
+}
+
+resolve {
+    doFirst {
+        configurations.ruleDownloader.resolve() // trigger resolution before rules are added
+    }
+}
+
+"""
+
+        when:
+        repositoryInteractions {
+            'org.test:projectA:1.0' {
+                allowAll()
+            }
+        }
+
+        then:
+        succeeds 'resolve'
+
+        and:
+        outputContains "I am executed on org.test:projectA:1.0"
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -47,7 +47,6 @@ import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
@@ -62,6 +61,7 @@ import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public class DefaultComponentMetadataHandler implements ComponentMetadataHandler, ComponentMetadataHandlerInternal {
     private static final String ADAPTER_NAME = ComponentMetadataHandler.class.getSimpleName();
@@ -254,7 +254,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
         // we need to defer the creation of the actual factory until configuration is completed
         // Typically the state of whether to prefer project rules or not is not known when this
         // method is called.
-        Lazy<ComponentMetadataHandlerInternal> actualHandler = Lazy.unsafe().of(() -> {
+        Supplier<ComponentMetadataHandlerInternal> actualHandler = () -> {
             // determine whether to use the project local handler or the settings handler
             boolean useRules = dependencyResolutionManagement.getConfiguredRulesMode().useProjectRules();
             if (metadataRuleContainer.isEmpty() || !useRules) {
@@ -268,7 +268,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
                 return delegate;
             }
             return this;
-        });
+        };
         return resolutionContext -> actualHandler.get().createComponentMetadataProcessor(resolutionContext);
     }
 


### PR DESCRIPTION
When reworking the creation of the component metadata handler to
support settings level component metadata rules, we assumed that
rules were added _before the first resolution in a project_.

This assumption doesn't hold: it is possible, today, to resolve
a configuration, _then_ add rules. While in theory we should
disallow this, a popular plugin, the "Nebula Resolution Rules"
plugin, relies on this behavior, because it uses the dependency
resolution engine itself to download rules which are then
added to the project.

Fixes #15312
