### PR TITLE
Make configuration-cache tests compatible with Spock2

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.configurationcache.fixtures.BuildLogicChangeFixture
 import org.gradle.configurationcache.fixtures.ScriptChangeFixture
-import org.junit.Test
 import spock.lang.Unroll
 
 import static org.junit.Assume.assumeFalse
@@ -28,7 +27,6 @@ import static org.junit.Assume.assumeFalse
 class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     @Unroll
-    @Test
     def "invalidates cache upon change to #scriptChangeSpec of included build"() {
         given:
         def configurationCache = newConfigurationCacheFixture()

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptChangesIntegrationTest.groovy
@@ -17,13 +17,11 @@
 package org.gradle.configurationcache
 
 import org.gradle.configurationcache.fixtures.ScriptChangeFixture
-import org.junit.Test
 import spock.lang.Unroll
 
 class ConfigurationCacheScriptChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     @Unroll
-    @Test
     def "invalidates cache upon change to #scriptChangeSpec"() {
         given:
         def configurationCache = newConfigurationCacheFixture()


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Remove JUnit annotations from Spock tests - those cause JUnit engine to try and execute the test as a JUnit test in addition to executing it as a Spock test which results in a failure.
