### PR TITLE
Fix exception being rethrown without context

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
+import org.gradle.util.GradleVersion
 import org.gradle.util.TestPrecondition
 import org.gradle.util.ToBeImplemented
 import spock.lang.IgnoreIf
@@ -736,7 +737,7 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15336")
-    @ToBeFixedForConfigurationCache(because = "Decorated exception is not rethrown")
+    @ToBeFixedForConfigurationCache(because = "Decorated exception is not recognized by the configuration cache")
     def "reasonable error message if a dependency cannot be resolved because local repositories differ"() {
         buildFile << """
             repositories {
@@ -755,12 +756,10 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
         fails ':checkDeps'
 
         then:
-        // FIXME wolfs
-//        failure.assertThatCause(containsNormalizedString("""Could not resolve all dependencies for configuration ':conf'.
-//The project declares repositories, effectively ignoring the repositories you have declared in the settings.
-//You can figure out how project repositories are declared by configuring your build to fail on project repositories.
-//See https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_repositories.html#sub:fail_build_on_project_repositories for details."""))
-        failure.assertThatCause(containsNormalizedString("""Could not resolve all files for configuration ':conf'."""))
+        failure.assertHasCause("""Could not resolve all dependencies for configuration ':conf'.
+The project declares repositories, effectively ignoring the repositories you have declared in the settings.
+You can figure out how project repositories are declared by configuring your build to fail on project repositories.
+See https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_repositories.html#sub:fail_build_on_project_repositories for details.""")
     }
 
     void withSettingsPlugin() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
@@ -35,7 +35,9 @@ class ErrorHandlingConfigurationResolverTest extends Specification {
     private resolutionResult = Mock(ResolutionResult)
     private projectConfigResult = Mock(ResolvedLocalComponentsResult)
     private visitedArtifactSet = Mock(VisitedArtifactSet)
-    private context = Mock(ConfigurationInternal.class)
+    private context = Mock(ConfigurationInternal) {
+        maybeAddContext(_) >> { args -> args[0] }
+    }
     private results = new DefaultResolverResults()
     private resolver = new ErrorHandlingConfigurationResolver(delegate);
 


### PR DESCRIPTION
Follow up to #15432, so that the exception is wrapped if using `rethrow` too. This is really a quick fix: it looks like we should more consistently throw `ResolveException` everywhere: currently, for some obscure reason, only lenient configuration result can create it.
