### PR TITLE
Make sure intermediate build operations are emitted

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultNestedTestSuiteDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultNestedTestSuiteDescriptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.internal.id.CompositeIdGenerator;
+
+public class DefaultNestedTestSuiteDescriptor extends DefaultTestSuiteDescriptor {
+    private final CompositeIdGenerator.CompositeId parentId;
+    private final String displayName;
+
+    public DefaultNestedTestSuiteDescriptor(Object id, String name, String displayName, CompositeIdGenerator.CompositeId parentId) {
+        super(id, name);
+        this.displayName = displayName;
+        this.parentId = parentId;
+    }
+
+    public CompositeIdGenerator.CompositeId getParentId() {
+        return parentId;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getClassName() {
+        return super.getClassName();
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSupport.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSupport.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.testing.junit;
+
+public abstract class JUnitSupport {
+    public static final String UNKNOWN_CLASS = "UnknownClass";
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -352,6 +352,10 @@ public class JUnitXmlResultWriter {
 
     private Iterable<TestCaseExecution> failures(final long classId, final TestMethodResult methodResult, final FailureType failureType) {
         List<TestFailure> failures = methodResult.getFailures();
+        if (failures.isEmpty()) {
+            // This can happen with a failing engine. For now we just ignore this.
+            return Collections.emptyList();
+        }
         final TestFailure firstFailure = failures.get(0);
         return Iterables.transform(failures, new Function<TestFailure, TestCaseExecution>() {
             @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -131,7 +131,7 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
 
     @Override
     public void onOutput(TestDescriptor testDescriptor, TestOutputEvent outputEvent) {
-        String className = testDescriptor.getClassName();
+        String className = findEnclosingClassName(testDescriptor);
         if (className == null) {
             pendingOutputEvents.put(((TestDescriptorInternal) testDescriptor).getId(), outputEvent);
             return;
@@ -151,5 +151,16 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
         } else {
             outputWriter.onOutput(classResult.getId(), methodResult.getId(), outputEvent);
         }
+    }
+
+    private static String findEnclosingClassName(TestDescriptor testDescriptor) {
+        if (testDescriptor == null) {
+            return null;
+        }
+        String className = testDescriptor.getClassName();
+        if (className != null) {
+            return className;
+        }
+        return findEnclosingClassName(testDescriptor.getParent());
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -28,6 +28,7 @@ public class TestEventSerializer {
         DefaultSerializerRegistry registry = new DefaultSerializerRegistry();
         registry.register(DefaultTestClassRunInfo.class, new DefaultTestClassRunInfoSerializer());
         registry.register(CompositeIdGenerator.CompositeId.class, new IdSerializer());
+        registry.register(DefaultNestedTestSuiteDescriptor.class, new DefaultNestedTestSuiteDescriptorSerializer());
         registry.register(DefaultTestSuiteDescriptor.class, new DefaultTestSuiteDescriptorSerializer());
         registry.register(WorkerTestClassProcessor.WorkerTestSuiteDescriptor.class, new WorkerTestSuiteDescriptorSerializer());
         registry.register(DefaultTestClassDescriptor.class, new DefaultTestClassDescriptorSerializer());
@@ -154,6 +155,27 @@ public class TestEventSerializer {
         public void write(Encoder encoder, DefaultTestSuiteDescriptor value) throws Exception {
             idSerializer.write(encoder, (CompositeIdGenerator.CompositeId) value.getId());
             encoder.writeString(value.getName());
+        }
+    }
+
+    private static class DefaultNestedTestSuiteDescriptorSerializer implements Serializer<DefaultNestedTestSuiteDescriptor> {
+        final Serializer<CompositeIdGenerator.CompositeId> idSerializer = new IdSerializer();
+
+        @Override
+        public DefaultNestedTestSuiteDescriptor read(Decoder decoder) throws Exception {
+            Object id = idSerializer.read(decoder);
+            String name = decoder.readString();
+            String displayName = decoder.readString();
+            CompositeIdGenerator.CompositeId parentId = idSerializer.read(decoder);
+            return new DefaultNestedTestSuiteDescriptor(id, name, displayName, parentId);
+        }
+
+        @Override
+        public void write(Encoder encoder, DefaultNestedTestSuiteDescriptor value) throws Exception {
+            idSerializer.write(encoder, (CompositeIdGenerator.CompositeId) value.getId());
+            encoder.writeString(value.getName());
+            encoder.writeString(value.getDisplayName());
+            idSerializer.write(encoder, value.getParentId());
         }
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/FullExceptionFormatterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/FullExceptionFormatterTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.logging
 
+import org.gradle.api.internal.tasks.testing.junit.JUnitSupport
 import spock.lang.Specification
 import org.gradle.api.tasks.testing.logging.TestLogging
 import org.gradle.api.tasks.testing.logging.TestStackTraceFilter
@@ -180,7 +181,7 @@ class FullExceptionFormatterTest extends Specification {
     def "retains stacktrace for inherited test classes"() {
         testLogging.getShowStackTraces() >> true
         testLogging.getStackTraceFilters() >> EnumSet.of(TestStackTraceFilter.TRUNCATE, TestStackTraceFilter.GROOVY)
-        testDescriptor.className = "UnknownClass"
+        testDescriptor.className = JUnitSupport.UNKNOWN_CLASS
 
         def exception = new Exception("ouch")
         exception.stackTrace = createGroovyTrace()

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -81,9 +81,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
-        if (testIdentifier.isTest() || hasClassSource(testIdentifier)) {
-            reportStartedUnlessAlreadyStarted(testIdentifier);
-        }
+        reportStartedUnlessAlreadyStarted(testIdentifier);
     }
 
     @Override
@@ -163,7 +161,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
             if (node.getType() == CONTAINER || isTestClassIdentifier(node)) {
                 TestIdentifier classIdentifier = findTestClassIdentifier(node);
                 String className = className(classIdentifier);
-                String classDisplayName = classDisplayName(classIdentifier);
+                String classDisplayName = node.getDisplayName();
                 return new DefaultTestClassDescriptor(idGenerator.generateId(), className, classDisplayName);
             }
             return createTestDescriptor(node, node.getLegacyReportingName(), node.getDisplayName());

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -16,14 +16,17 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
+import org.gradle.api.internal.tasks.testing.DefaultNestedTestSuiteDescriptor;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor;
 import org.gradle.api.internal.tasks.testing.DefaultTestDescriptor;
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
+import org.gradle.api.internal.tasks.testing.junit.JUnitSupport;
 import org.gradle.api.tasks.testing.TestResult.ResultType;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.id.CompositeIdGenerator;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.time.Clock;
 import org.junit.platform.engine.TestExecutionResult;
@@ -40,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED;
-import static org.junit.platform.engine.TestDescriptor.Type.CONTAINER;
 import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 
@@ -81,7 +83,12 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
-        reportStartedUnlessAlreadyStarted(testIdentifier);
+        // The root node will be "JUnit Jupiter" which isn't expected
+        // to be seen as a "real" test suite in many tests, so this
+        // test is to make sure we're at least under this event
+        if (testIdentifier.getParentId().isPresent()) {
+            reportStartedUnlessAlreadyStarted(testIdentifier);
+        }
     }
 
     @Override
@@ -158,15 +165,34 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         MutableBoolean wasCreated = new MutableBoolean(false);
         descriptorsByUniqueId.computeIfAbsent(node.getUniqueId(), uniqueId -> {
             wasCreated.set(true);
-            if (node.getType() == CONTAINER || isTestClassIdentifier(node)) {
-                TestIdentifier classIdentifier = findTestClassIdentifier(node);
-                String className = className(classIdentifier);
-                String classDisplayName = node.getDisplayName();
-                return new DefaultTestClassDescriptor(idGenerator.generateId(), className, classDisplayName);
+            boolean isTestClassId = isTestClassIdentifier(node);
+            if (node.getType().isContainer() || isTestClassId) {
+                if (isTestClassId) {
+                    return createTestClassDescriptor(node);
+                }
+                String displayName = node.getDisplayName();
+                Optional<TestDescriptorInternal> parentId = node.getParentId().map(descriptorsByUniqueId::get);
+                if (parentId.isPresent()) {
+                    Object candidateId = parentId.get().getId();
+                    if (candidateId instanceof CompositeIdGenerator.CompositeId) {
+                        return createNestedTestSuite(node, displayName, (CompositeIdGenerator.CompositeId) candidateId);
+                    }
+                }
             }
             return createTestDescriptor(node, node.getLegacyReportingName(), node.getDisplayName());
         });
         return wasCreated.get();
+    }
+
+    private DefaultNestedTestSuiteDescriptor createNestedTestSuite(TestIdentifier node, String displayName, CompositeIdGenerator.CompositeId candidateId) {
+        return new DefaultNestedTestSuiteDescriptor(idGenerator.generateId(), node.getLegacyReportingName(), displayName, candidateId);
+    }
+
+    private DefaultTestClassDescriptor createTestClassDescriptor(TestIdentifier node) {
+        TestIdentifier classIdentifier = findTestClassIdentifier(node);
+        String className = className(classIdentifier);
+        String classDisplayName = node.getDisplayName();
+        return new DefaultTestClassDescriptor(idGenerator.generateId(), className, classDisplayName);
     }
 
     private TestDescriptorInternal createSyntheticTestDescriptorForContainer(TestIdentifier node) {
@@ -222,14 +248,14 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
                 return classSource.get().getClassName();
             }
         }
-        return "UnknownClass";
+        return JUnitSupport.UNKNOWN_CLASS;
     }
 
     private String classDisplayName(TestIdentifier testClassIdentifier) {
         if (testClassIdentifier != null) {
             return testClassIdentifier.getDisplayName();
         }
-        return "UnknownClass";
+        return JUnitSupport.UNKNOWN_CLASS;
     }
 
     private static boolean hasClassSource(TestIdentifier testIdentifier) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.junitplatform
 
+import org.gradle.api.internal.tasks.testing.junit.JUnitSupport
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Issue
 import spock.lang.Timeout
@@ -241,7 +242,7 @@ public class UninstantiableExtension implements BeforeEachCallback {
 
         then:
         new DefaultTestExecutionResult(testDirectory)
-            .testClass('UnknownClass')
+            .testClass(JUnitSupport.UNKNOWN_CLASS)
             .assertTestFailed('initializationError', containsString('UninstantiableExtension'))
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -113,7 +113,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         true
     }
 
-    private static boolean optionalMatch(String actual, String requested) {
+    private static boolean matchIfPresent(String actual, String requested) {
         if (requested == null) {
             return true
         }
@@ -129,7 +129,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         def descriptorByClassAndMethod = descriptors.findAll {
             it.className == className &&
                 it.methodName == methodName &&
-                optionalMatch(it.displayName, displayName)
+                matchIfPresent(it.displayName, displayName)
         }
         if (taskpath == null) {
             return descriptorByClassAndMethod

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.tooling
 
+import groovy.transform.CompileStatic
 import org.gradle.integtests.tooling.fixture.GradleBuildCancellation
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -26,8 +27,11 @@ import org.gradle.tooling.CancellationToken
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.ResultHandler
 import org.gradle.tooling.TestLauncher
+import org.gradle.tooling.events.OperationDescriptor
 import org.gradle.tooling.events.task.TaskFinishEvent
 import org.gradle.tooling.events.task.TaskOperationDescriptor
+import org.gradle.tooling.events.test.JvmTestKind
+import org.gradle.tooling.events.test.JvmTestOperationDescriptor
 import org.gradle.tooling.events.test.TestOperationDescriptor
 import org.gradle.util.GradleVersion
 import org.junit.Rule
@@ -268,4 +272,165 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         """
     }
 
+    void jvmTestEvents(@DelegatesTo(value = TestEventsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> assertionSpec) {
+        DefaultTestEventsSpec spec = new DefaultTestEventsSpec()
+        assertionSpec.delegate = spec
+        assertionSpec.resolveStrategy = Closure.DELEGATE_FIRST
+        assertionSpec()
+        def remainingEvents = spec.testEvents - spec.verifiedEvents
+        if (remainingEvents) {
+            ErrorMessageBuilder err = new ErrorMessageBuilder()
+            err.title("The following test events were received but not verified")
+            remainingEvents.each { err.candidate("${it} : Kind=${it.jvmTestKind} suiteName=${it.suiteName} className=${it.className} methodName=${it.methodName} displayName=${it.displayName}") }
+            throw err.build()
+        }
+    }
+
+    interface TestEventsSpec {
+        void task(String path, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> rootSpec)
+    }
+
+    interface TestEventSpec {
+        void displayName(String displayName)
+
+        void suite(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
+
+        void testClass(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
+
+        void test(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
+    }
+
+    class DefaultTestEventsSpec implements TestEventsSpec {
+        final List<JvmTestOperationDescriptor> testEvents = events.tests.collect { (JvmTestOperationDescriptor) it.descriptor }
+        final Set<OperationDescriptor> verifiedEvents = []
+
+        @Override
+        void task(String path, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> rootSpec) {
+            def task = testEvents.find {
+                it.jvmTestKind == JvmTestKind.SUITE &&
+                    (it.parent instanceof TaskOperationDescriptor) &&
+                    it.parent.taskPath == path
+            }
+            if (task == null) {
+                throw new AssertionError("Expected to find a test task $path but none was found")
+            }
+            DefaultTestEventSpec.assertSpec(task.parent, testEvents, verifiedEvents, rootSpec)
+        }
+    }
+
+    @CompileStatic
+    static class DefaultTestEventSpec implements TestEventSpec {
+        private final List<JvmTestOperationDescriptor> testEvents
+        private final Set<OperationDescriptor> verifiedEvents
+        private final OperationDescriptor parent
+        private String displayName
+
+        static void assertSpec(OperationDescriptor descriptor, List<JvmTestOperationDescriptor> testEvents, Set<OperationDescriptor> verifiedEvents, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+            verifiedEvents.add(descriptor)
+            DefaultTestEventSpec childSpec = new DefaultTestEventSpec(descriptor, testEvents, verifiedEvents)
+            spec.delegate = childSpec
+            spec.resolveStrategy = Closure.DELEGATE_FIRST
+            spec()
+            childSpec.validate()
+        }
+
+        DefaultTestEventSpec(OperationDescriptor parent, List<JvmTestOperationDescriptor> testEvents, Set<OperationDescriptor> verifiedEvents) {
+            this.parent = parent
+            this.testEvents = testEvents
+            this.verifiedEvents = verifiedEvents
+        }
+
+        @Override
+        void displayName(String displayName) {
+            this.displayName = displayName
+        }
+
+        private static String normalizeExecutor(String name) {
+            if (name.startsWith("Gradle Test Executor")) {
+                return "Gradle Test Executor"
+            }
+            return name
+        }
+
+        @Override
+        void suite(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+            def child = testEvents.find { it.parent == parent && it.jvmTestKind == JvmTestKind.SUITE && normalizeExecutor(it.suiteName) == name }
+            if (child == null) {
+                failWith("test suite", name)
+            }
+            assertSpec(child, testEvents, verifiedEvents, spec)
+        }
+
+        @Override
+        void testClass(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+            def child = testEvents.find {
+                it.parent == parent &&
+                    it.jvmTestKind == JvmTestKind.SUITE &&
+                    it.suiteName == null &&
+                    it.className == name
+            }
+            if (child == null) {
+                failWith("test class", name)
+            }
+            assertSpec(child, testEvents, verifiedEvents, spec)
+        }
+
+        @Override
+        void test(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+            def child = testEvents.find {
+                it.parent == parent &&
+                    it.jvmTestKind == JvmTestKind.ATOMIC &&
+                    it.suiteName == null &&
+                    it.name == name
+            }
+            if (child == null) {
+                failWith("test", name)
+            }
+            assertSpec(child, testEvents, verifiedEvents, spec)
+        }
+
+        private void failWith(String what, String name) {
+            ErrorMessageBuilder err = new ErrorMessageBuilder()
+            def remaining = testEvents.findAll { it.parent == parent && !verifiedEvents.contains(it) }
+            if (remaining) {
+                err.title("Expected to find a $what named $name under ${parent.displayName} and none was found. Possible events are:")
+                remaining.each {
+                    err.candidate("${it} : Kind=${it.jvmTestKind} suiteName=${it.suiteName} className=${it.className} methodName=${it.methodName} displayName=${it.displayName}")
+                }
+            } else {
+                err.title("Expected to find a $what named $name under ${parent.displayName} and none was found. There are no more events available for this parent.")
+            }
+            throw err.build()
+        }
+
+        void validate() {
+            if (displayName != null) {
+                assert displayName == parent.displayName
+            }
+        }
+    }
+
+    @CompileStatic
+    static class ErrorMessageBuilder {
+        private final StringBuilder builder = new StringBuilder()
+        boolean inCandidates = false
+
+
+        void title(String title) {
+            builder.append(title)
+        }
+
+        void candidate(String candidate) {
+            if (!inCandidates) {
+                builder.append(":\n")
+            }
+            inCandidates = true
+            builder.append("   - ").append(candidate).append("\n")
+        }
+
+        AssertionError build() {
+            new AssertionError(builder)
+        }
+
+    }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r69/TestDisplayNameCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r69/TestDisplayNameCrossVersionSpec.groovy
@@ -68,10 +68,20 @@ public class SimpleTests {
         }
 
         then:
-
-        assertTaskExecuted(":test")
-        assertTestExecuted(className: "org.example.SimpleTests", methodName: null, displayName: "a class display name")
-        assertTestExecuted(className: "org.example.SimpleTests", methodName: "test()", displayName: "and a test display name")
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        suite("org.example.SimpleTests") {
+                            displayName "a class display name"
+                            test("test()") {
+                                displayName "and a test display name"
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     def "reports display names of nested test classes"() {
@@ -170,18 +180,43 @@ class TestingAStackDemo {
         }
 
         then:
-
-        assertTaskExecuted(":test")
-        assertTestExecuted(className: "org.example.TestingAStackDemo", methodName: null, displayName: "A stack")
-        assertTestExecuted(className: "org.example.TestingAStackDemo", methodName: "isInstantiatedWithNew()", displayName: "is instantiated with new Stack()")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: null, displayName: "when new")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "isEmpty()", displayName: "is empty")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "throwsExceptionWhenPopped()", displayName: "throws EmptyStackException when popped")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew", methodName: "throwsExceptionWhenPeeked()", displayName: "throws EmptyStackException when peeked")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: null, displayName: "after pushing an element")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "isNotEmpty()", displayName: "it is no longer empty")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "returnElementWhenPopped()", displayName: "returns the element when popped and is empty")
-        assertTestExecuted(className: "org.example.TestingAStackDemo\$WhenNew\$AfterPushing", methodName: "returnElementWhenPeeked()", displayName: "returns the element when peeked but remains not empty")
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        suite("org.example.TestingAStackDemo") {
+                            displayName "A stack"
+                            test("isInstantiatedWithNew()") {
+                                displayName "is instantiated with new Stack()"
+                            }
+                            suite("org.example.TestingAStackDemo\$WhenNew") {
+                                displayName "when new"
+                                test("isEmpty()") {
+                                    displayName "is empty"
+                                }
+                                test("throwsExceptionWhenPeeked()") {
+                                    displayName "throws EmptyStackException when peeked"
+                                }
+                                test("throwsExceptionWhenPopped()") {
+                                    displayName "throws EmptyStackException when popped"
+                                }
+                                suite("org.example.TestingAStackDemo\$WhenNew\$AfterPushing") {
+                                    test("isNotEmpty()") {
+                                        displayName "it is no longer empty"
+                                    }
+                                    test("returnElementWhenPeeked()") {
+                                        displayName "returns the element when peeked but remains not empty"
+                                    }
+                                    test("returnElementWhenPopped()") {
+                                        displayName "returns the element when popped and is empty"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     def "reports display names of parameterized tests"() {
@@ -218,14 +253,34 @@ public class ParameterizedTests {
         }
 
         then:
-        assertTaskExecuted(":test")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: null, displayName: "Parameterized test")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: null, displayName: "1st test")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: "test1(String)[1]", displayName: "[1] foo")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: "test1(String)[2]", displayName: "[2] bar")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: null, displayName: "2nd test")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: "test2(String)[1]", displayName: "[1] foo")
-        assertTestExecuted(className: "org.example.ParameterizedTests", methodName: "test2(String)[2]", displayName: "[2] bar")
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        suite("org.example.ParameterizedTests") {
+                            suite("test1(String)") {
+                                displayName "1st test"
+                                test("test1(String)[1]") {
+                                    displayName "[1] foo"
+                                }
+                                test("test1(String)[2]") {
+                                    displayName "[2] bar"
+                                }
+                            }
+                            suite("test2(String)") {
+                                displayName "2nd test"
+                                test("test2(String)[1]") {
+                                    displayName "[1] foo"
+                                }
+                                test("test2(String)[2]") {
+                                    displayName "[2] bar"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     def "reports display names for dynamic tests"() {
@@ -274,13 +329,36 @@ public class DynamicTests {
         }
 
         then:
-        assertTaskExecuted(":test")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: null)
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: null, displayName: "testFactory()")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: null, displayName: "some nested container")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: "testFactory()[1][1][1]", displayName: "foo")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: "testFactory()[1][1][2]", displayName: "bar")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: null, displayName: "another test factory")
-        assertTestExecuted(className: "org.example.DynamicTests", methodName: "anotherTestFactory()[1]", displayName: "foo")
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        suite("org.example.DynamicTests") {
+                            suite("testFactory()") {
+                                displayName "Test suite 'testFactory()'"
+                                suite("testFactory()[1]") {
+                                    displayName "some container"
+                                    suite("testFactory()[1][1]") {
+                                        displayName "some nested container"
+                                        test("testFactory()[1][1][1]") {
+                                            displayName "foo"
+                                        }
+                                        test("testFactory()[1][1][2]") {
+                                            displayName "bar"
+                                        }
+                                    }
+                                }
+                            }
+                            suite("anotherTestFactory()") {
+                                displayName "another test factory"
+                                test("anotherTestFactory()[1]") {
+                                    displayName "foo"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameCrossVersionSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling.r69
+package org.gradle.integtests.tooling.r70
 
 import org.gradle.integtests.tooling.TestLauncherSpec
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
@@ -24,7 +24,7 @@ import spock.lang.Timeout
 
 @Timeout(120)
 @ToolingApiVersion('>=6.1')
-@TargetGradleVersion(">=6.9")
+@TargetGradleVersion(">=7.0")
 class TestDisplayNameCrossVersionSpec extends TestLauncherSpec {
     @Override
     void addDefaultTests() {


### PR DESCRIPTION
This commit simplifies the JUnit Platform test execution listener, so that
it also generates test events for "intermediate" tests. The previous implementation
was mostly copied from the legacy JUnit listener, which didn't account for
nested test structures.

There is one drawback of the approach used in this PR, which is that
because there wasn't such a concept before, we had to make a decision on
how to expose the nested tests. We're using "test classes", because it
matches closely the concept of a "test suite" which is already in use.
But it means that for those intermediate operations, the method name isn't
properly available: one has to rely on the display name, which will
actually resolve to the method name by default.

See #5975
