### PR TITLE
Support TestOperationDescriptors referencing included builds in TestLauncher

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -70,7 +70,7 @@ class ClientForwardingTestOperationListener implements BuildOperationListener {
             if (!(task instanceof Test)) {
                 return;
             }
-            runningTasks.put(buildOperation.getId(), task.getPath());
+            runningTasks.put(buildOperation.getId(), ((Test) task).getIdentityPath().getPath());
         } else if (details instanceof ExecuteTestBuildOperationType.Details) {
             ExecuteTestBuildOperationType.Details testOperationDetails = (ExecuteTestBuildOperationType.Details) details;
             TestDescriptorInternal testDescriptor = (TestDescriptorInternal) testOperationDetails.getTestDescriptor();

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -149,7 +149,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
         }
         Set<Test> result = new LinkedHashSet<>();
-        for (Task task : taskSelection.getTasks()) {
+        for (Task task : tasks) {
             if (!(task instanceof Test)) {
                 throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
             }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -127,26 +127,30 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
 
         List<Test> testTasksToRun = new ArrayList<Test>();
         for (final String testTaskPath : testTaskPaths) {
-            final Task task = gradle.getRootProject().getTasks().findByPath(testTaskPath);
-            if (task == null) {
+            TaskSelection taskSelection = taskSelector.getSelection(testTaskPath);
+            Set<Task> tasks = taskSelection.getTasks();
+            if (tasks.isEmpty()) {
                 throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
-            } else if (!(task instanceof Test)) {
-                throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
-            } else {
-                Test testTask = (Test) task;
-                for (InternalTestDescriptor testDescriptor : testDescriptors) {
-                    DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
-                    if (defaultTestDescriptor.getTaskPath().equals(testTaskPath)) {
-                        String className = defaultTestDescriptor.getClassName();
-                        String methodName = defaultTestDescriptor.getMethodName();
-                        if (className == null && methodName == null) {
-                            testTask.getFilter().includeTestsMatching("*");
-                        } else {
-                            testTask.getFilter().includeTest(className, methodName);
+            }
+            for (Task task : tasks) {
+                if (!(task instanceof Test)) {
+                    throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
+                } else {
+                    Test testTask = (Test) task;
+                    for (InternalTestDescriptor testDescriptor : testDescriptors) {
+                        DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
+                        if (defaultTestDescriptor.getTaskPath().equals(testTaskPath)) {
+                            String className = defaultTestDescriptor.getClassName();
+                            String methodName = defaultTestDescriptor.getMethodName();
+                            if (className == null && methodName == null) {
+                                testTask.getFilter().includeTestsMatching("*");
+                            } else {
+                                testTask.getFilter().includeTest(className, methodName);
+                            }
                         }
                     }
+                    testTasksToRun.add(testTask);
                 }
-                testTasksToRun.add(testTask);
             }
         }
         return testTasksToRun;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.testing.TestFilter;
 import org.gradle.execution.BuildConfigurationAction;
 import org.gradle.execution.BuildExecutionContext;
 import org.gradle.execution.TaskSelection;
+import org.gradle.execution.TaskSelectionException;
 import org.gradle.execution.TaskSelector;
 import org.gradle.internal.build.event.types.DefaultTestDescriptor;
 import org.gradle.process.JavaDebugOptions;
@@ -94,22 +95,12 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         List<Test> testTasksToRun = new ArrayList<Test>();
         for (final Map.Entry<String, List<InternalJvmTestRequest>> entry : taskAndTests.entrySet()) {
             String testTaskPath = entry.getKey();
-            TaskSelection taskSelection = taskSelector.getSelection(testTaskPath);
-            Set<Task> tasks = taskSelection.getTasks();
-            if (tasks.isEmpty()) {
-                throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
-            }
-            for (Task task : tasks) {
-                if (!(task instanceof Test)) {
-                    throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
-                } else {
-                    Test testTask = (Test) task;
-                    for (InternalJvmTestRequest jvmTestRequest : entry.getValue()) {
-                        final TestFilter filter = testTask.getFilter();
-                        filter.includeTest(jvmTestRequest.getClassName(), jvmTestRequest.getMethodName());
-                    }
-                    testTasksToRun.add(testTask);
+            for (Test testTask : queryTestTasks(testTaskPath)) {
+                for (InternalJvmTestRequest jvmTestRequest : entry.getValue()) {
+                    final TestFilter filter = testTask.getFilter();
+                    filter.includeTest(jvmTestRequest.getClassName(), jvmTestRequest.getMethodName());
                 }
+                testTasksToRun.add(testTask);
             }
         }
         return testTasksToRun;
@@ -125,35 +116,46 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             }
         });
 
-        List<Test> testTasksToRun = new ArrayList<Test>();
+        List<Test> testTasksToRun = new ArrayList<>();
         for (final String testTaskPath : testTaskPaths) {
-            TaskSelection taskSelection = taskSelector.getSelection(testTaskPath);
-            Set<Task> tasks = taskSelection.getTasks();
-            if (tasks.isEmpty()) {
-                throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
-            }
-            for (Task task : tasks) {
-                if (!(task instanceof Test)) {
-                    throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
-                } else {
-                    Test testTask = (Test) task;
-                    for (InternalTestDescriptor testDescriptor : testDescriptors) {
-                        DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
-                        if (defaultTestDescriptor.getTaskPath().equals(testTaskPath)) {
-                            String className = defaultTestDescriptor.getClassName();
-                            String methodName = defaultTestDescriptor.getMethodName();
-                            if (className == null && methodName == null) {
-                                testTask.getFilter().includeTestsMatching("*");
-                            } else {
-                                testTask.getFilter().includeTest(className, methodName);
-                            }
+            for (Test testTask: queryTestTasks(testTaskPath)) {
+                for (InternalTestDescriptor testDescriptor : testDescriptors) {
+                    DefaultTestDescriptor defaultTestDescriptor = (DefaultTestDescriptor) testDescriptor;
+                    if (defaultTestDescriptor.getTaskPath().equals(testTaskPath)) {
+                        String className = defaultTestDescriptor.getClassName();
+                        String methodName = defaultTestDescriptor.getMethodName();
+                        if (className == null && methodName == null) {
+                            testTask.getFilter().includeTestsMatching("*");
+                        } else {
+                            testTask.getFilter().includeTest(className, methodName);
                         }
                     }
-                    testTasksToRun.add(testTask);
                 }
+                testTasksToRun.add(testTask);
             }
         }
         return testTasksToRun;
+    }
+
+    private Set<Test> queryTestTasks(String testTaskPath) {
+        TaskSelection taskSelection;
+        try {
+            taskSelection = taskSelector.getSelection(testTaskPath);
+        } catch (TaskSelectionException e) {
+            throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
+        }
+        Set<Task> tasks = taskSelection.getTasks();
+        if (tasks.isEmpty()) {
+            throw new TestExecutionException(String.format("Requested test task with path '%s' cannot be found.", testTaskPath));
+        }
+        Set<Test> result = new LinkedHashSet<>();
+        for (Task task : taskSelection.getTasks()) {
+            if (!(task instanceof Test)) {
+                throw new TestExecutionException(String.format("Task '%s' of type '%s' not supported for executing tests via TestLauncher API.", testTaskPath, task.getClass().getName()));
+            }
+            result.add((Test) task);
+        }
+        return result;
     }
 
     private List<Test> configureBuildForInternalJvmTestRequest(GradleInternal gradle, TestExecutionRequestAction testExecutionRequest) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r68
+
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ModelBuilder
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.GradleProject
+
+@ToolingApiVersion(">=3.3")
+@TargetGradleVersion('>=6.8')
+class CompositeBuildBuildActionExecuterCrossVersionSpec extends ToolingApiSpecification {
+
+    def "Can run task from included build when running a build action"() {
+        given:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            tasks.register('doSomething') {
+                doLast {
+                    println 'do something'
+                }
+            }
+        """
+
+        when:
+        toolingApi.withConnection { ProjectConnection connection ->
+            def buildAction = connection.action(new LoadCompositeModel(GradleProject))
+            collectOutputs(buildAction)
+            buildAction.forTasks([':other-build:sub:doSomething'])
+            buildAction.run()
+        }
+
+        then:
+        stdout.toString().contains("do something")
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
@@ -16,11 +16,9 @@
 
 package org.gradle.integtests.tooling.r68
 
-
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.tooling.ModelBuilder
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildModelBuilderCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildModelBuilderCrossVersionSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r68
+
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ModelBuilder
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.GradleProject
+
+@ToolingApiVersion(">=3.3")
+@TargetGradleVersion('>=6.8')
+class CompositeBuildModelBuilderCrossVersionSpec extends ToolingApiSpecification {
+
+    def "Can run task from included build when querying a model"() {
+        given:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            tasks.register('doSomething') {
+                doLast {
+                    println 'do something'
+                }
+            }
+        """
+
+        when:
+        toolingApi.withConnection { ProjectConnection connection ->
+            ModelBuilder<GradleProject> modelBuilder = connection.model(GradleProject.class)
+            collectOutputs(modelBuilder)
+            modelBuilder.forTasks([':other-build:sub:doSomething'])
+            modelBuilder.get()
+        }
+
+        then:
+        stdout.toString().contains("do something")
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
@@ -19,6 +19,12 @@ package org.gradle.integtests.tooling.r68
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestExecutionException
+import org.gradle.tooling.TestLauncher
+import org.gradle.tooling.events.ProgressEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.test.TestFinishEvent
+import org.gradle.tooling.events.test.TestOperationDescriptor
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.GradleTask
 import org.gradle.tooling.model.gradle.BuildInvocations
@@ -369,6 +375,137 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
         outputContains("do something")
     }
 
+    @ToolingApiVersion(">=6.8")
+    def "Can launch test with test launcher via build operation"() {
+        setup:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+             ${mavenCentralRepository()}
+
+             dependencies { testImplementation 'junit:junit:4.13' }
+        """
+        file("other-build/sub/src/test/java/MyIncludedTest.java") << """
+            import org.junit.Test;
+            import static org.junit.Assert.assertTrue;
+
+            public class MyIncludedTest {
+
+                @Test
+                public void myTestMethod() {
+                    assertTrue(true);
+                }
+            }
+        """
+
+        TestOperationCollector collector = new TestOperationCollector()
+        withConnection { connection ->
+            def build = connection.newBuild()
+            build.addProgressListener(collector)
+            build.forTasks(":other-build:sub:test").run()
+        }
+        TestOperationDescriptor descriptor = collector.descriptors.find { it.name == "myTestMethod" }
+
+        when:
+        withConnection { connection ->
+            TestLauncher launcher = connection.newTestLauncher().withTests(descriptor)
+            collectOutputs(launcher)
+            launcher.run()
+        }
+
+        then:
+        outputContains("BUILD SUCCESSFUL")
+    }
+
+    @ToolingApiVersion(">=6.8")
+    def "Can launch test with test launcher via test filter"() {
+        setup:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+             ${mavenCentralRepository()}
+
+             dependencies { testImplementation 'junit:junit:4.13' }
+        """
+        file("other-build/sub/src/test/java/MyIncludedTest.java") << """
+            import org.junit.Test;
+            import static org.junit.Assert.assertTrue;
+
+            public class MyIncludedTest {
+
+                @Test
+                public void myTestMethod() {
+                    assertTrue(true);
+                }
+            }
+        """
+
+        when:
+        withConnection { connection ->
+            def testLauncher = connection.newTestLauncher()
+            collectOutputs(testLauncher)
+            testLauncher.withJvmTestClasses("MyIncludedTest").run()
+        }
+
+        then:
+        thrown(TestExecutionException)
+    }
+
+    @ToolingApiVersion(">=6.8")
+    def "Can launch test with test launcher via test filter targeting a specific task"() {
+        setup:
+        settingsFile << "includeBuild('other-build')"
+        file('other-build/settings.gradle') << """
+            rootProject.name = 'other-build'
+            include 'sub'
+        """
+        file('other-build/sub/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+             ${mavenCentralRepository()}
+
+             dependencies { testImplementation 'junit:junit:4.13' }
+        """
+        file("other-build/sub/src/test/java/MyIncludedTest.java") << """
+            import org.junit.Test;
+            import static org.junit.Assert.assertTrue;
+
+            public class MyIncludedTest {
+
+                @Test
+                public void myTestMethod() {
+                    assertTrue(true);
+                }
+            }
+        """
+
+        when:
+        withConnection { connection ->
+            def testLauncher = connection.newTestLauncher()
+            collectOutputs(testLauncher)
+            testLauncher.withTaskAndTestClasses(":other-build:sub:test", ["MyIncludedTest"]).run()
+        }
+
+        then:
+        outputContains("BUILD SUCCESSFUL")
+    }
+
     private void executeTaskViaTAPI(String... task) {
         withConnection { connection ->
             def build = connection.newBuild()
@@ -411,5 +548,17 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
     private boolean outputContains(String expectedOutput) {
         return stdout.toString().contains(expectedOutput)
+    }
+
+    class TestOperationCollector implements ProgressListener {
+
+        List<TestOperationDescriptor> descriptors = []
+
+        @Override
+        void statusChanged(ProgressEvent event) {
+            if (event instanceof TestFinishEvent) {
+                descriptors += ((TestFinishEvent) event).descriptor
+            }
+        }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r68
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.tooling.TestExecutionException
 import org.gradle.tooling.TestLauncher
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
@@ -422,47 +421,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
         then:
         outputContains("BUILD SUCCESSFUL")
-    }
-
-    @ToolingApiVersion(">=6.8")
-    def "Can launch test with test launcher via test filter"() {
-        setup:
-        settingsFile << "includeBuild('other-build')"
-        file('other-build/settings.gradle') << """
-            rootProject.name = 'other-build'
-            include 'sub'
-        """
-        file('other-build/sub/build.gradle') << """
-            plugins {
-                id 'java-library'
-            }
-
-             ${mavenCentralRepository()}
-
-             dependencies { testImplementation 'junit:junit:4.13' }
-        """
-        file("other-build/sub/src/test/java/MyIncludedTest.java") << """
-            import org.junit.Test;
-            import static org.junit.Assert.assertTrue;
-
-            public class MyIncludedTest {
-
-                @Test
-                public void myTestMethod() {
-                    assertTrue(true);
-                }
-            }
-        """
-
-        when:
-        withConnection { connection ->
-            def testLauncher = connection.newTestLauncher()
-            collectOutputs(testLauncher)
-            testLauncher.withJvmTestClasses("MyIncludedTest").run()
-        }
-
-        then:
-        thrown(TestExecutionException)
     }
 
     @ToolingApiVersion(">=6.8")


### PR DESCRIPTION
Implemented by changing `DefaultTestOperation.getTaskPath()` to return the task identity path.

The PR also adds coverage for the following:
- launching tests within exact test task defined in an included build
- launching tasks from included builds via `ModelBuilder`
- launching tasks from included builds via `BuildActionExecuter`