### PR TITLE
Add missing getter on version catalogs container

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -66,6 +66,13 @@ public interface DependencyResolutionManagement {
     void versionCatalogs(Action<? super MutableVersionCatalogContainer> spec);
 
     /**
+     * Returns the configurable version catalogs.
+     *
+     * @since 7.0
+     */
+    MutableVersionCatalogContainer getVersionCatalogs();
+
+    /**
      * Returns the name of the extension generated for type-safe project accessors.
      * Defaults to "projects"
      *

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -134,6 +134,11 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     }
 
     @Override
+    public MutableVersionCatalogContainer getVersionCatalogs() {
+        return versionCatalogs;
+    }
+
+    @Override
     public RulesModeInternal getConfiguredRulesMode() {
         rulesMode.finalizeValue();
         return RulesModeInternal.of(rulesMode.get());


### PR DESCRIPTION
For consistency, add a getter for the mutable version catalogs.