### PR TITLE
JavaCompilerArgumentsBuilder: Allow users to specify the --processor-module-path

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -191,7 +191,11 @@ public class JavaCompilerArgumentsBuilder {
         if (spec.getSourceCompatibility() == null || JavaVersion.toVersion(spec.getSourceCompatibility()).compareTo(JavaVersion.VERSION_1_6) >= 0) {
             List<File> annotationProcessorPath = spec.getAnnotationProcessorPath();
             if (annotationProcessorPath == null || annotationProcessorPath.isEmpty()) {
-                args.add("-proc:none");
+                if (!compilerArgs.contains("--processor-module-path")) {
+                    args.add("-proc:none");
+                }
+            } else if (compilerArgs.contains("--processor-module-path")) {
+                LOGGER.warn("You specified both --processor-module-path and an annotation processor path. These options are mutually exclusive. Ignoring annotation processor path.");
             } else {
                 args.add("-processorpath");
                 args.add(Joiner.on(File.pathSeparator).join(annotationProcessorPath));


### PR DESCRIPTION
Remix of #10862 from @rgoldberg:
>JavaCompilerArgumentsBuilder: Allow users to specify the `--processor-module-path`.

### Context
Fixes #9519

> This isn't necessarily a full fix for #9519, as it just allows users to manually set `--processor-module-path`, instead of outputting `--processor-module-path` with the contents of JavaCompileSpec#annotationProcessorPath. I did this simple change because:
>
 > 1.   it's simple
 > 2.   it's similar to the existing handling of --module-source-path


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
