### PR TITLE
Add `sanityFix` task to run all automated fixup tasks

### DIFF
--- a/build-logic-commons/code-quality/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/code-quality/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -31,6 +31,7 @@ tasks.withType<Test>().configureEach {
 tasks.check {
     dependsOn(codeQuality)
 }
+tasks.register("codeQualityFix")
 
 val rules by configurations.creating {
     isVisible = false

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jlleitschuh.gradle.ktlint.KtlintFormatTask
 import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -43,17 +44,24 @@ ktlint {
         exclude("gradle/kotlin/dsl/accessors/_*/**")
     }
 }
-
+// Only check the build files, not all *.kts files in the project
+val ktlintScriptSourceSets = files("build.gradle.kts", "settings.gradle.kts")
 tasks.ktlintKotlinScriptCheck {
-    // Only check the build files, not all *.kts files in the project
-    setSource(files("build.gradle.kts", "settings.gradle.kts"))
+    setSource(ktlintScriptSourceSets)
+}
+
+tasks.ktlintKotlinScriptFormat {
+    setSource(ktlintScriptSourceSets)
+}
+
+tasks.named("codeQualityFix") {
+    dependsOn(tasks.withType<KtlintFormatTask>())
 }
 
 tasks.validatePlugins {
     failOnWarning.set(true)
     enableStricterValidation.set(true)
 }
-
 
 val isCiServer = "CI" in System.getenv()
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,6 +2,10 @@ tasks.register("check") {
     dependsOn(subprojects.map { "${it.name}:check" })
 }
 
+tasks.register("codeQualityFix") {
+    dependsOn(subprojects.flatMap { project -> project.tasks.matching { it.name == "codeQualityFix" }})
+}
+
 val clean by tasks.registering {
     val buildSrcPropertiesFile = layout.projectDirectory.file("gradle.properties")
     val rootPropertiesFile = layout.projectDirectory.file("../gradle.properties")

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -27,6 +27,8 @@ val compileAllBuild = "compileAllBuild"
 
 val sanityCheck = "sanityCheck"
 
+val sanityFix = "sanityFix"
+
 val quickTest = "quickTest"
 
 val platformTest = "platformTest"
@@ -113,6 +115,15 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
             ":tooling-api:toolingApiShadedJar",
             ":performance:verifyPerformanceScenarioDefinitions",
             ":checkSubprojectsInfo"
+        )
+    }
+
+    register(sanityFix) {
+        description = "Run all simple fixup tasks"
+        group = "verification"
+        dependsOn(
+            gradle.includedBuild("build-logic").task(":codeQualityFix"),
+            ":generateSubprojectsInfo"
         )
     }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.ci-lifecycle.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.ci-lifecycle.gradle.kts
@@ -41,6 +41,12 @@ fun TaskContainer.registerEarlyFeedbackLifecycleTasks() {
         group = "verification"
         dependsOn("compileAll", "codeQuality")
     }
+
+    register("sanityFix") {
+        description = "Run all simple fixup tasks"
+        group = "verification"
+        dependsOn("codeQualityFix")
+    }
 }
 
 fun TaskContainer.configureCIIntegrationTestDistributionLifecycleTasks() {

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
@@ -16,6 +16,7 @@
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
+import org.jlleitschuh.gradle.ktlint.KtlintFormatTask
 
 plugins {
     kotlin("js")
@@ -49,6 +50,7 @@ tasks {
     }
 
     val ktlintCheckTasks = withType<KtlintCheckTask>()
+    val ktlintFormatTasks = withType<KtlintFormatTask>()
 
     withType<Test>().configureEach {
         shouldRunAfter(ktlintCheckTasks)
@@ -56,6 +58,10 @@ tasks {
 
     named("codeQuality") {
         dependsOn(ktlintCheckTasks)
+    }
+
+    named("codeQualityFix") {
+        dependsOn(ktlintFormatTasks)
     }
 
     register("quickTest") {

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
@@ -32,3 +32,7 @@ plugins {
     id("gradlebuild.ci-reporting") // CI: Prepare reports to be uploaded to TeamCity
     id("gradlebuild.spotless")
 }
+
+tasks.named("codeQualityFix") {
+    dependsOn(tasks.named("spotlessApply"))
+}

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -18,6 +18,7 @@ import gradlebuild.basics.accessors.kotlin
 import org.gradle.api.internal.initialization.DefaultClassLoaderScope
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
+import org.jlleitschuh.gradle.ktlint.KtlintFormatTask
 
 
 plugins {
@@ -44,14 +45,24 @@ tasks {
     }
 
     val ktlintCheckTasks = withType<KtlintCheckTask>()
+    val ktlintFormatTasks = withType<KtlintFormatTask>()
 
     named("codeQuality") {
         dependsOn(ktlintCheckTasks)
     }
 
+    named("codeQualityFix") {
+        dependsOn(ktlintFormatTasks)
+    }
+
+    // Only check the build files, not all *.kts files in the project
+    val ktlintScriptSourceSets = files("build.gradle.kts", "settings.gradle.kts")
     ktlintKotlinScriptCheck {
-        // Only check the build files, not all *.kts files in the project
-        setSource(files("build.gradle.kts", "settings.gradle.kts"))
+        setSource(ktlintScriptSourceSets)
+    }
+
+    ktlintKotlinScriptFormat {
+        setSource(ktlintScriptSourceSets)
     }
 
     withType<Test>().configureEach {


### PR DESCRIPTION
Adds the `sanityFix` task which is designed to run any automation we have to fix build issues that don't require developer intervention.