### PR TITLE
Make :core unit tests compatible with Spock 2

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
-import org.junit.Test
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.copy.CopyActionExecuterUtil.visit
@@ -129,7 +128,6 @@ class ZipCopyActionTest extends Specification {
         e.message == "xyz\n\nTo build this archive, please enable the zip64 extension.\nSee: doc url"
     }
 
-    @Test
     void wrapsFailureToAddElement() {
         given:
         Throwable failure = new RuntimeException("broken")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.configuration.ScriptPlugin
 import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.internal.resource.TextUriResourceLoader
-import org.junit.Test
 import spock.lang.Specification
 
 class DefaultObjectConfigurationActionTest extends Specification {
@@ -49,8 +48,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         action.execute()
     }
 
-    @Test
-    public void appliesScriptsToDefaultTargetObject() {
+    void appliesScriptsToDefaultTargetObject() {
         given:
         1 * resolver.resolveUri('script') >> file
         1 * parentCompileScope.createChild("script-$file") >> scriptCompileScope
@@ -64,8 +62,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         action.execute()
     }
 
-    @Test
-    public void appliesScriptsToTargetObjects() {
+    void appliesScriptsToTargetObjects() {
         when:
         Object target1 = new Object()
         Object target2 = new Object()
@@ -83,8 +80,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         action.execute()
     }
 
-    @Test
-    public void flattensCollections() {
+    void flattensCollections() {
         when:
         Object target1 = new Object()
         Object target2 = new Object()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -28,6 +28,8 @@ import org.gradle.internal.work.DefaultWorkerLeaseService
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.Path
 
+import static org.junit.Assert.assertTrue
+
 class DefaultProjectStateRegistryTest extends ConcurrentSpec {
     def workerLeaseService = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), new DefaultParallelismConfiguration(true, 4))
     def parentLease = workerLeaseService.getWorkerLease()
@@ -266,9 +268,9 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
                 def state = registry.stateFor(project("p1"))
                 assert state.hasMutableState()
                 registry.blocking {
-                    assert !state.hasMutableState()
+                    assertTrue !state.hasMutableState()
                 }
-                assert state.hasMutableState()
+                state.hasMutableState()
             }
         }
 
@@ -332,12 +334,12 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
                     assert state1.hasMutableState()
                     assert state2.hasMutableState()
                     registry.allowUncontrolledAccessToAnyProject {
-                        assert state1.hasMutableState()
-                        assert state2.hasMutableState()
+                        assertTrue state1.hasMutableState()
+                        assertTrue state2.hasMutableState()
                     }
                     state1.applyToMutableState {
-                        assert state1.hasMutableState()
-                        assert state2.hasMutableState()
+                        assertTrue state1.hasMutableState()
+                        assertTrue state2.hasMutableState()
                     }
                     assert state1.hasMutableState()
                     assert state2.hasMutableState()
@@ -412,16 +414,16 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
                     assert state1.hasMutableState()
                     assert !state2.hasMutableState()
                     state1.forceAccessToMutableState {
-                        assert state1.hasMutableState()
-                        assert !state2.hasMutableState()
+                        assertTrue state1.hasMutableState()
+                        assertTrue !state2.hasMutableState()
                     }
                     state1.applyToMutableState {
-                        assert state1.hasMutableState()
-                        assert !state2.hasMutableState()
+                        assertTrue state1.hasMutableState()
+                        assertTrue !state2.hasMutableState()
                     }
                     state2.applyToMutableState {
-                        assert state1.hasMutableState()
-                        assert state2.hasMutableState()
+                        assertTrue state1.hasMutableState()
+                        assertTrue state2.hasMutableState()
                     }
                     assert state1.hasMutableState()
                     assert !state2.hasMutableState()
@@ -661,4 +663,5 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
             workerLeaseService.withLocks([parentLease.createChild()], closure)
         }
     }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -208,7 +208,6 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         interaction {
             0 * action1._
             0 * action2._
-            0 * executionContext._
             0 * standardOutputCapture._
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -33,7 +33,7 @@ class BuildLayoutFactoryTest extends Specification {
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Unroll
-    def "returns current directory when it contains a #settingsFilename file when script languages #extensions"() {
+    def "returns current directory when it contains a #settingsFilename file when script languages"() {
         given:
         def locator = buildLayoutFactoryFor()
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
@@ -43,7 +43,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
         buildOperationListenerManager = Mock(BuildOperationListenerManager)
 
         when:
-        def bridge = bridge()
+        def bridge = createOrGetBridge()
         bridge.valve.start()
 
         then:
@@ -62,7 +62,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "does not allow duplicate registration"() {
         when:
-        def bridge = bridge()
+        def bridge = createOrGetBridge()
         bridge.valve.start()
         bridge.register(listener)
         bridge.register(listener)
@@ -73,7 +73,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "can register again after resetting valve"() {
         when:
-        def bridge = bridge()
+        def bridge = createOrGetBridge()
         bridge.valve.start()
         bridge.register(listener)
         bridge.valve.stop()
@@ -94,7 +94,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "passes recorded events to listeners registering"() {
         def d1 = d(1, null, 1)
-        def bridge = bridge()
+        def bridge = createOrGetBridge()
         bridge.valve.start()
 
         when:
@@ -115,7 +115,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
         def d2 = d(2, null, null)
         def d3 = d(3, null, 3)
         def e1 = new Exception()
-        bridge().valve.start()
+        createOrGetBridge().valve.start()
         register(listener)
 
         // operation with details and non null result
@@ -208,7 +208,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "parentId is of last parent that a notification was sent for"() {
         given:
-        bridge().valve.start()
+        createOrGetBridge().valve.start()
         register(listener)
         def d1 = d(1, null, 1)
         def d2 = d(2, 1, null)
@@ -295,7 +295,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "emits progress events"() {
         given:
-        bridge().valve.start()
+        createOrGetBridge().valve.start()
         register(listener)
         def d1 = d(1, null, 1)
         def d2 = d(2, 1, null)
@@ -358,10 +358,10 @@ class BuildOperationNotificationBridgeTest extends Specification {
     }
 
     void register(BuildOperationNotificationListener listener) {
-        bridge().register(listener)
+        createOrGetBridge().register(listener)
     }
 
-    BuildOperationNotificationBridge bridge() {
+    BuildOperationNotificationBridge createOrGetBridge() {
         if (bridgeInstance == null) {
             bridgeInstance = new BuildOperationNotificationBridge(buildOperationListenerManager, listenerManager)
         } else {

--- a/subprojects/core/src/test/groovy/org/gradle/util/StdinSwapperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/StdinSwapperTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.gradle.util
 
-import spock.lang.*
-import java.util.concurrent.Callable
+import spock.lang.Specification
 
 class StdinSwapperTest extends Specification {
 
@@ -25,7 +24,7 @@ class StdinSwapperTest extends Specification {
         def text = "abc"
 
         expect:
-        new StdinSwapper().swap(new ByteArrayInputStream("abc".bytes), { System.in.text } as Callable)  == text
+        new StdinSwapper().swap(new ByteArrayInputStream("abc".bytes), { System.in.text })  == text
     }
 
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/ports/FixedAvailablePortAllocatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/ports/FixedAvailablePortAllocatorTest.groovy
@@ -21,7 +21,7 @@ import spock.lang.Unroll
 class FixedAvailablePortAllocatorTest extends AbstractPortAllocatorTest {
 
     @Unroll
-    def "assigns a unique fixed port range based on worker id (maxForks: #maxForks, totalAgents: #totalAgents)" () {
+    def "assigns a unique fixed port range based on worker id (totalWorkers: #totalWorkers, totalAgents: #totalAgents)" () {
         int rangeSize = FixedAvailablePortAllocator.DEFAULT_RANGE_SIZE - 1
         def portAllocators = (1..totalAgents).collect { agentNum ->
             (1..totalWorkers).collect { workerId ->


### PR DESCRIPTION
Update unit tests in `:core` project to be compatible with Spock 2.
This involves:
- removing leftover `@Test` annotations from test classes converted to Spock that are executed with Spock. Those are ignored with current version of Spock, but become an error in Spock 2.
- Fixing unrolled methods that have incorrect `#template` arguments in their names
- Working around the bug with nested assertions: https://github.com/spockframework/spock/issues/1232
- Not verifying stub interactions
- Fixing field/method name clashes that fail to compile with Spock 2