### PR TITLE
Fix source of consistent resolution being eagerly resolved

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -225,6 +225,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         }
     }
 
+    @ToBeFixedForConfigurationCache(because="exception doesn't seem to be recognized by configuration cache")
     def "detects cycles in consistency"() {
         repository {
             'org:foo:1.0'()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import spock.lang.Issue
 
 // Limit the combinations of tests since we're only interested in the consistency
 // behavior, not actual metadata
@@ -296,4 +297,57 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
         }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/15588")
+    def "shouldn't resolve source configuration during task dependency resolution phase"() {
+        repository {
+            'org:foo:1.1'()
+        }
+
+        buildFile << """
+            configurations {
+                other
+                conf.shouldResolveConsistentlyWith(other)
+            }
+
+            dependencies {
+                conf 'org:foo:1.0'
+                other 'org:foo:1.1'
+            }
+        """
+        withEagerResolutionPrevention()
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.1' {
+                expectResolve()
+            }
+        }
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:foo:1.0', 'org:foo:1.1') {
+                    byConsistentResolution('other')
+                }
+                constraint("org:foo:{strictly 1.1}", "org:foo:1.1")
+            }
+        }
+    }
+
+    void withEagerResolutionPrevention() {
+        buildFile << """
+            def beforeTaskExecutionPhase = true
+            gradle.taskGraph.whenReady {
+                beforeTaskExecutionPhase = false
+            }
+            project.configurations.all {
+                it.incoming.beforeResolve { configuration ->
+                    if (beforeTaskExecutionPhase) {
+                        throw new RuntimeException("Configuration \${configuration.name} is being resolved before task execution phase.")
+                    }
+                }
+            }
+        """
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
@@ -33,5 +33,6 @@ public interface ArtifactDependencyResolver {
                  DependencyGraphVisitor graphVisitor,
                  DependencyArtifactsVisitor artifactsVisitor,
                  AttributesSchemaInternal consumerSchema,
-                 ArtifactTypeRegistry artifactTypeRegistry);
+                 ArtifactTypeRegistry artifactTypeRegistry,
+                 boolean includeSyntheticDependencies);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -133,7 +133,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         InMemoryResolutionResultBuilder resolutionResultBuilder = new InMemoryResolutionResultBuilder();
         CompositeDependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(failureCollector, resolutionResultBuilder);
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, resolutionStrategy.getSortOrder());
-        resolver.resolve(configuration, ImmutableList.of(), metadataHandler, IS_LOCAL_EDGE, graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry);
+        resolver.resolve(configuration, ImmutableList.of(), metadataHandler, IS_LOCAL_EDGE, graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry, false);
         result.graphResolved(resolutionResultBuilder.getResolutionResult(), new ResolvedLocalComponentsResultGraphVisitor(currentBuild), new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.emptySet()), artifactsVisitor.complete(), artifactTransforms, configuration.getDependenciesResolver()));
     }
 
@@ -175,7 +175,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ImmutableList<DependencyArtifactsVisitor> allVisitors = visitors.build();
         CompositeDependencyArtifactsVisitor artifactsVisitor = new CompositeDependencyArtifactsVisitor(allVisitors);
 
-        resolver.resolve(configuration, resolutionAwareRepositories, metadataHandler, Specs.satisfyAll(), graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry);
+        resolver.resolve(configuration, resolutionAwareRepositories, metadataHandler, Specs.satisfyAll(), graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry, true);
 
         VisitedArtifactsResults artifactsResults = artifactsBuilder.complete();
         VisitedFileDependencyResults fileDependencyResults = fileDependencyVisitor.complete();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -48,7 +48,9 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
                                                ComponentIdentifierFactory componentIdentifierFactory,
                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                LocalComponentMetadataBuilder localComponentMetadataBuilder,
-                                               ConfigurationsProvider configurationsProvider, ProjectStateRegistry projectStateRegistry, DependencyLockingProvider dependencyLockingProvider) {
+                                               ConfigurationsProvider configurationsProvider,
+                                               ProjectStateRegistry projectStateRegistry,
+                                               DependencyLockingProvider dependencyLockingProvider) {
         this.metadataProvider = metadataProvider;
         this.componentIdentifierFactory = componentIdentifierFactory;
         this.moduleIdentifierFactory = moduleIdentifierFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -131,7 +131,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     }
 
     @Override
-    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry) {
+    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry, boolean includeSyntheticDependencies) {
         LOGGER.debug("Resolving {}", resolveContext);
 
         validateResolutionStrategy(resolveContext.getResolutionStrategy());
@@ -142,7 +142,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         DependencyGraphVisitor artifactsGraphVisitor = new ResolvedArtifactsGraphVisitor(artifactsVisitor, resolvers.getArtifactSelector());
 
         // Resolve the dependency graph
-        builder.resolve(resolveContext, new CompositeDependencyGraphVisitor(graphVisitor, artifactsGraphVisitor));
+        builder.resolve(resolveContext, new CompositeDependencyGraphVisitor(graphVisitor, artifactsGraphVisitor), includeSyntheticDependencies);
     }
 
     private static void validateResolutionStrategy(ResolutionStrategyInternal resolutionStrategy) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -466,7 +466,7 @@ public class NodeState implements DependencyGraphNode {
             cachedDependencyStates = null;
             cachedFilteredDependencyStates = null;
         }
-        List<? extends DependencyMetadata> dependencies = metaData.getDependencies();
+        List<? extends DependencyMetadata> dependencies = getAllDependencies();
         if (transitiveEdgeCount == 0 && metaData.isExternalVariant()) {
             // there must be a single dependency state because this variant is an "available-at"
             // variant and here we are in the case the "including" component said that transitive
@@ -476,6 +476,10 @@ public class NodeState implements DependencyGraphNode {
         }
         doesNotHaveDependencies = dependencies.isEmpty();
         return dependencies;
+    }
+
+    protected List<? extends DependencyMetadata> getAllDependencies() {
+        return metaData.getDependencies();
     }
 
     private static DependencyMetadata makeNonTransitive(DependencyMetadata dependencyMetadata) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -55,6 +55,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,6 +87,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final ResolveOptimizations resolveOptimizations;
     private final Map<VersionConstraint, ResolvedVersionConstraint> resolvedVersionConstraints = Maps.newHashMap();
     private final AttributeDesugaring attributeDesugaring;
+    private final List<? extends DependencyMetadata> generatedRootDependencies;
 
     public ResolveState(IdGenerator<Long> idGenerator,
                         ComponentResolveResult rootResult,
@@ -103,7 +105,8 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
                         VersionParser versionParser,
                         ModuleConflictResolver<ComponentState> conflictResolver,
                         int graphSize,
-                        ConflictResolution conflictResolution) {
+                        ConflictResolution conflictResolution,
+                        List<? extends DependencyMetadata> generatedRootDependencies) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
         this.metaDataResolver = metaDataResolver;
@@ -121,6 +124,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         this.selectors = new LinkedHashMap<>(5 * graphSize / 2);
         this.queue = new ArrayDeque<>(graphSize);
         this.conflictResolution = conflictResolution;
+        this.generatedRootDependencies = generatedRootDependencies;
         this.resolveOptimizations = new ResolveOptimizations();
         this.attributeDesugaring = new AttributeDesugaring(attributesFactory);
         // Create root module
@@ -154,6 +158,10 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
 
     private ModuleResolveState getModule(ModuleIdentifier id, boolean rootModule) {
         return modules.computeIfAbsent(id, mid -> new ModuleResolveState(idGenerator, id, metaDataResolver, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations, rootModule, conflictResolution));
+    }
+
+    List<? extends DependencyMetadata> getGeneratedRootDependencies() {
+        return generatedRootDependencies;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -421,7 +421,6 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                         configuration.addDefinedDependencies(result);
                     }
                 }
-                maybeAddGeneratedDependencies(result);
                 AttributeValue<Category> attributeValue = this.getAttributes().findEntry(Category.CATEGORY_ATTRIBUTE);
                 if (attributeValue.isPresent() && attributeValue.get().getName().equals(Category.ENFORCED_PLATFORM)) {
                     // need to wrap all dependencies to force them
@@ -436,8 +435,8 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             return configurationDependencies;
         }
 
-        void maybeAddGeneratedDependencies(ImmutableList.Builder<LocalOriginDependencyMetadata> result) {
-            // No-op
+        List<LocalOriginDependencyMetadata> getSyntheticDependencies() {
+            return Collections.emptyList();
         }
 
         void addDefinedDependencies(ImmutableList.Builder<LocalOriginDependencyMetadata> result) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -134,7 +134,7 @@ class DependencyGraphBuilderTest extends Specification {
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
         def graphVisitor = new TestGraphVisitor()
-        builder.resolve(configuration, graphVisitor)
+        builder.resolve(configuration, graphVisitor, false)
         return graphVisitor
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -46,8 +46,8 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
         def child = metadata.getConfiguration('child')
 
         then:
-        conf.dependencies.size() == 1
-        child.dependencies.size() == 0
+        conf.syntheticDependencies.size() == 1
+        child.syntheticDependencies.size() == 0
     }
 
     def 'locking constraints are not transitive'() {
@@ -60,8 +60,8 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
         def conf = metadata.getConfiguration('conf')
 
         then:
-        conf.dependencies.size() == 1
-        conf.dependencies.each {
+        conf.syntheticDependencies.size() == 1
+        conf.syntheticDependencies.each {
             assert !it.transitive
         }
     }
@@ -77,8 +77,8 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
         def conf = metadata.getConfiguration('conf')
 
         then:
-        conf.dependencies.size() == 1
-        conf.dependencies.each { DependencyMetadata dep ->
+        conf.syntheticDependencies.size() == 1
+        conf.syntheticDependencies.each { DependencyMetadata dep ->
             assert dep.reason == reason
         }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -162,7 +162,7 @@ public class DependencyResolvingClasspath extends AbstractOpaqueFileCollection {
             public ArtifactTypeContainer create() {
                 throw new UnsupportedOperationException();
             }
-        });
+        }, false);
         return result;
     }
 


### PR DESCRIPTION
This commit fixes an issue with consistent resolution, which caused
the consistent resolution source to be fully resolved (including
external dependencies) during task dependencies computation.

To fix this problem, we reworked how "synthetic" dependencies are
added to the resolution process. Synthetic dependencies include
dependency locking constraints, as well as constraints for
dependency resolution consistency. They would now only be added
to the resolution graph if we're actually at the execution phase,
not during task dependency computation.

Fixes #15588

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
