### PR TITLE
Create .gitignore and .gitattributes with LF

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LineFeedPrintWriter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LineFeedPrintWriter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.io;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.nio.charset.Charset;
+
+public class LineFeedPrintWriter extends PrintWriter {
+    public LineFeedPrintWriter(Writer out) {
+        super(out);
+    }
+
+    public LineFeedPrintWriter(Writer out, boolean autoFlush) {
+        super(out, autoFlush);
+    }
+
+    public LineFeedPrintWriter(OutputStream out) {
+        super(out);
+    }
+
+    public LineFeedPrintWriter(OutputStream out, boolean autoFlush) {
+        super(out, autoFlush);
+    }
+
+    public LineFeedPrintWriter(OutputStream out, boolean autoFlush, Charset charset) {
+        super(out, autoFlush, charset);
+    }
+
+    public LineFeedPrintWriter(String fileName) throws FileNotFoundException {
+        super(fileName);
+    }
+
+    public LineFeedPrintWriter(String fileName, String csn) throws FileNotFoundException, UnsupportedEncodingException {
+        super(fileName, csn);
+    }
+
+    public LineFeedPrintWriter(String fileName, Charset charset) throws IOException {
+        super(fileName, charset);
+    }
+
+    public LineFeedPrintWriter(File file) throws FileNotFoundException {
+        super(file);
+    }
+
+    public LineFeedPrintWriter(File file, String csn) throws FileNotFoundException, UnsupportedEncodingException {
+        super(file, csn);
+    }
+
+    public LineFeedPrintWriter(File file, Charset charset) throws IOException {
+        super(file, charset);
+    }
+
+    @Override
+    public void println() {
+        write('\n');
+    }
+}

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitAttributesGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitAttributesGenerator.java
@@ -17,6 +17,7 @@
 package org.gradle.buildinit.plugins.internal;
 
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.io.LineFeedPrintWriter;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -29,7 +30,7 @@ public class GitAttributesGenerator implements BuildContentGenerator {
     public void generate(InitSettings settings) {
         File file = settings.getTarget().file(".gitattributes").getAsFile();
         try {
-            try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
+            try (PrintWriter writer = new LineFeedPrintWriter(new FileWriter(file))) {
                 writer.println("#");
                 writer.println("# https://help.github.com/articles/dealing-with-line-endings/");
                 writer.println("#");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -19,6 +19,7 @@ package org.gradle.buildinit.plugins.internal;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.io.LineFeedPrintWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -41,7 +42,7 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
         Set<String> gitignoresToAppend = getGitignoresToAppend(file);
         if (!gitignoresToAppend.isEmpty()) {
             boolean shouldAppendNewLine = file.exists();
-            try (PrintWriter writer = new PrintWriter(new FileWriter(file, true))) {
+            try (PrintWriter writer = new LineFeedPrintWriter(new FileWriter(file, true))) {
                 if (shouldAppendNewLine) {
                     writer.println();
                 }


### PR DESCRIPTION
Issue: #11318

Let build init plugin always create .gitignore and .gitattributes with LF
instead of platform dependant line breaks.

Signed-off-by: Alexander Veit <alexander.veit@gmx.net>

<!--- The issue this PR addresses -->
Fixes gradle/gradle#11318

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
