### PR TITLE
Update Kotlin DSL Gradle plugin to 2.0.0

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -12,6 +12,6 @@ kotlinDslPluginOptions.experimentalWarning.set(false)
 dependencies {
     implementation(project(":code-quality"))
 
-    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:1.4.9")
+    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.0.0")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.6.0")
 }

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -38,10 +38,6 @@ dependencies {
     implementation("gradlebuild:code-quality")
 }
 
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-
 ktlint {
     filter {
         exclude("gradle/kotlin/dsl/accessors/_*/**")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.8-20201204050948+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20201214165340+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
And remove the usage of now deprecated `kotlinDslPluginOptions.experimentalWarning`.

A follow-up to #15460.