### PR TITLE
Do not register included build substitutions several times

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
@@ -38,6 +38,9 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
         final TestFile settingsFile
         final TestFile buildFile
 
+        final TestFile settingsPluginFile
+        final TestFile projectPluginFile
+
         PluginBuildFixture(String buildName) {
             this.buildName = buildName
             this.settingsPluginId = "${buildName}.settings-plugin"
@@ -53,11 +56,13 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
                     id("groovy-gradle-plugin")
                 }
             """
-            file("$buildName/src/main/groovy/${projectPluginId}.gradle") << """
-                println('$projectPluginId applied')
-            """
-            file("$buildName/src/main/groovy/${settingsPluginId}.settings.gradle") << """
+            settingsPluginFile = file("$buildName/src/main/groovy/${settingsPluginId}.settings.gradle")
+            settingsPluginFile << """
                 println('$settingsPluginId applied')
+            """
+            projectPluginFile = file("$buildName/src/main/groovy/${projectPluginId}.gradle")
+            projectPluginFile << """
+                println('$projectPluginId applied')
             """
         }
 


### PR DESCRIPTION
This may even lead to an error in specific setups with cycles, where Gradle may attempt to start the configuration of a build again that is currently configuring.

The error case can be observed when running an included build task from IDEA in #15526, when IDEA adds a `--include-build build-logic` under the hood.
