### PR TITLE
Update integration tests with included plugin builds to use the new API

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -73,7 +73,7 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
         if (mappings == "") {
             buildA.settingsFile << """
                 includeBuild('${build.toURI()}')
-"""
+            """
         } else {
             buildA.settingsFile << """
                 includeBuild('${build.toURI()}') {
@@ -81,9 +81,18 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
                         $mappings
                     }
                 }
-"""
+            """
 
         }
+    }
+
+    def includePluginBuild(File build) {
+            buildA.settingsFile.setText("""
+                pluginManagement {
+                    includeBuild('${build.toURI()}')
+                }
+                ${buildA.settingsFile.text}
+            """)
     }
 
     protected void execute(BuildTestFile build, String[] tasks, Iterable<String> arguments = []) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
@@ -157,10 +157,10 @@ class CompositeBuildNestingIntegrationTest extends AbstractCompositeBuildIntegra
                 }
             """
         }
-        includeBuild(buildB)
 
         buildA.settingsFile.text = """
             pluginManagement {
+                includeBuild("${buildB.toURI()}")
                 resolutionStrategy.eachPlugin { details ->
                     if (details.requested.id.name == 'b') {
                         details.useModule('org.test:buildB:1.2')

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExecutionIntegrationTest.groovy
@@ -106,7 +106,11 @@ class CompositeBuildTaskExecutionIntegrationTest extends AbstractIntegrationSpec
                 id 'other.plugin'
             }
         """
-        settingsFile << "includeBuild('other-plugin')"
+        settingsFile << """
+            pluginManagement {
+                includeBuild('other-plugin')
+            }
+        """
         file('other-plugin/settings.gradle') << "rootProject.name = 'other-plugin'"
         file('other-plugin/build.gradle') << """
             plugins {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -138,6 +138,9 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         }
         createDir("included") {
             file("settings.gradle") << """
+                pluginManagement {
+                    includeBuild '../probe-plugin'
+                }
                 include 'classloader1', 'boundary:classloader2'
             """
             file("classloader1/build.gradle") << """
@@ -152,7 +155,6 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         }
         createDir("root") {
             file("settings.gradle") << """
-                includeBuild '../probe-plugin'
                 includeBuild '../included'
             """
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
@@ -81,7 +81,9 @@ class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConf
         def fixture = fixtureSpec.fixtureForProjectDir(file('build-logic'))
         fixture.setup()
         settingsFile << """
-            includeBuild 'build-logic'
+            pluginManagement {
+                includeBuild 'build-logic'
+            }
         """
         buildFile << """
             plugins { id('$fixture.pluginId') }
@@ -159,7 +161,9 @@ class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConf
             }
         """
         settingsFile << """
-            includeBuild 'build-logic'
+            pluginManagement {
+                includeBuild 'build-logic'
+            }
         """
         buildFile << """
             plugins { id('$fixture.pluginId') }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -116,8 +116,10 @@ plugins {
 }
 '''
         settingsFile << '''
-includeBuild('included')
-'''
+            pluginManagement {
+                includeBuild('included')
+            }
+        '''
         when:
         fails('runBrokenWorker')
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
@@ -77,6 +77,9 @@ class PluginVariantResolveIntegrationTest extends AbstractPluginIntegrationTest 
     @Issue("https://github.com/gradle/gradle/issues/13659")
     def "should report an incompatible Java version of a plugin properly (#id) using composite builds"() {
         settingsFile << """
+            pluginManagement {
+                includeBuild('my-plugin')
+            }
             rootProject.name = 'test-plugin'
 
             includeBuild('my-plugin') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -219,8 +219,12 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
             'org:module:1.0'()
         }
 
-        settingsFile << """
-            includeBuild 'my-plugin'
+        settingsFile.text = """
+            pluginManagement {
+                includeBuild 'my-plugin'
+            }
+
+            $settingsFile.text
 
             dependencyResolutionManagement {
                 repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -30,9 +30,11 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
     @Issue("https://github.com/gradle/gradle/issues/10317")
     def "can use worker api with composite builds using #pluginId"() {
         settingsFile << """
+            pluginManagement {
+                includeBuild "plugin"
+            }
             rootProject.name = "app"
 
-            includeBuild "plugin"
             includeBuild "lib"
         """
 
@@ -40,6 +42,11 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         withLegacyWorkerPluginInPluginBuild()
         withTypedWorkerPluginInPluginBuild()
 
+        lib.file('settings.gradle') << """
+            pluginManagement {
+                includeBuild "../plugin"
+            }
+        """
         lib.file("build.gradle") << """
             buildscript {
                 dependencies {


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/14562

Tests that include builds to contribute plugins updated to use:
```
pluginManagement {
    includeBuild('plugin-build')
}
```
