### PR TITLE
Fix display names not being propagated to the TAPI events

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/operations/TestListenerBuildOperationAdapter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/operations/TestListenerBuildOperationAdapter.java
@@ -80,7 +80,7 @@ public class TestListenerBuildOperationAdapter implements TestListenerInternal {
         Details details = new Details(testDescriptor, testStartEvent.getStartTime());
         InProgressExecuteTestBuildOperation parentOperation = runningTests.get(testDescriptor.getParent());
         OperationIdentifier parentId = parentOperation == null ? CurrentBuildOperationRef.instance().getId() : parentOperation.descriptor.getId();
-        return BuildOperationDescriptor.displayName(testDescriptor.getName())
+        return BuildOperationDescriptor.displayName(testDescriptor.getDisplayName())
             .details(details)
             .build(newOperationIdentifier(), parentId);
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -100,7 +100,7 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
     private DefaultTestDescriptor toTestDescriptorForSuite(OperationIdentifier buildOperationId, TestDescriptorInternal suite) {
         Object id = suite.getId();
         String name = suite.getName();
-        String displayName = suite.toString();
+        String displayName = backwardsCompatibleDisplayNameOf(suite);
         String testKind = InternalJvmTestDescriptor.KIND_SUITE;
         String className = suite.getClassName();
         String methodName = null;
@@ -112,13 +112,27 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
     private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, TestDescriptorInternal test) {
         Object id = test.getId();
         String name = test.getName();
-        String displayName = test.toString();
+        String displayName = backwardsCompatibleDisplayNameOf(test);
         String testKind = InternalJvmTestDescriptor.KIND_ATOMIC;
         String className = test.getClassName();
         String methodName = test.getName();
         Object parentId = getParentId(buildOperationId, test);
         String taskPath = getTaskPath(buildOperationId);
         return new DefaultTestDescriptor(id, name, displayName, testKind, null, className, methodName, parentId, taskPath);
+    }
+
+    /**
+     * This method returns a display name which is "compatible with" what previous
+     * Gradle versions did.
+     */
+    private static String backwardsCompatibleDisplayNameOf(TestDescriptorInternal descriptor) {
+        String className = descriptor.getClassName();
+        String methodName = descriptor.getName();
+        String displayName = descriptor.getDisplayName();
+        if (methodName != null && methodName.equals(displayName) || className != null && className.equals(displayName)) {
+            return descriptor.toString();
+        }
+        return displayName;
     }
 
     @Nullable

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -511,7 +511,7 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         """
     }
 
-    def simpleJavaProject() {
+    String simpleJavaProject() {
         """
         allprojects{
             apply plugin: 'java'

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r69/TestDisplayNameCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r69/TestDisplayNameCrossVersionSpec.groovy
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r69
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestLauncher
+import spock.lang.Timeout
+
+@Timeout(120)
+@ToolingApiVersion('>=6.1')
+@TargetGradleVersion(">=6.9")
+class TestDisplayNameCrossVersionSpec extends TestLauncherSpec {
+    @Override
+    void addDefaultTests() {
+    }
+
+    @Override
+    String simpleJavaProject() {
+        """
+        allprojects{
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
+            }
+
+            test {
+                useJUnitPlatform()
+            }
+        }
+        """
+    }
+
+    def "reports display names of class and method"() {
+        file("src/test/java/org/example/SimpleTests.java") << """package org.example;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("a class display name")
+public class SimpleTests {
+
+    @Test
+    @DisplayName("and a test display name")
+    void test() {
+    }
+}
+"""
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test',['org.example.SimpleTests'])
+        }
+
+        then:
+
+        assertTaskExecuted(":test")
+        assertTestExecuted(className: "org.example.SimpleTests", methodName: null, displayName: "a class display name")
+        assertTestExecuted(className: "org.example.SimpleTests", methodName: "test()", displayName: "and a test display name")
+    }
+
+    def "reports display names of nested test classes"() {
+        file("src/test/java/org/example/TestingAStackDemo.java") << """package org.example;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.EmptyStackException;
+import java.util.Stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("A stack")
+class TestingAStackDemo {
+
+    Stack<Object> stack;
+
+    @Test
+    @DisplayName("is instantiated with new Stack()")
+    void isInstantiatedWithNew() {
+        new Stack<>();
+    }
+
+    @Nested
+    @DisplayName("when new")
+    class WhenNew {
+
+        @BeforeEach
+        void createNewStack() {
+            stack = new Stack<>();
+        }
+
+        @Test
+        @DisplayName("is empty")
+        void isEmpty() {
+            assertTrue(stack.isEmpty());
+        }
+
+        @Test
+        @DisplayName("throws EmptyStackException when popped")
+        void throwsExceptionWhenPopped() {
+            assertThrows(EmptyStackException.class, stack::pop);
+        }
+
+        @Test
+        @DisplayName("throws EmptyStackException when peeked")
+        void throwsExceptionWhenPeeked() {
+            assertThrows(EmptyStackException.class, stack::peek);
+        }
+
+        @Nested
+        @DisplayName("after pushing an element")
+        class AfterPushing {
+
+            String anElement = "an element";
+
+            @BeforeEach
+            void pushAnElement() {
+                stack.push(anElement);
+            }
+
+            @Test
+            @DisplayName("it is no longer empty")
+            void isNotEmpty() throws InterruptedException {
+                Thread.sleep(5_000);
+                assertFalse(stack.isEmpty());
+            }
+
+            @Test
+            @DisplayName("returns the element when popped and is empty")
+            void returnElementWhenPopped() {
+                assertEquals(anElement, stack.pop());
+                assertTrue(stack.isEmpty());
+            }
+
+            @Test
+            @DisplayName("returns the element when peeked but remains not empty")
+            void returnElementWhenPeeked() {
+                assertEquals(anElement, stack.peek());
+                assertFalse(stack.isEmpty());
+            }
+        }
+    }
+}
+"""
+
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test',['org.example.TestingAStackDemo*'])
+        }
+
+        then:
+
+        assertTaskExecuted(":test")
+        assertTestExecuted(className: "org.example.TestingAStackDemo", methodName: null, displayName: "A stack")
+        assertTestExecuted(className: "org.example.TestingAStackDemo", methodName: "isInstantiatedWithNew()", displayName: "is instantiated with new Stack()")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: null, displayName: "when new")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "isEmpty()", displayName: "is empty")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "throwsExceptionWhenPopped()", displayName: "throws EmptyStackException when popped")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "throwsExceptionWhenPeeked()", displayName: "throws EmptyStackException when peeked")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: null, displayName: "after pushing an element")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "isNotEmpty()", displayName: "it is no longer empty")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "returnElementWhenPopped()", displayName: "returns the element when popped and is empty")
+        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "returnElementWhenPeeked()", displayName: "returns the element when peeked but remains not empty")
+    }
+}


### PR DESCRIPTION
### Context

This commit is a first step in fixing some of the test reporting
issues described in #5975. It will now propagate the display
names of test classes and methods to the TAPI generated events.

Note that this solves the TAPI events, but it will typically not
fix what you see in IntelliJ IDEA because they are actually not
consuming the "displayName" of test descriptors.
