### PR TITLE
Revert "Resolve task properties when checking for mutations"

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 import spock.lang.Unroll
 
+import java.nio.file.Files
+
 @Unroll
 class UpToDateIntegTest extends AbstractIntegrationSpec {
 
@@ -191,5 +193,71 @@ public abstract class CreateEmptyDirectory extends DefaultTask {
 
         where:
         type << ["dir", "file"]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/15397")
+    def "can add a file input in a task execution listener"() {
+        buildFile << """
+            abstract class TaskMissingPathSensitivity extends DefaultTask {
+                @InputFiles
+                FileCollection inputFiles
+
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
+                @TaskAction
+                void doWork() {
+                    outputFile.get().asFile.text = "output"
+                }
+            }
+
+            tasks.register("customTask", TaskMissingPathSensitivity) {
+                inputFiles = files("input1", "input2")
+                outputFile = layout.buildDirectory.file("output.txt")
+            }
+
+            // This is what the Android cache fix plugin is doing:
+            tasks.withType(TaskMissingPathSensitivity).configureEach { TaskMissingPathSensitivity task ->
+                ConfigurableFileCollection newInputs = files()
+                FileCollection originalPropertyValue
+                // Create a synthetic input with the original property value and RELATIVE path sensitivity
+                project.gradle.taskGraph.beforeTask {
+                    if (it == task) {
+                        originalPropertyValue = task.inputFiles
+                        task.inputFiles = project.files()
+                        task.inputs.files(originalPropertyValue)
+                            .withPathSensitivity(PathSensitivity.RELATIVE)
+                            .withPropertyName("inputFiles.workaround")
+                            .optional()
+                    }
+                }
+                // Set the task property back to its original value
+                task.doFirst {
+                    task.inputFiles = originalPropertyValue
+                }
+            }
+        """
+        def inputDir1 = file("input1").createDir()
+        def inputDir2 = file("input2").createDir()
+        def inputFileName = "inputFile.txt"
+        def inputFile = inputDir1.file(inputFileName)
+        inputFile.text = "input"
+
+        when:
+        run "customTask"
+        then:
+        executedAndNotSkipped(":customTask")
+
+        when:
+        Files.move(inputFile.toPath(), inputDir2.file(inputFileName).toPath())
+        run "customTask"
+        then:
+        skipped(":customTask")
+
+        when:
+        inputDir2.file(inputFileName).text = "changed"
+        run "customTask"
+        then:
+        executedAndNotSkipped(":customTask")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -761,13 +761,13 @@ task someTask(type: SomeTask) {
         """
         def inputFile = file('input.txt')
         inputFile.text = "input"
-        def expectedCounts = [inputFile: 3, outputFile: 2, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+        def expectedCounts = [inputFile: 3, outputFile: 3, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
         def expectedIncrementalCounts = GradleContextualExecuter.configCache ?
-            [inputFile: 2, outputFile: 2, nestedInput: 1, inputValue: 1, nestedInputValue: 1]
+            [inputFile: 2, outputFile: 3, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
             : expectedCounts
         def expectedUpToDateCounts = GradleContextualExecuter.configCache ?
-            [inputFile: 1, outputFile: 1, nestedInput: 1, inputValue: 1, nestedInputValue: 1]
-            : [inputFile: 2, outputFile: 1, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+            [inputFile: 1, outputFile: 2, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+            : [inputFile: 2, outputFile: 2, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
         def arguments = ["assertInputCounts"] + expectedCounts.collect { name, count -> "-P${name}Count=${count}" }
         def incrementalBuildArguments = ["assertInputCounts"] + expectedIncrementalCounts.collect { name, count -> "-P${name}Count=${count}" }
         def upToDateArguments = ["assertInputCounts"] + expectedUpToDateCounts.collect { name, count -> "-P${name}Count=${count}" }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -139,7 +139,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     }
 
     public ImmutableSortedSet<OutputFilePropertySpec> getFileProperties() {
-        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileCollectionFactory, false);
+        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileCollectionFactory);
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.getFileProperties();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -44,6 +44,8 @@ public interface TaskExecutionContext {
      */
     long markExecutionTime();
 
+    void setTaskProperties(TaskProperties properties);
+
     TaskProperties getTaskProperties();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -73,11 +73,11 @@ public class TaskStateInternal implements TaskState {
             this.failure = failure;
         } else if (this.failure instanceof TaskExecutionException) {
             TaskExecutionException taskExecutionException = (TaskExecutionException) this.failure;
-            List<Throwable> causes = new ArrayList<>(taskExecutionException.getCauses());
+            List<Throwable> causes = new ArrayList<Throwable>(taskExecutionException.getCauses());
             CollectionUtils.addAll(causes, failure.getCauses());
             taskExecutionException.initCauses(causes);
         } else {
-            List<Throwable> causes = new ArrayList<>();
+            List<Throwable> causes = new ArrayList<Throwable>();
             causes.add(this.failure);
             causes.addAll(failure.getCauses());
             failure.initCauses(causes);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -28,16 +28,15 @@ import java.util.Optional;
 public class DefaultTaskExecutionContext implements TaskExecutionContext {
 
     private final LocalTaskNode localTaskNode;
-    private final TaskProperties properties;
     private TaskExecutionMode taskExecutionMode;
+    private TaskProperties properties;
     private Long executionTime;
     private BuildOperationContext snapshotTaskInputsBuildOperationContext;
 
     private final Timer executionTimer;
 
-    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode, TaskProperties taskProperties) {
+    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode) {
         this.localTaskNode = localTaskNode;
-        this.properties = taskProperties;
         this.executionTimer = Time.startTimer();
     }
 
@@ -63,6 +62,11 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
         }
 
         return this.executionTime = executionTimer.getElapsedMillis();
+    }
+
+    @Override
+    public void setTaskProperties(TaskProperties properties) {
+        this.properties = properties;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuter.java
@@ -20,10 +20,14 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.changedetection.TaskExecutionMode;
 import org.gradle.api.internal.changedetection.TaskExecutionModeResolver;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecuterResult;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.internal.tasks.properties.DefaultTaskProperties;
+import org.gradle.api.internal.tasks.properties.PropertyWalker;
+import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.slf4j.Logger;
@@ -33,10 +37,14 @@ import org.slf4j.LoggerFactory;
 public class ResolveTaskExecutionModeExecuter implements TaskExecuter {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveTaskExecutionModeExecuter.class);
 
+    private final PropertyWalker propertyWalker;
     private final TaskExecuter executer;
     private final TaskExecutionModeResolver executionModeResolver;
+    private final FileCollectionFactory fileCollectionFactory;
 
-    public ResolveTaskExecutionModeExecuter(TaskExecutionModeResolver executionModeResolver, TaskExecuter executer) {
+    public ResolveTaskExecutionModeExecuter(TaskExecutionModeResolver executionModeResolver, FileCollectionFactory fileCollectionFactory, PropertyWalker propertyWalker, TaskExecuter executer) {
+        this.fileCollectionFactory = fileCollectionFactory;
+        this.propertyWalker = propertyWalker;
         this.executer = executer;
         this.executionModeResolver = executionModeResolver;
     }
@@ -44,13 +52,17 @@ public class ResolveTaskExecutionModeExecuter implements TaskExecuter {
     @Override
     public TaskExecuterResult execute(final TaskInternal task, TaskStateInternal state, final TaskExecutionContext context) {
         Timer clock = Time.startTimer();
-        TaskExecutionMode taskExecutionMode = executionModeResolver.getExecutionMode(task, context.getTaskProperties());
+        TaskProperties properties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
+        context.setTaskProperties(properties);
+        TaskExecutionMode taskExecutionMode = executionModeResolver.getExecutionMode(task, properties);
+
         context.setTaskExecutionMode(taskExecutionMode);
         LOGGER.debug("Putting task artifact state for {} into context took {}.", task, clock.getElapsed());
         try {
             return executer.execute(task, state, context);
         } finally {
             context.setTaskExecutionMode(null);
+            context.setTaskProperties(null);
             LOGGER.debug("Removed task artifact state for {} from context.", task);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -55,7 +55,7 @@ public class DefaultTaskProperties implements TaskProperties {
         String beanName = task.toString();
         GetInputPropertiesVisitor inputPropertiesVisitor = new GetInputPropertiesVisitor();
         GetInputFilesVisitor inputFilesVisitor = new GetInputFilesVisitor(beanName, fileCollectionFactory);
-        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, fileCollectionFactory, true);
+        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, fileCollectionFactory);
         GetLocalStateVisitor localStateVisitor = new GetLocalStateVisitor(beanName, fileCollectionFactory);
         GetDestroyablesVisitor destroyablesVisitor = new GetDestroyablesVisitor(beanName, fileCollectionFactory);
         ValidationVisitor validationVisitor = new ValidationVisitor();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
@@ -28,20 +28,18 @@ public class GetOutputFilesVisitor extends PropertyVisitor.Adapter {
     private final List<OutputFilePropertySpec> specs = Lists.newArrayList();
     private final String ownerDisplayName;
     private final FileCollectionFactory fileCollectionFactory;
-    private final boolean locationOnly;
     private ImmutableSortedSet<OutputFilePropertySpec> fileProperties;
     private boolean hasDeclaredOutputs;
 
-    public GetOutputFilesVisitor(String ownerDisplayName, FileCollectionFactory fileCollectionFactory, boolean locationOnly) {
+    public GetOutputFilesVisitor(String ownerDisplayName, FileCollectionFactory fileCollectionFactory) {
         this.ownerDisplayName = ownerDisplayName;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.locationOnly = locationOnly;
     }
 
     @Override
     public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
         hasDeclaredOutputs = true;
-        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, locationOnly, specs::add);
+        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, false, specs::add);
     }
 
     public ImmutableSortedSet<OutputFilePropertySpec> getFileProperties() {

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
+import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
@@ -117,6 +118,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         ListenerManager listenerManager,
         OutputChangeListener outputChangeListener,
         OutputFilesRepository outputFilesRepository,
+        PropertyWalker propertyWalker,
         ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
         TaskActionListener actionListener,
         TaskCacheabilityResolver taskCacheabilityResolver,
@@ -156,7 +158,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             executer
         );
         executer = new FinalizePropertiesTaskExecuter(executer);
-        executer = new ResolveTaskExecutionModeExecuter(repository, executer);
+        executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, executer);
         executer = new SkipTaskWithNoActionsExecuter(taskExecutionGraph, executer);
         executer = new SkipOnlyIfTaskExecuter(executer);
         executer = new CatchExceptionTaskExecuter(executer);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -36,7 +36,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
                 // This should move earlier in task scheduling, so that a worker thread does not even bother trying to run this task
                 return true;
             }
-            TaskExecutionContext ctx = new DefaultTaskExecutionContext(localTaskNode, localTaskNode.getTaskProperties());
+            TaskExecutionContext ctx = new DefaultTaskExecutionContext(localTaskNode);
             TaskExecuter taskExecuter = context.getService(TaskExecuter.class);
             taskExecuter.execute(task, state, ctx);
             localTaskNode.getPostAction().execute(task);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuterTest.groovy
@@ -16,43 +16,68 @@
 
 package org.gradle.api.internal.tasks.execution
 
+import org.gradle.api.Action
+import org.gradle.api.Task
+import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.TaskExecutionMode
 import org.gradle.api.internal.changedetection.TaskExecutionModeResolver
+import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.TaskDestroyablesInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecuterResult
 import org.gradle.api.internal.tasks.TaskExecutionContext
+import org.gradle.api.internal.tasks.TaskLocalStateInternal
 import org.gradle.api.internal.tasks.TaskStateInternal
-import org.gradle.api.internal.tasks.properties.TaskProperties
+import org.gradle.api.internal.tasks.properties.PropertyWalker
 import spock.lang.Specification
 import spock.lang.Subject
 
 @Subject(ResolveTaskExecutionModeExecuter)
 class ResolveTaskExecutionModeExecuterTest extends Specification {
     final delegate = Mock(TaskExecuter)
-    final taskProperties = Mock(TaskProperties)
+    final outputs = Mock(TaskOutputsInternal)
+    final inputs = Mock(TaskInputsInternal)
+    final destroyables = Stub(TaskDestroyablesInternal)
+    final localState = Stub(TaskLocalStateInternal)
     final task = Mock(TaskInternal)
     final taskState = Mock(TaskStateInternal)
     final taskContext = Mock(TaskExecutionContext)
     final repository = Mock(TaskExecutionModeResolver)
     final executionMode = TaskExecutionMode.INCREMENTAL
+    final fileCollectionFactory = Mock(FileCollectionFactory)
+    final propertyWalker = Mock(PropertyWalker)
+    final project = Mock(ProjectInternal)
+    final Action<Task> action = Mock(Action)
 
-    final executer = new ResolveTaskExecutionModeExecuter(repository, delegate)
+    final executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, delegate)
 
     def 'taskContext is initialized and cleaned as expected'() {
         when:
         executer.execute(task, taskState, taskContext)
 
         then: 'taskContext is initialized with task artifact state'
-        1 * taskContext.taskProperties >> taskProperties
-        1 * repository.getExecutionMode(task, taskProperties) >> executionMode
+        1 * taskContext.setTaskProperties(_)
+        1 * repository.getExecutionMode(task, _) >> executionMode
         1 * taskContext.setTaskExecutionMode(executionMode)
+        1 * task.getOutputs() >> outputs
+        1 * task.getInputs() >> inputs
+        1 * task.getDestroyables() >> destroyables
+        1 * task.getLocalState() >> localState
+        2 * fileCollectionFactory.resolving(_, _) >> Stub(FileCollectionInternal)
+        1 * propertyWalker.visitProperties(task, _, _)
+        1 * inputs.visitRegisteredProperties(_)
+        1 * outputs.visitRegisteredProperties(_)
 
         then: 'delegate is executed'
         1 * delegate.execute(task, taskState, taskContext) >> TaskExecuterResult.WITHOUT_OUTPUTS
 
         then: 'task artifact state is removed from taskContext'
         1 * taskContext.setTaskExecutionMode(null)
+        1 * taskContext.setTaskProperties(null)
 
         and: 'nothing else'
         0 * _

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -18,13 +18,10 @@ package org.gradle.test.fixtures
 
 import org.gradle.api.Task
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
-import org.gradle.api.internal.tasks.properties.DefaultTaskProperties
-import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.execution.ProjectExecutionServices
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -62,7 +59,7 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     }
 
     void execute(Task task) {
-        executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, new DefaultTaskExecutionContext(null, DefaultTaskProperties.resolve(executionServices.get(PropertyWalker), executionServices.get(FileCollectionFactory), task as TaskInternal)))
+        executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, new DefaultTaskExecutionContext(null))
         task.state.rethrowFailure()
     }
 }


### PR DESCRIPTION
This allows the cache fix plugin to continue working with Gradle 6.8.

This reverts commit c9543ead83fc916d3fbf484d5ef9869d05914202.