### PR TITLE
Fix some assertions not being executed

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
@@ -19,10 +19,17 @@ package org.gradle.integtests.resolve.api
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FluidDependenciesResolveRunner
 import org.junit.runner.RunWith
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 @RunWith(FluidDependenciesResolveRunner)
 class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
+
+    @Ignore
+    def "Spock bug workaround - do not remove or the test won't execute" () {
+        expect:
+        true
+    }
 
     @Unroll("cannot resolve a configuration with role #role at execution time")
     def "cannot resolve a configuration which is for publishing only at execution time"() {
@@ -157,7 +164,7 @@ class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
         fails 'a:check'
 
         then:
-        failure.assertHasCause "Selected configuration 'internal' but it can't be used as a project dependency because it isn't intended for consumption by other components."
+        failure.assertHasCause "Selected configuration 'internal' on 'project :b' but it can't be used as a project dependency because it isn't intended for consumption by other components."
 
         where:
         role                    | code
@@ -196,7 +203,7 @@ class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
         fails 'a:check'
 
         then:
-        failure.assertHasCause "Selected configuration 'default' but it can't be used as a project dependency because it isn't intended for consumption by other components."
+        failure.assertHasCause "Selected configuration 'default' on 'project :b' but it can't be used as a project dependency because it isn't intended for consumption by other components."
 
         where:
         role                    | code

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1427,6 +1427,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
+    protected void assertCanCarryBuildDependencies() {
+        assertIsResolvable();
+    }
+
+    @Override
     public AttributeContainerInternal getAttributes() {
         return configurationAttributes;
     }
@@ -1672,6 +1677,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public FileCollection getFiles() {
+            assertIsResolvable();
             return intrinsicFiles;
         }
 
@@ -1709,6 +1715,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public ResolutionResult getResolutionResult() {
+            assertIsResolvable();
             return new LenientResolutionResult(DEFAULT_ERROR_HANDLER);
         }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -93,6 +93,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     // This is final - override {@link TaskDependencyContainer#visitDependencies} to provide the dependencies instead.
     @Override
     public final TaskDependency getBuildDependencies() {
+        assertCanCarryBuildDependencies();
         return new AbstractTaskDependency() {
             @Override
             public String toString() {
@@ -104,6 +105,9 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
                 context.add(AbstractFileCollection.this);
             }
         };
+    }
+
+    protected void assertCanCarryBuildDependencies() {
     }
 
     @Override


### PR DESCRIPTION
The `ConfigurationRoleIntegrationTest` wasn't executed because of a bug
in Spock. In between, some refactoring made some assertions not executed
anymore, in case of fluid dependencies.

This commit fixes the problem by reintroducing checks at various
points where they should be performed.
