### PR TITLE
Make test-kit tests compatible with Spock2

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -93,8 +93,8 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
 
         when:
         def runner = gradleVersion >= GradleVersion.version("4.5")
-            ? runner('helloWorld', '--warning-mode=none')
-            : runner('helloWorld')
+            ? this.runner('helloWorld', '--warning-mode=none')
+            : this.runner('helloWorld')
         runner.buildAndFail()
 
         then:
@@ -143,7 +143,7 @@ $t.buildResult.output"""
         """
 
         when:
-        def runner = runner('helloWorld')
+        def runner = this.runner('helloWorld')
         runner.build()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
@@ -61,7 +61,7 @@ class GradleRunnerGradleVersionIntegrationTest extends BaseGradleRunnerIntegrati
         """
 
         when:
-        def runner = runner('writeVersion')
+        def runner = this.runner('writeVersion')
         configurer.execute(runner)
         runner.build()
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -158,7 +158,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
         """
 
         when:
-        def runner = runner('helloWorld')
+        def runner = this.runner('helloWorld')
         runner.build()
 
         then:


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Spock2 tests fail when a local variable is given the same name as a method used when initializing that variable.
Explicitly prefixing the method invocation with this. works around this issue.
