### PR TITLE
Use a separate Javadoc location per source set

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -370,7 +370,7 @@ public class JavaPlugin implements Plugin<Project> {
 
     private void configureJavadocTask(Project project, JavaPluginExtension javaPluginExtension, JavaPluginConvention pluginConvention) {
         SourceSet main = mainSourceSetOf(pluginConvention);
-        configureJavaDocTask(null, main, project.getTasks(), javaPluginExtension);
+        configureJavaDocTask(null, main, project.getTasks(), javaPluginExtension, pluginConvention::getDocsDir);
     }
 
     private void registerSoftwareComponents(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -60,10 +60,12 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.TextUtil;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Helpers for Jvm plugins. They are in a separate class so that they don't leak
@@ -152,7 +154,7 @@ public class JvmPluginsHelper {
         sourceDirectorySet.compiledBy(compileTask, classesDirectoryExtractor);
     }
 
-    public static void configureJavaDocTask(@Nullable String featureName, SourceSet sourceSet, TaskContainer tasks, @Nullable JavaPluginExtension javaPluginExtension) {
+    public static void configureJavaDocTask(@Nullable String featureName, SourceSet sourceSet, TaskContainer tasks, @Nullable JavaPluginExtension javaPluginExtension, Supplier<File> docsDir) {
         String javadocTaskName = sourceSet.getJavadocTaskName();
         if (!tasks.getNames().contains(javadocTaskName)) {
             tasks.register(javadocTaskName, Javadoc.class, javadoc -> {
@@ -160,6 +162,7 @@ public class JvmPluginsHelper {
                 javadoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
                 javadoc.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
                 javadoc.setSource(sourceSet.getAllJava());
+                javadoc.getConventionMapping().map("destinationDir", () -> new File(docsDir.get(), javadocTaskName));
                 if (javaPluginExtension != null) {
                     javadoc.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
                 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmVariantBuilder.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmVariantBuilder.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping;
 import org.gradle.api.tasks.SourceSet;
@@ -221,7 +222,8 @@ public class DefaultJvmVariantBuilder implements JvmVariantBuilderInternal {
 
         final AdhocComponentWithVariants component = findJavaComponent();
         JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
-        configureJavaDocTask(name, sourceSet, tasks, javaPluginExtension);
+        JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+        configureJavaDocTask(name, sourceSet, tasks, javaPluginExtension, javaPluginConvention::getDocsDir);
         if (javadocJar) {
             configureDocumentationVariantWithArtifact(sourceSet.getJavadocElementsConfigurationName(), mainSourceSet ? null : name, displayName, JAVADOC, sourceSet.getJavadocJarTaskName(), tasks.named(sourceSet.getJavadocTaskName()), component);
         }


### PR DESCRIPTION
instead of using the same `docs/javadoc` location for all source sets.