### PR TITLE
Make build-cache-http tests compatible with Spock2

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheFixture.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheFixture.groovy
@@ -16,34 +16,23 @@
 
 package org.gradle.caching.http.internal
 
-import groovy.transform.SelfType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.server.http.HttpBuildCacheServer
-import org.junit.Before
 import org.junit.Rule
 
-@SelfType(AbstractIntegrationSpec)
-trait HttpBuildCacheFixture {
-    private HttpBuildCacheServer httpBuildCacheServer
+class HttpBuildCacheFixture extends AbstractIntegrationSpec {
 
     @Rule
-    HttpBuildCacheServer getHttpBuildCacheServer() {
-        return httpBuildCacheServer
-    }
-
-    @Before
-    void createBuildCache() {
-        httpBuildCacheServer = new HttpBuildCacheServer(temporaryFolder)
-    }
+    HttpBuildCacheServer httpBuildCacheServer = new HttpBuildCacheServer(temporaryFolder)
 
     String withHttpBuildCacheServer() {
         httpBuildCacheServer.start()
         return useHttpBuildCache(httpBuildCacheServer.uri)
     }
 
-    String useHttpBuildCache(URI uri) {
+    static String useHttpBuildCache(URI uri) {
         """
-            buildCache {  
+            buildCache {
                 local {
                     enabled = false
                 }

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheRequestHeadersIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheRequestHeadersIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.caching.http.internal
 
 import org.eclipse.jetty.servlet.FilterHolder
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.GradleVersion
 
 import javax.servlet.DispatcherType
@@ -28,7 +27,7 @@ import javax.servlet.ServletException
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 
-class HttpBuildCacheRequestHeadersIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
+class HttpBuildCacheRequestHeadersIntegrationTest extends HttpBuildCacheFixture {
     def "sends X-Gradle-Version header with store and load requests"() {
         given:
         buildFile << """

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -17,13 +17,12 @@
 package org.gradle.caching.http.internal
 
 import org.gradle.caching.internal.services.BuildCacheControllerFactory
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 import java.util.concurrent.atomic.AtomicInteger
 
 import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
 
-class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
+class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFixture {
     def setup() {
         buildFile << """
             import org.gradle.api.*

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.caching.http.internal
 
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.keystore.TestKeyStore
 
 @IntegrationTestTimeout(120)
-class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
+class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
 
     static final String ORIGINAL_HELLO_WORLD = """
             public class Hello {


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

A JUnit4 Before annotated method coming from a trait is not picked up by Spock 2.
Use an abstract class instead.