### PR TITLE
Fix transform definition in console progress test

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -329,7 +329,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     ${server.callFromBuild('size-transform')}
-                    File output = outputs.registerOutput(input.name + parameters.suffix)
+                    File output = outputs.file(input.name + parameters.suffix)
                     output.text = String.valueOf(input.length())
                 }
             }
@@ -393,6 +393,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
 
                     doLast {
                         ${server.callFromBuild('resolve-task')}
+                        size.artifactFiles.files.each { println it }
                     }
                 }
             }
@@ -408,7 +409,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         def buildFinished = server.expectAndBlock('build-finished')
 
         when:
-        gradle = executer.withTasks(":util:resolve").start()
+        gradle = executer.withTasks(":util:resolve", "--info").start()
 
         then:
         jar.waitForAllPendingCalls()


### PR DESCRIPTION
and make sure the test fails when the transform definition is invalid.

The test still used `registerOutput`, which never saw the light.