### PR TITLE
Publish test distribution trace files on CI

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
@@ -92,7 +92,7 @@ fun prepareReportsForCiPublishing(failedTasks: List<Task>, executedTasks: List<T
     val failedTaskCustomReports = failedTasks.flatMap { it.failedTaskGenericHtmlReports() }
     val attachedReports = executedTasks.flatMap { it.attachedReportLocations() }
     val executedTaskCustomReports = failedTasks.flatMap { it.failedTaskCustomReports() }
-    val testDistributionTraceJsons = executedTasks.flatMap { it.findTraceJson() }
+    val testDistributionTraceJsons = executedTasks.filterIsInstance<Test>().flatMap { it.findTraceJson() }
 
     val allReports = failedTaskCustomReports + attachedReports + executedTaskCustomReports + tmpTestFiles + testDistributionTraceJsons
     allReports.forEach { report ->

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
@@ -92,10 +92,21 @@ fun prepareReportsForCiPublishing(failedTasks: List<Task>, executedTasks: List<T
     val failedTaskCustomReports = failedTasks.flatMap { it.failedTaskGenericHtmlReports() }
     val attachedReports = executedTasks.flatMap { it.attachedReportLocations() }
     val executedTaskCustomReports = failedTasks.flatMap { it.failedTaskCustomReports() }
+    val testDistributionTraceJsons = executedTasks.flatMap { it.findTraceJson() }
 
-    val allReports = failedTaskCustomReports + attachedReports + executedTaskCustomReports + tmpTestFiles
+    val allReports = failedTaskCustomReports + attachedReports + executedTaskCustomReports + tmpTestFiles + testDistributionTraceJsons
     allReports.forEach { report ->
         prepareReportForCiPublishing(report)
+    }
+}
+
+fun Task.findTraceJson(): List<File> {
+    // build/test-results/embeddedIntegTest/trace.json
+    val traceJson = project.buildDir.resolve("test-results/$name/trace.json")
+    return if (traceJson.isFile) {
+        listOf(traceJson)
+    } else {
+        emptyList()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ kotlin.stdlib.default.dependency=false
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.writeTraceFile=true
+systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S


### PR DESCRIPTION
### Context

- Increase query time out for test distribution.
- Publish trace jsons on CI.

