### PR TITLE
Remove @Incubating from replacement of @Deprecated

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -551,6 +551,22 @@
             "changes": [
                 "org.gradle.api.internal.AbstractTask.replaceLogger(org.gradle.api.logging.Logger)"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.Pmd",
+            "member": "Method org.gradle.api.plugins.quality.Pmd.getRulesMinimumPriority()",
+            "acceptation": "New property, skipping incubation step as replacement is deprecated immediately",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.PmdExtension",
+            "member": "Method org.gradle.api.plugins.quality.PmdExtension.getRulesMinimumPriority()",
+            "acceptation": "New property, skipping incubation step as replacement is deprecated immediately",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
         }
     ]
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.quality;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -286,7 +285,6 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      * @return path to other Checkstyle configuration files
      * @since 6.0
      */
-    @Incubating
     @Internal
     public DirectoryProperty getConfigDirectory() {
         return configDirectory;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -315,7 +315,6 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @see PmdExtension#getRulesMinimumPriority()
      * @since 6.8
      */
-    @Incubating
     @Input
     public Property<Integer> getRulesMinimumPriority() {
         return rulesMinimumPriority;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -138,7 +138,6 @@ public class PmdExtension extends CodeQualityExtension {
      *
      * @since 6.8
      */
-    @Incubating
     public Property<Integer> getRulesMinimumPriority() {
         return rulesMinimumPriority;
     }


### PR DESCRIPTION
Otherwise users only have the choice between deprecated or potentially
unstable. And in this case, there is no need for @Incubating.