### PR TITLE
Ignore cacheability warnings in scheduling

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -82,6 +82,10 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec {
                 @Optional @Input File invalidInput
             }
 
+            abstract class PingWithCacheableWarnings extends Ping {
+                @Optional @InputFile File invalidInput
+            }
+
             class FailingPing extends DefaultTask {
 
                 FailingPing() { outputs.upToDateWhen { false } }
@@ -107,6 +111,11 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec {
                 tasks.addRule("<>InvalidPing") { String name ->
                     if (name.endsWith("InvalidPing")) {
                         tasks.create(name, InvalidPing)
+                    }
+                }
+                tasks.addRule("<>PingWithCacheableWarnings") { String name ->
+                    if (name.endsWith("PingWithCacheableWarnings")) {
+                        tasks.create(name, PingWithCacheableWarnings)
                     }
                 }
                 tasks.addRule("<>SerialPing") { String name ->
@@ -480,6 +489,15 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec {
             blockingServer.expectConcurrent(":bPing", ":cPing")
             run ":aInvalidPing", ":bPing", ":cPing"
         }
+    }
+
+    def "cacheable warnings do not prevent a task from running in parallel"() {
+        given:
+        withParallelThreads(3)
+
+        expect:
+        blockingServer.expectConcurrent(":aPingWithCacheableWarnings", ":bPing", ":cPing")
+        run ":aPingWithCacheableWarnings", ":bPing", ":cPing"
     }
 
     def "invalid task is not executed in parallel with other task"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -491,7 +491,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    def "cacheable warnings do not prevent a task from running in parallel"() {
+    def "cacheability warnings do not prevent a task from running in parallel"() {
         given:
         withParallelThreads(3)
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -29,13 +29,16 @@ public class DefaultNodeValidator implements NodeValidator {
             TypeValidationContext context = new TypeValidationContext() {
                 @Override
                 public void visitTypeProblem(Severity severity, Class<?> type, String message) {
-                    if (severity != Severity.CACHEABILITY_WARNING) {
-                        foundProblem.set(true);
-                    }
+                    recordNonCacheabilityProblem(severity);
                 }
 
                 @Override
                 public void visitPropertyProblem(Severity severity, @Nullable String parentProperty, @Nullable String property, String message) {
+                    recordNonCacheabilityProblem(severity);
+                }
+
+                private void recordNonCacheabilityProblem(Severity severity) {
+                    // We don't know whether the task is cacheable or not, so we ignore cacheability problems for scheduling
                     if (severity != Severity.CACHEABILITY_WARNING) {
                         foundProblem.set(true);
                     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -29,12 +29,16 @@ public class DefaultNodeValidator implements NodeValidator {
             TypeValidationContext context = new TypeValidationContext() {
                 @Override
                 public void visitTypeProblem(Severity severity, Class<?> type, String message) {
-                    foundProblem.set(true);
+                    if (severity != Severity.CACHEABILITY_WARNING) {
+                        foundProblem.set(true);
+                    }
                 }
 
                 @Override
                 public void visitPropertyProblem(Severity severity, @Nullable String parentProperty, @Nullable String property, String message) {
-                    foundProblem.set(true);
+                    if (severity != Severity.CACHEABILITY_WARNING) {
+                        foundProblem.set(true);
+                    }
                 }
             };
             ((LocalTaskNode) node).getTaskProperties().validateType(context);


### PR DESCRIPTION
We don't determine whether a task is cacheable or not, so we should ignore cacheability problems for now.