### PR TITLE
Use `--continue` for performance tests as well

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -85,7 +85,7 @@ class PerformanceTest(
                             extraParameters,
                             os
                         ) +
-                            buildToolGradleParameters(isContinue = false) +
+                            buildToolGradleParameters() +
                             buildScanTag("PerformanceTest") +
                             model.parentBuildCache.gradleParameters(os)
                         ).joinToString(separator = " ")

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -52,10 +52,6 @@ fun performanceTestCommandLine(task: String, baselines: String, extraParameters:
     "-PteamCityToken" to "%teamcity.user.bot-gradle.token%"
 ).map { (key, value) -> os.escapeKeyValuePair(key, value) }
 
-fun distributedPerformanceTestParameters(workerId: String = "Gradle_Check_IndividualPerformanceScenarioWorkersLinux") = listOf(
-    "-Porg.gradle.performance.buildTypeId=$workerId -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%"
-)
-
 const val individualPerformanceTestArtifactRules = """
 subprojects/*/build/test-results-*.zip => results
 subprojects/*/build/tmp/**/log.txt => failure-logs

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -76,7 +76,7 @@ class PerformanceTestBuildTypeTest {
             "-PmaxParallelForks=%maxParallelForks%",
             "-s",
             "--daemon",
-            "",
+            "--continue",
             "\"-Dscan.tag.PerformanceTest\"",
             "\"-Dgradle.cache.remote.url=%gradle.cache.remote.url%\"",
             "\"-Dgradle.cache.remote.username=%gradle.cache.remote.username%\"",


### PR DESCRIPTION
given that we may be running multiple performance test tasks in the same build.

I had a problem on a branch that a performance test didn't run because another performance test in the same bucket failed for a different test project. `--continue` should fix the problem.