### PR TITLE
Fix excludes being ignored when using `available-at`

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -459,6 +459,11 @@ class EdgeState implements DependencyGraphEdge {
         }
     }
 
+    @Nullable
+    ExcludeSpec getTransitiveExclusions() {
+        return transitiveExclusions;
+    }
+
     public void markUnattached() {
         this.unattached = true;
     }


### PR DESCRIPTION
This commit fixes a regression introduced by a bugfix
about `available-at` (see 4be5952141fc64f0f1f754807730b1b18bfb32b5).

Basically the problem is that if an exclude from an incoming edge
is supposed to exclude the target of an available-at variant, then
the exclusion would be ignored. In fact, instead of allowing all
dependencies like we did in the previous fix, we should only allow
non excluded variants, which corresponds to the union of the
"transitive exclusions" of all the incoming edges to a node.
