### PR TITLE
Don't fail on empty source directories.

### DIFF
--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -43,7 +43,6 @@ configureCompile()
 configureSourcesVariant()
 configureJarTasks()
 configureTests()
-failOnEmptySourceFolder()
 
 tasks.registerCITestDistributionLifecycleTasks()
 
@@ -246,20 +245,6 @@ fun removeTeamcityTempProperty() {
 
 val Project.maxParallelForks: Int
     get() = findProperty("maxParallelForks")?.toString()?.toInt() ?: 4
-
-fun failOnEmptySourceFolder() {
-    // Empty source dirs produce cache misses, and are not caught by `git status`.
-    // Fail if we find any.
-    tasks.withType<SourceTask>().configureEach {
-        doFirst {
-            source.visit {
-                if (file.isDirectory && file.listFiles()?.isEmpty() == true) {
-                    throw IllegalStateException("Empty src dir found. This causes build cache misses. See github.com/gradle/gradle/issues/2463.\nRun the following command to fix it.\nrmdir ${file.absolutePath}")
-                }
-            }
-        }
-    }
-}
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).


### PR DESCRIPTION
Gradle now ignores these by default! Yay!

Ref #2463

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
