### PR TITLE
Replace `val p by extra {e}` syntax by `val p by extra.creating {e}`

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -33,6 +33,27 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << "rootProject.buildFileName = '$defaultBuildFileName'"
     }
 
+    def 'can configure ext extension'() {
+        given:
+        buildFile << """
+            ext {
+                set("prop", "it works!")
+            }
+
+            task("build") {
+                doLast {
+                    println(project.ext["prop"])
+                }
+            }
+        """
+
+        when:
+        run 'build'
+
+        then:
+        outputContains('it works!')
+    }
+
     def 'can run a simple task'() {
         given:
         buildFile << """

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -22,6 +22,7 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
 
 import org.gradle.kotlin.dsl.support.uncheckedCast
+import java.util.concurrent.Callable
 
 import kotlin.reflect.KProperty
 
@@ -80,18 +81,19 @@ class NullableExtraPropertyDelegate(
  * Returns a property delegate provider that will initialize the extra property to the value provided
  * by [initialValueProvider].
  *
- * Usage: `val answer by extra { 42 }`
+ * Usage: `val answer by extra.creating { 42 }`
  */
-inline operator fun <T> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): InitialValueExtraPropertyDelegateProvider<T> =
-    invoke(initialValueProvider())
+@Suppress("nothing_to_inline")
+inline fun <T> ExtraPropertiesExtension.creating(initialValueProvider: Callable<T>): InitialValueExtraPropertyDelegateProvider<T> =
+    creating(initialValueProvider())
 
 
 /**
  * Returns a property delegate provider that will initialize the extra property to the given [initialValue].
  *
- * Usage: `val answer by extra(42)`
+ * Usage: `val answer by extra.creating(42)`
  */
-operator fun <T> ExtraPropertiesExtension.invoke(initialValue: T): InitialValueExtraPropertyDelegateProvider<T> =
+fun <T> ExtraPropertiesExtension.creating(initialValue: T): InitialValueExtraPropertyDelegateProvider<T> =
     InitialValueExtraPropertyDelegateProvider.of(this, initialValue)
 
 


### PR DESCRIPTION
Mainly to recover the `ext { set("p", e) }` syntax with Kotlin 1.4.x which changed how invoke operators are resolved.

It's a good opportunity to align the syntax with how similar operations are implemented for other containers.
