### PR TITLE
Upgrade test-distribution plugin to latest RC

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:1.1.2-rc-1")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:1.3.1-rc-1")
         api("org.gradle.guides:gradle-guides-plugin:0.16.8")
         api("com.gradle.publish:plugin-publish-plugin:0.11.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")

--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation("org.ow2.asm:asm-commons")
     implementation("com.google.code.gson:gson")
     implementation("org.gradle:test-retry-gradle-plugin")
-    implementation("com.gradle.enterprise:test-distribution-gradle-plugin:1.2.2-rc-1")
+    implementation("com.gradle.enterprise:test-distribution-gradle-plugin")
 
     implementation("com.thoughtworks.qdox:qdox") {
         because("ParameterNamesIndex")


### PR DESCRIPTION
The RC now reports JVM output as part of the exception message in case
test discovery fails.