### PR TITLE
Let the configuration cache support ResourceHandler

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.resources.ResourceHandler
 import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheRecreateOption
 import org.gradle.integtests.fixtures.BuildOperationsFixture
@@ -552,6 +553,7 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         type                             | reference                                                   | invocation
         Logger.name                      | "logger"                                                    | "info('hi')"
         ObjectFactory.name               | "objects"                                                   | "newInstance(SomeBean)"
+        ResourceHandler.name             | "resources"                                                 | "toString()"
         ToolingModelBuilderRegistry.name | "project.services.get(${ToolingModelBuilderRegistry.name})" | "toString()"
         WorkerExecutor.name              | "project.services.get(${WorkerExecutor.name})"              | "noIsolation()"
         FileSystemOperations.name        | "project.services.get(${FileSystemOperations.name})"        | "toString()"

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -130,6 +130,7 @@ class Codecs(
 
         fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, artifactSetConverter, fileOperations, fileFactory, patternSetFactory)
 
+        bind(ResourceHandlerCodec(fileOperations))
         bind(ApiTextResourceAdapterCodec)
 
         bind(ClosureCodec)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ResourceHandlerCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ResourceHandlerCodec.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.resources.ResourceHandler
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+
+
+class ResourceHandlerCodec(
+    private val fileOperations: FileOperations
+) : Codec<ResourceHandler> {
+
+    override suspend fun WriteContext.encode(value: ResourceHandler) = Unit
+
+    override suspend fun ReadContext.decode(): ResourceHandler =
+        fileOperations.resources
+}


### PR DESCRIPTION
`ResourceHandler` is no service and requires special handling.

With this support, one can use `resources.gzip(path)` and `resources.bzip2(path)`.