### PR TITLE
Fix launching tests from composite via TestLauncher

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
@@ -32,9 +32,9 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
     private final String methodName;
     private final Object parentId;
     private String taskPath;
-    private final String buildId;
+    private final String buildIdentityPath;
 
-    public DefaultTestDescriptor(Object id, String name, String displayName, String testKind, String suiteName, String className, String methodName, Object parentId, String taskPath, String buildId) {
+    public DefaultTestDescriptor(Object id, String name, String displayName, String testKind, String suiteName, String className, String methodName, Object parentId, String taskPath, String buildIdentityPath) {
         this.id = id;
         this.name = name;
         this.displayName = displayName;
@@ -44,7 +44,7 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
         this.methodName = methodName;
         this.parentId = parentId;
         this.taskPath = taskPath;
-        this.buildId = buildId;
+        this.buildIdentityPath = buildIdentityPath;
     }
 
     @Override
@@ -91,7 +91,12 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
         return taskPath;
     }
 
+    /**
+     * The identity path of the build that executed this test.
+     *
+     * @return the identity path of the build of {@code null} for the root build.
+     */
     public String getBuildIdentityPath() {
-        return buildId;
+        return buildIdentityPath;
     }
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
@@ -32,8 +32,9 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
     private final String methodName;
     private final Object parentId;
     private String taskPath;
+    private final String buildId;
 
-    public DefaultTestDescriptor(Object id, String name, String displayName, String testKind, String suiteName, String className, String methodName, Object parentId, String taskPath) {
+    public DefaultTestDescriptor(Object id, String name, String displayName, String testKind, String suiteName, String className, String methodName, Object parentId, String taskPath, String buildId) {
         this.id = id;
         this.name = name;
         this.displayName = displayName;
@@ -43,6 +44,7 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
         this.methodName = methodName;
         this.parentId = parentId;
         this.taskPath = taskPath;
+        this.buildId = buildId;
     }
 
     @Override
@@ -87,5 +89,9 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
 
     public String getTaskPath() {
         return taskPath;
+    }
+
+    public String getBuildIdentityPath() {
+        return buildId;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
@@ -18,6 +18,7 @@ package org.gradle.execution;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.BuildRequestMetaData;
+import org.gradle.initialization.RunWorkBuildOperationType;
 import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -72,7 +73,12 @@ public class BuildOperationFiringBuildWorkerExecutor implements BuildWorkExecuto
                 builder.metadata(BuildOperationCategory.RUN_WORK);
             }
             builder.totalProgress(gradle.getTaskGraph().size());
-            return builder;
+            return builder.details(new RunWorkBuildOperationType.Details() {
+                @Override
+                public String getBuildPath() {
+                    return gradle.getIdentityPath().toString();
+                }
+            });
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
@@ -18,7 +18,7 @@ package org.gradle.execution;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.BuildRequestMetaData;
-import org.gradle.initialization.RunWorkBuildOperationType;
+import org.gradle.initialization.RunIncludedBuildWorkBuildOperationType;
 import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -71,14 +71,15 @@ public class BuildOperationFiringBuildWorkerExecutor implements BuildWorkExecuto
                 builder.details(new RunRootBuildWorkBuildOperationType.Details(buildStartTime));
             } else {
                 builder.metadata(BuildOperationCategory.RUN_WORK);
+                builder.details(new RunIncludedBuildWorkBuildOperationType.Details() {
+                    @Override
+                    public String getBuildIdentityPath() {
+                        return gradle.getIdentityPath().toString();
+                    }
+                });
             }
             builder.totalProgress(gradle.getTaskGraph().size());
-            return builder.details(new RunWorkBuildOperationType.Details() {
-                @Override
-                public String getBuildIdentityPath() {
-                    return gradle.getIdentityPath().toString();
-                }
-            });
+            return builder;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
@@ -75,7 +75,7 @@ public class BuildOperationFiringBuildWorkerExecutor implements BuildWorkExecuto
             builder.totalProgress(gradle.getTaskGraph().size());
             return builder.details(new RunWorkBuildOperationType.Details() {
                 @Override
-                public String getBuildPath() {
+                public String getBuildIdentityPath() {
                     return gradle.getIdentityPath().toString();
                 }
             });

--- a/subprojects/core/src/main/java/org/gradle/initialization/RunIncludedBuildWorkBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RunIncludedBuildWorkBuildOperationType.java
@@ -18,7 +18,7 @@ package org.gradle.initialization;
 
 import org.gradle.internal.operations.BuildOperationType;
 
-public class RunWorkBuildOperationType implements BuildOperationType<RunWorkBuildOperationType.Details, RunWorkBuildOperationType.Result> {
+public class RunIncludedBuildWorkBuildOperationType implements BuildOperationType<RunIncludedBuildWorkBuildOperationType.Details, RunIncludedBuildWorkBuildOperationType.Result> {
     public interface Details {
         /**
          * @since 6.8
@@ -29,6 +29,6 @@ public class RunWorkBuildOperationType implements BuildOperationType<RunWorkBuil
     public interface Result {
     }
 
-    private RunWorkBuildOperationType() {
+    private RunIncludedBuildWorkBuildOperationType() {
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
@@ -23,7 +23,7 @@ public class RunWorkBuildOperationType implements BuildOperationType<RunWorkBuil
         /**
          * @since 6.8
          */
-        String getBuildPath();
+        String getBuildIdentityPath();
     }
 
     public interface Result {

--- a/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+public class RunWorkBuildOperationType implements BuildOperationType<RunWorkBuildOperationType.Details, RunWorkBuildOperationType.Result> {
+    public interface Details {
+        /**
+         * @since 6.8
+         */
+        String getBuildPath();
+    }
+
+    public interface Result {
+    }
+
+    private RunWorkBuildOperationType() {
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RunWorkBuildOperationType.java
@@ -17,7 +17,6 @@
 package org.gradle.initialization;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 public class RunWorkBuildOperationType implements BuildOperationType<RunWorkBuildOperationType.Details, RunWorkBuildOperationType.Result> {
     public interface Details {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -57,7 +57,7 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
     private final BuildOperationAncestryTracker ancestryTracker;
     private final BuildEventSubscriptions clientSubscriptions;
     private final Map<Object, String> runningTasks = Maps.newConcurrentMap();
-    private final Map<Object, String> includedBuildIds = Maps.newConcurrentMap();
+    private final Map<Object, String> includedBuildIdentityPaths = Maps.newConcurrentMap();
 
     ClientForwardingTestOperationListener(ProgressEventConsumer eventConsumer, BuildOperationAncestryTracker ancestryTracker, BuildEventSubscriptions clientSubscriptions) {
         this.eventConsumer = eventConsumer;
@@ -70,7 +70,7 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         if (buildOperation.getMetadata().equals(BuildOperationCategory.RUN_WORK)) {
             Object details = buildOperation.getDetails();
             if (details instanceof RunWorkBuildOperationType.Details) {
-                includedBuildIds.put(buildOperation.getId(), ((RunWorkBuildOperationType.Details)details).getBuildPath());
+                includedBuildIdentityPaths.put(buildOperation.getId(), ((RunWorkBuildOperationType.Details)details).getBuildIdentityPath());
             }
         }
 
@@ -116,8 +116,8 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         String methodName = null;
         Object parentId = getParentId(buildOperationId, suite);
         String testTaskPath = getTaskPath(buildOperationId);
-        String buildId = getBuildId(buildOperationId);
-        return new DefaultTestDescriptor(id, name, displayName, testKind, suite.getName(), className, methodName, parentId, testTaskPath, buildId);
+        String buildIdentityPath = getBuildIdentityPath(buildOperationId);
+        return new DefaultTestDescriptor(id, name, displayName, testKind, suite.getName(), className, methodName, parentId, testTaskPath, buildIdentityPath);
     }
 
     private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, TestDescriptorInternal test) {
@@ -129,8 +129,8 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         String methodName = test.getName();
         Object parentId = getParentId(buildOperationId, test);
         String taskPath = getTaskPath(buildOperationId);
-        String buildId = getBuildId(buildOperationId);
-        return new DefaultTestDescriptor(id, name, displayName, testKind, null, className, methodName, parentId, taskPath, buildId);
+        String buildIdentityPath = getBuildIdentityPath(buildOperationId);
+        return new DefaultTestDescriptor(id, name, displayName, testKind, null, className, methodName, parentId, taskPath, buildIdentityPath);
     }
 
     @Nullable
@@ -138,8 +138,8 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
         return ancestryTracker.findClosestExistingAncestor(buildOperationId, runningTasks::get).orElse(null);
     }
 
-    private String getBuildId(OperationIdentifier buildOperationId) {
-        return ancestryTracker.findClosestExistingAncestor(buildOperationId, includedBuildIds::get).orElse(null);
+    private String getBuildIdentityPath(OperationIdentifier buildOperationId) {
+        return ancestryTracker.findClosestExistingAncestor(buildOperationId, includedBuildIdentityPaths::get).orElse(null);
     }
 
     private Object getParentId(OperationIdentifier buildOperationId, TestDescriptorInternal descriptor) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperationType;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestResult;
-import org.gradle.initialization.RunWorkBuildOperationType;
+import org.gradle.initialization.RunIncludedBuildWorkBuildOperationType;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
 import org.gradle.internal.build.event.types.AbstractTestResult;
 import org.gradle.internal.build.event.types.DefaultFailure;
@@ -69,8 +69,8 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
     public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
         if (buildOperation.getMetadata().equals(BuildOperationCategory.RUN_WORK)) {
             Object details = buildOperation.getDetails();
-            if (details instanceof RunWorkBuildOperationType.Details) {
-                includedBuildIdentityPaths.put(buildOperation.getId(), ((RunWorkBuildOperationType.Details)details).getBuildIdentityPath());
+            if (details instanceof RunIncludedBuildWorkBuildOperationType.Details) {
+                includedBuildIdentityPaths.put(buildOperation.getId(), ((RunIncludedBuildWorkBuildOperationType.Details)details).getBuildIdentityPath());
             }
         }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -127,11 +127,11 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         Map<String, GradleInternal> testTaskPaths = new LinkedHashMap<>();
         for (InternalTestDescriptor testDescriptor : testExecutionRequest.getTestExecutionDescriptors()) {
             DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
-            String buildId = defaultTestDescriptor.getBuildIdentityPath();
-            if (buildId != null) {
-                GradleInternal includedBuild = includedBuilds.get(buildId);
+            String buildIdentityPath = defaultTestDescriptor.getBuildIdentityPath();
+            if (buildIdentityPath != null) {
+                GradleInternal includedBuild = includedBuilds.get(buildIdentityPath);
                 if (includedBuild == null) {
-                    throw new IllegalStateException("Build operation references nonexisting included build: " + buildId);
+                    throw new IllegalStateException("Build operation references nonexisting included build: " + buildIdentityPath);
                 }
                 testTaskPaths.put(defaultTestDescriptor.getTaskPath(), includedBuild);
             } else {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -117,13 +117,13 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
     }
 
     private static List<Test> configureBuildForTestTasks(GradleInternal rootBuild, TestExecutionRequestAction testExecutionRequest) {
-        List<ContainerAwareTaskPath> testTaskPaths = collectTaskPaths(rootBuild, testExecutionRequest);
+        final Collection<InternalTestDescriptor> testDescriptors = testExecutionRequest.getTestExecutionDescriptors();
+        List<ContainerAwareTaskPath> testTaskPaths = collectTaskPaths(rootBuild, testDescriptors);
 
         List<Test> testTasksToRun = new ArrayList<>();
         for (ContainerAwareTaskPath testTaskPath : testTaskPaths) {
             Set<Test> tasks = lookupTestTasks(testTaskPath);
             for (Test testTask : tasks) {
-                final Collection<InternalTestDescriptor> testDescriptors = testExecutionRequest.getTestExecutionDescriptors();
                 for (InternalTestDescriptor testDescriptor : testDescriptors) {
                     DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
                     if (defaultTestDescriptor.getTaskPath().equals(testTaskPath.getPath())) {
@@ -142,11 +142,11 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         return testTasksToRun;
     }
 
-    private static List<ContainerAwareTaskPath> collectTaskPaths(GradleInternal rootBuild, TestExecutionRequestAction testExecutionRequest) {
+    private static List<ContainerAwareTaskPath> collectTaskPaths(GradleInternal rootBuild, Collection<InternalTestDescriptor> testDescriptors) {
         Map<String, GradleInternal> includedBuilds = getIncludedBuilds(rootBuild);
 
         List<ContainerAwareTaskPath> testTaskPaths = new ArrayList<>();
-        for (InternalTestDescriptor testDescriptor : testExecutionRequest.getTestExecutionDescriptors()) {
+        for (InternalTestDescriptor testDescriptor : testDescriptors) {
             DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
             String buildIdentityPath = defaultTestDescriptor.getBuildIdentityPath();
             if (buildIdentityPath != null) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -201,8 +201,11 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         }
 
         List<Test> tasksToExecute = new ArrayList<>();
-
         final Set<Project> allprojects = gradle.getRootProject().getAllprojects();
+        // TODO this should be cleaned up
+        for (Map.Entry<String, GradleInternal> entry : getIncludedBuilds(gradle).entrySet()) {
+            allprojects.addAll(entry.getValue().getDefaultProject().getAllprojects());
+        }
         for (Project project : allprojects) {
             final Collection<Test> testTasks = project.getTasks().withType(Test.class);
             for (Test testTask : testTasks) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -202,7 +202,6 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
 
         List<Test> tasksToExecute = new ArrayList<>();
         final Set<Project> allprojects = gradle.getRootProject().getAllprojects();
-        // TODO this should be cleaned up
         for (Map.Entry<String, GradleInternal> entry : getIncludedBuilds(gradle).entrySet()) {
             allprojects.addAll(entry.getValue().getDefaultProject().getAllprojects());
         }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -203,7 +203,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         List<Test> tasksToExecute = new ArrayList<>();
         final Set<Project> allprojects = gradle.getRootProject().getAllprojects();
         for (Map.Entry<String, GradleInternal> entry : getIncludedBuilds(gradle).entrySet()) {
-            allprojects.addAll(entry.getValue().getDefaultProject().getAllprojects());
+            allprojects.addAll(entry.getValue().getRootProject().getAllprojects());
         }
         for (Project project : allprojects) {
             final Collection<Test> testTasks = project.getTasks().withType(Test.class);

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -60,7 +60,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
 
     @Override
     public void configure(BuildExecutionContext context) {
-        final Set<Test> allTestTasksToRun = new LinkedHashSet<Test>();
+        final Set<Test> allTestTasksToRun = new LinkedHashSet<>();
         final GradleInternal gradleInternal = context.getGradle();
         List<GradleInternal> includedBuilds = gradleInternal.getServices().get(BuildStateRegistry.class).getIncludedBuilds().stream().map(IncludedBuildState::getBuild).collect(Collectors.toList());
         allTestTasksToRun.addAll(configureBuildForTestDescriptors(gradleInternal.getServices().get(TaskSelector.class), testExecutionRequest));
@@ -94,7 +94,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
     private List<Test> configureBuildForTestDescriptors(TaskSelector taskSelector, TestExecutionRequestAction testExecutionRequest) {
         Map<String, List<InternalJvmTestRequest>> taskAndTests = testExecutionRequest.getTaskAndTests();
 
-        List<Test> testTasksToRun = new ArrayList<Test>();
+        List<Test> testTasksToRun = new ArrayList<>();
         for (final Map.Entry<String, List<InternalJvmTestRequest>> entry : taskAndTests.entrySet()) {
             String testTaskPath = entry.getKey();
             TaskSelection taskSelection = taskSelector.getSelection(testTaskPath);

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
@@ -143,7 +143,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
     }
 
     private DefaultTestDescriptor testDescriptor() {
-        new DefaultTestDescriptor(1, "test1", "test 1", "ATOMIC", "test suite", TEST_CLASS_NAME, TEST_METHOD_NAME, 0, TEST_TASK_NAME)
+        new DefaultTestDescriptor(1, "test1", "test 1", "ATOMIC", "test suite", TEST_CLASS_NAME, TEST_METHOD_NAME, 0, TEST_TASK_NAME, null)
     }
 
 }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.execution.TaskNameResolver
 import org.gradle.execution.TaskSelection
 import org.gradle.execution.TaskSelector
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
+import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.event.types.DefaultTestDescriptor
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.tooling.internal.protocol.test.InternalDebugOptions
@@ -46,6 +47,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
     ProjectInternal projectInternal
     ServiceRegistry serviceRegistry = Mock()
     TaskSelector taskSelector = Mock()
+    BuildStateRegistry buildStateRegistry = Mock()
     Test testTask
     TaskContainerInternal tasksContainerInternal
     TestFilter testFilter
@@ -71,6 +73,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
         debugOptions.isDebugMode() >> false
         testExecutionRequest.getDebugOptions() >> debugOptions
 
+        buildStateRegistry.getIncludedBuilds() >> []
         setupProject()
         setupTestTask()
     }
@@ -81,6 +84,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
         _ * gradleInternal.getRootProject() >> projectInternal
         _ * gradleInternal.getServices() >> serviceRegistry
         _ * serviceRegistry.get(TaskSelector) >> taskSelector
+        _ * serviceRegistry.get(BuildStateRegistry) >> buildStateRegistry
     }
 
     def "empty test execution request configures no tasks"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
@@ -19,6 +19,11 @@ package org.gradle.integtests.tooling.r68
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestLauncher
+import org.gradle.tooling.events.ProgressEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.test.TestFinishEvent
+import org.gradle.tooling.events.test.TestOperationDescriptor
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.GradleTask
 import org.gradle.tooling.model.gradle.BuildInvocations
@@ -369,6 +374,55 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
         outputContains("do something")
     }
 
+    @ToolingApiVersion(">=6.8")
+    def "Can launch test from included build via build operation"() {
+        setup:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+             ${mavenCentralRepository()}
+
+             dependencies { testImplementation 'junit:junit:4.13' }
+        """
+        file("other-build/sub/src/test/java/MyIncludedTest.java") << """
+            import org.junit.Test;
+            import static org.junit.Assert.assertTrue;
+
+            public class MyIncludedTest {
+
+                @Test
+                public void myTestMethod() {
+                    assertTrue(true);
+                }
+            }
+        """
+
+        TestOperationCollector collector = new TestOperationCollector()
+        withConnection { connection ->
+            def build = connection.newBuild()
+            build.addProgressListener(collector)
+            build.forTasks(":other-build:sub:test").run()
+        }
+        TestOperationDescriptor descriptor = collector.descriptors.find { it.name == "myTestMethod" }
+
+        when:
+        withConnection { connection ->
+            TestLauncher launcher = connection.newTestLauncher().withTests(descriptor)
+            collectOutputs(launcher)
+            launcher.run()
+        }
+
+        then:
+        outputContains("BUILD SUCCESSFUL")
+    }
+
     private void executeTaskViaTAPI(String... task) {
         withConnection { connection ->
             def build = connection.newBuild()
@@ -411,5 +465,17 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
     private boolean outputContains(String expectedOutput) {
         return stdout.toString().contains(expectedOutput)
+    }
+
+    class TestOperationCollector implements ProgressListener {
+
+        List<TestOperationDescriptor> descriptors = []
+
+        @Override
+        void statusChanged(ProgressEvent event) {
+            if (event instanceof TestFinishEvent) {
+                descriptors += ((TestFinishEvent) event).descriptor
+            }
+        }
     }
 }


### PR DESCRIPTION
### Problem

The Tooling API can execute tests by using build operations received from a previous build. This feature is being used by Buildship to implement a "Run failed tests" action. Unfortunately, this does not work yet when the test descriptor comes from an included build. On top of that, `TestLauncher.withJvmTestXXX()` methods don't support test classes and methods declared in included builds.

### Solution

Re-running the tests via the test operations does not have the information which included build hosted the test. To obtain a reference, this PR injects a custom details object to `BuildOperationCategory.RUN_WORK` type of build operations that can return the build identity path. That build operation is a parent for the test operations and then can be looked up at the time of the creation of the `DefaultTestDescriptor` instance by traversing the operation hierarchy upwards. 

With the identity path available, `TestExecutionBuildConfigurationAction` can decide which build to use for the task lookup.

Regarding `TestLauncher.withJvmTestXXX()`, the implementation traverses all projects and configures all tasks to include the specified test classes and methods. The PR adjusts that so that all projects from all included builds are considered.