### PR TITLE
Avoid exercising the executable for version detection

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
@@ -41,7 +41,7 @@ public class DefaultJvmMetadataDetector implements JvmMetadataDetector {
 
     @Override
     public JvmInstallationMetadata getMetadata(File javaHome) {
-        if (!javaHome.exists()) {
+        if (javaHome == null || !javaHome.exists()) {
             return failure(javaHome, "No such directory: " + javaHome);
         }
         EnumMap<ProbedSystemProperty, String> metadata;

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
@@ -22,6 +22,7 @@ import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.process.internal.ExecException;
 
 import java.io.File;
+import java.nio.file.NoSuchFileException;
 
 public class DefaultJvmVersionDetector implements JvmVersionDetector {
 
@@ -38,11 +39,13 @@ public class DefaultJvmVersionDetector implements JvmVersionDetector {
 
     @Override
     public JavaVersion getJavaVersion(String javaCommand) {
-        final File executable = new File(javaCommand);
-        if(!executable.exists()) {
-            throw new ExecException("A problem occurred starting process 'command '" + javaCommand + "''");
+        File executable = new File(javaCommand);
+        File parentFolder = executable.getParentFile();
+        if(parentFolder == null || !parentFolder.exists()) {
+            Exception cause = new NoSuchFileException(javaCommand);
+            throw new ExecException("A problem occurred starting process 'command '" + javaCommand + "''", cause);
         }
-        return getVersionFromJavaHome(executable.getParentFile().getParentFile());
+        return getVersionFromJavaHome(parentFolder.getParentFile());
     }
 
     private JavaVersion getVersionFromJavaHome(File javaHome) {

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm
+import org.gradle.process.internal.ExecException
 import spock.lang.Specification
 
 class DefaultJvmVersionDetectorTest extends Specification {
@@ -34,6 +35,20 @@ class DefaultJvmVersionDetectorTest extends Specification {
     def "can determine version of java command for current jvm"() {
         expect:
         detector.getJavaVersion(Jvm.current().getJavaExecutable().path) == JavaVersion.current()
+    }
+
+    def "can determine version of java command without file extension"() {
+        expect:
+        detector.getJavaVersion(Jvm.current().getJavaExecutable().path.replace(".exe", "")) == JavaVersion.current()
+    }
+
+    def "fails for unknown java command"() {
+        when:
+        detector.getJavaVersion("unknown")
+
+        then:
+        def e = thrown(ExecException)
+        e.message.contains("A problem occurred starting process 'command 'unknown''")
     }
 
     def "fails for invalid jvm"() {


### PR DESCRIPTION
To determine the java version, we used to accept a java command. This
can but must not end with an executable file extension (see `PATHEXT`
environment variable). So `/some/path/java` is valid on Windows even
though when executing, it would use `java.exe`. Thus, we need to avoid
checking for file existence for the given executable.

<!--- The issue this PR addresses -->
Fixes #15392
