### PR TITLE
Replace k9Mail by santa tracker

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -13,9 +13,6 @@
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
   "durations" : [ {
-    "testProject" : "k9AndroidBuild",
-    "linux" : 184000
-  }, {
     "testProject" : "largeAndroidBuild",
     "linux" : 702000
   }, {
@@ -31,7 +28,7 @@
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
   "durations" : [ {
-    "testProject" : "k9AndroidBuild",
+    "testProject" : "santaTrackerAndroidBuild",
     "linux" : 133000
   }, {
     "testProject" : "largeAndroidBuild",
@@ -55,7 +52,7 @@
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
   "durations" : [ {
-    "testProject" : "k9AndroidBuild",
+    "testProject" : "santaTrackerAndroidBuild",
     "linux" : 222000
   }, {
     "testProject" : "largeAndroidBuild",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -179,11 +179,6 @@
   }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
     "groups" : [ {
-      "testProject" : "k9AndroidBuild",
-      "coverage" : {
-        "test" : [ "linux" ]
-      }
-    }, {
       "testProject" : "largeAndroidBuild",
       "coverage" : {
         "test" : [ "linux" ]
@@ -205,12 +200,12 @@
   }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run help",
     "groups" : [ {
-      "testProject" : "k9AndroidBuild",
+      "testProject" : "largeAndroidBuild",
       "coverage" : {
         "test" : [ "linux" ]
       }
     }, {
-      "testProject" : "largeAndroidBuild",
+      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "test" : [ "linux" ]
       }
@@ -239,12 +234,12 @@
   }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidStudioMockupPerformanceTest.get IDE model for Android Studio",
     "groups" : [ {
-      "testProject" : "k9AndroidBuild",
+      "testProject" : "largeAndroidBuild",
       "coverage" : {
         "test" : [ "linux" ]
       }
     }, {
-      "testProject" : "largeAndroidBuild",
+      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "test" : [ "linux" ]
       }

--- a/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/buildSrc/subprojects/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -384,15 +384,6 @@ performanceTest.registerTestProject("bigSwiftApp", BuildBuilderGenerator) {
 }
 
 // === Android ===
-performanceTest.registerTestProject("k9AndroidBuild", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/perf-android-k-9.git'
-    // From android-31 branch
-    ref = "d9776762e7da63cd9b2925efa2b7d8bcdc373600"
-    doLast {
-        setMaxWorkers(outputDirectory, 8)
-    }
-}
-
 performanceTest.registerTestProject("largeAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
     // From android-35 branch

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -25,13 +25,8 @@ class AndroidTestProject implements TestProject {
         templateName: 'largeAndroidBuild'
     )
 
-    public static final K9_ANDROID = new AndroidTestProject(
-        templateName: 'k9AndroidBuild'
-    )
-
     public static final List<AndroidTestProject> ANDROID_TEST_PROJECTS = [
         LARGE_ANDROID_BUILD,
-        K9_ANDROID,
         IncrementalAndroidTestProject.SANTA_TRACKER_JAVA,
         IncrementalAndroidTestProject.SANTA_TRACKER_KOTLIN
     ]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.performance.fixture.IncrementalAndroidTestProject
 import spock.lang.Unroll
 
 import static org.gradle.performance.annotations.ScenarioType.TEST
-import static org.gradle.performance.fixture.AndroidTestProject.K9_ANDROID
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
@@ -33,19 +32,16 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractRealLifeAndroidBuildPe
 
     @Unroll
     @RunFor([
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["k9AndroidBuild", "largeAndroidBuild"], iterationMatcher = "run help"),
-        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["k9AndroidBuild", "largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "run assembleDebug"),
+        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["santaTrackerAndroidBuild", "largeAndroidBuild"], iterationMatcher = "run help"),
+        @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "run assembleDebug"),
         @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild"], iterationMatcher = ".*phthalic.*")
     ])
     def "run #tasks"() {
         given:
         AndroidTestProject testProject = androidTestProject
-        boolean parallel = testProject != K9_ANDROID
         testProject.configure(runner)
         runner.tasksToRun = tasks.split(' ')
-        if (parallel) {
-            runner.args.add('-Dorg.gradle.parallel=true')
-        }
+        runner.args.add('-Dorg.gradle.parallel=true')
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         applyEnterprisePlugin()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.performance.annotations.ScenarioType.TEST
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "k9AndroidBuild"])
+    @Scenario(type = TEST, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"])
 )
 class RealLifeAndroidStudioMockupPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
@@ -35,9 +35,8 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractCrossVersionPer
         given:
         def testProject = AndroidTestProject.projectFor(runner.testProject)
         testProject.configure(runner)
-        int iterations = (testProject == AndroidTestProject.K9_ANDROID) ? 200 : 40
-        runner.warmUpRuns = iterations
-        runner.runs = iterations
+        runner.warmUpRuns = 40
+        runner.runs = 40
         runner.minimumBaseVersion = "5.4.1"
         runner.targetVersions = ["6.8-20201108230029+0000"]
 


### PR DESCRIPTION
Testing one medium sized Android project is good enough. Let's go with santa tracker for now, since we did maintain that better.

Fixes https://github.com/gradle/gradle-private/issues/2297