### PR TITLE
Update deprecation logger tests to not depend on nextMajor version

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
@@ -36,17 +35,17 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
             public class DeprecatedTask extends DefaultTask {
                 @TaskAction
                 void causeDeprecationWarning() {
-                    DeprecationLogger.deprecateTask("deprecated").replaceWith("foobar").willBeRemovedInGradle7().undocumented().nagUser();
+                    DeprecationLogger.deprecateTask("deprecated").replaceWith("foobar").willBeRemovedInGradle8().undocumented().nagUser();
                     System.out.println("DeprecatedTask.causeDeprecationWarning() executed.");
                 }
 
                 public static void someFeature() {
-                    DeprecationLogger.deprecateMethod(DeprecatedTask.class, "someFeature()").willBeRemovedInGradle7().undocumented().nagUser();
+                    DeprecationLogger.deprecateMethod(DeprecatedTask.class, "someFeature()").willBeRemovedInGradle8().undocumented().nagUser();
                     System.out.println("DeprecatedTask.someFeature() executed.");
                 }
 
                 void otherFeature() {
-                    DeprecationLogger.deprecateMethod(DeprecatedTask.class, "otherFeature()").withAdvice("Relax. This is just a test.").willBeRemovedInGradle7().undocumented().nagUser();
+                    DeprecationLogger.deprecateMethod(DeprecatedTask.class, "otherFeature()").withAdvice("Relax. This is just a test.").willBeRemovedInGradle8().undocumented().nagUser();
                     System.out.println("DeprecatedTask.otherFeature() executed.");
                 }
 
@@ -60,7 +59,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
             public class DeprecatedPlugin implements Plugin<Project> {
                 @Override
                 public void apply(Project project) {
-                    DeprecationLogger.deprecatePlugin("DeprecatedPlugin").replaceWithExternalPlugin("Foobar").willBeRemovedInGradle7().undocumented().nagUser();
+                    DeprecationLogger.deprecatePlugin("DeprecatedPlugin").replaceWithExternalPlugin("Foobar").willBeRemovedInGradle8().undocumented().nagUser();
                     project.getTasks().create("deprecated", DeprecatedTask.class);
                 }
             }
@@ -124,7 +123,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         if (warnings == WarningMode.Fail) {
-            failure.assertHasDescription("Deprecated Gradle features were used in this build, making it incompatible with Gradle ${GradleVersion.current().nextMajor.version}")
+            failure.assertHasDescription("Deprecated Gradle features were used in this build, making it incompatible with ${GradleVersion.current().nextMajor}")
         }
 
         where:
@@ -152,7 +151,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
-        executer.expectDeprecationWarning("The DeprecatedPlugin plugin has been deprecated. This is scheduled to be removed in ${GradleVersion.current().nextMajor}. Consider using the Foobar plugin instead.")
+        executer.expectDeprecationWarning("The DeprecatedPlugin plugin has been deprecated. This is scheduled to be removed in Gradle 8.0. Consider using the Foobar plugin instead.")
         executer.withWarningMode(WarningMode.Fail)
 
         then:
@@ -166,7 +165,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         given:
         def initScript = file("init.gradle") << """
             allprojects {
-                org.gradle.internal.deprecation.DeprecationLogger.deprecatePlugin("DeprecatedPlugin").replaceWithExternalPlugin("Foobar").willBeRemovedInGradle7().undocumented().nagUser() // line 2
+                org.gradle.internal.deprecation.DeprecationLogger.deprecatePlugin("DeprecatedPlugin").replaceWithExternalPlugin("Foobar").willBeRemovedInGradle8().undocumented().nagUser() // line 2
             }
         """.stripIndent()
 
@@ -252,10 +251,6 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         scenario                  | withFullStacktrace
         'without full stacktrace' | false
         'with full stacktrace'    | true
-    }
-
-    def incrementWarningCountIfJava7(int warningCount) {
-        return JavaVersion.current().isJava7() ? warningCount + 1 : warningCount
     }
 
     boolean assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCountInConsole) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
@@ -127,13 +127,13 @@ class DeprecationLoggerTest extends ConcurrentSpec {
         when:
         DeprecationLogger.deprecate("foo")
             .withAdvice("bar.")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .undocumented()
             .nagUser();
 
         then:
         def events = outputEventListener.events
         events.size() == 1
-        events[0].message.startsWith("foo has been deprecated. This is scheduled to be removed in Gradle ${major.version}. bar.")
+        events[0].message.startsWith("foo has been deprecated. This is scheduled to be removed in Gradle 8.0. bar.")
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class DeprecationMessagesTest extends Specification {
 
-    private static final String NEXT_GRADLE_VERSION = GradleVersion.current().nextMajor.version
+    private static final String NEXT_GRADLE_VERSION = "8.0"
     private static final DOCUMENTATION_REGISTRY = new DocumentationRegistry()
 
     private final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
@@ -51,10 +51,10 @@ class DeprecationMessagesTest extends Specification {
         builder.setSummary("Summary.")
 
         when:
-        builder.willBeRemovedInGradle7().undocumented().nagUser()
+        builder.willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
-        expectMessage 'Summary. This is scheduled to be removed in Gradle 7.0.'
+        expectMessage "Summary. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}."
     }
 
     def "logs deprecation message with advice"() {
@@ -64,10 +64,10 @@ class DeprecationMessagesTest extends Specification {
         builder.withAdvice("Advice.")
 
         when:
-        builder.willBeRemovedInGradle7().undocumented().nagUser()
+        builder.willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
-        expectMessage 'Summary. This is scheduled to be removed in Gradle 7.0. Advice.'
+        expectMessage "Summary. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
     }
 
     def "logs deprecation message with contextual advice"() {
@@ -77,10 +77,10 @@ class DeprecationMessagesTest extends Specification {
         builder.withContext("Context.")
 
         when:
-        builder.willBeRemovedInGradle7().undocumented().nagUser()
+        builder.willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
-        expectMessage 'Summary. This is scheduled to be removed in Gradle 7.0. Context.'
+        expectMessage "Summary. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Context."
     }
 
     def "logs deprecation message with advice and contextual advice"() {
@@ -91,15 +91,15 @@ class DeprecationMessagesTest extends Specification {
         builder.withContext("Context.")
 
         when:
-        builder.willBeRemovedInGradle7().undocumented().nagUser()
+        builder.willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
-        expectMessage 'Summary. This is scheduled to be removed in Gradle 7.0. Context. Advice.'
+        expectMessage "Summary. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Context. Advice."
     }
 
     def "logs generic deprecation message for specific thing"() {
         when:
-        DeprecationLogger.deprecate("Something").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecate("Something").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Something has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}."
@@ -107,7 +107,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated behaviour message"() {
         when:
-        DeprecationLogger.deprecateBehaviour("Some behaviour.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateBehaviour("Some behaviour.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Some behaviour. This behaviour has been deprecated and is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}."
@@ -115,7 +115,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated indirect user code cause message"() {
         when:
-        DeprecationLogger.deprecate("Something").withAdvice("Advice.").withContext("Contextual advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecate("Something").withAdvice("Advice.").withContext("Contextual advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Something has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Contextual advice. Advice."
@@ -123,7 +123,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated build invocation message"() {
         when:
-        DeprecationLogger.deprecateBuildInvocationFeature("Feature").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateBuildInvocationFeature("Feature").withAdvice("Advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Feature has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -131,7 +131,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated and replaced parameter usage message"() {
         when:
-        DeprecationLogger.deprecateNamedParameter("paramName").replaceWith("replacement").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateNamedParameter("paramName").replaceWith("replacement").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The paramName named parameter has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacement named parameter instead."
@@ -139,7 +139,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated property message"() {
         when:
-        DeprecationLogger.deprecateProperty(DeprecationLogger, "propertyName").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateProperty(DeprecationLogger, "propertyName").withAdvice("Advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The DeprecationLogger.propertyName property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -147,7 +147,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated and replaced property message"() {
         when:
-        DeprecationLogger.deprecateProperty(DeprecationLogger, "propertyName").replaceWith("replacement").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateProperty(DeprecationLogger, "propertyName").replaceWith("replacement").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The DeprecationLogger.propertyName property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacement property instead."
@@ -155,7 +155,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated system property message"() {
         when:
-        DeprecationLogger.deprecateSystemProperty("org.gradle.test").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateSystemProperty("org.gradle.test").withAdvice("Advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The org.gradle.test system property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -163,7 +163,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated and replaced system property message"() {
         when:
-        DeprecationLogger.deprecateSystemProperty("org.gradle.deprecated.test").replaceWith("org.gradle.test").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateSystemProperty("org.gradle.deprecated.test").replaceWith("org.gradle.test").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The org.gradle.deprecated.test system property has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the org.gradle.test system property instead."
@@ -171,7 +171,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs discontinued method message"() {
         when:
-        DeprecationLogger.deprecateMethod(DeprecationLogger, "method()").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateMethod(DeprecationLogger, "method()").withAdvice("Advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The DeprecationLogger.method() method has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -179,7 +179,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs replaced method message"() {
         when:
-        DeprecationLogger.deprecateMethod(DeprecationLogger, "method()").replaceWith("replacementMethod()").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateMethod(DeprecationLogger, "method()").replaceWith("replacementMethod()").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The DeprecationLogger.method() method has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacementMethod() method instead."
@@ -187,7 +187,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs discontinued invocation message"() {
         when:
-        DeprecationLogger.deprecateAction("Some action").willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateAction("Some action").willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Some action has been deprecated. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}."
@@ -195,7 +195,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated method invocation message"() {
         when:
-        DeprecationLogger.deprecateInvocation("method()").withAdvice("Advice.").willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateInvocation("method()").withAdvice("Advice.").willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Using method method() has been deprecated. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -203,7 +203,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs replaced method invocation message"() {
         when:
-        DeprecationLogger.deprecateInvocation("method()").replaceWith("replacementMethod()").willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateInvocation("method()").replaceWith("replacementMethod()").willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "Using method method() has been deprecated. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacementMethod() method instead."
@@ -211,7 +211,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs replaced task"() {
         when:
-        DeprecationLogger.deprecateTask("taskName").replaceWith("replacementTask").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateTask("taskName").replaceWith("replacementTask").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The taskName task has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacementTask task instead."
@@ -219,7 +219,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs plugin replaced with external one message"() {
         when:
-        DeprecationLogger.deprecatePlugin("pluginName").replaceWithExternalPlugin("replacement").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecatePlugin("pluginName").replaceWithExternalPlugin("replacement").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The pluginName plugin has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Consider using the replacement plugin instead."
@@ -227,7 +227,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated plugin message"() {
         when:
-        DeprecationLogger.deprecatePlugin("pluginName").withAdvice("Advice.").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecatePlugin("pluginName").withAdvice("Advice.").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The pluginName plugin has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Advice."
@@ -235,7 +235,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs replaced plugin message"() {
         when:
-        DeprecationLogger.deprecatePlugin("pluginName").replaceWith("replacement").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecatePlugin("pluginName").replaceWith("replacement").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The pluginName plugin has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Please use the replacement plugin instead."
@@ -243,7 +243,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs deprecated plugin message with link to upgrade guide"() {
         when:
-        DeprecationLogger.deprecatePlugin("pluginName").willBeRemovedInGradle7().withUpgradeGuideSection(42, "upgradeGuideSection").nagUser()
+        DeprecationLogger.deprecatePlugin("pluginName").willBeRemovedInGradle8().withUpgradeGuideSection(42, "upgradeGuideSection").nagUser()
 
         then:
         expectMessage "The pluginName plugin has been deprecated. This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_42.html#upgradeGuideSection"
@@ -251,7 +251,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs configuration deprecation message for artifact declaration"() {
         when:
-        DeprecationLogger.deprecateConfiguration("ConfigurationType").forArtifactDeclaration().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateConfiguration("ConfigurationType").forArtifactDeclaration().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The ConfigurationType configuration has been deprecated for artifact declaration. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Please use the r1 or r2 or r3 configuration instead."
@@ -259,7 +259,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs configuration deprecation message for consumption"() {
         when:
-        DeprecationLogger.deprecateConfiguration("ConfigurationType").forConsumption().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateConfiguration("ConfigurationType").forConsumption().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The ConfigurationType configuration has been deprecated for consumption. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Please use attributes to consume the r1 or r2 or r3 configuration instead."
@@ -267,7 +267,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs configuration deprecation message for dependency declaration"() {
         when:
-        DeprecationLogger.deprecateConfiguration("ConfigurationType").forDependencyDeclaration().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateConfiguration("ConfigurationType").forDependencyDeclaration().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The ConfigurationType configuration has been deprecated for dependency declaration. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Please use the r1 or r2 or r3 configuration instead."
@@ -275,7 +275,7 @@ class DeprecationMessagesTest extends Specification {
 
     def "logs configuration deprecation message for resolution"() {
         when:
-        DeprecationLogger.deprecateConfiguration("ConfigurationType").forResolution().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecateConfiguration("ConfigurationType").forResolution().replaceWith(['r1', 'r2', 'r3']).willBecomeAnErrorInGradle8().undocumented().nagUser()
 
         then:
         expectMessage "The ConfigurationType configuration has been deprecated for resolution. This will fail with an error in Gradle ${NEXT_GRADLE_VERSION}. Please resolve the r1 or r2 or r3 configuration instead."
@@ -285,7 +285,7 @@ class DeprecationMessagesTest extends Specification {
         when:
         DeprecationLogger.deprecateInternalApi("constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)")
             .replaceWith("ObjectFactory.polymorphicDomainObjectContainer(Class<T>)")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .undocumented()
             .nagUser()
 
@@ -298,7 +298,7 @@ class DeprecationMessagesTest extends Specification {
         DeprecationLogger.deprecateInternalApi("constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)")
             .replaceWith("ObjectFactory.polymorphicDomainObjectContainer(Class<T>)")
             .withAdvice("foobar")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .undocumented()
             .nagUser()
 
@@ -319,7 +319,7 @@ class DeprecationMessagesTest extends Specification {
     def "logs documentation reference"() {
         when:
         DeprecationLogger.deprecateBehaviour("Some behaviour.")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")
             .nagUser()
 
@@ -331,7 +331,7 @@ class DeprecationMessagesTest extends Specification {
     def "logs DSL property documentation reference"() {
         when:
         DeprecationLogger.deprecateProperty(DeprecationLogger, "archiveName").replaceWith("archiveFileName")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .withDslReference(AbstractArchiveTask, "bar")
             .nagUser()
 
@@ -343,7 +343,7 @@ class DeprecationMessagesTest extends Specification {
     def "logs DSL documentation reference for deprecated property implicitly"() {
         when:
         DeprecationLogger.deprecateProperty(AbstractArchiveTask, "archiveName").replaceWith("archiveFileName")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .withDslReference()
             .nagUser()
 


### PR DESCRIPTION
So that they do not fail on major version increases.
Also update them to use toBeRemovedInGradle8() methods in preparations to remove the counterpart with version 7 in it.
