### PR TITLE
Move C++ below dependency management

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -228,14 +228,6 @@
             </li>
         </ul>
 
-        <h3 id="authoring-gradle-builds-native">Authoring C++/Swift Builds</h3>
-        <ul>
-            <li><a href="../userguide/building_cpp_projects.html">Building C++ projects</a></li>
-            <li><a href="../userguide/cpp_testing.html">Testing C++ projects</a></li>
-            <li><a href="../userguide/building_swift_projects.html">Building Swift projects</a></li>
-            <li><a href="../userguide/swift_testing.html">Testing Swift projects</a></li>
-        </ul>
-
         <h3 id="managing-dependencies">Working with Dependencies</h3>
         <ul>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#learning-the-basics-dependency-management" aria-expanded="false" aria-controls="learning-the-basics-dependency-management">Learning the Basics</a>
@@ -290,6 +282,14 @@
                 </ul>
             </li>
             <li><a href="../userguide/dependency_management_terminology.html">Terminology</a></li>
+        </ul>
+
+        <h3 id="authoring-gradle-builds-native">Authoring C++/Swift Builds</h3>
+        <ul>
+            <li><a href="../userguide/building_cpp_projects.html">Building C++ projects</a></li>
+            <li><a href="../userguide/cpp_testing.html">Testing C++ projects</a></li>
+            <li><a href="../userguide/building_swift_projects.html">Building Swift projects</a></li>
+            <li><a href="../userguide/swift_testing.html">Testing Swift projects</a></li>
         </ul>
 
         <h3 id="extending-gradle">Extending Gradle</h3>


### PR DESCRIPTION
Just saw that the documentation for “Dependency management” is sorted below the C++/Swift docs, I think the order should be the other way around for people browsing the TOC. 