### PR TITLE
Make platform-native tests compatible with Spock2

### DIFF
--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform
 
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
 import spock.lang.Ignore
@@ -85,6 +86,7 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         'build'    | _
     }
 
+    @ToBeFixedForConfigurationCache
     @Unroll
     def "#task triggers expected tasks only"() {
         when:

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChainIntegrationSpec {
@@ -53,6 +54,14 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         '''.stripIndent()
 
         helloWorldApp.writeSources(file("src/main"), file("src/hello"), file("src/greetings"))
+    }
+
+    @Ignore
+    def "spock workaround - remove when upgrading to Spock2"() {
+        when:
+        true
+        then:
+        true
     }
 
     @Unroll
@@ -97,7 +106,7 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         'assembleDependentsGreetings'              | _
     }
 
-    private static List<String> getExpectedTasks(String task) {
+    private static String[] getExpectedTasks(String task) {
         switch(task) {
             case 'assembleDependentsMainExecutable':
                 return [':mainExecutable']
@@ -120,7 +129,7 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         }
     }
 
-    private static List<String> getUnexpectedTasks(String task) {
+    private static String[] getUnexpectedTasks(String task) {
         switch(task) {
             case 'assembleDependentsHelloStaticLibrary':
                 return [':mainExecutable']


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

This test is never executed currently because of a bug in Spock.
With an ignored-test-workaround, it fails because of incorrect object types passed to assertion methods - this change corrects those types so that the test runs and passes.
