### PR TITLE
Automatically add required exclusion for JDK 9+ & includeNoLocationClasses

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoTaskExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoTaskExtension.xml
@@ -56,6 +56,9 @@
             <tr>
                 <td>jmx</td>
             </tr>
+            <tr>
+                <td>jdkInternalAutomaticallyAddedAboveJDK8</td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoAgentJar.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoAgentJar.java
@@ -23,6 +23,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.util.VersionNumber;
 
 import java.io.File;
+import java.lang.management.ManagementFactory;
 import javax.inject.Inject;
 
 /**
@@ -92,6 +93,23 @@ public class JacocoAgentJar {
         });
         return !pre076;
     }
+
+    /** JVMs' above Java 8 need to have jdk.internal excluded, see https://github.com/gradle/gradle/issues/5184 */
+    public boolean includeNoLocationClassesNeedsJdkInternalExcluded() {
+        String jvmSpec = ManagementFactory.getRuntimeMXBean().getSpecVersion();
+        int majorSeparator = jvmSpec.indexOf('.');
+        if (majorSeparator != -1) {
+            jvmSpec = jvmSpec.substring(0, majorSeparator);
+        }
+        try {
+            int majorVersionNumber = Integer.parseInt(jvmSpec);
+            return majorVersionNumber > 8;
+        } catch(NumberFormatException e) {
+            // If the spec version is unparsable we shouldn't alter the excludes list
+            return false;
+        }
+    }
+
 
     public static VersionNumber extractVersion(String jarName) {
         // jarName format: org.jacoco.agent-<version>.jar

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -70,6 +70,7 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
             port = 100
             classDumpDir = project.file('build/jacoco-dump')
             jmx = true
+            jdkInternalAutomaticallyAddedAboveJDK8 = false
         }
 
         def expected = new StringBuilder().with { builder ->


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #5184

### Context
When includeNoLocationClasses is set to true, and a JVM version 9 or above is used, the JaCoCo plugin fails with an exception. While using includeNoLocationClasses is uncommon it is used by a number of folks who currently have to all add a manual workaround to their builds. This change moves the fix into the plugin code so folk don't need to add the manual workaround.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
