### PR TITLE
Provide access to version catalogs from plugins

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,35 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.Provider,kotlin.jvm.functions.Function1)",
+            "acceptation": "Bug in the binary compatiblity checker: https://github.com/gradle/gradle/issues/15448",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.Provider)",
+            "acceptation": "Bug in the binary compatiblity checker: https://github.com/gradle/gradle/issues/15448",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },{
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.Provider,kotlin.jvm.functions.Function1)",
+            "acceptation": "Bug in the binary compatiblity checker: https://github.com/gradle/gradle/issues/15448",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.Provider)",
+            "acceptation": "Bug in the binary compatiblity checker: https://github.com/gradle/gradle/issues/15448",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        }
+    ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.provider.Provider;
+
+import java.util.Optional;
+
+/**
+ * Provides access to a version catalog. Unlike generated extension
+ * classes for catalogs, there is no guarantee that the requested
+ * aliases exist so you must check existence on the returned optional
+ * values.
+ *
+ * @since 6.9
+ */
+@Incubating
+@NonNullApi
+public interface VersionCatalog extends Named {
+    /**
+     * Returns the dependency provider for the corresponding alias.
+     * @param alias the alias of the dependency
+     */
+    Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias);
+
+    /**
+     * Returns the dependency provider for the corresponding bundle.
+     * @param bundle the alias of the bundle
+     */
+    Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle);
+
+    /**
+     * Returns the version constraint with the corresponding name in the catalog.
+     * @param name the name of the version
+     */
+    Optional<VersionConstraint> findVersion(String name);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.InvalidUserDataException;
+
+import java.util.Optional;
+
+/**
+ * Gives access to all version catalogs available.
+ *
+ * @since 6.9
+ */
+@Incubating
+public interface VersionCatalogsExtension extends Iterable<VersionCatalog> {
+
+    /**
+     * Tries to find a catalog with the corresponding name
+     * @param name the name of the catalog
+     */
+    Optional<VersionCatalog> find(String name);
+
+    /**
+     * Returns the catalog with the supplied name or throws an exception
+     * if it doesn't exist.
+     */
+    default VersionCatalog named(String name) {
+        return find(name).orElseThrow(() -> new InvalidUserDataException("Catalog named " + name + " doesn't exist"));
+    }
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -303,6 +303,17 @@ public interface DependencyHandler extends ExtensionAware {
     <T, U extends ExternalModuleDependency> void addProvider(String configurationName, Provider<T> dependencyNotation, Action<? super U> configuration);
 
     /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param configurationName The name of the configuration.
+     * @param dependencyNotation The dependency provider notation, in one of the notations described above.
+     *
+     * @since 6.9
+     */
+    @Incubating
+    <T> void addProvider(String configurationName, Provider<T> dependencyNotation);
+
+    /**
      * Creates a dependency without adding it to a configuration.
      *
      * @param dependencyNotation The dependency notation, in one of the notations described above.

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -58,7 +58,7 @@ public interface DependencyResolutionManagement {
      *
      * @since 6.9
      */
-    void versionCatalogs(Action<? super VersionCatalogContainer> spec);
+    void versionCatalogs(Action<? super MutableVersionCatalogContainer> spec);
 
     /**
      * Returns the name of the extension generated for type-safe project accessors.

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
@@ -25,5 +25,5 @@ import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
  * @since 6.9
  */
 @Incubating
-public interface VersionCatalogContainer extends NamedDomainObjectContainer<VersionCatalogBuilder> {
+public interface MutableVersionCatalogContainer extends NamedDomainObjectContainer<VersionCatalogBuilder> {
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.central
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Issue
 
 /**
@@ -84,6 +85,7 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15382")
+    @LeaksFileHandles("Kotlin Compiler Daemon working directory")
     def "can add a dependency in a project via a precompiled script plugin"() {
         settingsKotlinFile << """
             dependencyResolutionManagement {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/KotlinDslDependenciesExtensionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.central
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Issue
@@ -86,6 +87,7 @@ class KotlinDslDependenciesExtensionIntegrationTest extends AbstractHttpDependen
 
     @Issue("https://github.com/gradle/gradle/issues/15382")
     @LeaksFileHandles("Kotlin Compiler Daemon working directory")
+    @ToBeFixedForConfigurationCache
     def "can add a dependency in a project via a precompiled script plugin"() {
         settingsKotlinFile << """
             dependencyResolutionManagement {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -51,6 +51,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ValueSource;
+import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapability;
@@ -126,6 +127,11 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     @Override
     public <T, U extends ExternalModuleDependency> void addProvider(String configurationName, Provider<T> dependencyNotation, Action<? super U> configuration) {
         doAddProvider(configurationContainer.getByName(configurationName), dependencyNotation, closureOf(configuration));
+    }
+
+    @Override
+    public <T> void addProvider(String configurationName, Provider<T> dependencyNotation) {
+        addProvider(configurationName, dependencyNotation, Actions.doNothing());
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/ExternalModuleDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/std/ExternalModuleDependencyFactory.java
@@ -15,5 +15,7 @@
  */
 package org.gradle.api.internal.std;
 
-public interface ExternalModuleDependencyFactory {
+import org.gradle.api.artifacts.VersionCatalog;
+
+public interface ExternalModuleDependencyFactory extends VersionCatalog {
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -32,7 +32,7 @@ import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.initialization.resolve.RulesMode;
-import org.gradle.api.initialization.resolve.VersionCatalogContainer;
+import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
@@ -129,7 +129,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     }
 
     @Override
-    public void versionCatalogs(Action<? super VersionCatalogContainer> spec) {
+    public void versionCatalogs(Action<? super MutableVersionCatalogContainer> spec) {
         spec.execute(versionCatalogs);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Interners;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
-import org.gradle.api.initialization.resolve.VersionCatalogContainer;
+import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 import static org.gradle.api.reflect.TypeOf.typeOf;
 
-public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainObjectContainer<VersionCatalogBuilder> implements VersionCatalogContainer {
+public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainObjectContainer<VersionCatalogBuilder> implements MutableVersionCatalogContainer {
     private static final String VALID_EXTENSION_NAME = "[a-z]([a-zA-Z0-9])+";
     private static final Pattern VALID_EXTENSION_PATTERN = Pattern.compile(VALID_EXTENSION_NAME);
 
@@ -96,7 +96,7 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
 
     @Override
     public TypeOf<?> getPublicType() {
-        return typeOf(VersionCatalogContainer.class);
+        return typeOf(MutableVersionCatalogContainer.class);
     }
 
     void setPlugins(PluginDependenciesSpec plugins) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -17,12 +17,14 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Action
+import org.gradle.api.Incubating
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.support.delegates.DependencyHandlerDelegate
 
 
@@ -223,6 +225,56 @@ private constructor(
      */
     inline operator fun <T : ModuleDependency> Configuration.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
         add(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 6.9
+     */
+    @Incubating
+    operator fun <T : Any> Configuration.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProvider(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 6.9
+     */
+    @Incubating
+    operator fun <T : Any> Configuration.invoke(dependency: Provider<T>) =
+        addProvider(name, dependency)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 6.9
+     */
+    @Incubating
+    operator fun <T : Any> String.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProvider(this, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 6.9
+     */
+    @Incubating
+    operator fun <T : Any> String.invoke(dependency: Provider<T>) =
+        addProvider(this, dependency)
 
     /**
      * Configures the dependencies.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -59,6 +59,9 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
     override fun <T : Any, U : ExternalModuleDependency> addProvider(configurationName: String, dependencyNotation: Provider<T>, configuration: Action<in U>) =
         delegate.addProvider(configurationName, dependencyNotation, configuration)
 
+    override fun <T : Any?> addProvider(configurationName: String, dependencyNotation: Provider<T>) =
+        delegate.addProvider(configurationName, dependencyNotation)
+
     override fun create(dependencyNotation: Any): Dependency =
         delegate.create(dependencyNotation)
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -16,10 +16,12 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Provider
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
@@ -319,6 +321,84 @@ class DependencyHandlerExtensionsTest {
             }
             verifyNoMoreInteractions()
         }
+    }
+
+    @Test
+    fun `can use a Provider as a dependency notation using String invoke`() {
+
+        val dependencyHandler = newDependencyHandlerMock {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val notation = mock<Provider<MinimalExternalModuleDependency>>()
+
+        val dependencies = DependencyHandlerScope.of(dependencyHandler)
+        dependencies {
+            "configuration"(notation)
+        }
+
+        verify(dependencyHandler).addProvider("configuration", notation)
+    }
+
+    @Test
+    fun `can use a Provider as a dependency notation using String invoke with configuration`() {
+
+        val dependencyHandler = newDependencyHandlerMock {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val notation = mock<Provider<MinimalExternalModuleDependency>>()
+
+        val dependencies = DependencyHandlerScope.of(dependencyHandler)
+        dependencies {
+            "configuration"(notation) {
+                because("Hello, Kotlin!")
+            }
+        }
+
+        verify(dependencyHandler).addProvider(eq("configuration"), eq(notation), any<Action<ExternalModuleDependency>>())
+    }
+
+    @Test
+    fun `can use a Provider as a dependency notation using Configuration invoke`() {
+
+        val dependencyHandler = newDependencyHandlerMock {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val notation = mock<Provider<MinimalExternalModuleDependency>>()
+        val config = mock<Configuration> {
+            on { getName() } doReturn "config"
+        }
+
+        val dependencies = DependencyHandlerScope.of(dependencyHandler)
+        dependencies {
+            config(notation)
+        }
+
+        verify(dependencyHandler).addProvider(eq("config"), eq(notation))
+    }
+
+    @Test
+    fun `can use a Provider as a dependency notation using Configuration invoke with configuration`() {
+
+        val dependencyHandler = newDependencyHandlerMock {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val notation = mock<Provider<MinimalExternalModuleDependency>>()
+        val config = mock<Configuration> {
+            on { getName() } doReturn "config"
+        }
+
+        val dependencies = DependencyHandlerScope.of(dependencyHandler)
+        dependencies {
+            config(notation) {
+                because("Hello, Kotlin!")
+            }
+        }
+
+        verify(dependencyHandler).addProvider(eq("config"), eq(notation), any<Action<ExternalModuleDependency>>())
     }
 }
 


### PR DESCRIPTION
Version catalogs are dynamically generated from definitions in settings.
This means that when we build a plugin, we actually don't have access to
the catalogs, because we don't know if there will be one or not.

In particular, it's not because a project declares a catalog that the
catalog is visible in `buildSrc` plugins.

This commit exposes an API which provides access to catalogs using
"unsafe" APIs. The user is expected to check that aliases, bundles, etc
are available.

Fixes #15382
