### PR TITLE
Correct cache version mapping

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -40,7 +40,7 @@ import static org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup.DEFAULT_MA
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class DefaultClasspathTransformerCacheFactory implements ClasspathTransformerCacheFactory {
-    private static final CacheVersionMapping CACHE_VERSION_MAPPING = introducedIn("3.1-rc-1")
+    private static final CacheVersionMapping CACHE_VERSION_MAPPING = introducedIn("2.2")
         .incrementedIn("3.2-rc-1")
         .incrementedIn("3.5-rc-1")
         .changedTo(8, "6.5-rc-1")


### PR DESCRIPTION
Because `jars-1` cache is actually introduced in Gradle 2.2.

This seems to be the cause of https://github.com/gradle/gradle-private/issues/3230