### PR TITLE
Clean up custom build logic for generating API incubation reports

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.incubation-report-aggregation.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.incubation-report-aggregation.gradle.kts
@@ -1,0 +1,34 @@
+import gradlebuild.incubation.tasks.IncubatingApiAggregateReportTask
+
+val reports by configurations.creating {
+    isVisible = false
+    isCanBeResolved = false
+    isCanBeConsumed = false
+    description = "Dependencies to aggregate reports from"
+}
+
+val allIncubationReports = tasks.register<IncubatingApiAggregateReportTask>("allIncubationReports") {
+    group = "verification"
+    reports.from(resolver("txt"))
+    htmlReportFile.set(project.layout.buildDirectory.file("reports/incubation/all-incubating.html"))
+}
+
+tasks.register<Zip>("allIncubationReportsZip") {
+    group = "verification"
+    destinationDirectory.set(layout.buildDirectory.dir("reports/incubation"))
+    archiveBaseName.set("incubating-apis")
+    from(allIncubationReports.get().htmlReportFile)
+    from(resolver("html"))
+}
+
+fun resolver(reportType: String) = configurations.create("incubatingReport${reportType.capitalize()}Path") {
+    isVisible = false
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("incubation-report-$reportType"))
+    }
+    extendsFrom(reports)
+}.incoming.artifactView { lenient(true) }.files

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationParameter.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationParameter.kt
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id("gradlebuild.incubation-report-aggregation")
-}
 
-dependencies {
-    reports(platform(project(":distributions-full")))
+package gradlebuild.incubation.action
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.workers.WorkParameters
+
+
+interface IncubatingApiReportAggregationParameter : WorkParameters {
+    val reports: ConfigurableFileCollection
+    val htmlReportFile: RegularFileProperty
 }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.incubation.action
+
+import org.gradle.workers.WorkAction
+
+
+abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingApiReportAggregationParameter> {
+    override fun execute() {
+        val byVersion = mutableMapOf<String, ReportNameToProblems>()
+        parameters.reports.files.sorted().forEach { file ->
+            file.forEachLine(Charsets.UTF_8) {
+                val (version, _, problem) = it.split(';')
+                byVersion.getOrPut(version) {
+                    mutableMapOf()
+                }.getOrPut(file.nameWithoutExtension) {
+                    mutableSetOf()
+                }.add(problem)
+            }
+        }
+        generateReport(byVersion)
+    }
+
+    private
+    fun generateReport(data: Map<String, ReportNameToProblems>) {
+        val outputFile = parameters.htmlReportFile.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.printWriter(Charsets.UTF_8).use { writer ->
+            writer.println(
+                """<html lang="en">
+    <head>
+       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+       <title>Incubating APIs</title>
+       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
+       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
+       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
+
+    </head>
+    <body>
+       <h1>Incubating APIs</h1>
+       <h2>Index</h2>
+       <ul>
+    """
+            )
+
+            data.toSortedMap().forEach { (version, _) ->
+                writer.println("<li><a href=\"#$version\">Incubating since $version</a><br></li>")
+            }
+            writer.println("</ul>")
+            data.toSortedMap().forEach { (version, problems) ->
+                writer.println("<a name=\"$version\"></a>")
+                writer.println("<h2>Incubating since $version</h2>")
+                problems.forEach { (name, issues) ->
+                    writer.println("<h3>In $name</h3>")
+                    writer.println("<ul>")
+                    issues.forEach {
+                        writer.println("   <li>${it.escape()}</li>")
+                    }
+                    writer.println("</ul>")
+                }
+            }
+            writer.println("</body></html>")
+        }
+    }
+
+    private
+    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
+}
+
+
+typealias ReportNameToProblems = MutableMap<String, MutableSet<String>>

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportParameter.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportParameter.kt
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id("gradlebuild.incubation-report-aggregation")
-}
 
-dependencies {
-    reports(platform(project(":distributions-full")))
+package gradlebuild.incubation.action
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkParameters
+
+
+interface IncubatingApiReportParameter : WorkParameters {
+    val srcDirs: ConfigurableFileCollection
+    val htmlReportFile: RegularFileProperty
+    val textReportFile: RegularFileProperty
+    val title: Property<String>
+    val releasedVersionsFile: RegularFileProperty
 }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.incubation.action
+
+import com.github.javaparser.JavaParser
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.body.AnnotationDeclaration
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
+import com.github.javaparser.ast.body.EnumDeclaration
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName
+import com.github.javaparser.javadoc.description.JavadocSnippet
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver
+import gradlebuild.basics.util.KotlinSourceParser
+import org.gradle.workers.WorkAction
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import java.io.File
+
+
+abstract class IncubatingApiReportWorkAction : WorkAction<IncubatingApiReportParameter> {
+
+    override fun execute() {
+        val versionToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
+        parameters.srcDirs.forEach { srcDir ->
+            if (srcDir.exists()) {
+                val collector = CompositeVersionsToIncubatingCollector(
+                    listOf(
+                        JavaVersionsToIncubatingCollector(srcDir),
+                        KotlinVersionsToIncubatingCollector()
+                    )
+                )
+                srcDir.walkTopDown().forEach { sourceFile ->
+                    try {
+                        collector.collectFrom(sourceFile).forEach { (version, incubating) ->
+                            versionToIncubating.getOrPut(version) { mutableSetOf() }.addAll(incubating)
+                        }
+                    } catch (e: Exception) {
+                        throw Exception("Unable to parse $sourceFile: ${e.message}")
+                    }
+                }
+            }
+        }
+        generateTextReport(versionToIncubating)
+        generateHtmlReport(versionToIncubating)
+    }
+
+    private
+    fun generateHtmlReport(versionToIncubating: VersionsToIncubating) {
+        val htmlReport = parameters.htmlReportFile.get().asFile
+        val title = parameters.title.get()
+        htmlReport.parentFile.mkdirs()
+        htmlReport.printWriter(Charsets.UTF_8).use { writer ->
+            writer.println(
+                """<html lang="en">
+    <head>
+       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+       <title>Incubating APIs for $title</title>
+       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
+       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
+       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
+
+    </head>
+    <body>
+       <h1>Incubating APIs for  $title</h1>
+    """
+            )
+            val versions = versionsDates()
+            versionToIncubating.toSortedMap().forEach { (version, incubatingDescriptions) ->
+                writer.println("<a name=\"sec_$version\"></a>")
+                writer.println(
+                    "<h2>Incubating since $version (${versions[version]?.run { "released on $this" } ?: "unreleased"})</h2>"
+                )
+                writer.println("<ul>")
+                incubatingDescriptions.sorted().forEach { incubating ->
+                    writer.println("   <li>${incubating.escape()}</li>")
+                }
+                writer.println("</ul>")
+            }
+            writer.println("</body></html>")
+        }
+    }
+
+    private
+    fun generateTextReport(versionToIncubating: VersionsToIncubating) {
+        val textReport = parameters.textReportFile.get().asFile
+        textReport.parentFile.mkdirs()
+        textReport.printWriter(Charsets.UTF_8).use { writer ->
+            val versions = versionsDates()
+            versionToIncubating.toSortedMap().forEach { (version, incubatingDescriptions) ->
+                val releaseDate = versions[version] ?: "unreleased"
+                incubatingDescriptions.sorted().forEach { incubating ->
+                    writer.println("$version;$releaseDate;$incubating")
+                }
+            }
+        }
+    }
+
+    private
+    fun versionsDates(): Map<Version, String> {
+        val versions = mutableMapOf<Version, String>()
+        var version: String? = null
+        parameters.releasedVersionsFile.get().asFile.forEachLine(Charsets.UTF_8) {
+            val line = it.trim()
+            if (line.startsWith("\"version\"")) {
+                version = line.substring(line.indexOf("\"", 11) + 1, line.lastIndexOf("\""))
+            }
+            if (line.startsWith("\"buildTime\"")) {
+                var date = line.substring(line.indexOf("\"", 12) + 1, line.lastIndexOf("\""))
+                date = date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6, 8)
+                versions[version!!] = date
+            }
+        }
+        return versions
+    }
+
+
+    private
+    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
+}
+
+
+private
+typealias Version = String
+
+
+private
+typealias IncubatingDescription = String
+
+
+private
+typealias VersionsToIncubating = Map<Version, MutableSet<IncubatingDescription>>
+
+
+private
+interface VersionsToIncubatingCollector {
+
+    fun collectFrom(sourceFile: File): VersionsToIncubating
+}
+
+
+private
+class CompositeVersionsToIncubatingCollector(
+
+    private
+    val collectors: List<VersionsToIncubatingCollector>
+
+) : VersionsToIncubatingCollector {
+
+    override fun collectFrom(sourceFile: File): VersionsToIncubating =
+        collectors
+            .flatMap { it.collectFrom(sourceFile).entries }
+            .associate { it.key to it.value }
+}
+
+
+private
+const val versionNotFound = "Not found"
+
+
+private
+class JavaVersionsToIncubatingCollector(srcDir: File) : VersionsToIncubatingCollector {
+
+    private
+    val solver = JavaSymbolSolver(CombinedTypeSolver(JavaParserTypeSolver(srcDir), ReflectionTypeSolver()))
+
+    override fun collectFrom(sourceFile: File): VersionsToIncubating {
+
+        if (!sourceFile.name.endsWith(".java")) return emptyMap()
+
+        val versionsToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
+        JavaParser.parse(sourceFile).run {
+            solver.inject(this)
+            findAllIncubating()
+                .map { node -> toVersionIncubating(sourceFile, node) }
+                .forEach { (version, incubating) ->
+                    versionsToIncubating.getOrPut(version) { mutableSetOf() }.add(incubating)
+                }
+        }
+        return versionsToIncubating
+    }
+
+    private
+    fun CompilationUnit.findAllIncubating() =
+        findAll(Node::class.java).filter { it.isIncubating }
+
+    private
+    val Node.isIncubating: Boolean
+        get() = (this as? NodeWithAnnotations<*>)?.annotations?.any { it.nameAsString == "Incubating" } ?: false
+
+    private
+    fun CompilationUnit.toVersionIncubating(sourceFile: File, node: Node) =
+        Pair(
+            findVersionFromJavadoc(node as NodeWithAnnotations<*>) ?: versionNotFound,
+            nodeName(node, this, sourceFile)
+        )
+
+    private
+    fun findVersionFromJavadoc(node: NodeWithAnnotations<*>): String? =
+        (node as? NodeWithJavadoc<*>)?.javadoc?.map { javadoc ->
+            javadoc.blockTags
+                .find { tag -> tag.tagName == "since" }
+                ?.content?.elements?.find { description -> description is JavadocSnippet }
+                ?.toText()
+        }?.orElse(null)
+
+    private
+    fun nodeName(it: Node?, unit: CompilationUnit, file: File) = when (it) {
+        is EnumDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is ClassOrInterfaceDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is MethodDeclaration -> tryResolve({ it.resolve().qualifiedSignature }) { inferClassName(unit) }
+        is AnnotationDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is NodeWithSimpleName<*> -> it.nameAsString
+        else -> unit.primaryTypeName.orElse(file.name)
+    }
+
+    private
+    fun inferClassName(unit: CompilationUnit) =
+        "${unit.packageDeclaration.map { it.nameAsString }.orElse("")}.${unit.primaryTypeName.orElse("")}"
+
+    private
+    inline fun tryResolve(resolver: () -> String, or: () -> String) = try {
+        resolver()
+    } catch (e: Throwable) {
+        or()
+    }
+}
+
+
+private
+class KotlinVersionsToIncubatingCollector : VersionsToIncubatingCollector {
+
+    override fun collectFrom(sourceFile: File): VersionsToIncubating {
+
+        if (!sourceFile.name.endsWith(".kt")) return emptyMap()
+
+        val versionsToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
+        KotlinSourceParser().mapParsedKotlinFiles(sourceFile) { ktFile ->
+            ktFile.forEachIncubatingDeclaration { declaration ->
+                versionsToIncubating
+                    .getOrPut(declaration.sinceVersion) { mutableSetOf() }
+                    .add(buildIncubatingDescription(sourceFile, ktFile, declaration))
+            }
+        }
+        return versionsToIncubating
+    }
+
+    private
+    fun buildIncubatingDescription(sourceFile: File, ktFile: KtFile, declaration: KtNamedDeclaration): String {
+        var incubating = "${declaration.typeParametersString}${declaration.fullyQualifiedName}"
+        if (declaration is KtCallableDeclaration) {
+            incubating += declaration.valueParametersString
+            declaration.receiverTypeString?.let { receiver ->
+                incubating += " with $receiver receiver"
+            }
+            if (declaration.parent == ktFile) {
+                incubating += ", top-level in ${sourceFile.name}"
+            }
+        }
+        return incubating
+    }
+
+    private
+    fun KtFile.forEachIncubatingDeclaration(block: (KtNamedDeclaration) -> Unit) {
+        collectDescendantsOfType<KtNamedDeclaration>().filter { it.isIncubating }.forEach(block)
+    }
+
+    private
+    val KtNamedDeclaration.isIncubating: Boolean
+        get() = annotationEntries.any { it.shortName?.asString() == "Incubating" }
+
+    private
+    val KtNamedDeclaration.typeParametersString: String
+        get() = (this as? KtCallableDeclaration)?.typeParameterList?.let { "${it.text} " } ?: ""
+
+    private
+    val KtNamedDeclaration.fullyQualifiedName: String
+        get() = fqName!!.asString()
+
+    private
+    val KtCallableDeclaration.valueParametersString: String
+        get() = valueParameterList?.text ?: ""
+
+    private
+    val KtCallableDeclaration.receiverTypeString: String?
+        get() = receiverTypeReference?.text
+
+    private
+    val KtNamedDeclaration.sinceVersion: String
+        get() = docComment?.getDefaultSection()?.findTagsByName("since")?.singleOrNull()?.getContent()
+            ?: versionNotFound
+}
+
+

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiAggregateReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiAggregateReportTask.kt
@@ -16,115 +16,37 @@
 
 package gradlebuild.incubation.tasks
 
+import gradlebuild.incubation.action.IncubatingApiReportAggregationWorkAction
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.workers.IsolationMode
+import org.gradle.kotlin.dsl.submit
 import org.gradle.workers.WorkerExecutor
-import java.io.File
 import javax.inject.Inject
 
 
 @CacheableTask
-open class IncubatingApiAggregateReportTask
-@Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
+abstract class IncubatingApiAggregateReportTask : DefaultTask() {
 
-    @Internal
-    var reports: Map<String, File>? = null
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val reports: ConfigurableFileCollection
 
-    @get:Nested
-    val reportFiles
-        get() = reports?.mapValues { IncubatingApiReportFile(it.value) }
+    @get:OutputFile
+    abstract val htmlReportFile: RegularFileProperty
 
-    @OutputFile
-    val htmlReportFile = project.objects.fileProperty().also {
-        it.set(project.layout.buildDirectory.file("reports/incubation/all-incubating.html"))
-    }
+    @get:Inject
+    abstract val workerExecutor: WorkerExecutor
 
     @TaskAction
-    fun generateReport() {
-        workerExecutor.submit(GenerateReport::class.java) {
-            isolationMode = IsolationMode.NONE
-            params(reports, htmlReportFile.asFile.get())
-        }
+    fun generateReport() = workerExecutor.noIsolation().submit(IncubatingApiReportAggregationWorkAction::class) {
+        reports.from(this@IncubatingApiAggregateReportTask.reports)
+        htmlReportFile.set(this@IncubatingApiAggregateReportTask.htmlReportFile)
     }
-}
-
-
-data class IncubatingApiReportFile(
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.NONE)
-    val file: File
-)
-
-
-typealias ReportNameToProblems = MutableMap<String, MutableSet<String>>
-
-
-open class GenerateReport @Inject constructor(private val reports: Map<String, File>, private val outputFile: File) : Runnable {
-    override
-    fun run() {
-        val byVersion = mutableMapOf<String, ReportNameToProblems>()
-        reports.forEach { name, file ->
-            file.forEachLine(Charsets.UTF_8) {
-                val (version, _, problem) = it.split(';')
-                byVersion.getOrPut(version) {
-                    mutableMapOf()
-                }.getOrPut(name) {
-                    mutableSetOf()
-                }.add(problem)
-            }
-        }
-        generateReport(byVersion)
-    }
-
-    private
-    fun generateReport(data: Map<String, ReportNameToProblems>) {
-        outputFile.parentFile.mkdirs()
-        outputFile.printWriter(Charsets.UTF_8).use { writer ->
-            writer.println(
-                """<html lang="en">
-    <head>
-       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-       <title>Incubating APIs</title>
-       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
-       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
-       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
-
-    </head>
-    <body>
-       <h1>Incubating APIs</h1>
-       <h2>Index</h2>
-       <ul>
-    """
-            )
-
-            data.toSortedMap().forEach { version, _ ->
-                writer.println("<li><a href=\"#$version\">Incubating since $version</a><br></li>")
-            }
-            writer.println("</ul>")
-            data.toSortedMap().forEach { version, problems ->
-                writer.println("<a name=\"$version\"></a>")
-                writer.println("<h2>Incubating since $version</h2>")
-                problems.forEach { name, issues ->
-                    writer.println("<h3>In $name</h3>")
-                    writer.println("<ul>")
-                    issues.forEach {
-                        writer.println("   <li>${it.escape()}</li>")
-                    }
-                    writer.println("</ul>")
-                }
-            }
-            writer.println("</body></html>")
-        }
-    }
-
-    private
-    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
 }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiReportTask.kt
@@ -1,23 +1,6 @@
 package gradlebuild.incubation.tasks
 
-import com.github.javaparser.JavaParser
-import com.github.javaparser.ast.CompilationUnit
-import com.github.javaparser.ast.Node
-import com.github.javaparser.ast.body.AnnotationDeclaration
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
-import com.github.javaparser.ast.body.EnumDeclaration
-import com.github.javaparser.ast.body.MethodDeclaration
-import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations
-import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc
-import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName
-import com.github.javaparser.javadoc.description.JavadocSnippet
-import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver
-
-import gradlebuild.basics.util.KotlinSourceParser
-
+import gradlebuild.incubation.action.IncubatingApiReportWorkAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -30,347 +13,45 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.workers.IsolationMode
+import org.gradle.kotlin.dsl.submit
 import org.gradle.workers.WorkerExecutor
 
-import org.jetbrains.kotlin.psi.KtCallableDeclaration
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
-
-import java.io.File
 import javax.inject.Inject
-
-import org.gradle.kotlin.dsl.*
 
 
 @CacheableTask
-open class IncubatingApiReportTask @Inject constructor(
+abstract class IncubatingApiReportTask : DefaultTask() {
 
-    private
-    val workerExecutor: WorkerExecutor
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val versionFile: RegularFileProperty
 
-) : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val releasedVersionsFile: RegularFileProperty
 
-    @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val versionFile: RegularFileProperty = project.objects.fileProperty()
+    @get:Input
+    abstract val title: Property<String>
 
-    @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val releasedVersionsFile: RegularFileProperty = project.objects.fileProperty()
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sources: ConfigurableFileCollection
 
-    @Input
-    val title: Property<String> = project.objects.property<String>().convention(
-        project.provider {
-            project.name
-        }
-    )
+    @get:OutputFile
+    abstract val htmlReportFile: RegularFileProperty
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val sources: ConfigurableFileCollection = project.objects.fileCollection()
+    @get:OutputFile
+    abstract val textReportFile: RegularFileProperty
 
-    @OutputFile
-    val htmlReportFile: RegularFileProperty = project.objects.fileProperty().convention(
-        project.layout.buildDirectory.file("reports/incubating.html")
-    )
-
-    @OutputFile
-    val textReportFile: RegularFileProperty = project.objects.fileProperty().convention(
-        project.layout.buildDirectory.file("reports/incubating.txt")
-    )
+    @get:Inject
+    abstract val workerExecutor: WorkerExecutor
 
     @TaskAction
-    @Suppress("unused")
-    fun analyze() = workerExecutor.submit(Analyzer::class.java) {
-        isolationMode = IsolationMode.NONE
-        params(
-            sources.files,
-            htmlReportFile.asFile.get(),
-            textReportFile.asFile.get(),
-            title.get(),
-            releasedVersionsFile.asFile.get()
-        )
+    fun analyze() = workerExecutor.noIsolation().submit(IncubatingApiReportWorkAction::class) {
+        srcDirs.from(this@IncubatingApiReportTask.sources)
+        htmlReportFile.set(this@IncubatingApiReportTask.htmlReportFile)
+        textReportFile.set(this@IncubatingApiReportTask.textReportFile)
+        title.set(this@IncubatingApiReportTask.title)
+        releasedVersionsFile.set(this@IncubatingApiReportTask.releasedVersionsFile)
     }
-}
-
-
-private
-typealias Version = String
-
-
-private
-typealias IncubatingDescription = String
-
-
-private
-typealias VersionsToIncubating = Map<Version, MutableSet<IncubatingDescription>>
-
-
-open
-class Analyzer @Inject constructor(
-    private val srcDirs: Set<File>,
-    private val htmlReportFile: File,
-    private val textReportFile: File,
-    private val title: String,
-    private val releasedVersionsFile: File
-) : Runnable {
-
-    override
-    fun run() {
-        val versionToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
-        srcDirs.forEach { srcDir ->
-            if (srcDir.exists()) {
-                val collector = CompositeVersionsToIncubatingCollector(
-                    listOf(
-                        JavaVersionsToIncubatingCollector(srcDir),
-                        KotlinVersionsToIncubatingCollector()
-                    )
-                )
-                srcDir.walkTopDown().forEach { sourceFile ->
-                    try {
-                        collector.collectFrom(sourceFile).forEach { (version, incubating) ->
-                            versionToIncubating.getOrPut(version) { mutableSetOf() }.addAll(incubating)
-                        }
-                    } catch (e: Exception) {
-                        throw Exception("Unable to parse $sourceFile: ${e.message}")
-                    }
-                }
-            }
-        }
-        generateTextReport(versionToIncubating)
-        generateHtmlReport(versionToIncubating)
-    }
-
-    private
-    fun generateHtmlReport(versionToIncubating: VersionsToIncubating) {
-        htmlReportFile.parentFile.mkdirs()
-        htmlReportFile.printWriter(Charsets.UTF_8).use { writer ->
-            writer.println(
-                """<html lang="en">
-    <head>
-       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-       <title>Incubating APIs for $title</title>
-       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
-       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
-       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
-
-    </head>
-    <body>
-       <h1>Incubating APIs for $title</h1>
-    """
-            )
-            val versions = versionsDates()
-            versionToIncubating.toSortedMap().forEach { (version, incubatingDescriptions) ->
-                writer.println("<a name=\"sec_$version\"></a>")
-                writer.println(
-                    "<h2>Incubating since $version (${versions[version]?.run { "released on $this" }
-                        ?: "unreleased"})</h2>"
-                )
-                writer.println("<ul>")
-                incubatingDescriptions.sorted().forEach { incubating ->
-                    writer.println("   <li>${incubating.escape()}</li>")
-                }
-                writer.println("</ul>")
-            }
-            writer.println("</body></html>")
-        }
-    }
-
-    private
-    fun generateTextReport(versionToIncubating: VersionsToIncubating) {
-        textReportFile.parentFile.mkdirs()
-        textReportFile.printWriter(Charsets.UTF_8).use { writer ->
-            val versions = versionsDates()
-            versionToIncubating.toSortedMap().forEach { (version, incubatingDescriptions) ->
-                val releaseDate = versions[version] ?: "unreleased"
-                incubatingDescriptions.sorted().forEach { incubating ->
-                    writer.println("$version;$releaseDate;$incubating")
-                }
-            }
-        }
-    }
-
-    private
-    fun versionsDates(): Map<Version, String> {
-        val versions = mutableMapOf<Version, String>()
-        var version: String? = null
-        releasedVersionsFile.forEachLine(Charsets.UTF_8) {
-            val line = it.trim()
-            if (line.startsWith("\"version\"")) {
-                version = line.substring(line.indexOf("\"", 11) + 1, line.lastIndexOf("\""))
-            }
-            if (line.startsWith("\"buildTime\"")) {
-                var date = line.substring(line.indexOf("\"", 12) + 1, line.lastIndexOf("\""))
-                date = date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6, 8)
-                versions[version!!] = date
-            }
-        }
-        return versions
-    }
-
-
-    private
-    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
-}
-
-
-private
-interface VersionsToIncubatingCollector {
-
-    fun collectFrom(sourceFile: File): VersionsToIncubating
-}
-
-
-private
-class CompositeVersionsToIncubatingCollector(
-
-    private
-    val collectors: List<VersionsToIncubatingCollector>
-
-) : VersionsToIncubatingCollector {
-
-    override fun collectFrom(sourceFile: File): VersionsToIncubating =
-        collectors
-            .flatMap { it.collectFrom(sourceFile).entries }
-            .associate { it.key to it.value }
-}
-
-
-private
-const val versionNotFound = "Not found"
-
-
-private
-class JavaVersionsToIncubatingCollector(srcDir: File) : VersionsToIncubatingCollector {
-
-    private
-    val solver = JavaSymbolSolver(CombinedTypeSolver(JavaParserTypeSolver(srcDir), ReflectionTypeSolver()))
-
-    override fun collectFrom(sourceFile: File): VersionsToIncubating {
-
-        if (!sourceFile.name.endsWith(".java")) return emptyMap()
-
-        val versionsToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
-        JavaParser.parse(sourceFile).run {
-            solver.inject(this)
-            findAllIncubating()
-                .map { node -> toVersionIncubating(sourceFile, node) }
-                .forEach { (version, incubating) ->
-                    versionsToIncubating.getOrPut(version) { mutableSetOf() }.add(incubating)
-                }
-        }
-        return versionsToIncubating
-    }
-
-    private
-    fun CompilationUnit.findAllIncubating() =
-        findAll(Node::class.java).filter { it.isIncubating }
-
-    private
-    val Node.isIncubating: Boolean
-        get() = (this as? NodeWithAnnotations<*>)?.annotations?.any { it.nameAsString == "Incubating" } ?: false
-
-    private
-    fun CompilationUnit.toVersionIncubating(sourceFile: File, node: Node) =
-        Pair(
-            findVersionFromJavadoc(node as NodeWithAnnotations<*>) ?: versionNotFound,
-            nodeName(node, this, sourceFile)
-        )
-
-    private
-    fun findVersionFromJavadoc(node: NodeWithAnnotations<*>): String? =
-        (node as? NodeWithJavadoc<*>)?.javadoc?.map { javadoc ->
-            javadoc.blockTags
-                .find { tag -> tag.tagName == "since" }
-                ?.content?.elements?.find { description -> description is JavadocSnippet }
-                ?.toText()
-        }?.orElse(null)
-
-    private
-    fun nodeName(it: Node?, unit: CompilationUnit, file: File) = when (it) {
-        is EnumDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
-        is ClassOrInterfaceDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
-        is MethodDeclaration -> tryResolve({ it.resolve().qualifiedSignature }) { inferClassName(unit) }
-        is AnnotationDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
-        is NodeWithSimpleName<*> -> it.nameAsString
-        else -> unit.primaryTypeName.orElse(file.name)
-    }
-
-    private
-    fun inferClassName(unit: CompilationUnit) =
-        "${unit.packageDeclaration.map { it.nameAsString }.orElse("")}.${unit.primaryTypeName.orElse("")}"
-
-    private
-    inline fun tryResolve(resolver: () -> String, or: () -> String) = try {
-        resolver()
-    } catch (e: Throwable) {
-        or()
-    }
-}
-
-
-private
-class KotlinVersionsToIncubatingCollector : VersionsToIncubatingCollector {
-
-    override fun collectFrom(sourceFile: File): VersionsToIncubating {
-
-        if (!sourceFile.name.endsWith(".kt")) return emptyMap()
-
-        val versionsToIncubating = mutableMapOf<Version, MutableSet<IncubatingDescription>>()
-        KotlinSourceParser().mapParsedKotlinFiles(sourceFile) { ktFile ->
-            ktFile.forEachIncubatingDeclaration { declaration ->
-                versionsToIncubating
-                    .getOrPut(declaration.sinceVersion) { mutableSetOf() }
-                    .add(buildIncubatingDescription(sourceFile, ktFile, declaration))
-            }
-        }
-        return versionsToIncubating
-    }
-
-    private
-    fun buildIncubatingDescription(sourceFile: File, ktFile: KtFile, declaration: KtNamedDeclaration): String {
-        var incubating = "${declaration.typeParametersString}${declaration.fullyQualifiedName}"
-        if (declaration is KtCallableDeclaration) {
-            incubating += declaration.valueParametersString
-            declaration.receiverTypeString?.let { receiver ->
-                incubating += " with $receiver receiver"
-            }
-            if (declaration.parent == ktFile) {
-                incubating += ", top-level in ${sourceFile.name}"
-            }
-        }
-        return incubating
-    }
-
-    private
-    fun KtFile.forEachIncubatingDeclaration(block: (KtNamedDeclaration) -> Unit) {
-        collectDescendantsOfType<KtNamedDeclaration>().filter { it.isIncubating }.forEach(block)
-    }
-
-    private
-    val KtNamedDeclaration.isIncubating: Boolean
-        get() = annotationEntries.any { it.shortName?.asString() == "Incubating" }
-
-    private
-    val KtNamedDeclaration.typeParametersString: String
-        get() = (this as? KtCallableDeclaration)?.typeParameterList?.let { "${it.text} " } ?: ""
-
-    private
-    val KtNamedDeclaration.fullyQualifiedName: String
-        get() = fqName!!.asString()
-
-    private
-    val KtCallableDeclaration.valueParametersString: String
-        get() = valueParameterList?.text ?: ""
-
-    private
-    val KtCallableDeclaration.receiverTypeString: String?
-        get() = receiverTypeReference?.text
-
-    private
-    val KtNamedDeclaration.sinceVersion: String
-        get() = docComment?.getDefaultSection()?.findTagsByName("since")?.singleOrNull()?.getContent()
-            ?: versionNotFound
 }


### PR DESCRIPTION
- Use the latest (and not deprecated) version of Worker API
- Move all aggregation logic to buildSrc
- Use proper variants and dependencies to aggregate reports
