### PR TITLE
Let `KotlinDslWorkspaceProvider` declare the depth of the workspace tree to be 2

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -121,7 +121,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
             buildscript {
                 repositories {
                     flatDir { dirs 'repo' }
-                    maven{ url "${repo.uri}" }
+                    maven { url "${repo.uri}" }
                 }
                 dependencies {
                     ${dependencies}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -30,12 +30,12 @@ trait CachingIntegrationFixture {
     }
 
     TestFile getMetadataCacheDir() {
-        return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME).file(CacheLayout.ROOT.key)
+        return userHomeCacheDir.file(CacheLayout.ROOT.key)
     }
 
     void markForArtifactCacheCleanup() {
         executer.withArgument("-Dorg.gradle.internal.cleanup.external.max.age=-1")
-        def gcFile = executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME).file(CacheLayout.ROOT.key).file("gc.properties")
+        TestFile gcFile = metadataCacheDir.file("gc.properties")
         gcFile.createFile()
         assert gcFile.setLastModified(0)
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
@@ -67,11 +67,16 @@ class ConcurrentTestUtil extends ExternalResource {
     }
 
     //simplistic polling assertion. attempts asserting every x millis up to some max timeout
-    static void poll(double timeout = 10, double initialDelay = 0, double pollInterval = 0.1, Closure assertion) {
+    static void poll(
+        double timeoutInSeconds = 10,
+        double initialDelayInSeconds = 0,
+        double pollIntervalInSeconds = 0.1,
+        Closure assertion
+    ) {
         def start = monotonicClockMillis()
-        Thread.sleep(toMillis(initialDelay))
-        def expiry = start + toMillis(timeout) // convert to ms
-        long sleepTime = toMillis(pollInterval)
+        Thread.sleep(toMillis(initialDelayInSeconds))
+        def expiry = start + toMillis(timeoutInSeconds) // convert to ms
+        long sleepTime = toMillis(pollIntervalInSeconds)
         while(true) {
             try {
                 assertion()
@@ -81,7 +86,7 @@ class ConcurrentTestUtil extends ExternalResource {
                     throw t
                 }
                 sleepTime = Math.min(250, (long) (sleepTime * 1.2))
-                Thread.sleep(sleepTime);
+                Thread.sleep(sleepTime)
             }
         }
     }
@@ -91,7 +96,7 @@ class ConcurrentTestUtil extends ExternalResource {
     }
 
     static long toMillis(double seconds) {
-        return (long) (seconds * 1000);
+        return (long) (seconds * 1000)
     }
 
     void setShortTimeout(int millis) {

--- a/subprojects/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinScriptCacheCleanupIntegrationTest.groovy
+++ b/subprojects/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinScriptCacheCleanupIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
@@ -25,6 +26,7 @@ class KotlinScriptCacheCleanupIntegrationTest
     extends AbstractIntegrationSpec
     implements FileAccessTimeJournalFixture {
 
+    @UnsupportedWithConfigurationCache(because = "tests script compilation")
     def "cleanup deletes old script cache entries"() {
         given:
         requireOwnGradleUserHomeDir()

--- a/subprojects/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinScriptCacheCleanupIntegrationTest.groovy
+++ b/subprojects/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinScriptCacheCleanupIntegrationTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.GradleVersion
+
+class KotlinScriptCacheCleanupIntegrationTest
+    extends AbstractIntegrationSpec
+    implements FileAccessTimeJournalFixture {
+
+    def "cleanup deletes old script cache entries"() {
+        given:
+        requireOwnGradleUserHomeDir()
+        executer.requireIsolatedDaemons()
+
+        and: 'seed script cache to have a baseline to compare against'
+        buildKotlinFile.text = """
+            tasks.register("run") {
+                doLast { println("ok") }
+            }
+        """
+        run 'run'
+
+        and:
+        TestFile scriptCacheDir = kotlinDslWorkspace.file('scripts')
+        String[] scriptCacheBaseLine = scriptCacheDir.list()
+
+        and:
+        TestFile outdatedScriptCache = scriptCacheDir.file('7c8e05b2aa9d61f6b8422a683803c455').tap {
+            assert !exists()
+            file('classes/Program.class').createFile()
+        }
+        TestFile gcFile = kotlinDslWorkspace.file('gc.properties')
+        gcFile.createFile().lastModified = daysAgo(8)
+        writeJournalInceptionTimestamp(daysAgo(8))
+        writeLastFileAccessTimeToJournal(outdatedScriptCache, daysAgo(16))
+
+        when:
+        run 'run'
+
+        then:
+        scriptCacheDir.list() == scriptCacheBaseLine
+    }
+
+    private TestFile getKotlinDslWorkspace() {
+        userHomeCacheDir.file(GradleVersion.current().version).file('kotlin-dsl')
+    }
+}

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/TaskContainerDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/TaskContainerDslIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.kotlin.dsl
+package org.gradle.kotlin.dsl.integration
 
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
+import org.gradle.kotlin.dsl.*
 
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DslTestFixture

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
@@ -42,7 +42,8 @@ class KotlinDslWorkspaceProvider(
             .withDisplayName("kotlin-dsl"),
         fileAccessTimeJournal,
         inMemoryCacheDecoratorFactory,
-        stringInterner
+        stringInterner,
+        2 // scripts and accessors caches sit below the root directory
     )
 
     val accessors = subWorkspace("accessors")

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -82,7 +82,15 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         }
     }
 
-    private PersistentCache doOpen(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CleanupAction cleanup) {
+    private PersistentCache doOpen(
+        File cacheDir,
+        String displayName,
+        Map<String, ?> properties,
+        CacheBuilder.LockTarget lockTarget,
+        LockOptions lockOptions,
+        @Nullable Action<? super PersistentCache> initializer,
+        @Nullable CleanupAction cleanup
+    ) {
         File canonicalDir = FileUtils.canonicalize(cacheDir);
         DirCacheReference dirCacheReference = dirCaches.get(canonicalDir);
         if (dirCacheReference == null) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -34,6 +34,7 @@ import org.gradle.util.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +49,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     private final File dir;
     private final CacheBuilder.LockTarget lockTarget;
     private final LockOptions lockOptions;
+    @Nullable
     private final CleanupAction cleanupAction;
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
@@ -57,7 +59,16 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     private final ProgressLoggerFactory progressLoggerFactory;
     private CacheCoordinator cacheAccess;
 
-    public DefaultPersistentDirectoryStore(File dir, String displayName, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, CleanupAction cleanupAction, FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+    public DefaultPersistentDirectoryStore(
+        File dir,
+        @Nullable String displayName,
+        CacheBuilder.LockTarget lockTarget,
+        LockOptions lockOptions,
+        @Nullable CleanupAction cleanupAction,
+        FileLockManager fileLockManager,
+        ExecutorFactory executorFactory,
+        ProgressLoggerFactory progressLoggerFactory
+    ) {
         this.dir = dir;
         this.lockTarget = lockTarget;
         this.lockOptions = lockOptions;


### PR DESCRIPTION
Since the `accessors` and `scripts` caches sit below the root workspace directory.

A followup to https://github.com/gradle/gradle/pull/15081.