### PR TITLE
Turn deprecated AbstractTask usages into errors

### DIFF
--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.wrapper
 
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.AbstractTaskTest
 import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.test.fixtures.file.TestFile
@@ -45,7 +44,7 @@ class WrapperTest extends AbstractTaskTest {
         wrapper.setDistributionSha256Sum("somehash")
     }
 
-    AbstractTask getTask() {
+    Wrapper getTask() {
         return wrapper
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -157,7 +157,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("thing")
     }
 
-    def "creating a task of type AbstractTask is deprecated"() {
+    def "creating a task of type AbstractTask is not supported"() {
         buildFile << """
             task thing(type: ${AbstractTask.name}) { t ->
                 assert t instanceof DefaultTask
@@ -166,11 +166,11 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Registering task ':thing' with type 'AbstractTask' has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
-        succeeds("thing")
+        fails("thing")
+        failureHasCause("Cannot create task ':thing' of type 'AbstractTask' as this type is not supported for task registration.")
     }
 
-    def "creating a task of type TaskInternal is deprecated"() {
+    def "creating a task of type TaskInternal is not supported"() {
         buildFile << """
             task thing(type: ${TaskInternal.name}) { t ->
                 assert t instanceof DefaultTask
@@ -179,11 +179,11 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Registering task ':thing' with type 'TaskInternal' has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
-        succeeds("thing")
+        fails("thing")
+        failureHasCause("Cannot create task ':thing' of type 'TaskInternal' as this type is not supported for task registration.")
     }
 
-    def "creating a task that is a subtype of AbstractTask is deprecated"() {
+    def "creating a task that is a subtype of AbstractTask is not supported"() {
         buildFile << """
             class CustomTask extends ${AbstractTask.name} {
             }
@@ -193,8 +193,8 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Registering task ':thing' with a type (CustomTask) that directly extends AbstractTask has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#abstract_task_deprecated")
-        succeeds("thing")
+        fails("thing")
+        failureHasCause("Cannot create task ':thing' of type 'CustomTask' as directly extending AbstractTask is not supported.")
     }
 
     def "does not hide local methods and variables"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -100,7 +100,7 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.factory;
 import static org.gradle.util.GUtil.uncheckedCall;
 
 /**
- * @deprecated This class will be removed in Gradle 7.0. Please use {@link org.gradle.api.DefaultTask} instead.
+ * @deprecated This class will be removed in Gradle 8.0. Please use {@link org.gradle.api.DefaultTask} instead.
  */
 @Deprecated
 public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -60,11 +60,11 @@ public class TaskFactory implements ITaskFactory {
 
         NameValidator.validate(identity.name, "task name", "");
 
-        final Class<? extends org.gradle.api.internal.AbstractTask> implType;
+        final Class<? extends DefaultTask> implType;
         if (identity.type == Task.class) {
             implType = DefaultTask.class;
         } else if (DefaultTask.class.isAssignableFrom(identity.type)) {
-            implType = identity.type.asSubclass(org.gradle.api.internal.AbstractTask.class);
+            implType = identity.type.asSubclass(DefaultTask.class);
         } else if (identity.type == org.gradle.api.internal.AbstractTask.class || identity.type == TaskInternal.class) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as this type is not supported for task registration.",

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.api.tasks.TaskInstantiationException;
 import org.gradle.internal.Describables;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.util.NameValidator;
 
@@ -72,11 +71,10 @@ public class TaskFactory implements ITaskFactory {
                 identity.identityPath.toString(),
                 identity.type.getSimpleName()));
         } else {
-            DeprecationLogger.deprecate(String.format("Registering task '%s' with a type (%s) that directly extends AbstractTask", identity.identityPath.toString(), identity.type.getSimpleName()))
-                .willBecomeAnErrorInGradle7()
-                .withUpgradeGuideSection(6, "abstract_task_deprecated")
-                .nagUser();
-            implType = identity.type.asSubclass(org.gradle.api.internal.AbstractTask.class);
+            throw new InvalidUserDataException(String.format(
+                "Cannot create task '%s' of type '%s' as directly extending AbstractTask is not supported.",
+                identity.identityPath.toString(),
+                identity.type.getSimpleName()));
         }
 
         Describable displayName = Describables.withTypeAndName("task", identity.getIdentityPath());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -54,7 +54,8 @@ public class TaskFactory implements ITaskFactory {
     public <S extends Task> S create(final TaskIdentity<S> identity, @Nullable final Object[] constructorArgs) {
         if (!Task.class.isAssignableFrom(identity.type)) {
             throw new InvalidUserDataException(String.format(
-                "Cannot create task of type '%s' as it does not implement the Task interface.",
+                "Cannot create task '%s' of type '%s' as it does not implement the Task interface.",
+                identity.identityPath.toString(),
                 identity.type.getSimpleName()));
         }
 
@@ -66,6 +67,7 @@ public class TaskFactory implements ITaskFactory {
         } else if (DefaultTask.class.isAssignableFrom(identity.type)) {
             implType = identity.type.asSubclass(org.gradle.api.internal.AbstractTask.class);
         } else if (identity.type == org.gradle.api.internal.AbstractTask.class || identity.type == TaskInternal.class) {
+
             DeprecationLogger.deprecate(String.format("Registering task '%s' with type '%s'", identity.identityPath.toString(), identity.type.getSimpleName()))
                 .willBecomeAnErrorInGradle7()
                 .withUpgradeGuideSection(6, "abstract_task_deprecated")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -67,12 +67,10 @@ public class TaskFactory implements ITaskFactory {
         } else if (DefaultTask.class.isAssignableFrom(identity.type)) {
             implType = identity.type.asSubclass(org.gradle.api.internal.AbstractTask.class);
         } else if (identity.type == org.gradle.api.internal.AbstractTask.class || identity.type == TaskInternal.class) {
-
-            DeprecationLogger.deprecate(String.format("Registering task '%s' with type '%s'", identity.identityPath.toString(), identity.type.getSimpleName()))
-                .willBecomeAnErrorInGradle7()
-                .withUpgradeGuideSection(6, "abstract_task_deprecated")
-                .nagUser();
-            implType = DefaultTask.class;
+            throw new InvalidUserDataException(String.format(
+                "Cannot create task '%s' of type '%s' as this type is not supported for task registration.",
+                identity.identityPath.toString(),
+                identity.type.getSimpleName()));
         } else {
             DeprecationLogger.deprecate(String.format("Registering task '%s' with a type (%s) that directly extends AbstractTask", identity.identityPath.toString(), identity.type.getSimpleName()))
                 .willBecomeAnErrorInGradle7()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal
 
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
@@ -25,7 +26,7 @@ import static org.junit.Assert.assertTrue
 class AbstractTaskSpec extends AbstractProjectBuilderSpec {
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
 
-    static class TestTask extends AbstractTask {
+    static class TestTask extends DefaultTask {
     }
 
     TestTask createTask(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -51,7 +51,7 @@ class DefaultTaskTest extends AbstractTaskTest {
         Thread.currentThread().contextClassLoader = cl
     }
 
-    AbstractTask getTask() {
+    DefaultTask getTask() {
         defaultTask
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -68,7 +68,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
         task instanceof DefaultTask
 
         where:
-        type << [Task, TaskInternal, AbstractTask, DefaultTask]
+        type << [Task, DefaultTask]
     }
 
     void testCreateTaskForDeserialization() {
@@ -87,6 +87,18 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
         then:
         InvalidUserDataException e = thrown()
         e.message == "Cannot create task ':task' of type 'NotATask' as it does not implement the Task interface."
+    }
+
+    void testCreateTaskForUnsupportedType() {
+        when:
+        taskFactory.create(new TaskIdentity(taskType, 'task', null, Path.path(':task'), null, 12))
+
+        then:
+        InvalidUserDataException e = thrown()
+        e.message == "Cannot create task ':task' of type '$taskType.simpleName' as this type is not supported for task registration."
+
+        where:
+        taskType << [AbstractTask, TaskInternal]
     }
 
     void wrapsFailureToCreateTaskInstance() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -86,7 +86,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
 
         then:
         InvalidUserDataException e = thrown()
-        e.message == "Cannot create task of type 'NotATask' as it does not implement the Task interface."
+        e.message == "Cannot create task ':task' of type 'NotATask' as it does not implement the Task interface."
     }
 
     void wrapsFailureToCreateTaskInstance() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -101,6 +101,15 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
         taskType << [AbstractTask, TaskInternal]
     }
 
+    void testCreateTaskForTypeDirectlyExtendingAbstractTask() {
+        when:
+        taskFactory.create(new TaskIdentity(ExtendsAbstractTask, 'task', null, Path.path(':task'), null, 12))
+
+        then:
+        InvalidUserDataException e = thrown()
+        e.message == "Cannot create task ':task' of type 'ExtendsAbstractTask' as directly extending AbstractTask is not supported."
+    }
+
     void wrapsFailureToCreateTaskInstance() {
         def failure = new RuntimeException()
 
@@ -123,5 +132,8 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
     }
 
     static class NotATask {
+    }
+
+    static class ExtendsAbstractTask extends AbstractTask {
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultRealizableTaskCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultRealizableTaskCollectionTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks
 
-import org.gradle.api.internal.AbstractTask
+import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.model.internal.core.ModelNode
 import org.gradle.model.internal.core.ModelPath
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class DefaultRealizableTaskCollectionTest extends Specification {
 
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
-    
+
     def "realizes a nodes link of a given type when task dependencies visited"() {
         given:
         ModelRegistryHelper registry = new ModelRegistryHelper()
@@ -94,9 +94,9 @@ class DefaultRealizableTaskCollectionTest extends Specification {
     }
 }
 
-class BasicTask extends AbstractTask {}
+class BasicTask extends DefaultTask {}
 
 class ChildTask extends BasicTask {}
 
-class RedundantTask extends AbstractTask {}
+class RedundantTask extends DefaultTask {}
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuterTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.tasks.execution
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.execution.TaskExecutionListener
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.tasks.TaskExecuter
@@ -38,7 +38,7 @@ class EventFiringTaskExecuterTest extends Specification {
     def taskListener = Mock(TaskListenerInternal)
     def delegate = Mock(TaskExecuter)
     def task = Mock(TaskInternal)
-    def taskIdentity = new TaskIdentity(AbstractTask, "foo", null, null, null, 0)
+    def taskIdentity = new TaskIdentity(DefaultTask, "foo", null, null, null, 0)
     def state = new TaskStateInternal()
     def executionContext = Mock(TaskExecutionContext)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.tasks
 
-import org.gradle.api.internal.AbstractTask
-
 class ExecTest extends AbstractTaskTest {
     Exec execTask
 
@@ -24,7 +22,7 @@ class ExecTest extends AbstractTaskTest {
         execTask = createTask(Exec.class)
     }
 
-    AbstractTask getTask() {
+    Exec getTask() {
         return execTask
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
@@ -15,12 +15,10 @@
  */
 package org.gradle.api.tasks
 
-import org.gradle.api.internal.AbstractTask
-
 class SourceTaskTest extends AbstractTaskTest {
     private SourceTask task
 
-    AbstractTask getTask() {
+    SourceTask getTask() {
         return task
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractConventionTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractConventionTaskTest.groovy
@@ -16,17 +16,14 @@
 
 package org.gradle.api.tasks
 
-import org.gradle.api.internal.AbstractTask
 import org.gradle.internal.extensibility.ConventionAwareHelper
 import org.gradle.api.internal.ConventionTask
 
 public abstract class AbstractConventionTaskTest extends AbstractTaskTest {
 
-    public abstract AbstractTask getTask();
+    public abstract ConventionTask getTask();
 
     def "is aware of conventions"() {
-        given:
-        ConventionTask task = (ConventionTask) getTask();
 
         expect:
         task.getConventionMapping() instanceof ConventionAwareHelper

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -42,9 +43,9 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
     def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory())
     def taskFactory = new AnnotationProcessingTaskFactory(DirectInstantiator.INSTANCE, taskClassInfoStore, new TaskFactory())
 
-    abstract AbstractTask getTask()
+    abstract DefaultTask getTask()
 
-    def <T extends AbstractTask> T createTask(Class<T> type) {
+    def <T extends DefaultTask> T createTask(Class<T> type) {
         return createTask(type, project, TEST_TASK_NAME)
     }
 
@@ -52,7 +53,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
         return createTask(getTask().getClass(), project, name)
     }
 
-    def <T extends AbstractTask> T createTask(Class<T> type, ProjectInternal project, String name) {
+    def <T extends DefaultTask> T createTask(Class<T> type, ProjectInternal project, String name) {
         Task task = new TaskInstantiator(taskFactory.createChild(project, TestUtil.instantiatorFactory().decoratingLenientScheme), project).create(name, type)
         assert type.isAssignableFrom(task.getClass())
         return type.cast(task)
@@ -149,7 +150,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
     }
 
     def canSpecifyOnlyIfPredicateUsingClosure() {
-        AbstractTask task = getTask()
+        DefaultTask task = getTask()
 
         expect:
         task.getOnlyIf().isSatisfiedBy(task)
@@ -163,7 +164,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
 
     def canSpecifyOnlyIfPredicateUsingSpec() {
         final Spec<Task> spec = Mock()
-        final AbstractTask task = getTask()
+        final DefaultTask task = getTask()
 
         expect:
         task.getOnlyIf().isSatisfiedBy(task)
@@ -180,7 +181,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
         final MutableBoolean condition1 = new MutableBoolean(true)
         final MutableBoolean condition2 = new MutableBoolean(true)
 
-        AbstractTask task = getTask()
+        DefaultTask task = getTask()
         task.onlyIf {
             condition1.get()
         }
@@ -220,7 +221,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
 
     def canReplaceOnlyIfSpec() {
         final MutableBoolean condition1 = new MutableBoolean(true)
-        AbstractTask task = getTask()
+        DefaultTask task = getTask()
         task.onlyIf(Mock(Spec))
         task.setOnlyIf {
             return condition1.get()

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -18,10 +18,10 @@ package org.gradle.api.tasks
 
 import com.google.common.collect.Lists
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction
@@ -41,9 +41,9 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
     protected DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry()
     protected ObjectFactory objectFactory = TestUtil.objectFactory()
 
-    abstract AbstractTask getTask()
+    abstract DefaultTask getTask()
 
-    def <T extends AbstractTask> T createTask(Class<T> type) {
+    def <T extends DefaultTask> T createTask(Class<T> type) {
         return createTask(type, project, TEST_TASK_NAME)
     }
 
@@ -51,7 +51,7 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
         return createTask(getTask().getClass(), project, name)
     }
 
-    def <T extends AbstractTask> T createTask(Class<T> type, ProjectInternal project, String name) {
+    def <T extends DefaultTask> T createTask(Class<T> type, ProjectInternal project, String name) {
         Task task = project.getServices().get(TaskInstantiator.class).create(name, type)
         assertTrue(type.isAssignableFrom(task.getClass()))
         return type.cast(task)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TaskPropertyTestUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TaskPropertyTestUtils.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.api.tasks
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.CompositeFileCollection
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -30,7 +30,7 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker
 import java.util.function.Consumer
 
 class TaskPropertyTestUtils {
-    static Map<String, Object> getProperties(AbstractTask task) {
+    static Map<String, Object> getProperties(DefaultTask task) {
         getProperties(task, task.getServices().get(PropertyWalker))
     }
 
@@ -40,7 +40,7 @@ class TaskPropertyTestUtils {
         return visitor.getProperties().collectEntries { [it.propertyName, it.value.call()] }
     }
 
-    static FileCollection getInputFiles(AbstractTask task) {
+    static FileCollection getInputFiles(DefaultTask task) {
         def fileCollectionFactory = task.getServices().get(FileCollectionFactory)
         GetInputFilesVisitor visitor = new GetInputFilesVisitor(task.toString(), fileCollectionFactory)
         def walker = task.getServices().get(PropertyWalker)

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -67,6 +67,11 @@ Use the `configDirectory` property instead.
 * The `rulePriority` getter and setter have been removed from the Pmd task and extension.
 Use the `rulesMinimumPriority` property instead.
 
+==== Using `AbstractTask`
+
+Registering a task with the `AbstractTask` type or with a type extending `AbstractTask` was deprecated in Gradle 6.5 and is now an error in Gradle 7.0.
+You can use link:{javadocPath}/org/gradle/api/DefaultTask.html[DefaultTask] instead.
+
 === Deprecations
 
 [[missing_dependencies]]

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/TasksFactoryTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/TasksFactoryTest.groovy
@@ -15,8 +15,8 @@
  */
 package org.gradle.plugins.ide.internal.tooling
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.Project
-import org.gradle.api.internal.AbstractTask
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultEclipseProject
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -28,7 +28,7 @@ class TasksFactoryTest extends Specification {
     public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     final Project project = Mock()
     final def eclipseProject = new DefaultEclipseProject(null, null, null, null, [])
-    final task = TestUtil.create(temporaryFolder).task(AbstractTask)
+    final task = TestUtil.create(temporaryFolder).task(DefaultTask)
 
     def "does not return tasks"() {
         TasksFactory factory = new TasksFactory(false)

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocSpec.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocSpec.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.scala
 
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.tasks.AbstractConventionTaskTest
@@ -33,7 +32,7 @@ class ScalaDocSpec extends AbstractConventionTaskTest {
     }
 
     @Override
-    AbstractTask getTask() {
+    ScalaDoc getTask() {
         return scalaDoc
     }
 


### PR DESCRIPTION
About #15585

Alternative to https://github.com/gradle/gradle/pull/15597. This one is simpler and doesn't break smoke tested plugins nor our own build in a bad way. I think we should do this first and then consider if we want to remove the type altogether.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
