### PR TITLE
Remove cross-project references in Kotlin DSL integration test project

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
@@ -31,45 +31,13 @@ dependencies {
     integTestImplementation(project(":internal-testing"))
     integTestImplementation("com.squareup.okhttp3:mockwebserver:3.9.1")
 
+    integTestRuntimeOnly(project(":kotlin-dsl-plugins")) {
+        because("Tests require 'future-plugin-versions.properties' on the test classpath")
+    }
+
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 
     integTestLocalRepository(project(":kotlin-dsl-plugins"))
-}
-
-val pluginBundles = listOf(
-    ":kotlin-dsl-plugins"
-)
-
-pluginBundles.forEach {
-    evaluationDependsOn(it)
-}
-
-tasks {
-    val writeFuturePluginVersions by registering {
-
-        group = "build"
-        description = "Merges all future plugin bundle versions so they can all be tested at once"
-
-        val futurePluginVersionsTasks =
-            pluginBundles.map {
-                project(it).tasks["writeFuturePluginVersions"] as WriteProperties
-            }
-
-        dependsOn(futurePluginVersionsTasks)
-        inputs.files(futurePluginVersionsTasks.map { it.outputFile })
-        outputs.file(layout.buildDirectory.file("generated-resources/future-plugin-versions/future-plugin-versions.properties"))
-
-        doLast {
-            outputs.files.singleFile.bufferedWriter().use { writer ->
-                inputs.files.forEach { input ->
-                    writer.appendln(input.readText())
-                }
-            }
-        }
-    }
-    sourceSets.integTest.get().output.dir(
-        writeFuturePluginVersions.map { it.outputs.files.singleFile.parentFile }
-    )
 }
 
 testFilesCleanup {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -19,6 +19,8 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @ToBeFixedForConfigurationCache
     fun `generated code follows kotlin-dsl coding conventions`() {
 
+        assumeNonEmbeddedGradleExecuter() // ktlint plugin issue in embedded mode
+
         withBuildScript(
             """
             plugins {

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -72,7 +72,6 @@ classycle {
     excludePatterns.set(listOf("org/gradle/kotlin/dsl/plugins/base/**"))
 }
 
-// plugins ------------------------------------------------------------
 pluginPublish {
     bundledGradlePlugin(
         name = "embeddedKotlin",
@@ -110,13 +109,6 @@ pluginPublish {
     )
 }
 
-// TODO:kotlin-dsl investigate
-// See https://builds.gradle.org/viewLog.html?buildId=19024848&problemId=23230
-tasks.noDaemonIntegTest {
-    enabled = false
-}
-
-// TODO:kotlin-dsl
 testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }


### PR DESCRIPTION
The logic is no longer necessary. Depending on the ':kotlin-dsl-plugins' project to have the Jar with 'future-plugin-versions.properties' on the test runner classpath is sufficient.
