### PR TITLE
Fix Kotlin DSL sync when failing on project repositories

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -74,4 +74,11 @@ public interface DomainObjectContext {
      */
     boolean isRootScript();
 
+    /**
+     * Returns true if the context represents a detached state, for
+     * example detached dependency resolution
+     */
+    default boolean isDetachedState() {
+        return false;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -46,14 +46,19 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.ProcessOperations;
+import org.gradle.api.internal.artifacts.DependencyManagementServices;
+import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultProjectLayout;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
@@ -96,6 +101,7 @@ import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.TextUriResourceLoader;
+import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.typeconversion.TypeConverter;
@@ -1486,5 +1492,105 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public ProjectState getMutationState() {
         return container;
+    }
+
+    @Override
+    public DetachedResolver newDetachedResolver() {
+        DependencyManagementServices dms = getServices().get(DependencyManagementServices.class);
+        InstantiatorFactory instantiatorFactory = services.get(InstantiatorFactory.class);
+        DefaultServiceRegistry lookup = new DefaultServiceRegistry(services);
+        lookup.addProvider(new Object() {
+            public DependencyResolutionServices createServices() {
+                return dms.create(
+                    services.get(FileResolver.class),
+                    services.get(FileCollectionFactory.class),
+                    services.get(DependencyMetaDataProvider.class),
+                    new UnknownProjectFinder("Detached resolvers do not support resolving projects"),
+                    new DetachedDependencyResolutionDomainObjectContext(services.get(DomainObjectContext.class))
+                );
+            }
+        });
+        return instantiatorFactory.decorate(lookup).newInstance(
+            LocalDetachedResolver.class
+        );
+    }
+
+    public static class LocalDetachedResolver implements DetachedResolver {
+        private final DependencyResolutionServices resolutionServices;
+
+        @Inject
+        public LocalDetachedResolver(DependencyResolutionServices resolutionServices) {
+            this.resolutionServices = resolutionServices;
+        }
+
+        @Override
+        public RepositoryHandler getRepositories() {
+            return resolutionServices.getResolveRepositoryHandler();
+        }
+
+        @Override
+        public DependencyHandler getDependencies() {
+            return resolutionServices.getDependencyHandler();
+        }
+
+        @Override
+        public ConfigurationContainer getConfigurations() {
+            return resolutionServices.getConfigurationContainer();
+        }
+    }
+
+    private static class DetachedDependencyResolutionDomainObjectContext implements DomainObjectContext {
+        private final DomainObjectContext delegate;
+
+        private DetachedDependencyResolutionDomainObjectContext(DomainObjectContext delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Path identityPath(String name) {
+            return delegate.identityPath(name);
+        }
+
+        @Override
+        public Path projectPath(String name) {
+            return delegate.projectPath(name);
+        }
+
+        @Override
+        @Nullable
+        public Path getProjectPath() {
+            return delegate.getProjectPath();
+        }
+
+        @Override
+        @Nullable
+        public ProjectInternal getProject() {
+            return delegate.getProject();
+        }
+
+        @Override
+        public ModelContainer<?> getModel() {
+            return delegate.getModel();
+        }
+
+        @Override
+        public Path getBuildPath() {
+            return delegate.getBuildPath();
+        }
+
+        @Override
+        public boolean isRootScript() {
+            return delegate.isRootScript();
+        }
+
+        @Override
+        public boolean isScript() {
+            return delegate.isScript();
+        }
+
+        @Override
+        public boolean isDetachedState() {
+            return true;
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -20,6 +20,9 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownProjectException;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
@@ -150,4 +153,19 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     @Override
     ScriptHandlerInternal getBuildscript();
+
+    /**
+     * Returns a dependency resolver which can be used to resolve
+     * dependencies in isolation from the project itself. This is
+     * particularly useful if the repositories or configurations
+     * needed for resolution shouldn't leak to the project state.
+     * @return a detached resolver
+     */
+    DetachedResolver newDetachedResolver();
+
+    interface DetachedResolver {
+        RepositoryHandler getRepositories();
+        DependencyHandler getDependencies();
+        ConfigurationContainer getConfigurations();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -548,7 +548,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         RepositoriesSupplier createRepositoriesSupplier(RepositoryHandler repositoryHandler, DependencyResolutionManagementInternal drm, DomainObjectContext context) {
             return () -> {
                 List<ResolutionAwareRepository> repositories = collectRepositories(repositoryHandler);
-                if (context.isScript()) {
+                if (context.isScript() || context.isDetachedState()) {
                     return repositories;
                 }
                 DependencyResolutionManagementInternal.RepositoriesModeInternal mode = drm.getConfiguredRepositoriesMode();

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
@@ -1,6 +1,8 @@
 package org.gradle.kotlin.dsl.resolver
 
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.test.fixtures.dsl.GradleDsl
 
 import org.junit.Test
 
@@ -9,6 +11,37 @@ class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest(
 
     @Test
     fun `can download source distribution`() {
+
+        withBuildScript(
+            """
+
+            val sourceDirs =
+                ${SourceDistributionResolver::class.qualifiedName}(project).run {
+                    sourceDirs()
+                }
+            require(sourceDirs.isNotEmpty()) {
+                "Expected source directories but got none"
+            }
+
+            """
+        )
+
+        build()
+    }
+
+    @Test
+    fun `can download source distribution when repositories are declared in settings`() {
+
+        withSettings(
+            """
+            dependencyResolutionManagement {
+                repositories {
+                    ${mavenCentralRepositoryDefinition(GradleDsl.KOTLIN)}
+                }
+                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            }
+            """.trimIndent()
+        )
 
         withBuildScript(
             """


### PR DESCRIPTION
When using the central repositories declaration and the Kotlin DSL,
IDE sync could fail if the repositories mode was set to failing on
project repositories.

The reason is that the Kotlin DSL sources provider was adding a
repository transparently, to resolve the Gradle sources, then removed
it silently.

However, this behavior is not allowed when failing on project
repositories.

This commit fixes the problem by making sure the Kotlin DSL sources
provider works in isolation, not leaking any repository to the
project. To do this, we introduced an _internal_ detached resolver,
which is basically an isolated dependency resolution engine, with
its own repositories, configurations, dependencies, ...

The goal of this PR is _not_ to provide a public API for this, but
use a pragmatic solution for fixing the problem mentioned above.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
