### PR TITLE
Remove deprecated methods from BasePluginConvention

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -427,6 +427,38 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getDistsDir()",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getLibsDir()",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getProject()",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.setProject(org.gradle.api.internal.project.ProjectInternal)",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.BasePluginConvention.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.BasePluginConvention.xml
@@ -9,20 +9,12 @@
                 </tr>
             </thead>
             <tr>
-                <td>distsDir</td>
-                <td><literal><replaceable>${project.buildDir}</replaceable>/<replaceable>${project.distsDirName}</replaceable></literal></td>
-            </tr>
-            <tr>
                 <td>distsDirectory</td>
                 <td><literal><replaceable>${project.buildDir}</replaceable>/<replaceable>${project.distsDirName}</replaceable></literal></td>
             </tr>
             <tr>
                 <td>distsDirName</td>
                 <td><literal>'distributions'</literal></td>
-            </tr>
-            <tr>
-                <td>libsDir</td>
-                <td><literal><replaceable>${project.buildDir}</replaceable>/<replaceable>${project.libsDirName}</replaceable></literal></td>
             </tr>
             <tr>
                 <td>libsDirectory</td>

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -73,6 +73,10 @@ The `layout` method taking a configuration block has been removed and is replace
 
 Please use `ObjectFactory#fileCollection()` instead.
 
+==== Removal of `BasePluginConvention.libsDir` and `BasePluginConvention.distsDir`
+
+Please use the the `libsDirectory` and `distsDirectory` properties instead.
+
 ==== Removal of `UnableToDeleteFileException`
 
 Existing usages should be replaced with `RuntimeException`.

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -47,7 +47,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
 </application>
 """
 
-    def appliesBasePluginAndAddsConvention() {
+    def "applies base plugin and adds convention"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -56,7 +56,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         project.convention.plugins.ear instanceof EarPluginConvention
     }
 
-    def createsConfigurations() {
+    def "creates configurations"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -75,7 +75,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         configuration.transitive
     }
 
-    def addsTasks() {
+    def "adds tasks"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -84,7 +84,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task instanceof Ear
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
 
         when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
@@ -93,7 +93,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         task dependsOn(EarPlugin.EAR_TASK_NAME)
     }
 
-    def addsTasksToJavaProject() {
+    def "adds tasks to java project"() {
         when:
         project.pluginManager.apply(JavaPlugin.class)
         project.pluginManager.apply(EarPlugin)
@@ -104,7 +104,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         then:
         task instanceof Ear
         task dependsOn(JavaPlugin.CLASSES_TASK_NAME)
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
 
         when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
@@ -113,7 +113,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         task dependsOn(EarPlugin.EAR_TASK_NAME)
     }
 
-    def dependsOnEarlibConfig() {
+    def "depends on earlib config"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -133,7 +133,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         task.taskDependencies.getDependencies(task)*.path.contains(':child:jar')
     }
 
-    def appliesMappingsToArchiveTasks() {
+    def "applies mappings to archive tasks"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -141,10 +141,10 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
     }
 
-    def worksWithJavaBasePluginAppliedBeforeEarPlugin() {
+    def "works with java base plugin applied before ear plugin"() {
         when:
         project.pluginManager.apply(JavaBasePlugin.class)
         project.pluginManager.apply(EarPlugin)
@@ -153,10 +153,10 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
     }
 
-    def appliesMappingsToArchiveTasksForJavaProject() {
+    def "applies mappings to archive tasks for java project"() {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(JavaPlugin.class)
@@ -165,11 +165,11 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
         task dependsOn(hasItems(JavaPlugin.CLASSES_TASK_NAME))
     }
 
-    def addsEarAsPublication() {
+    def "adds ear as publication"() {
         when:
         project.pluginManager.apply(EarPlugin)
 
@@ -181,7 +181,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         archiveConfiguration.getAllArtifacts().iterator().next().getType() == "ear"
     }
 
-    def replacesWarAsPublication() {
+    def "replaces war as publication"() {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(WarPlugin)
@@ -194,7 +194,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         archiveConfiguration.getAllArtifacts().iterator().next().getType() == "ear"
     }
 
-    def replacesJarAsPublication() {
+    def "replaces jar as publication"() {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(JavaPlugin)
@@ -207,7 +207,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         archiveConfiguration.getAllArtifacts().iterator().next().getType() == "ear"
     }
 
-    def supportsAppDir() {
+    def "supports app dir"() {
         given:
         project.file("src/main/application/META-INF").mkdirs()
         project.file("src/main/application/META-INF/test.txt").createNewFile()
@@ -224,7 +224,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "META-INF/test.txt"
     }
 
-    def supportsRenamedAppDir() {
+    def "supports renamed app dir"() {
         given:
         project.file("src/main/myapp").mkdirs()
         project.file("src/main/myapp/test.txt").createNewFile()
@@ -240,7 +240,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "test.txt"
     }
 
-    def supportsRenamingLibDir() {
+    def "supports renaming lib dir"() {
         given:
         def childProject = TestUtil.createChildProject(project, 'child')
         childProject.file("src/main/resources").mkdirs()
@@ -261,7 +261,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "APP-INF/lib/child.jar"
     }
 
-    def supportsDuplicateDependencies() {
+    def "supports duplicate dependencies"() {
         given:
         def pojoProject = TestUtil.createChildProject(project, 'pojo')
         pojoProject.pluginManager.apply(JavaPlugin)
@@ -288,7 +288,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         notInEar "lib/bean.jar"
     }
 
-    def supportsGeneratingDeploymentDescriptor() {
+    def "supports generating deployment descriptor"() {
         when:
         project.pluginManager.apply(EarPlugin)
         executeWithDependencies project.tasks[EarPlugin.EAR_TASK_NAME]
@@ -297,7 +297,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "META-INF/application.xml"
     }
 
-    def supportsSkippingDeploymentDescriptorCreation() {
+    def "supports skipping deployment descriptor creation"() {
         when:
         project.pluginManager.apply(EarPlugin)
         project.convention.plugins.ear.generateDeploymentDescriptor = false
@@ -307,7 +307,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         notInEar "META-INF/application.xml"
     }
 
-    def avoidsOverwritingDeploymentDescriptor() {
+    def "avoids overwriting deployment descriptor"() {
         given:
         project.file("src/main/application/META-INF").mkdirs()
         project.file("src/main/application/META-INF/application.xml").text = TEST_APP_XML
@@ -320,7 +320,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar("META-INF/application.xml").text == TEST_APP_XML
     }
 
-    def supportsRenamingDeploymentDescriptor() {
+    def "supports renaming deployment descriptor"() {
         when:
         project.pluginManager.apply(EarPlugin)
         project.convention.plugins.ear.deploymentDescriptor {
@@ -332,7 +332,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "META-INF/myapp.xml"
     }
 
-    def avoidsOverwritingRenamedDeploymentDescriptor() {
+    def "avoids overwriting renamed deployment descriptor"() {
         given:
         project.file("src/main/application/META-INF").mkdirs()
         project.file("src/main/application/META-INF/myapp.xml").text = TEST_APP_XML

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
@@ -17,26 +17,11 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.project.ProjectInternal;
-
-import java.io.File;
 
 /**
  * <p>A {@link Convention} used for the BasePlugin.</p>
  */
 public abstract class BasePluginConvention {
-    /**
-     * Returns the directory to generate TAR and ZIP archives into.
-     *
-     * <p>
-     * This property has been replaced by distsDirectory.
-     * </p>
-     *
-     * @return The directory. Never returns null.
-     */
-    @Deprecated
-    public abstract File getDistsDir();
-
     /**
      * Returns the directory to generate TAR and ZIP archives into.
      *
@@ -49,29 +34,11 @@ public abstract class BasePluginConvention {
     /**
      * Returns the directory to generate JAR and WAR archives into.
      *
-     * <p>
-     * This property has been replaced by libsDirectory.
-     * </p>
-     *
-     * @return The directory. Never returns null.
-     */
-    @Deprecated
-    public abstract File getLibsDir();
-
-    /**
-     * Returns the directory to generate JAR and WAR archives into.
-     *
      * @return The directory. Never returns null.
      *
      * @since 6.0
      */
     public abstract DirectoryProperty getLibsDirectory();
-
-    @Deprecated
-    public abstract ProjectInternal getProject();
-
-    @Deprecated
-    public abstract void setProject(ProjectInternal project);
 
     /**
      * The name for the distributions directory. This in interpreted relative to the project' build directory.

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
@@ -18,13 +18,9 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
-import org.gradle.internal.deprecation.DeprecationLogger;
-
-import java.io.File;
 
 import static org.gradle.api.reflect.TypeOf.typeOf;
 
@@ -33,14 +29,11 @@ public class DefaultBasePluginConvention extends BasePluginConvention implements
     private final DirectoryProperty distsDirectory;
     private final DirectoryProperty libsDirectory;
 
-    private ProjectInternal project;
-
     private String distsDirName;
     private String libsDirName;
     private String archivesBaseName;
 
     public DefaultBasePluginConvention(Project project) {
-        this.project = (ProjectInternal) project;
         this.buildDirectory = project.getLayout().getBuildDirectory();
         this.archivesBaseName = project.getName();
 
@@ -59,45 +52,13 @@ public class DefaultBasePluginConvention extends BasePluginConvention implements
     }
 
     @Override
-    @Deprecated
-    public File getDistsDir() {
-        DeprecationLogger.deprecateProperty(Project.class, "distsDir").replaceWith("distsDirectory").willBeRemovedInGradle7().withDslReference().nagUser();
-        return getDistsDirectory().get().getAsFile();
-    }
-
-    @Override
     public DirectoryProperty getDistsDirectory() {
         return distsDirectory;
     }
 
     @Override
-    @Deprecated
-    public File getLibsDir() {
-        DeprecationLogger.deprecateProperty(Project.class, "libsDir").replaceWith("libsDirectory").willBeRemovedInGradle7().withDslReference().nagUser();
-        return getLibsDirectory().get().getAsFile();
-    }
-
-    @Override
     public DirectoryProperty getLibsDirectory() {
         return libsDirectory;
-    }
-
-    @Override
-    public ProjectInternal getProject() {
-        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "getProject()")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(6, "discontinued_methods")
-            .nagUser();
-        return project;
-    }
-
-    @Override
-    public void setProject(ProjectInternal project) {
-        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "setProject()")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(6, "discontinued_methods")
-            .nagUser();
-        this.project = project;
     }
 
     @Override

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.instanceOf
 
 class BasePluginTest extends AbstractProjectBuilderSpec {
 
-    public void addsConventionObjects() {
+    def "adds convention objects"() {
         when:
         project.pluginManager.apply(BasePlugin)
 
@@ -42,7 +42,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         project.extensions.findByType(DefaultArtifactPublicationSet) != null
     }
 
-    public void createsTasksAndAppliesMappings() {
+    def "creates tasks and applies mappings"() {
         when:
         project.pluginManager.apply(BasePlugin)
 
@@ -57,7 +57,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         assemble instanceOf(DefaultTask)
     }
 
-    public void assembleTaskBuildsThePublishedArtifacts() {
+    def "assemble task builds the published artifacts"() {
         given:
         def someJar = project.tasks.create('someJar', Jar)
 
@@ -70,7 +70,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         assemble dependsOn('someJar')
     }
 
-    public void addsRulesWhenAConfigurationIsAdded() {
+    def "adds rules when a configuration is added"() {
         when:
         project.pluginManager.apply(BasePlugin)
 
@@ -78,7 +78,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         !project.tasks.rules.empty
     }
 
-    public void addsImplicitTasksForConfiguration() {
+    def "adds implicit tasks for configuration"() {
         given:
         def someJar = project.tasks.create('someJar', Jar)
 
@@ -112,7 +112,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         uploadConf.configuration == project.configurations.conf
     }
 
-    public void addsACleanRule() {
+    def "adds a clean rule"() {
         given:
         Task test = project.task('test')
         test.outputs.dir(project.buildDir)
@@ -126,7 +126,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         cleanTest.delete == [test.outputs.files] as Set
     }
 
-    public void cleanRuleIsCaseSensitive() {
+    def "clean rule is case sensitive"() {
         given:
         project.task('testTask')
         project.task('12')
@@ -141,31 +141,31 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName('clean12') instanceof Delete
     }
 
-    public void appliesMappingsForArchiveTasks() {
+    def "applies mappings for archive tasks"() {
         when:
         project.pluginManager.apply(BasePlugin)
         project.version = '1.0'
 
         then:
         def someJar = project.tasks.create('someJar', Jar)
-        someJar.destinationDir == project.libsDir
+        someJar.destinationDir == project.libsDirectory.get().asFile
         someJar.version == project.version
         someJar.baseName == project.archivesBaseName
 
         and:
         def someZip = project.tasks.create('someZip', Zip)
-        someZip.destinationDir == project.distsDir
+        someZip.destinationDir == project.distsDirectory.get().asFile
         someZip.version == project.version
         someZip.baseName == project.archivesBaseName
 
         and:
         def someTar = project.tasks.create('someTar', Tar)
-        someTar.destinationDir == project.distsDir
+        someTar.destinationDir == project.distsDirectory.get().asFile
         someTar.version == project.version
         someTar.baseName == project.archivesBaseName
     }
 
-    public void usesNullVersionWhenProjectVersionNotSpecified() {
+    def "uses null version when project version not specified"() {
         when:
         project.pluginManager.apply(BasePlugin)
 
@@ -180,7 +180,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         task.version == '1.0'
     }
 
-    public void addsConfigurationsToTheProject() {
+    def "adds configurations to the project"() {
         when:
         project.pluginManager.apply(BasePlugin)
 
@@ -197,7 +197,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         archives.transitive
     }
 
-    public void addsEveryPublishedArtifactToTheArchivesConfiguration() {
+    def "adds every published artifact to the archives configuration"() {
         PublishArtifact artifact = Mock()
 
         when:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
@@ -31,40 +31,39 @@ class DefaultBasePluginConventionTest {
     public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     private ProjectInternal project = TestUtil.create(temporaryFolder).rootProject()
-    private File testDir = project.projectDir
     private BasePluginConvention convention
 
-    @Before public void setUp() {
+    @Before void setUp() {
         convention = new DefaultBasePluginConvention(project)
     }
 
-    @Test public void defaultValues() {
+    @Test void defaultValues() {
         assertEquals(project.name, convention.archivesBaseName)
         assertEquals('distributions', convention.distsDirName)
-        assertEquals(new File(project.buildDir, 'distributions'), convention.distsDir)
+        assertEquals(new File(project.buildDir, 'distributions'), convention.distsDirectory.getAsFile().get())
         assertEquals('libs', convention.libsDirName)
-        assertEquals(new File(project.buildDir, 'libs'), convention.libsDir)
+        assertEquals(new File(project.buildDir, 'libs'), convention.libsDirectory.getAsFile().get())
     }
 
-    @Test public void dirsRelativeToBuildDir() {
+    @Test void dirsRelativeToBuildDir() {
         project.buildDir = project.file('mybuild')
         convention.distsDirName = 'mydists'
-        assertEquals(project.file('mybuild/mydists'), convention.distsDir)
+        assertEquals(project.file('mybuild/mydists'), convention.distsDirectory.getAsFile().get())
         convention.libsDirName = 'mylibs'
-        assertEquals(project.file('mybuild/mylibs'), convention.libsDir)
+        assertEquals(project.file('mybuild/mylibs'), convention.libsDirectory.getAsFile().get())
     }
 
-    @Test public void dirsAreCachedProperly() {
+    @Test void dirsAreCachedProperly() {
         project.buildDir = project.file('mybuild')
         convention.distsDirName = 'mydists'
-        assertEquals(project.file('mybuild/mydists'), convention.distsDir)
+        assertEquals(project.file('mybuild/mydists'), convention.distsDirectory.getAsFile().get())
         convention.libsDirName = 'mylibs'
-        assertEquals(project.file('mybuild/mylibs'), convention.libsDir)
+        assertEquals(project.file('mybuild/mylibs'), convention.libsDirectory.getAsFile().get())
         convention.distsDirName = 'mydists2'
-        assertEquals(project.file('mybuild/mydists2'), convention.distsDir)
+        assertEquals(project.file('mybuild/mydists2'), convention.distsDirectory.getAsFile().get())
         convention.libsDirName = 'mylibs2'
-        assertEquals(project.file('mybuild/mylibs2'), convention.libsDir)
+        assertEquals(project.file('mybuild/mylibs2'), convention.libsDirectory.getAsFile().get())
         project.buildDir = project.file('mybuild2')
-        assertEquals(project.file('mybuild2/mylibs2'), convention.libsDir)
+        assertEquals(project.file('mybuild2/mylibs2'), convention.libsDirectory.getAsFile().get())
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -58,7 +58,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     @Rule
     public SetSystemProperties sysProperties = new SetSystemProperties()
 
-    void "applies base plugins and adds convention and extensions"() {
+    def "applies base plugins and adds convention and extensions"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -72,7 +72,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.extensions.javaInstalls instanceof JavaInstallationRegistry
     }
 
-    void "sourceSets extension is exposed as SourceSetContainer"() {
+    def "sourceSets extension is exposed as SourceSetContainer"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -80,7 +80,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.extensions.extensionsSchema.find { it.name == "sourceSets" }.publicType == typeOf(SourceSetContainer)
     }
 
-    void "properties on convention and extension are synchronized"() {
+    def "properties on convention and extension are synchronized"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -128,7 +128,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         ext.targetCompatibility == JavaVersion.VERSION_1_6
     }
 
-    void "creates tasks and applies mappings for source set"() {
+    def "creates tasks and applies mappings for source set"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         project.sourceSets.create('custom')
@@ -168,7 +168,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         TaskDependencyMatchers.builtBy('customClasses').matches(project.sourceSets.custom.output)
     }
 
-    void "creates tasks and applies mappings for main source set"() {
+    def "creates tasks and applies mappings for main source set"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         project.sourceSets.create('main')
@@ -194,7 +194,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         TaskDependencyMatchers.dependsOn('processResources', 'compileJava').matches(classes)
     }
 
-    void "wires generated resources task into classes task for sourceset"() {
+    def "wires generated resources task into classes task for sourceset"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         project.sourceSets.create('custom')
@@ -208,7 +208,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         TaskDependencyMatchers.dependsOn('someTask', 'processCustomResources', 'compileCustomJava').matches(customClasses)
     }
 
-    void "wires toolchain for sourceset if toolchain is configured"() {
+    def "wires toolchain for sourceset if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
@@ -222,7 +222,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredToolchain.displayName.contains(someJdk.javaVersion.getMajorVersion())
     }
 
-    void "source and target compatibility are configured if toolchain is configured"() {
+    def "source and target compatibility are configured if toolchain is configured"() {
         given:
         setupProjectWithToolchain(Jvm.current().javaVersion)
 
@@ -236,7 +236,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.tasks.compileCustomJava.getTargetCompatibility() == Jvm.current().javaVersion.majorVersion
     }
 
-    void "wires toolchain for test if toolchain is configured"() {
+    def "wires toolchain for test if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
@@ -249,7 +249,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredJavaLauncher.executablePath.toString().contains(someJdk.javaVersion.getMajorVersion())
     }
 
-    void "wires toolchain for javadoc if toolchain is configured"() {
+    def "wires toolchain for javadoc if toolchain is configured"() {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
@@ -262,7 +262,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         configuredJavadocTool.isPresent()
     }
 
-    void 'cannot set java compile source compatibility if toolchain is configured'() {
+    def 'cannot set java compile source compatibility if toolchain is configured'() {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
@@ -286,7 +286,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         ((DefaultProject) project).getServices().get(GradlePropertiesController.class).loadGradlePropertiesFrom(project.projectDir)
     }
 
-    void tasksReflectChangesToSourceSetConfiguration() {
+    def "tasks reflect changes to source set configuration"() {
         def classesDir = project.file('target/classes')
         def resourcesDir = project.file('target/resources')
 
@@ -304,7 +304,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         compileJava.destinationDir == classesDir
     }
 
-    void sourceSetReflectChangesToTasksConfiguration() {
+    def "sourceSet reflect changes to tasks configuration"() {
         def generatedSourcesDir = project.file('target/generated-sources')
 
         when:
@@ -317,7 +317,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.sourceSets.custom.output.generatedSourcesDirs.files == toLinkedSet(generatedSourcesDir)
     }
 
-    void createsConfigurationsForNewSourceSet() {
+    def "creates configurations for new sourceSet"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         def sourceSet = project.sourceSets.create('custom')
@@ -369,7 +369,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         sourceSetRuntimeClasspath sameCollection(sourceSet.output + runtimeClasspath)
     }
 
-    void appliesMappingsToTasksDefinedByBuildScript() {
+    def "applies mappings to tasks defined by build script"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -389,17 +389,17 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         javadoc.title == project.extensions.getByType(ReportingExtension).apiDocTitle
     }
 
-    void appliesMappingsToCustomJarTasks() {
+    def "applies mappings to custom jar tasks"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         def task = project.task('customJar', type: Jar)
 
         then:
         TaskDependencyMatchers.dependsOn().matches(task)
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
     }
 
-    void createsLifecycleBuildTasks() {
+    def "creates lifecycle build tasks"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -497,7 +497,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     }
 
     @Unroll
-    void "check Java usage compatibility rules (consumer value=#consumer, producer value=#producer, compatible=#compatible)"() {
+    def "check Java usage compatibility rules (consumer value=#consumer, producer value=#producer, compatible=#compatible)"() {
         given:
         JavaEcosystemSupport.UsageCompatibilityRules rules = new JavaEcosystemSupport.UsageCompatibilityRules()
         def details = Mock(CompatibilityCheckDetails)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -35,7 +35,7 @@ import static org.gradle.util.WrapUtil.toLinkedSet
 import static org.gradle.util.WrapUtil.toSet
 
 class JavaPluginTest extends AbstractProjectBuilderSpec {
-    def addsConfigurationsToTheProject() {
+    def "adds configurations to the project"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -175,7 +175,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         defaultConfig.extendsFrom == toSet()
     }
 
-    def addsJarAsPublication() {
+    def "adds jar as publication"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -186,7 +186,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         archivesConfiguration.artifacts.collect { it.file } == [project.tasks.getByName(JavaPlugin.JAR_TASK_NAME).archivePath]
     }
 
-    def addsJavaLibraryComponent() {
+    def "adds java library component"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -200,7 +200,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         runtime.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies
     }
 
-    def createsStandardSourceSetsAndAppliesMappings() {
+    def "creates standard source sets and applies mappings"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -239,7 +239,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/java/test'))
     }
 
-    def createsMappingsForCustomSourceSets() {
+    def "creates mappings for custom source sets"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -258,7 +258,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         Assert.assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntimeClasspath))
     }
 
-    def createsStandardTasksAndAppliesMappings() {
+    def "creates standard tasks and applies mappings"() {
         given:
         project.pluginManager.apply(JavaPlugin)
         new TestFile(project.file("src/main/java/File.java")) << "foo"
@@ -332,7 +332,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         then:
         task instanceof Jar
         task dependsOn(JavaPlugin.CLASSES_TASK_NAME)
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
         task.mainSpec.sourcePaths == [project.sourceSets.main.output] as Set
         task.manifest != null
         task.manifest.mergeSpecs.size() == 0
@@ -407,7 +407,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.workingDir == project.projectDir
     }
 
-    def appliesMappingsToTasksAddedByTheBuildScript() {
+    def "applies mappings to tasks added by the build script"() {
         given:
         project.pluginManager.apply(JavaPlugin)
 
@@ -422,7 +422,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.reports.html.destination == new File(project.testReportDir, 'customTest')
     }
 
-    def buildOtherProjects() {
+    def "build other projects"() {
         given:
         def commonProject = TestUtil.createChildProject(project, "common")
         def middleProject = TestUtil.createChildProject(project, "middle")
@@ -454,7 +454,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.taskDependencies.getDependencies(task)*.path as Set == [':middle:build', ':app:buildDependents'] as Set
     }
 
-    def buildOtherProjectsWithCyclicDependencies() {
+    def "build other projects with cyclic dependencies"() {
         given:
         def commonProject = TestUtil.createChildProject(project, "common")
         def middleProject = TestUtil.createChildProject(project, "middle")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -64,7 +64,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
         task instanceof War
         dependsOn(JavaPlugin.CLASSES_TASK_NAME).matches(task)
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
 
         when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
@@ -120,7 +120,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         dependsOn(JavaPlugin.CLASSES_TASK_NAME).matches(task)
-        task.destinationDir == project.libsDir
+        task.destinationDir == project.libsDirectory.get().asFile
     }
 
     def "replaces jar as publication"() {


### PR DESCRIPTION
### Checklist
- [x] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [x] Update the upgrade guide
- [x] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 