### PR TITLE
Improve error message in ivy repo validation

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -364,7 +364,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
                 }
             }
         } else {
-            result.assertHasCause 'You must specify a base url or at least one artifact pattern for an Ivy repository.'
+            result.assertHasCause "You must specify a base url or at least one artifact pattern for the Ivy repository 'custom repo'."
             operations.none(ResolveConfigurationDependenciesBuildOperationType)
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -218,7 +218,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
     private void validate(Set<String> schemes) {
         if (schemes.isEmpty()) {
-            throw new InvalidUserDataException("You must specify a base url or at least one artifact pattern for an Ivy repository.");
+            throw new InvalidUserDataException("You must specify a base url or at least one artifact pattern for the Ivy repository '" + getDisplayName() + "'.");
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -297,7 +297,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
         then:
         InvalidUserDataException e = thrown()
-        e.message == 'You must specify a base url or at least one artifact pattern for an Ivy repository.'
+        e.message == "You must specify a base url or at least one artifact pattern for the Ivy repository 'null'."
     }
 
     def "can set a custom metadata rule"() {


### PR DESCRIPTION
While investigating a weird error, I found that this message is missing any context. And since it is thrown during resolution, there is no link back to the place where the repository was defined.

This improves it slightly by at least appending repo `name` and `url` to the message.