### PR TITLE
Fix stack overflow in test runner when running with -Djava.security.debug=access,failure

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LineBufferingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LineBufferingOutputStream.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.internal.io;
 
-import org.gradle.internal.SystemProperties;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -33,21 +31,21 @@ public class LineBufferingOutputStream extends OutputStream {
     private final int lineMaxLength;
     private int counter;
 
-    public LineBufferingOutputStream(TextStream handler) {
-        this(handler, 8192);
+    public LineBufferingOutputStream(TextStream handler, String lineSeparator) {
+        this(handler, lineSeparator, 8192);
     }
 
-    public LineBufferingOutputStream(TextStream handler, int bufferLength) {
-        this(handler, bufferLength, LINE_MAX_LENGTH);
+    public LineBufferingOutputStream(TextStream handler, String lineSeparator, int bufferLength) {
+        this(handler, lineSeparator, bufferLength, LINE_MAX_LENGTH);
     }
 
-    public LineBufferingOutputStream(TextStream handler, int bufferLength, int lineMaxLength) {
+    public LineBufferingOutputStream(TextStream handler, String lineSeparator, int bufferLength, int lineMaxLength) {
         this.handler = handler;
         buffer = new StreamByteBuffer(bufferLength);
         this.lineMaxLength = lineMaxLength;
         output = buffer.getOutputStream();
-        byte[] lineSeparator = SystemProperties.getInstance().getLineSeparator().getBytes();
-        lastLineSeparatorByte = lineSeparator[lineSeparator.length - 1];
+        byte[] lineSeparatorBytes = lineSeparator.getBytes();
+        lastLineSeparatorByte = lineSeparatorBytes[lineSeparatorBytes.length - 1];
     }
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.io;
 
+import org.gradle.internal.SystemProperties;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Locale;
@@ -23,7 +25,7 @@ import java.util.Locale;
 public class LinePerThreadBufferingOutputStream extends PrintStream {
     private final TextStream handler;
     private final ThreadLocal<PrintStream> stream = new ThreadLocal<PrintStream>();
-
+    private final String lineSeparator = SystemProperties.getInstance().getLineSeparator();
     public LinePerThreadBufferingOutputStream(TextStream handler) {
         super(NullOutputStream.INSTANCE, true);
         this.handler = handler;
@@ -32,7 +34,7 @@ public class LinePerThreadBufferingOutputStream extends PrintStream {
     private PrintStream getStream() {
         PrintStream printStream = stream.get();
         if (printStream == null) {
-            printStream = new PrintStream(new LineBufferingOutputStream(handler));
+            printStream = new PrintStream(new LineBufferingOutputStream(handler, lineSeparator));
             stream.set(printStream);
         }
         return printStream;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
@@ -157,52 +157,88 @@ public class LinePerThreadBufferingOutputStream extends PrintStream {
 
     @Override
     public void println() {
-        getStream().println();
+        getStream().print(lineSeparator);
     }
 
     @Override
     public void println(boolean x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(char x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(char[] x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(double x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(float x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(int x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(long x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(Object x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override
     public void println(String x) {
-        getStream().println(x);
+        PrintStream stream = getStream();
+        synchronized (this) {
+            stream.print(x);
+            stream.print(lineSeparator);
+        }
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal.streams
 
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.io.LineBufferingOutputStream
 import org.gradle.internal.io.TextStream
 import spock.lang.Issue
@@ -46,7 +47,8 @@ class ExecOutputHandleRunnerTest extends Specification {
         def text2 = "\u0151" + ("a" * 5)
         def text = text1 + text2
         def action = Mock(TextStream)
-        def output = new LineBufferingOutputStream(action)
+        def lineSeparator = SystemProperties.instance.lineSeparator
+        def output = new LineBufferingOutputStream(action, lineSeparator)
         def input = new ByteArrayInputStream(text.getBytes("utf-8"))
         def runner = new ExecOutputHandleRunner("test", input, output, bufferLength, new CountDownLatch(1))
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/LineBufferingOutputStreamTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/LineBufferingOutputStreamTest.groovy
@@ -18,23 +18,16 @@ package org.gradle.util
 import org.gradle.internal.SystemProperties
 import org.gradle.internal.io.LineBufferingOutputStream
 import org.gradle.internal.io.TextStream
+import spock.lang.Shared
 import spock.lang.Specification
 
 class LineBufferingOutputStreamTest extends Specification {
     private TextStream action = Mock(TextStream)
-    private String eol
-
-    def setup() {
-        eol = SystemProperties.getInstance().getLineSeparator()
-    }
-
-    def cleanup() {
-        System.setProperty("line.separator", eol)
-    }
+    @Shared String eol = SystemProperties.getInstance().getLineSeparator()
 
     def logsEachLineAsASeparateLogMessage() {
         when:
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8)
         outputStream.write(TextUtil.toPlatformLineSeparators("line 1\nline 2\n").getBytes())
 
         then:
@@ -44,8 +37,8 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def buffersTextUntilEndOfLineReached() {
         when:
-        System.setProperty("line.separator", "-")
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        final String separator = "-"
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
         outputStream.write("line ".getBytes())
         outputStream.write("1-line 2".getBytes())
 
@@ -61,8 +54,8 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def logsEmptyLines() {
         when:
-        System.setProperty("line.separator", "-")
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        final String separator = "-"
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
 
         outputStream.write("--".getBytes())
 
@@ -72,8 +65,8 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def handlesSingleCharacterLineSeparator() {
         when:
-        System.setProperty("line.separator", "-")
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        final String separator = "-"
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
 
         outputStream.write(String.format("line 1-line 2-").getBytes())
 
@@ -84,8 +77,7 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def handlesMultiCharacterLineSeparator() {
         final String separator = "\r\n"
-        System.setProperty("line.separator", separator)
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
 
         when:
         outputStream.write(("line 1" + separator + "line 2" + separator).getBytes())
@@ -97,8 +89,8 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def logsLineWhichIsLongerThanInitialBufferLength() {
         when:
-        System.setProperty("line.separator", "-")
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        final String separator = "-"
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
         outputStream.write("a line longer than 8 bytes long-".getBytes())
         outputStream.write("line 2".getBytes())
         outputStream.flush()
@@ -110,7 +102,7 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def logsPartialLineOnFlush() {
         given:
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8)
         outputStream.write("line 1".getBytes())
 
         when:
@@ -121,7 +113,7 @@ class LineBufferingOutputStreamTest extends Specification {
     }
 
     def logsNothingOnCloseWhenNothingHasBeenWrittenToStream() {
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8)
 
         when:
         outputStream.close()
@@ -132,8 +124,8 @@ class LineBufferingOutputStreamTest extends Specification {
     }
 
     def logsNothingOnCloseWhenCompleteLineHasBeenWrittenToStream() {
-        System.setProperty("line.separator", "-")
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        final String separator = "-"
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, separator, 8)
 
         when:
         outputStream.write("line 1-".getBytes())
@@ -145,7 +137,7 @@ class LineBufferingOutputStreamTest extends Specification {
     }
 
     def logsPartialLineOnClose()  {
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8)
 
         when:
         outputStream.write("line 1".getBytes())
@@ -157,7 +149,7 @@ class LineBufferingOutputStreamTest extends Specification {
     }
 
     def cannotWriteAfterClose() {
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8)
 
         when:
         outputStream.close()
@@ -174,7 +166,7 @@ class LineBufferingOutputStreamTest extends Specification {
 
     def splitsLongLines() {
         when:
-        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, 8, 13)
+        LineBufferingOutputStream outputStream = new LineBufferingOutputStream(action, eol, 8, 13)
         outputStream.write("12345678901234567890123456789".getBytes())
         outputStream.close()
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/InputForwarder.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/InputForwarder.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.launcher.daemon.client;
 
+import org.gradle.internal.SystemProperties;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.Stoppable;
@@ -63,7 +64,9 @@ public class InputForwarder implements Stoppable {
             }
 
             disconnectableInput = new DisconnectableInputStream(input, bufferSize);
-            outputBuffer = new LineBufferingOutputStream(handler, bufferSize);
+            outputBuffer = new LineBufferingOutputStream(handler,
+                SystemProperties.getInstance().getLineSeparator(),
+                bufferSize);
 
             forwardingExecuter = executorFactory.create("Forward input");
             forwardingExecuter.execute(new Runnable() {

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.testing
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.util.GradleVersion
+import spock.lang.IgnoreIf
 
 import static org.gradle.util.Matchers.containsText
 import static org.gradle.util.Matchers.matchesRegexp
@@ -66,6 +68,7 @@ public class SecurityManagerTest {
         failure.assertThatCause(containsText("Please refer to the test execution section in the User Manual at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_testing.html#sec:test_execution"))
     }
 
+    @IgnoreIf({ JavaVersion.current() == JavaVersion.VERSION_1_8})
     @IntegrationTestTimeout(120)
     def "should not hang when running with security manager debug flag"() {
         given:
@@ -112,7 +115,7 @@ public class SecurityManagerTest {
 }
 '''
         expect:
-        run('test',  "-Djava.security.debug=access,failure")
+        run('test')
         def result = new JUnitXmlTestExecutionResult(testDirectory)
         result.assertTestClassesExecuted('SecurityManagerTest')
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.testing.TestExecuter;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.processors.TestMainAction;
 import org.gradle.api.tasks.testing.TestOutputEvent;
+import org.gradle.internal.SystemProperties;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.io.LineBufferingOutputStream;
@@ -142,7 +143,8 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
             TextStream stdOut = new XCTestScraper(TestOutputEvent.Destination.StdOut, resultProcessor, idGenerator, clock, rootTestSuiteId, testDescriptors);
             TextStream stdErr = new XCTestScraper(TestOutputEvent.Destination.StdErr, resultProcessor, idGenerator, clock, rootTestSuiteId, testDescriptors);
 
-            execHandle = executeTest(testClass.getTestClassName(), new LineBufferingOutputStream(stdOut), new LineBufferingOutputStream(stdErr));
+            String lineSeparator = SystemProperties.getInstance().getLineSeparator();
+            execHandle = executeTest(testClass.getTestClassName(), new LineBufferingOutputStream(stdOut, lineSeparator), new LineBufferingOutputStream(stdErr, lineSeparator));
             try {
                 execHandle.start();
                 ExecResult result = execHandle.waitForFinish();


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/11609

### Context
This fixes a a stackoverflow in the test runner output when debugging security manager. The stackoverflow was caused by a recursive call to System.getProperty('line.separator') when having debugging java security enabled.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
