### PR TITLE
Finalize Deprecation of HTTP dependencies download

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.caching.http.internal
 
+import org.gradle.caching.http.HttpBuildCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+import org.gradle.internal.deprecation.Documentation
 import org.gradle.test.fixtures.keystore.TestKeyStore
 
 @IntegrationTestTimeout(120)
@@ -240,21 +242,18 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         skipped(":compileJava")
     }
 
-    def "produces deprecation warning when using plain HTTP"() {
+    def "throws exception when using plain HTTP"() {
+        when:
         httpBuildCacheServer.useHostname()
         settingsFile.text = useHttpBuildCache(httpBuildCacheServer.uri)
 
-        when:
-        executer.expectDeprecationWarning()
-        withBuildCache().run "jar"
-        succeeds "clean"
-        executer.expectDocumentedDeprecationWarning("Using insecure protocols with remote build cache, without explicit opt-in, has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
-            "Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols. " +
-            "See https://docs.gradle.org/current/dsl/org.gradle.caching.http.HttpBuildCache.html#org.gradle.caching.http.HttpBuildCache:allowInsecureProtocol for more details.")
-
         then:
-        withBuildCache().run "jar"
-        skipped(":compileJava")
+        def failure = withBuildCache().fails "jar"
+        failure.assertHasCause(
+            "Using insecure protocols with remote build cache, without explicit opt-in, is unsupported. " +
+                "Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols. " +
+                Documentation.dslReference(HttpBuildCache, "allowInsecureProtocol").consultDocumentationMessage()
+        )
     }
 
     def "ssl certificate is validated"() {

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
@@ -18,13 +18,14 @@ package org.gradle.caching.http.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.authentication.Authentication;
 import org.gradle.caching.BuildCacheService;
 import org.gradle.caching.BuildCacheServiceFactory;
 import org.gradle.caching.http.HttpBuildCache;
 import org.gradle.caching.http.HttpBuildCacheCredentials;
 import org.gradle.internal.authentication.DefaultBasicAuthentication;
-import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.resource.transport.http.DefaultHttpSettings;
 import org.gradle.internal.resource.transport.http.HttpClientHelper;
 import org.gradle.internal.resource.transport.http.SslContextFactory;
@@ -106,11 +107,13 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
             .create(
                 url,
                 allowInsecureProtocol,
-                () -> DeprecationLogger.deprecate("Using insecure protocols with remote build cache, without explicit opt-in,")
-                    .withAdvice("Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols.")
-                    .willBeRemovedInGradle7()
-                    .withDslReference(HttpBuildCache.class, "allowInsecureProtocol")
-                    .nagUser(),
+                () -> {
+                    String message =
+                        "Using insecure protocols with remote build cache, without explicit opt-in, is unsupported. " +
+                            "Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols. " +
+                            Documentation.dslReference(HttpBuildCache.class, "allowInsecureProtocol").consultDocumentationMessage();
+                    throw new InvalidUserCodeException(message);
+                },
                 redirect -> {
                     throw new IllegalStateException("Redirects are unsupported by the the build cache.");
                 });

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -15,9 +15,12 @@
  */
 package org.gradle.api
 
+import org.gradle.api.resources.TextResourceFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
+import org.gradle.internal.deprecation.Documentation
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.matchers.UserAgentMatcher
@@ -25,6 +28,8 @@ import org.gradle.util.GUtil
 import org.gradle.util.GradleVersion
 import spock.lang.Issue
 import spock.lang.Unroll
+
+import static org.junit.Assert.fail
 
 class HttpScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
     @org.junit.Rule
@@ -69,7 +74,9 @@ class HttpScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
         when:
         server.useHostname()
         def script = file('external.gradle')
-        server.expectGet('/external.gradle', script)
+        server.beforeHandle {
+            fail("No requests were expected.")
+        }
 
         script << """
             task doStuff
@@ -83,11 +90,12 @@ class HttpScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
 """
 
         then:
-        executer.expectDocumentedDeprecationWarning("Applying script plugins from insecure URIs has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
+        ExecutionFailure failure = fails(":help")
+        failure.assertHasCause("Applying script plugins from insecure URIs, without explicit opt-in, is unsupported. " +
             "The provided URI '${server.uri("/external.gradle")}' uses an insecure protocol (HTTP). " +
-            "Use '${GUtil.toSecureUrl(server.uri("/external.gradle"))}' instead or try 'apply from: resources.text.fromInsecureUri(\"${server.uri("/external.gradle")}\")' to silence the warning. " +
-            "See https://docs.gradle.org/current/dsl/org.gradle.api.resources.TextResourceFactory.html#org.gradle.api.resources.TextResourceFactory:fromInsecureUri(java.lang.Object) for more details.")
-        succeeds()
+            "Use '${GUtil.toSecureUrl(server.uri("/external.gradle"))}' instead or try 'apply from: resources.text.fromInsecureUri(\"${server.uri("/external.gradle")}\")' to fix this. " +
+            Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+        )
     }
 
     def "does not complain when applying script plugin via http using text resource"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -15,9 +15,11 @@
  */
 package org.gradle.api.resource
 
+import org.gradle.api.resources.TextResourceFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
+import org.gradle.internal.deprecation.Documentation
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.GUtil
@@ -108,11 +110,11 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "uri backed text resource over http"() {
-        given:
+        when:
         def uuid = UUID.randomUUID()
         def resourceFile = file("web-file.txt")
         server.useHostname() // use localhost vs ip
-        server.expectGet("/myConfig-${uuid}.txt", resourceFile)
+        server.forbidGet("/myConfig-${uuid}.txt", resourceFile)
         server.start()
 
         buildFile << """
@@ -121,23 +123,15 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
                 output = project.file("output.txt")
             }
 """
-        when:
-        executer.expectDocumentedDeprecationWarning("Loading a TextResource from an insecure URI has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
-            "The provided URI '${server.uri("/myConfig-" + uuid + ".txt")}' uses an insecure protocol (HTTP). " +
-            "Switch the URI to '${GUtil.toSecureUrl(server.uri("/myConfig-" + uuid + ".txt"))}' or try 'resources.text.fromInsecureUri(\"${server.uri("/myConfig-" + uuid + ".txt")}\")' to silence the warning. " +
-            "See https://docs.gradle.org/current/dsl/org.gradle.api.resources.TextResourceFactory.html#org.gradle.api.resources.TextResourceFactory:fromInsecureUri(java.lang.Object) for more details.")
-        run("uriText")
-
         then:
-        result.assertTasksExecuted(":uriText")
-        file("output.txt").text == "my config\n"
+        def failure = fails("uriText")
 
-        when:
-        executer.noDeprecationChecks()
-        run("uriText")
-
-        then:
-        result.assertTasksSkipped(":uriText")
+        failure.assertHasCause(
+            "Loading a TextResource from an insecure URI, without explicit opt-in, is unsupported. " +
+                "The provided URI '${server.uri}/myConfig-${uuid}.txt' uses an insecure protocol (HTTP). " +
+                "Switch the URI to '${GUtil.toSecureUrl(server.uri)}/myConfig-${uuid}.txt' or try 'resources.text.fromInsecureUri(\"${server.uri}/myConfig-${uuid}.txt\")' to silence the warning. " +
+                Documentation.dslReference(TextResourceFactory, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+        )
     }
 
     def "uri backed text resource over https"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveBaseIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveBaseIntegrationTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.http
+
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
+
+abstract class AbstractRedirectResolveBaseIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    @Rule SetSystemProperties systemProperties = new SetSystemProperties()
+    @Rule HttpServer backingServer = new HttpServer()
+
+    abstract String getFrontServerBaseUrl();
+
+    abstract boolean defaultAllowInsecureProtocol();
+
+    def module = ivyRepo().module('group', 'projectA').publish()
+
+    abstract void beforeServerStart();
+
+    def setupServer() {
+        beforeServerStart()
+        server.useHostname()
+        backingServer.useHostname()
+        backingServer.start()
+    }
+
+    @Override
+    def setup() {
+        setupServer()
+        executer.withWarningMode(WarningMode.All)
+    }
+
+    void optionallyExpectDeprecation() {
+//        if (shouldWarnAboutDeprecation()) {
+//            outputContains("Following insecure redirects, without explicit opt-in, has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+//            outputContains("Switch "); outputContains(" repository ")
+//            outputContains(" to redirect to a secure protocol (like HTTPS) or allow insecure protocols.")
+//        }
+    }
+
+    def configurationWithIvyDependencyAndExpectedArtifact(String dependency, String expectedArtifact, boolean allowInsecureProtocol = defaultAllowInsecureProtocol()) {
+        String allowInsecureProtocolCall =  allowInsecureProtocol ? "allowInsecureProtocol true" : ""
+        """
+            repositories {
+                ivy {
+                    url "$frontServerBaseUrl/repo"
+                    metadataSources {
+                        ivyDescriptor()
+                        artifact()
+                    }
+                    $allowInsecureProtocolCall
+                }
+            }
+            configurations { compile }
+            dependencies { compile '$dependency' }
+            task listJars {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['$expectedArtifact']
+                }
+            }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpRedirectResolveIntegrationTest.groovy
@@ -24,11 +24,23 @@ class HttpRedirectResolveIntegrationTest extends AbstractRedirectResolveIntegrat
     }
 
     @Override
-    boolean shouldWarnAboutDeprecation() {
+    boolean defaultAllowInsecureProtocol() {
         return true
     }
 
     void beforeServerStart() {
         // No-op
+    }
+
+    def "fails to resolves module artifacts via HTTP redirect"() {
+        given:
+        buildFile << configurationWithIvyDependencyAndExpectedArtifact('group:projectA:1.0', 'projectA-1.0.jar', false)
+
+        when:
+        server.forbidGetRedirected('/repo/group/projectA/1.0/ivy-1.0.xml', "${backingServer.uri}/redirected/group/projectA/1.0/ivy-1.0.xml")
+        backingServer.forbidGet('/redirected/group/projectA/1.0/ivy-1.0.xml', module.ivyFile)
+
+        then:
+        fails('listJars')
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpsRedirectResolveIntegrationTest.groovy
@@ -31,7 +31,7 @@ class HttpsToHttpsRedirectResolveIntegrationTest extends AbstractRedirectResolve
     }
 
     @Override
-    boolean shouldWarnAboutDeprecation() {
+    boolean defaultAllowInsecureProtocol() {
         return false
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -79,13 +79,13 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "creates a resolver for HTTP patterns"() {
         repository.name = 'name'
-        repository.artifactPattern 'http://host/[organisation]/[artifact]-[revision].[ext]'
-        repository.artifactPattern 'http://other/[module]/[artifact]-[revision].[ext]'
-        repository.ivyPattern 'http://host/[module]/ivy-[revision].xml'
+        repository.artifactPattern 'https://host/[organisation]/[artifact]-[revision].[ext]'
+        repository.artifactPattern 'https://other/[module]/[artifact]-[revision].[ext]'
+        repository.ivyPattern 'https://host/[module]/ivy-[revision].xml'
 
         given:
-        fileResolver.resolveUri('http://host/') >> new URI('http://host/')
-        fileResolver.resolveUri('http://other/') >> new URI('http://other/')
+        fileResolver.resolveUri('https://host/') >> new URI('https://host/')
+        fileResolver.resolveUri('https://other/') >> new URI('https://other/')
         standardMockHttpTransport()
 
         when:
@@ -96,8 +96,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository == resourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[artifact]-[revision].[ext]', 'http://other/[module]/[artifact]-[revision].[ext]']
-            ivyPatterns == ['http://host/[module]/ivy-[revision].xml']
+            artifactPatterns == ['https://host/[organisation]/[artifact]-[revision].[ext]', 'https://other/[module]/[artifact]-[revision].[ext]']
+            ivyPatterns == ['https://host/[module]/ivy-[revision].xml']
         }
     }
 
@@ -127,11 +127,11 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "uses ivy patterns with specified url and default layout"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
         repository.layout 'ivy'
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -142,17 +142,17 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[type]s/[artifact](.[ext])']
-            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/[type]s/[artifact](.[ext])"]
+            artifactPatterns == ['https://host/[organisation]/[module]/[revision]/[type]s/[artifact](.[ext])']
+            ivyPatterns == ["https://host/[organisation]/[module]/[revision]/[type]s/[artifact](.[ext])"]
         }
     }
 
     def "uses gradle patterns with specified url and default layout"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -163,18 +163,18 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])']
-            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/ivy-[revision].xml"]
+            artifactPatterns == ['https://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])']
+            ivyPatterns == ["https://host/[organisation]/[module]/[revision]/ivy-[revision].xml"]
         }
     }
 
     def "uses maven patterns with specified url and maven layout"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
         repository.layout 'maven'
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -185,22 +185,22 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])']
-            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/ivy-[revision].xml"]
+            artifactPatterns == ['https://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])']
+            ivyPatterns == ["https://host/[organisation]/[module]/[revision]/ivy-[revision].xml"]
             m2compatible
         }
     }
 
     def "uses specified base url with configured pattern layout"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
         repository.patternLayout {
             artifact '[module]/[revision]/[artifact](.[ext])'
             ivy '[module]/[revision]/ivy.xml'
         }
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -211,15 +211,15 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[module]/[revision]/[artifact](.[ext])']
-            ivyPatterns == ["http://host/[module]/[revision]/ivy.xml"]
+            artifactPatterns == ['https://host/[module]/[revision]/[artifact](.[ext])']
+            ivyPatterns == ["https://host/[module]/[revision]/ivy.xml"]
             !resolver.m2compatible
         }
     }
 
     def "when requested uses maven patterns with configured pattern layout"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
         repository.patternLayout {
             artifact '[module]/[revision]/[artifact](.[ext])'
             ivy '[module]/[revision]/ivy.xml'
@@ -227,7 +227,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         }
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -238,20 +238,20 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[module]/[revision]/[artifact](.[ext])']
-            ivyPatterns == ["http://host/[module]/[revision]/ivy.xml"]
+            artifactPatterns == ['https://host/[module]/[revision]/[artifact](.[ext])']
+            ivyPatterns == ["https://host/[module]/[revision]/ivy.xml"]
             m2compatible
         }
     }
 
     def "combines layout patterns with additionally specified patterns"() {
         repository.name = 'name'
-        repository.url = 'http://host/'
-        repository.artifactPattern 'http://host/[other]/artifact'
-        repository.ivyPattern 'http://host/[other]/ivy'
+        repository.url = 'https://host/'
+        repository.artifactPattern 'https://host/[other]/artifact'
+        repository.ivyPattern 'https://host/[other]/ivy'
 
         given:
-        fileResolver.resolveUri('http://host/') >> new URI('http://host/')
+        fileResolver.resolveUri('https://host/') >> new URI('https://host/')
         standardMockHttpTransport()
 
         when:
@@ -262,29 +262,29 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])', 'http://host/[other]/artifact']
-            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/ivy-[revision].xml", 'http://host/[other]/ivy']
+            artifactPatterns == ['https://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])', 'https://host/[other]/artifact']
+            ivyPatterns == ["https://host/[organisation]/[module]/[revision]/ivy-[revision].xml", 'https://host/[other]/ivy']
         }
     }
 
     def "uses artifact pattern for ivy files when no ivy pattern provided"() {
         repository.name = 'name'
-        repository.url = 'http://host'
+        repository.url = 'https://host'
         repository.patternLayout {
             artifact '[layoutPattern]'
         }
-        repository.artifactPattern 'http://other/[additionalPattern]'
+        repository.artifactPattern 'https://other/[additionalPattern]'
         standardMockHttpTransport()
 
         given:
-        fileResolver.resolveUri('http://host') >> new URI('http://host')
-        fileResolver.resolveUri('http://other/') >> new URI('http://other/')
+        fileResolver.resolveUri('https://host') >> new URI('https://host')
+        fileResolver.resolveUri('https://other/') >> new URI('https://other/')
 
         when:
         def resolver = repository.createResolver()
 
         then:
-        resolver.artifactPatterns == ['http://host/[layoutPattern]', 'http://other/[additionalPattern]']
+        resolver.artifactPatterns == ['https://host/[layoutPattern]', 'https://other/[additionalPattern]']
         resolver.ivyPatterns == resolver.artifactPatterns
     }
 
@@ -302,8 +302,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "can set a custom metadata rule"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        repository.url = 'https://host'
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         given:
@@ -319,8 +319,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "can inject configuration into a custom metadata rule"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        repository.url = 'https://host'
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         given:
@@ -337,8 +337,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "can set a custom version lister"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        repository.url = 'https://host'
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         given:
@@ -354,8 +354,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "can inject configuration into a custom version lister"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        repository.url = 'https://host'
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         given:
@@ -371,8 +371,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
 
     def "can retrieve metadataSources"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        repository.url = 'https://host'
+        fileResolver.resolveUri('https://host') >> new URI('https://host/')
         standardMockHttpTransport()
 
         given:
@@ -401,7 +401,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     }
 
     private void standardMockHttpTransport() {
-        transportFactory.createTransport({ it == ['http'] as Set }, 'name', _, _) >> transport()
+        transportFactory.createTransport({ it == ['https'] as Set }, 'name', _, _) >> transport()
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -86,9 +86,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "creates http repository"() {
         given:
-        def uri = new URI("http://localhost:9090/repo")
+        def uri = new URI("https://localhost:9090/repo")
         _ * resolver.resolveUri('repo-dir') >> uri
-        transportFactory.createTransport('http', 'repo', _, _) >> transport()
+        transportFactory.createTransport('https', 'repo', _, _) >> transport()
 
         and:
         repository.name = 'repo'
@@ -104,13 +104,13 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "creates repository with additional artifact URLs"() {
         given:
-        def uri = new URI("http://localhost:9090/repo")
-        def uri1 = new URI("http://localhost:9090/repo1")
-        def uri2 = new URI("http://localhost:9090/repo2")
+        def uri = new URI("https://localhost:9090/repo")
+        def uri1 = new URI("https://localhost:9090/repo1")
+        def uri2 = new URI("https://localhost:9090/repo2")
         _ * resolver.resolveUri('repo-dir') >> uri
         _ * resolver.resolveUri('repo1') >> uri1
         _ * resolver.resolveUri('repo2') >> uri2
-        transportFactory.createTransport('http', 'repo', _, _) >> transport()
+        transportFactory.createTransport('https', 'repo', _, _) >> transport()
 
         and:
         repository.name = 'repo'
@@ -159,7 +159,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "create repository from strongly typed URI"() {
         given:
-        def uri = new URI("http://localhost:9090/repo")
+        def uri = new URI("https://localhost:9090/repo")
         _ * resolver.resolveUri(_) >> uri
         transportFactory.createTransport(_, 'repo', _, _) >> transport()
 
@@ -177,9 +177,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "can set a custom metadata rule"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        resolver.resolveUri('http://host') >> new URI('http://host/')
-        transportFactory.createTransport('http', 'name', _, _) >> transport()
+        repository.url = 'https://host'
+        resolver.resolveUri('https://host') >> new URI('https://host/')
+        transportFactory.createTransport('https', 'name', _, _) >> transport()
 
         given:
         repository.setMetadataSupplier(CustomMetadataSupplier)
@@ -195,9 +195,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "can inject configuration into a custom metadata rule"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        resolver.resolveUri('http://host') >> new URI('http://host/')
-        transportFactory.createTransport('http', 'name', _, _) >> transport()
+        repository.url = 'https://host'
+        resolver.resolveUri('https://host') >> new URI('https://host/')
+        transportFactory.createTransport('https', 'name', _, _) >> transport()
 
         given:
         repository.setMetadataSupplier(CustomMetadataSupplierWithParams) { it.params("a", 12, [1, 2, 3]) }
@@ -213,9 +213,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "can set a custom version lister"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        resolver.resolveUri('http://host') >> new URI('http://host/')
-        transportFactory.createTransport('http', 'name', _, _) >> transport()
+        repository.url = 'https://host'
+        resolver.resolveUri('https://host') >> new URI('https://host/')
+        transportFactory.createTransport('https', 'name', _, _) >> transport()
 
         given:
         repository.setComponentVersionsLister(CustomVersionLister)
@@ -230,9 +230,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "can inject configuration into a custom version lister"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        resolver.resolveUri('http://host') >> new URI('http://host/')
-        transportFactory.createTransport('http', 'name', _, _) >> transport()
+        repository.url = 'https://host'
+        resolver.resolveUri('https://host') >> new URI('https://host/')
+        transportFactory.createTransport('https', 'name', _, _) >> transport()
 
         given:
         repository.setComponentVersionsLister(CustomVersionListerWithParams) { it.params("a", 12, [1, 2, 3]) }
@@ -247,9 +247,9 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     def "can retrieve metadataSources"() {
         repository.name = 'name'
-        repository.url = 'http://host'
-        resolver.resolveUri('http://host') >> new URI('http://host/')
-        transportFactory.createTransport('http', 'name', _, _) >> transport()
+        repository.url = 'https://host'
+        resolver.resolveUri('https://host') >> new URI('https://host/')
+        transportFactory.createTransport('https', 'name', _, _) >> transport()
 
         given:
         repository.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/ForbidOne.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/ForbidOne.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,10 @@ package org.gradle.test.fixtures.server
 import groovy.transform.CompileStatic
 
 @CompileStatic
-abstract class ExpectOne extends OneRequestServerExpectation {
+abstract class ForbidOne extends OneRequestServerExpectation {
 
-    @Override
     void assertMet() {
-        if (!run) {
+        if (run) {
             throw new AssertionError(notMetMessage as Object)
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/OneRequestServerExpectation.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/OneRequestServerExpectation.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,13 @@ package org.gradle.test.fixtures.server
 
 import groovy.transform.CompileStatic
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 @CompileStatic
-abstract class ExpectOne extends OneRequestServerExpectation {
+abstract class OneRequestServerExpectation implements ServerExpectation {
+    AtomicBoolean atomicRun = new AtomicBoolean()
 
-    @Override
-    void assertMet() {
-        if (!run) {
-            throw new AssertionError(notMetMessage as Object)
-        }
+    boolean isRun() {
+        return atomicRun.get()
     }
-
-    abstract String getNotMetMessage()
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -19,7 +19,7 @@ package org.gradle.internal.deprecation;
 import com.google.common.base.Preconditions;
 import org.gradle.api.internal.DocumentationRegistry;
 
-abstract class Documentation {
+public abstract class Documentation {
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
 
     static final Documentation NO_DOCUMENTATION = new NullDocumentation();
@@ -36,13 +36,13 @@ abstract class Documentation {
         return new UpgradeGuide(majorVersion, upgradeGuideSection);
     }
 
-    static Documentation dslReference(Class<?> targetClass, String property) {
+    public static Documentation dslReference(Class<?> targetClass, String property) {
         return new DslReference(targetClass, property);
     }
 
     abstract String documentationUrl();
 
-    String consultDocumentationMessage() {
+    public String consultDocumentationMessage() {
         return String.format("See %s for more details.", documentationUrl());
     }
 
@@ -57,7 +57,7 @@ abstract class Documentation {
         }
 
         @Override
-        String consultDocumentationMessage() {
+        public String consultDocumentationMessage() {
             return null;
         }
     }
@@ -95,7 +95,7 @@ abstract class Documentation {
         }
 
         @Override
-        String consultDocumentationMessage() {
+        public String consultDocumentationMessage() {
             return "Consult the upgrading guide for further information: " + documentationUrl();
         }
     }

--- a/subprojects/resources/src/main/java/org/gradle/internal/verifier/HttpRedirectVerifierFactory.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/verifier/HttpRedirectVerifierFactory.java
@@ -23,6 +23,8 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.function.Consumer;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Used to create instances of {@link HttpRedirectVerifier}.
  */
@@ -43,6 +45,8 @@ public class HttpRedirectVerifierFactory {
         Runnable insecureBaseHost,
         Consumer<URI> insecureRedirect
     ) {
+        requireNonNull(insecureBaseHost, "insecureBaseHost must not be null");
+        requireNonNull(insecureRedirect, "insecureRedirect must not be null");
         if (allowInsecureProtocol) {
             return NoopHttpRedirectVerifier.instance;
         } else {


### PR DESCRIPTION
Finalizes the removal of support for downloading dependencies over HTTP, forcing explicit opt-in.

For 7.0