### PR TITLE
Fail build when consumer and producer task run in parallel

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -125,6 +125,8 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
     }
 
     private void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext) {
+        // If the consumer and producer are running at the same time, then something is very wrong in the current build.
+        // So we fail the build in that case to expose the problem.
         TypeValidationContext.Severity severity = producer.isExecuting() && consumer.isExecuting()
             ? TypeValidationContext.Severity.ERROR
             : TypeValidationContext.Severity.WARNING;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -69,7 +69,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         for (String outputPath : node.getMutationInfo().outputPaths) {
             consumedLocations.getNodesRelatedTo(outputPath).stream()
                 .filter(consumerNode -> missesDependency(node, consumerNode))
-                .forEach(consumerWithoutDependency -> collectValidationWarningOrError(node, consumerWithoutDependency, validationContext));
+                .forEach(consumerWithoutDependency -> collectValidationProblem(node, consumerWithoutDependency, validationContext));
         }
         Set<String> locationsConsumedByThisTask = new LinkedHashSet<>();
         node.getTaskProperties().getInputFileProperties()
@@ -98,7 +98,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         for (String locationConsumedByThisTask : locationsConsumedByThisTask) {
             producedLocations.getNodesRelatedTo(locationConsumedByThisTask).stream()
                 .filter(producerNode -> missesDependency(producerNode, node))
-                .forEach(producerWithoutDependency -> collectValidationWarningOrError(producerWithoutDependency, node, validationContext));
+                .forEach(producerWithoutDependency -> collectValidationProblem(producerWithoutDependency, node, validationContext));
         }
     }
 
@@ -124,7 +124,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         return true;
     }
 
-    private void collectValidationWarningOrError(Node producer, Node consumer, TypeValidationContext validationContext) {
+    private void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext) {
         TypeValidationContext.Severity severity = producer.isExecuting() && consumer.isExecuting()
             ? TypeValidationContext.Severity.ERROR
             : TypeValidationContext.Severity.WARNING;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -79,6 +79,10 @@ public abstract class Node implements Comparable<Node> {
         return state != ExecutionState.UNKNOWN;
     }
 
+    public boolean isExecuting() {
+        return state == ExecutionState.EXECUTING;
+    }
+
     public boolean isComplete() {
         return state == ExecutionState.EXECUTED
             || state == ExecutionState.SKIPPED
@@ -99,10 +103,6 @@ public abstract class Node implements Comparable<Node> {
 
     public boolean isExecuted() {
         return state == ExecutionState.EXECUTED;
-    }
-
-    public boolean isExecuting() {
-        return state == ExecutionState.EXECUTING;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -101,6 +101,10 @@ public abstract class Node implements Comparable<Node> {
         return state == ExecutionState.EXECUTED;
     }
 
+    public boolean isExecuting() {
+        return state == ExecutionState.EXECUTING;
+    }
+
     /**
      * Returns any error that happened during the execution of the node itself,
      * i.e. a task action has thrown an exception.


### PR DESCRIPTION
In that case the build is really broken, so we can as well fail it
to expose the problem.

Follow up to #15411.