### PR TITLE
Handle exceptions thrown in shutting-down process

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/shutdown/ShutdownHooks.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/shutdown/ShutdownHooks.java
@@ -15,10 +15,14 @@
  */
 package org.gradle.process.internal.shutdown;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ShutdownHooks {
+    private static final Logger LOGGER = Logging.getLogger(ShutdownHooks.class);
     private static final Map<Runnable, Thread> HOOKS = new ConcurrentHashMap<Runnable, Thread>();
 
     public static void addShutdownHook(Runnable shutdownHook) {
@@ -28,10 +32,19 @@ public class ShutdownHooks {
     }
 
     public static void removeShutdownHook(Runnable shutdownHook) {
-        Thread thread = HOOKS.remove(shutdownHook);
-        if (thread != null) {
-            Runtime.getRuntime().removeShutdownHook(thread);
+        try {
+            Thread thread = HOOKS.remove(shutdownHook);
+            if (thread != null) {
+                Runtime.getRuntime().removeShutdownHook(thread);
+            }
+        } catch (IllegalStateException e) {
+            // When shutting down is in progress, invocation of this method throws exception,
+            // interrupting other shutdown hooks, so we catch it here.
+            //
+            // Caused by: java.lang.IllegalStateException: Shutdown in progress
+            //        at java.base/java.lang.ApplicationShutdownHooks.remove(ApplicationShutdownHooks.java:82)
+            //        at java.base/java.lang.Runtime.removeShutdownHook(Runtime.java:243)
+            LOGGER.error("Remove shutdown hook failed", e);
         }
     }
-
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonRegistryUpdater.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonRegistryUpdater.java
@@ -27,6 +27,7 @@ import org.gradle.launcher.daemon.registry.DaemonRegistry;
 import org.gradle.launcher.daemon.registry.DaemonStopEvent;
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*;
@@ -47,7 +48,7 @@ class DaemonRegistryUpdater implements Stoppable {
     }
 
     public void onStartActivity() {
-        LOGGER.info("Marking the daemon as busy, address: {}", connectorAddress);
+        LOGGER.info("Marking the daemon as busy, address: {}, token: {}", connectorAddress, Arrays.toString(token));
         try {
             daemonRegistry.markState(connectorAddress, Busy);
         } catch (DaemonRegistry.EmptyRegistryException e) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
@@ -156,7 +156,8 @@ public class DefaultIncomingConnectionHandler implements IncomingConnectionHandl
             LOGGER.debug("{}{} with connection: {}.", DaemonMessages.STARTED_EXECUTING_COMMAND, command, connection);
             try {
                 if (!Arrays.equals(command.getToken(), token)) {
-                    throw new BadlyFormedRequestException(String.format("Unexpected authentication token in command %s received from %s", command, connection));
+                    throw new BadlyFormedRequestException(String.format("Unexpected authentication token in command %s received from %s, expected: %s, incoming: %s.",
+                        command, connection, Arrays.toString(token), Arrays.toString(token)));
                 }
                 commandExecuter.executeCommand(daemonConnection, command, daemonContext, daemonStateControl);
             } catch (Throwable e) {


### PR DESCRIPTION
### Context

We've seen `org.gradle.launcher.daemon.server.BadlyFormedRequestException: Unexpected authentication token in command Build{id=5bd12d2f-010d-4bfb-a376-4b23cc9f4b0b, currentDir=/home/tcagent1/agent/work/e67123fb5b9af0ac} received from socket connection from /127.0.0.1:37339 to /127.0.0.1:39124` twice this week. Looking at the daemon log, there's something interesting.

This is a **normal** daemon shutting down log:

```
Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt.
16:49:53.127 [DEBUG] [org.gradle.launcher.daemon.registry.PersistentDaemonRegistry] Removing daemon address: [d3ef27ea-fb4d-4e49-8c3f-2523f559ad50 port:60038, addresses:[/0:0:0:0:0:0:0:1%lo0, /127.0.0.1]]
```

The current running daemon was correctly removed from daemon registry. This is the problematic daemon log:

```
Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt.
failed to abort Gradle Test Executor 2
org.gradle.process.internal.ExecException: A problem occurred waiting for process 'Gradle Test Executor 2' to complete.
        at org.gradle.process.internal.DefaultExecHandle.execExceptionFor(DefaultExecHandle.java:241)
        at org.gradle.process.internal.DefaultExecHandle.setEndStateInfo(DefaultExecHandle.java:218)
        at org.gradle.process.internal.DefaultExecHandle.failed(DefaultExecHandle.java:369)
        at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:87)
        at org.gradle.internal.operations.CurrentBuildOperationPreservingRunnable.run(CurrentBuildOperationPreservingRunnable.java:42)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.IllegalStateException: Shutdown in progress
        at java.base/java.lang.ApplicationShutdownHooks.remove(ApplicationShutdownHooks.java:82)
        at java.base/java.lang.Runtime.removeShutdownHook(Runtime.java:243)
        at org.gradle.process.internal.shutdown.ShutdownHooks.removeShutdownHook(ShutdownHooks.java:33)
        at org.gradle.process.internal.DefaultExecHandle.setEndStateInfo(DefaultExecHandle.java:208)
        at org.gradle.process.internal.DefaultExecHandle.aborted(DefaultExecHandle.java:365)
        at org.gradle.process.internal.ExecHandleRunner.completed(ExecHandleRunner.java:108)
        at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:84)
        ... 7 more

End of file
```

So it looks like that during shutting down process, an exception was thrown, interrupting the shutdown hook which removes current daemon from daemon registry. This PR catches this exception.

However, this shouldn't be a problem, because even daemon exits unexpectedly, the daemon registry file should not be broken. The token information is recorded in daemon log for further investigation. IIUC, the token is not credential, right? cc @big-guy @adammurdoch 