### PR TITLE
Enable detecting auto-provisioned toolchains

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/AutoDetectingInstallationSupplier.java
@@ -53,7 +53,7 @@ public abstract class AutoDetectingInstallationSupplier implements InstallationS
 
     protected abstract Set<InstallationLocation> findCandidates();
 
-    private boolean isAutoDetectionEnabled() {
+    protected boolean isAutoDetectionEnabled() {
         return detectionEnabled.getOrElse(true);
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplier.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplier.java
@@ -16,7 +16,9 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.jvm.toolchain.install.internal.DefaultJavaToolchainProvisioningService;
 import org.gradle.jvm.toolchain.install.internal.JdkCacheDirectory;
 
 import java.io.File;
@@ -26,10 +28,12 @@ import java.util.stream.Collectors;
 public class AutoInstalledInstallationSupplier extends AutoDetectingInstallationSupplier {
 
     private final JdkCacheDirectory cacheDirProvider;
+    private final Provider<Boolean> downloadEnabled;
 
     public AutoInstalledInstallationSupplier(ProviderFactory factory, JdkCacheDirectory cacheDirProvider) {
         super(factory);
         this.cacheDirProvider = cacheDirProvider;
+        this.downloadEnabled = factory.gradleProperty(DefaultJavaToolchainProvisioningService.AUTO_DOWNLOAD).forUseAtConfigurationTime().map(Boolean::parseBoolean);
     }
 
     @Override
@@ -41,6 +45,11 @@ public class AutoInstalledInstallationSupplier extends AutoDetectingInstallation
 
     private InstallationLocation asInstallation(File javaHome) {
         return new InstallationLocation(javaHome, "Auto-provisioned by Gradle");
+    }
+
+    @Override
+    protected boolean isAutoDetectionEnabled() {
+        return super.isAutoDetectionEnabled() || downloadEnabled.getOrElse(true);
     }
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import com.google.common.base.Objects;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
@@ -59,5 +60,22 @@ public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<Jav
     @Override
     public String toString() {
         return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultJvmVendorSpec that = (DefaultJvmVendorSpec) o;
+        return Objects.equal(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(description);
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -17,6 +17,7 @@
 package org.gradle.jvm.toolchain.internal;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
@@ -68,4 +69,22 @@ public class DefaultToolchainSpec implements JavaToolchainSpec {
         return builder.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultToolchainSpec that = (DefaultToolchainSpec) o;
+        return Objects.equal(languageVersion.get(), that.languageVersion.get()) &&
+            Objects.equal(vendor.get(), that.vendor.get()) &&
+            Objects.equal(implementation.get(), that.implementation.get());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(languageVersion.get(), vendor.get(), implementation.get());
+    }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultToolchainSpecTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultToolchainSpecTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmImplementation
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.util.Matchers
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class DefaultToolchainSpecTest extends Specification {
+
+    def "implements equals"() {
+        given:
+        def spec11 = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def spec12 = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def spec11Vendor1 = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def spec11Vendor2 = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def spec11Impl1 = new DefaultToolchainSpec(TestUtil.objectFactory())
+        def spec11Impl2 = new DefaultToolchainSpec(TestUtil.objectFactory())
+
+        when:
+        spec11.languageVersion.set(JavaLanguageVersion.of(11))
+        spec12.languageVersion.set(JavaLanguageVersion.of(12))
+        spec11Vendor1.languageVersion.set(JavaLanguageVersion.of(11))
+        spec11Vendor1.vendor.set(JvmVendorSpec.AMAZON)
+        spec11Vendor2.languageVersion.set(JavaLanguageVersion.of(11))
+        spec11Vendor2.vendor.set(JvmVendorSpec.matching("foo"))
+        spec11Impl1.languageVersion.set(JavaLanguageVersion.of(11))
+        spec11Impl1.implementation.set(JvmImplementation.VENDOR_SPECIFIC)
+        spec11Impl2.languageVersion.set(JavaLanguageVersion.of(11))
+        spec11Impl2.implementation.set(JvmImplementation.J9)
+
+        spec12.languageVersion.set(JavaLanguageVersion.of(12))
+
+        then:
+        Matchers.strictlyEquals(spec11, spec11)
+        Matchers.strictlyEquals(spec11, spec11Impl1)
+        Matchers.strictlyEquals(spec11Vendor1, spec11Vendor1)
+        !Matchers.strictlyEquals(spec11Vendor1, spec11Vendor2)
+        !Matchers.strictlyEquals(spec11, spec12)
+        Matchers.strictlyEquals(spec11Impl1, spec11Impl1)
+        !Matchers.strictlyEquals(spec11Impl1, spec11Impl2)
+        !Matchers.strictlyEquals(spec11Vendor1, spec11Vendor2)
+    }
+}


### PR DESCRIPTION
By reusing matches for toolchains given a specific filter, we can avoid
the matching if the provider is queried multiple times
(e.g. `isPresent`). Further, this allows short-circuiting looking up a provisioned JDK.
If no JDK is found and a new one is provisioned, it is returned as a
toolchain directly from the provisioning service. If you query the same
provider again, we don't detect the new toolchain via the regular means
(as they're cached per daemon) and thus incur the cost of looking up
the archive and trying to reprovision. By reusing the query match, this
can be avoided.

See issue #15325