### PR TITLE
Remove Distribution.baseName

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -338,6 +338,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.distribution.Distribution",
+            "member": "Method org.gradle.api.distribution.Distribution.getBaseName()",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.distribution.Distribution",
+            "member": "Method org.gradle.api.distribution.Distribution.setBaseName(java.lang.String)",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.distribution.Distribution.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.distribution.Distribution.xml
@@ -11,9 +11,6 @@
                 <td>name</td>
             </tr>
             <tr>
-                <td>baseName</td>
-            </tr>
-            <tr>
                 <td>distributionBaseName</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -131,6 +131,8 @@ In Gradle 7.0 we moved the following classes out of incubation phase.
 - org.gradle.api.model.ObjectFactory.fileProperty
 - org.gradle.api.model.ObjectFactory.sourceDirectorySet
 
+- org.gradle.api.distribution.Distribution.getDistributionBaseName()
+
 <!--
 ### Example promoted
 -->

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -74,6 +74,10 @@ Use the `configDirectory` property instead.
 * The `rulePriority` getter and setter have been removed from the Pmd task and extension.
 Use the `rulesMinimumPriority` property instead.
 
+==== Removal of `baseName` property in `distribution` plugin
+
+The `getBaseName()` and `setBaseName()` methods were removed from the `Distribution` class. Clients should replace the usages with the `distributionBaseName` property.
+
 ==== Using `AbstractTask`
 
 Registering a task with the `AbstractTask` type or with a type extending `AbstractTask` was deprecated in Gradle 6.5 and is now an error in Gradle 7.0.

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
@@ -131,7 +131,8 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
 
             distributions {
                 main{
-                    baseName = null
+                    distributionBaseName = null
+                    distributionBaseName.convention(null)
                 }
             }
             """
@@ -140,24 +141,6 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
         executer.noDeprecationChecks()
         runAndFail 'distZip'
         failure.assertHasCause "Cannot query the value of property 'distributionBaseName' because it has no value available."
-    }
-
-    def "emits deprecation warning when baseName property is used"() {
-        given:
-        buildFile << """
-            apply plugin:'java-library-distribution'
-            distributions {
-                main {
-                    baseName = 'sample'
-                }
-            }
-            """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("The Distribution.baseName property has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
-            "Please use the distributionBaseName property instead. " +
-            "See https://docs.gradle.org/current/dsl/org.gradle.api.distribution.Distribution.html#org.gradle.api.distribution.Distribution:baseName for more details.")
-        succeeds 'distZip'
     }
 
     def "compile only dependencies are not included in distribution"() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/Distribution.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/Distribution.java
@@ -17,7 +17,6 @@
 package org.gradle.api.distribution;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.provider.Property;
@@ -41,7 +40,6 @@ public interface Distribution extends Named {
      *
      * @since 6.0
      */
-    @Incubating
     Property<String> getDistributionBaseName();
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/Distribution.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/Distribution.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.file.CopySpec;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.Property;
 
 /**
@@ -33,29 +32,6 @@ public interface Distribution extends Named {
      */
     @Override
     String getName();
-
-    /**
-     * The baseName of the distribution, used in naming the distribution archives.
-     * <p>
-     * If the {@link #getName()} of this distribution is "{@code main}" this defaults to the project's name.
-     * Otherwise it is "{@code $project.name-$this.name}".
-     * </p>
-     *
-     * @deprecated Use #getDistributionBaseName()
-     */
-    @Deprecated
-    @ReplacedBy("distributionBaseName")
-    String getBaseName();
-
-    /**
-     * The baseName of the distribution.
-     * <p>
-     * Set to change the name of the distribution archives.
-     *
-     * @deprecated Use #getDistributionBaseName()
-     */
-    @Deprecated
-    void setBaseName(String baseName);
 
     /**
      * The baseName of the distribution, used in naming the distribution archives.

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/internal/DefaultDistribution.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/internal/DefaultDistribution.java
@@ -18,7 +18,6 @@ package org.gradle.api.distribution.internal;
 import org.gradle.api.Action;
 import org.gradle.api.distribution.Distribution;
 import org.gradle.api.file.CopySpec;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.inject.Inject;
 
@@ -38,19 +37,6 @@ public abstract class DefaultDistribution implements Distribution {
     @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public String getBaseName() {
-        DeprecationLogger.deprecateProperty(Distribution.class, "baseName").replaceWith("distributionBaseName").willBeRemovedInGradle7().withDslReference().nagUser();
-        return getDistributionBaseName().getOrNull();
-    }
-
-    @Override
-    public void setBaseName(String baseName) {
-        DeprecationLogger.deprecateProperty(Distribution.class, "baseName").replaceWith("distributionBaseName").willBeRemovedInGradle7().withDslReference().nagUser();
-        getDistributionBaseName().set(baseName);
-        getDistributionBaseName().convention(baseName);
     }
 
     @Override

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
@@ -37,7 +37,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         def distributions = project.extensions.getByType(DistributionContainer.class)
         def dist = distributions.main
         dist.name == 'main'
-        dist.baseName == 'test-project'
+        dist.distributionBaseName.get() == 'test-project'
     }
 
     def "provides default values for additional distributions"() {
@@ -48,7 +48,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         def distributions = project.extensions.getByType(DistributionContainer.class)
         def dist = distributions.create('custom')
         dist.name == 'custom'
-        dist.baseName == 'test-project-custom'
+        dist.distributionBaseName.get() == 'test-project-custom'
     }
 
     def "adds distZip task for main distribution"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
@@ -146,10 +146,10 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         task.dependsOn.containsAll(["distTar", "distZip"])
     }
 
-    public void "distribution name is configurable"() {
+    def "distribution name is configurable"() {
         when:
         project.pluginManager.apply(DistributionPlugin)
-        project.distributions.main.baseName = "SuperApp";
+        project.distributions.main.distributionBaseName = "SuperApp";
 
         then:
         def distZipTask = project.tasks.distZip

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
@@ -33,7 +33,7 @@ class JavaLibraryDistributionPluginTest extends AbstractProjectBuilderSpec {
         project.plugins.hasPlugin(JavaLibraryPlugin.class)
         project.extensions.getByType(DistributionContainer.class) != null
         project.plugins.hasPlugin(DistributionPlugin.class)
-        project.distributions.main.baseName == project.name
+        project.distributions.main.distributionBaseName.get() == project.name
     }
 
     def "adds distZip task to project"() {


### PR DESCRIPTION
### Summary
- Removed `org.gradle.api.distribution.Distribution.getBaseName()` and `org.gradle.api.distribution.Distribution.setBaseName()`
- Deincubated `org.gradle.api.distribution.Distribution.getDistributionBaseName()`

### Checklist
- [x] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [x] Update the upgrade guide/release notes
- [x] Check User Manual for dangling references and outdated documentation
- [ ] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
