### PR TITLE
Fix available-at behavior for artifact only dependencies

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -91,7 +91,7 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * <p>Adds an artifact to this dependency.</p>
      *
      * <p>If no artifact is added to a dependency, an implicit default artifact is used. This default artifact has the
-     * same name as the module and its type and extension is <em>jar</em>. If at least one artifact is explicitly added,
+     * same name as the module and its type and extension is {@code jar}. If at least one artifact is explicitly added,
      * the implicit default artifact won't be used any longer.</p>
      *
      * @return this
@@ -103,10 +103,12 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * org.gradle.api.artifacts.DependencyArtifact} instance, which it can configure.</p>
      *
      * <p>If no artifact is added to a dependency, an implicit default artifact is used. This default artifact has the
-     * same name as the module and its type and extension is <em>jar</em>. If at least one artifact is explicitly added,
+     * same name as the module and its type and extension is {@code jar}. If at least one artifact is explicitly added,
      * the implicit default artifact won't be used any longer.</p>
      *
-     * @return this
+     * @return the added artifact
+     *
+     * @see DependencyArtifact
      */
     DependencyArtifact artifact(@DelegatesTo(value = DependencyArtifact.class, strategy = DELEGATE_FIRST) Closure configureClosure);
 
@@ -115,10 +117,12 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * org.gradle.api.artifacts.DependencyArtifact} instance, which it can configure.</p>
      *
      * <p>If no artifact is added to a dependency, an implicit default artifact is used. This default artifact has the
-     * same name as the module and its type and extension is <em>jar</em>. If at least one artifact is explicitly added,
+     * same name as the module and its type and extension is {@code jar}. If at least one artifact is explicitly added,
      * the implicit default artifact won't be used any longer.</p>
      *
-     * @return this
+     * @return the added artifact
+     *
+     * @see DependencyArtifact
      *
      * @since 3.1
      */
@@ -178,6 +182,7 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * target variant, in particular when a single component provides different variants.
      *
      * @param configureAction the attributes mutation action
+     * @return this
      *
      * @since 4.8
      */
@@ -186,7 +191,9 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
 
     /**
      * Configures the requested capabilities of this dependency.
+     *
      * @param configureAction the configuration action
+     * @return this
      *
      * @since 5.3
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -488,4 +488,8 @@ class EdgeState implements DependencyGraphEdge {
     boolean isUsed() {
         return used;
     }
+
+    public boolean isArtifactOnlyEdge() {
+        return !isTransitive && !dependencyMetadata.getArtifacts().isEmpty();
+    }
 }


### PR DESCRIPTION
When a first level dependency is marked non transitive and contains an
artifact reference, we ignore the available-at from Gradle Module
Metadata.