### PR TITLE
Fix ResidualProgramCompiler compiling inside build directory

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
@@ -21,6 +21,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.ProcessOperations
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.TemporaryFileProvider
+import org.gradle.api.internal.file.TmpDirTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction
 import org.gradle.api.plugins.ObjectConfigurationAction
@@ -58,7 +59,10 @@ class KotlinScriptHost<out T : Any>(
 
     internal
     val temporaryFileProvider: TemporaryFileProvider by unsafeLazy {
-        serviceRegistry.get<TemporaryFileProvider>()
+        // TmpDirTemporaryFileProvider must be used instead of the TemporaryFileProvider.
+        // In this scope the TemporaryFileProvider would be provided by the ProjectScopeServices.
+        // That would generate this temporary directory inside of the project build directory.
+        serviceRegistry.get<TmpDirTemporaryFileProvider>()
     }
 
     internal

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -25,8 +25,8 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
 
 import org.gradle.api.initialization.Settings
-import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.file.TmpDirTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
 
 import org.gradle.groovy.scripts.ScriptSource
@@ -103,7 +103,7 @@ class InterpreterTest : TestWithTempFiles() {
         val stage2CacheDir = root.resolve("stage2").apply { mkdir() }
 
         val mockServiceRegistry = mock<ServiceRegistry> {
-            on { get(TemporaryFileProvider::class.java) } doReturn TestFiles.tmpDirTemporaryFileProvider(tempFolder.root)
+            on { get(TmpDirTemporaryFileProvider::class.java) } doReturn TestFiles.tmpDirTemporaryFileProvider(tempFolder.root)
         }
 
         val host = mock<Interpreter.Host> {


### PR DESCRIPTION
Make KotlinScriptHost depend upon TmpDirTemporaryFileProvider instead of the ProjectScopeServices TemporaryFileProvider.

Closes https://github.com/gradle/gradle-private/issues/3251