### PR TITLE
`ktlintKotlinScriptCheck` should only check the build files

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
 import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -46,6 +47,11 @@ ktlint {
     filter {
         exclude("gradle/kotlin/dsl/accessors/_*/**")
     }
+}
+
+tasks.named<KtlintCheckTask>("ktlintKotlinScriptCheck") {
+    // Only check the build files, not all *.kts files in the project
+    setSource(files("build.gradle.kts", "settings.gradle.kts"))
 }
 
 tasks.validatePlugins {

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
 import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -49,7 +48,7 @@ ktlint {
     }
 }
 
-tasks.named<KtlintCheckTask>("ktlintKotlinScriptCheck") {
+tasks.ktlintKotlinScriptCheck {
     // Only check the build files, not all *.kts files in the project
     setSource(files("build.gradle.kts", "settings.gradle.kts"))
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-import org.gradle.api.internal.initialization.DefaultClassLoaderScope
-
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
-
 import gradlebuild.basics.accessors.kotlin
+import org.gradle.api.internal.initialization.DefaultClassLoaderScope
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
 
 
 plugins {
@@ -50,6 +47,11 @@ tasks {
 
     named("codeQuality") {
         dependsOn(ktlintCheckTasks)
+    }
+
+    tasks.named<KtlintCheckTask>("ktlintKotlinScriptCheck") {
+        // Only check the build files, not all *.kts files in the project
+        setSource(files("build.gradle.kts", "settings.gradle.kts"))
     }
 
     withType<Test>().configureEach {

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -49,7 +49,7 @@ tasks {
         dependsOn(ktlintCheckTasks)
     }
 
-    tasks.named<KtlintCheckTask>("ktlintKotlinScriptCheck") {
+    ktlintKotlinScriptCheck {
         // Only check the build files, not all *.kts files in the project
         setSource(files("build.gradle.kts", "settings.gradle.kts"))
     }


### PR DESCRIPTION
And not all the *.kts files in the project directory. Checking all
those would mean that the check can't run in parallel with any other
task which produces anything in the project. It also made the task
fail, since we detected missing dependencies between this task
and any other task in the same build.