### PR TITLE
Add extension for configuring sources as input for auto-tested samples

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -150,7 +150,7 @@
     "dirName": "core-api",
     "name": "core-api",
     "unitTests": true,
-    "functionalTests": false,
+    "functionalTests": true,
     "crossVersionTests": false
   },
   {

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/gradlebuild/cleanup/extension/TestFileCleanUpExtension.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/gradlebuild/cleanup/extension/TestFileCleanUpExtension.kt
@@ -20,6 +20,6 @@ import gradlebuild.cleanup.WhenNotEmpty
 import org.gradle.api.provider.Property
 
 
-abstract class TestFileCleanUpExtension() {
+abstract class TestFileCleanUpExtension {
     abstract val policy: Property<WhenNotEmpty>
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
@@ -21,10 +21,15 @@ import gradlebuild.integrationtests.configureIde
 import gradlebuild.integrationtests.createTasks
 import gradlebuild.integrationtests.createTestTask
 import gradlebuild.integrationtests.includeCategories
+import gradlebuild.integrationtests.extension.IntegrationTestExtension
 
 plugins {
     java
     id("gradlebuild.dependency-modules")
+}
+
+extensions.create<IntegrationTestExtension>("integTest").apply {
+    usesSamples.convention(false)
 }
 
 val sourceSet = addSourceSet(TestType.INTEGRATION)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.samples
+package gradlebuild.integrationtests.extension
 
-import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
-import org.junit.Test
+import org.gradle.api.provider.Property
 
-class AutoTestedSamplesCoreIntegrationTest extends AbstractAutoTestedSamplesTest {
 
-    @Test
-    void runSamples() {
-        runSamplesFrom("subprojects/core/src/main/java")
-    }
+abstract class IntegrationTestExtension {
+    abstract val usesSamples: Property<Boolean>
 }

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     testImplementation(testFixtures(project(":logging")))
 
     testFixturesImplementation(project(":base-services"))
+
+    integTestDistributionRuntimeOnly(project(":distributions-basics"))
 }
 
 classycle {
@@ -40,3 +42,5 @@ strictCompile {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+integTest.usesSamples.set(true)

--- a/subprojects/core-api/src/integTest/groovy/org/gradle/samples/AutoTestedSamplesCoreApiIntegrationTest.groovy
+++ b/subprojects/core-api/src/integTest/groovy/org/gradle/samples/AutoTestedSamplesCoreApiIntegrationTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.samples
+package org.gradle.samples
 
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
 import org.junit.Test
@@ -31,6 +31,6 @@ class AutoTestedSamplesCoreApiIntegrationTest extends AbstractAutoTestedSamplesT
             include 'api', 'util'
         """
 
-        runSamplesFrom("subprojects/core-api/src/main/java")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -177,3 +177,5 @@ tasks.compileTestGroovy {
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
+
+integTest.usesSamples.set(true)

--- a/subprojects/core/src/integTest/groovy/org/gradle/samples/AutoTestedSamplesCoreIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/samples/AutoTestedSamplesCoreIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2010 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-package org.gradle.api.publish
+package org.gradle.samples
 
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
 import org.junit.Test
 
-class AutoTestedSamplesPublishIntegrationTest extends AbstractAutoTestedSamplesTest {
+class AutoTestedSamplesCoreIntegrationTest extends AbstractAutoTestedSamplesTest {
 
     @Test
     void runSamples() {
         runSamplesFrom("src/main")
     }
-
 }
-
-

--- a/subprojects/ide-native/build.gradle.kts
+++ b/subprojects/ide-native/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -61,4 +60,4 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-native"))
 }
 
-integrationTestUsesSampleDir("subprojects/ide-native/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/AutoTestedSamplesIdeNativeIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/AutoTestedSamplesIdeNativeIntegrationTest.groovy
@@ -23,7 +23,7 @@ class AutoTestedSamplesIdeNativeIntegrationTest extends AbstractAutoTestedSample
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/ide-native/src/main")
+        runSamplesFrom("src/main")
     }
 
 }

--- a/subprojects/ide/build.gradle.kts
+++ b/subprojects/ide/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -85,4 +84,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/ide/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AutoTestedSamplesIdeIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AutoTestedSamplesIdeIntegrationTest.groovy
@@ -23,6 +23,6 @@ class AutoTestedSamplesIdeIntegrationTest extends AbstractAutoTestedSamplesTest 
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/ide/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractAutoTestedSamplesTest.groovy
@@ -20,14 +20,7 @@ class AbstractAutoTestedSamplesTest extends AbstractIntegrationTest {
 
     def util = new AutoTestedSamplesUtil()
 
-    static void assertDeclaredAsInput(String dir) {
-        String inputs = System.getProperty("declaredSampleInputs")
-        assert inputs: "Must declare samples dir as inputs!"
-        assert inputs.split(";").contains(dir): "Must declare input: $dir"
-    }
-
     void runSamplesFrom(String dir) {
-        assertDeclaredAsInput(dir)
         util.findSamples(dir) { file, sample, tagSuffix ->
             println "Found sample: ${sample.split("\n")[0]} (...) in $file"
             def buildFile = testFile('build.gradle')

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AutoTestedSamplesUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AutoTestedSamplesUtil.groovy
@@ -39,23 +39,23 @@ class AutoTestedSamplesUtil {
         list.each() { runSamplesFromFile(it, runner) }
     }
 
-    String findDir(String dir) {
+    static String findDir(String dir) {
         def workDir = SystemProperties.instance.currentDir
-        def candidates = [
-            "$workDir/$dir",        //when ran from IDEA
-            "$workDir/../../$dir"  //when ran from command line
-        ]
-        for (c in candidates) {
-            if (new File(c).exists()) {
-                return c
-            }
+        def samplesDir = new File("$workDir/$dir")
+        if (samplesDir.exists()) {
+            assertDeclaredAsInput(samplesDir.absolutePath)
+            return samplesDir
         }
-        throw new RuntimeException("""Couldn't find the root folder :-( Please update the logic so that it detects the root folder correctly.
-I tried looking for a root folder here: $candidates
-""")
+        throw new RuntimeException("$samplesDir does not exist")
     }
 
-    void runSamplesFromFile(File file, Closure runner) {
+    static void assertDeclaredAsInput(String dir) {
+        String inputs = System.getProperty("declaredSampleInputs")
+        assert inputs: "Must declare samples dir as inputs: 'integTest.usesSamples.set(true)'"
+        assert inputs == dir
+    }
+
+    static void runSamplesFromFile(File file, Closure runner) {
         String text = file.text
         def samples = SAMPLE_START.matcher(text)
         while (samples.find()) {

--- a/subprojects/ivy/build.gradle.kts
+++ b/subprojects/ivy/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -82,5 +81,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-
-integrationTestUsesSampleDir("subprojects/ivy/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/AutoTestedSamplesIvyIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/AutoTestedSamplesIvyIntegrationTest.groovy
@@ -23,7 +23,7 @@ class AutoTestedSamplesIvyIntegrationTest extends AbstractAutoTestedSamplesTest 
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/ivy/src/main")
+        runSamplesFrom("src/main")
     }
 
 }

--- a/subprojects/language-java/build.gradle.kts
+++ b/subprojects/language-java/build.gradle.kts
@@ -1,5 +1,4 @@
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -84,4 +83,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/language-java/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/AutoTestedSamplesLanguageJavaIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/AutoTestedSamplesLanguageJavaIntegrationTest.groovy
@@ -23,6 +23,6 @@ class AutoTestedSamplesLanguageJavaIntegrationTest extends AbstractAutoTestedSam
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/language-java/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/language-native/build.gradle.kts
+++ b/subprojects/language-native/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -84,4 +83,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/language/nativeplatform/internal/**"))
 }
 
-integrationTestUsesSampleDir("subprojects/language-native/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AutoTestedSamplesLanguageNativeIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AutoTestedSamplesLanguageNativeIntegrationTest.groovy
@@ -25,7 +25,7 @@ class AutoTestedSamplesLanguageNativeIntegrationTest extends AbstractAutoTestedS
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/language-native/src/main")
+        runSamplesFrom("src/main")
     }
 
 }

--- a/subprojects/maven/build.gradle.kts
+++ b/subprojects/maven/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -89,4 +88,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/maven/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/AutoTestedSamplesMavenIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/AutoTestedSamplesMavenIntegrationTest.groovy
@@ -25,7 +25,7 @@ class AutoTestedSamplesMavenIntegrationTest extends AbstractAutoTestedSamplesTes
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/maven/src/main")
+        runSamplesFrom("src/main")
     }
 
 }

--- a/subprojects/platform-base/build.gradle.kts
+++ b/subprojects/platform-base/build.gradle.kts
@@ -1,5 +1,3 @@
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
-
 plugins {
     id("gradlebuild.distribution.api-java")
 }
@@ -42,4 +40,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/**"))
 }
 
-integrationTestUsesSampleDir("subprojects/platform-base/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/AutoTestedSamplePlatformBaseIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/AutoTestedSamplePlatformBaseIntegrationTest.groovy
@@ -24,6 +24,6 @@ import org.junit.Test
 class AutoTestedSamplePlatformBaseIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/platform-base/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/platform-jvm/build.gradle.kts
+++ b/subprojects/platform-jvm/build.gradle.kts
@@ -1,5 +1,3 @@
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
-
 plugins {
     id("gradlebuild.distribution.api-java")
     id("gradlebuild.jmh")
@@ -53,8 +51,6 @@ strictCompile {
     ignoreDeprecations() // most of this project has been deprecated
 }
 
-integrationTestUsesSampleDir("subprojects/platform-jvm/src/main")
-
 classycle {
     excludePatterns.set(listOf(
         // Needed for the factory methods in the interface
@@ -62,3 +58,5 @@ classycle {
         "org/gradle/jvm/toolchain/internal/**"
     ))
 }
+
+integTest.usesSamples.set(true)

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/AutoTestedSamplePlatformJvmIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/AutoTestedSamplePlatformJvmIntegrationTest.groovy
@@ -25,6 +25,6 @@ class AutoTestedSamplePlatformJvmIntegrationTest extends AbstractAutoTestedSampl
     @Test
     void runSamples() {
         executer.noDeprecationChecks()
-        runSamplesFrom("subprojects/platform-jvm/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/platform-native/build.gradle.kts
+++ b/subprojects/platform-native/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -81,4 +80,4 @@ classycle {
     ))
 }
 
-integrationTestUsesSampleDir("subprojects/platform-native/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/AutoTestedSamplesPlatformNativeIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/AutoTestedSamplesPlatformNativeIntegrationTest.groovy
@@ -23,7 +23,7 @@ class AutoTestedSamplesPlatformNativeIntegrationTest extends AbstractAutoTestedS
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/platform-native/src/main")
+        runSamplesFrom("src/main")
     }
 
 }

--- a/subprojects/platform-play/build.gradle.kts
+++ b/subprojects/platform-play/build.gradle.kts
@@ -1,5 +1,4 @@
 import gradlebuild.basics.BuildEnvironment
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 import gradlebuild.integrationtests.tasks.IntegrationTest
 
 plugins {
@@ -114,4 +113,4 @@ tasks.withType<IntegrationTest>().configureEach {
     }
 }
 
-integrationTestUsesSampleDir("subprojects/platform-play/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/AutoTestedSamplePlatformPlayIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/AutoTestedSamplePlatformPlayIntegrationTest.groovy
@@ -23,6 +23,6 @@ class AutoTestedSamplePlatformPlayIntegrationTest extends AbstractAutoTestedSamp
     @Test
     void runSamples() {
         executer.noDeprecationChecks()
-        runSamplesFrom("subprojects/platform-play/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/plugin-development/build.gradle.kts
+++ b/subprojects/plugin-development/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -74,4 +73,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/plugin-development/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/AutoTestedSamplesPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/AutoTestedSamplesPluginDevelopmentIntegrationTest.groovy
@@ -23,6 +23,6 @@ class AutoTestedSamplesPluginDevelopmentIntegrationTest extends AbstractAutoTest
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/plugin-development/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/plugins/build.gradle.kts
+++ b/subprojects/plugins/build.gradle.kts
@@ -1,6 +1,3 @@
-import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
-
 /*
  * Copyright 2010 the original author or authors.
  *
@@ -16,6 +13,8 @@ import gradlebuild.integrationtests.integrationTestUsesSampleDir
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import gradlebuild.cleanup.WhenNotEmpty
+
 plugins {
     id("gradlebuild.distribution.api-java")
 }
@@ -99,4 +98,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/plugins/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesPluginsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesPluginsIntegrationTest.groovy
@@ -25,6 +25,6 @@ class AutoTestedSamplesPluginsIntegrationTest extends AbstractAutoTestedSamplesT
     void runSamples() {
         //for debugging purposes you can samples for a single class
 //        includeOnly '**/Test.java'
-        runSamplesFrom("subprojects/plugins/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/publish/build.gradle.kts
+++ b/subprojects/publish/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -44,4 +43,4 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
 
-integrationTestUsesSampleDir("subprojects/publish/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/samples/build.gradle.kts
+++ b/subprojects/samples/build.gradle.kts
@@ -1,5 +1,4 @@
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.internal.java")
@@ -27,4 +26,4 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-integrationTestUsesSampleDir("subprojects/core-api/src/main/java", "subprojects/core/src/main/java")
+integTest.usesSamples.set(true)

--- a/subprojects/scala/build.gradle.kts
+++ b/subprojects/scala/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -67,4 +66,4 @@ classycle {
         "org/gradle/api/tasks/ScalaRuntime*"))
 }
 
-integrationTestUsesSampleDir("subprojects/scala/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesScalaIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesScalaIntegrationTest.groovy
@@ -23,6 +23,6 @@ class AutoTestedSamplesScalaIntegrationTest extends AbstractAutoTestedSamplesTes
 
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/scala/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/signing/build.gradle.kts
+++ b/subprojects/signing/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -57,4 +56,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/plugins/signing/**"))
 }
 
-integrationTestUsesSampleDir("subprojects/signing/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/AutoTestedSamplesSigningIntegrationTest.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/AutoTestedSamplesSigningIntegrationTest.groovy
@@ -22,6 +22,6 @@ import org.junit.Test
 class AutoTestedSamplesSigningIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/signing/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/testing-base/build.gradle.kts
+++ b/subprojects/testing-base/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -71,4 +70,4 @@ classycle {
     excludePatterns.set(listOf("org/gradle/api/internal/tasks/testing/**"))
 }
 
-integrationTestUsesSampleDir("subprojects/testing-base/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/AutoTestedSamplesTestingBaseIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/AutoTestedSamplesTestingBaseIntegrationTest.groovy
@@ -22,6 +22,6 @@ import org.junit.Test
 class AutoTestedSamplesTestingBaseIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/testing-base/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -87,4 +86,4 @@ tasks.test {
     exclude("org/gradle/api/internal/tasks/testing/testng/ATestNGFactoryClass*.*")
 }
 
-integrationTestUsesSampleDir("subprojects/testing-jvm/src/main")
+integTest.usesSamples.set(true)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AutoTestedSampleTestingJvmIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AutoTestedSampleTestingJvmIntegrationTest.groovy
@@ -22,6 +22,6 @@ import org.junit.Test
 class AutoTestedSampleTestingJvmIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {
-        runSamplesFrom("subprojects/testing-jvm/src/main")
+        runSamplesFrom("src/main")
     }
 }

--- a/subprojects/tooling-api/build.gradle.kts
+++ b/subprojects/tooling-api/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import gradlebuild.cleanup.WhenNotEmpty
-import gradlebuild.integrationtests.integrationTestUsesSampleDir
 
 plugins {
     id("gradlebuild.distribution.api-java")
@@ -95,6 +94,7 @@ apply(from = "buildship.gradle")
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
-integrationTestUsesSampleDir("subprojects/tooling-api/src/main")
+
+integTest.usesSamples.set(true)
 
 gradlebuildJava.usedInToolingApi()

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/AutoTestedSamplesToolingApiTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/AutoTestedSamplesToolingApiTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.tooling.model.Element
 import org.junit.Rule
 import spock.lang.Specification
 
-public class AutoTestedSamplesToolingApiTest extends Specification {
+class AutoTestedSamplesToolingApiTest extends Specification {
 
     @Rule public final TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
@@ -31,7 +31,7 @@ public class AutoTestedSamplesToolingApiTest extends Specification {
         expect:
 
         def util = new AutoTestedSamplesUtil()
-        util.findSamples("subprojects/tooling-api/src/main") { file, sample, tagSuffix ->
+        util.findSamples("src/main") { file, sample, tagSuffix ->
             println "Found sample: ${sample.split("\n")[0]} (...) in $file"
             def javaSource = """
 //some typical imports


### PR DESCRIPTION
The fixtures now no longer rely on the absolute path of a source folder in the repository.

'core' and 'core-api' tests are moved to corresponding project to avoid reaching into source folders of other projects directly.
