### PR TITLE
Do not share identity cache between builds

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -118,7 +118,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         then:
         output.count("files: [lib1.jar.txt, lib1.jar]") == 2
 
-        output.count("Transformed") == 1
+        // From the Gradle user home cache
+        output.count("Transformed") == 0
     }
 
     private void setupProjectInDir(TestFile projectDir) {
@@ -851,7 +852,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         failure.assertHasCause("Failed to transform lib2.jar (project :lib) to match attributes {artifactType=size, usage=api}")
         def outputDir1 = projectOutputDir("lib1.jar", "lib1.jar.txt")
         def outputDir2 = projectOutputDir("lib2.jar", "lib2.jar.txt")
-        def outputDir3 = projectOutputDir("lib3.jar", "lib3.jar.txt")
+        def outputDir3 = gradleUserHomeOutputDir("lib3.jar", "lib3.jar.txt")
         def outputDir4 = gradleUserHomeOutputDir("lib4-1.0.jar", "lib4-1.0.jar.txt")
 
         when:
@@ -867,7 +868,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         isTransformed("lib4-1.0.jar", "lib4-1.0.jar.txt")
         projectOutputDir("lib1.jar", "lib1.jar.txt") == outputDir1
         projectOutputDir("lib2.jar", "lib2.jar.txt") == outputDir2
-        projectOutputDir("lib3.jar", "lib3.jar.txt") == outputDir3
+        gradleUserHomeOutputDir("lib3.jar", "lib3.jar.txt") == outputDir3
         gradleUserHomeOutputDir("lib4-1.0.jar", "lib4-1.0.jar.txt") == outputDir4
 
         when:
@@ -895,7 +896,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         isTransformed("dir1.classes", "dir1.classes.dir")
         isTransformed("lib1.jar", "lib1.jar.txt")
         def outputDir1 = projectOutputDir("dir1.classes", "dir1.classes.dir")
-        def outputDir2 = projectOutputDir("lib1.jar", "lib1.jar.txt")
+        def outputDir2 = gradleUserHomeOutputDir("lib1.jar", "lib1.jar.txt")
 
         when:
         succeeds ":util:resolve", ":app:resolve"
@@ -918,7 +919,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         isTransformed("dir1.classes", "dir1.classes.dir")
         isTransformed("lib1.jar", "lib1.jar.txt")
         outputDir("dir1.classes", "dir1.classes.dir") == outputDir1
-        projectOutputDir("lib1.jar", "lib1.jar.txt") == outputDir2
+        gradleUserHomeOutputDir("lib1.jar", "lib1.jar.txt") != outputDir2
 
         when:
         succeeds ":util:resolve", ":app:resolve"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCaches;
 import org.gradle.api.internal.artifacts.transform.ImmutableTransformationWorkspaceServices;
@@ -26,17 +28,21 @@ import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultExecutionHistoryCacheAccess;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
+import org.gradle.cache.ManualEvictionInMemoryCache;
 import org.gradle.cache.internal.CacheScopeMapping;
-import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.UsedGradleVersions;
+import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.Try;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.impl.DefaultExecutionHistoryStore;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.service.ServiceRegistry;
+
+import java.io.File;
 
 public class DependencyManagementGradleUserHomeScopeServices {
 
@@ -90,10 +96,21 @@ public class DependencyManagementGradleUserHomeScopeServices {
     ImmutableTransformationWorkspaceServices createTransformerWorkspaceServices(
         ArtifactCachesProvider artifactCaches,
         CacheRepository cacheRepository,
-        CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
         FileAccessTimeJournal fileAccessTimeJournal,
-        ExecutionHistoryStore executionHistoryStore
+        ExecutionHistoryStore executionHistoryStore,
+        ListenerManager listenerManager
     ) {
+        ManualEvictionInMemoryCache<UnitOfWork.Identity, Try<ImmutableList<File>>> identityCache = new ManualEvictionInMemoryCache<>();
+        listenerManager.addListener(new RootBuildLifecycleListener() {
+            @Override
+            public void afterStart(GradleInternal gradle) {
+            }
+
+            @Override
+            public void beforeComplete(GradleInternal gradle) {
+                identityCache.clear();
+            }
+        });
         return new ImmutableTransformationWorkspaceServices(
             cacheRepository
                 .cache(artifactCaches.getWritableCacheMetadata().getTransformsStoreDirectory())
@@ -101,7 +118,7 @@ public class DependencyManagementGradleUserHomeScopeServices {
                 .withDisplayName("Artifact transforms cache"),
             fileAccessTimeJournal,
             executionHistoryStore,
-            crossBuildInMemoryCacheFactory.newCacheRetainingDataFromPreviousBuild(Try::isSuccessful)
+            identityCache
         );
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.file.DefaultFileSystemLocation;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -31,7 +30,6 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Try;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
 import org.gradle.internal.execution.DeferredExecutionHandler;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputChangesContext;
@@ -199,8 +197,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         ComponentIdentifier componentIdentifier = subject.getInitialComponentIdentifier();
         if (componentIdentifier instanceof ProjectComponentIdentifier) {
             return projectStateRegistry.stateFor((ProjectComponentIdentifier) componentIdentifier).getMutableModel();
-        } else if (componentIdentifier instanceof OpaqueComponentArtifactIdentifier) {
-            return projectStateRegistry.stateFor(DefaultBuildIdentifier.ROOT, org.gradle.util.Path.ROOT).getMutableModel();
         } else {
             return null;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformationWorkspaceServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformationWorkspaceServices.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.cache.Cache;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.internal.Try;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
@@ -31,14 +31,14 @@ import java.io.File;
 
 @NotThreadSafe
 public class ImmutableTransformationWorkspaceServices implements TransformationWorkspaceServices, Closeable {
-    private final CrossBuildInMemoryCache<UnitOfWork.Identity, Try<ImmutableList<File>>> identityCache;
+    private final Cache<UnitOfWork.Identity, Try<ImmutableList<File>>> identityCache;
     private final DefaultImmutableWorkspaceProvider workspaceProvider;
 
     public ImmutableTransformationWorkspaceServices(
         CacheBuilder cacheBuilder,
         FileAccessTimeJournal fileAccessTimeJournal,
         ExecutionHistoryStore executionHistoryStore,
-        CrossBuildInMemoryCache<UnitOfWork.Identity, Try<ImmutableList<File>>> identityCache
+        Cache<UnitOfWork.Identity, Try<ImmutableList<File>>> identityCache
     ) {
         this.workspaceProvider = DefaultImmutableWorkspaceProvider.withExternalHistory(cacheBuilder, fileAccessTimeJournal, executionHistoryStore);
         this.identityCache = identityCache;
@@ -50,7 +50,7 @@ public class ImmutableTransformationWorkspaceServices implements TransformationW
     }
 
     @Override
-    public CrossBuildInMemoryCache<UnitOfWork.Identity, Try<ImmutableList<File>>> getIdentityCache() {
+    public Cache<UnitOfWork.Identity, Try<ImmutableList<File>>> getIdentityCache() {
         return identityCache;
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AbstractRealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AbstractRealLifeAndroidBuildPerformanceTest.groovy
@@ -28,7 +28,7 @@ class AbstractRealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPe
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        runner.targetVersions = ["6.8-20201116230039+0000"]
+        runner.targetVersions = ["6.8-20201223103229+0000"]
         // AGP 3.6 requires 5.6.1+
         // forUseAtConfigurationTime API used in this senario
         runner.minimumBaseVersion = "6.5"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/FileSystemWatchingPerformanceTest.groovy
@@ -44,7 +44,7 @@ class FileSystemWatchingPerformanceTest extends AbstractCrossVersionPerformanceT
 
     def setup() {
         runner.minimumBaseVersion = "6.7"
-        runner.targetVersions = ["6.8-20201108230029+0000"]
+        runner.targetVersions = ["6.8-20201223103229+0000"]
         runner.useToolingApi = true
         runner.args = ["--no-build-cache", "--no-scan"]
         if (OperatingSystem.current().windows) {


### PR DESCRIPTION
We revert that change for 6.8 and will re-introduce it in 7.0.

This reverts #15610 and #14926.