### PR TITLE
De-incubate types used in artifact queries

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -233,6 +233,9 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.artifacts.ComponentVariantIdentifier
         - org.gradle.api.artifacts.maven.PomModuleDescriptor
         - org.gradle.api.artifacts.repositories.AuthenticationSupported.credentials(java.lang.Class<? extends org.gradle.api.credentials.Credentials>)
+        - org.gradle.jvm.JvmLibrary
+        - org.gradle.language.base.artifact.SourcesArtifact
+        - org.gradle.language.java.artifact.JavadocArtifact
 - Tooling API
     - Eclipse models
         - org.gradle.tooling.model.eclipse.EclipseRuntime

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/artifact/JavadocArtifact.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/artifact/JavadocArtifact.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.language.java.artifact;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.Artifact;
 
 /**
@@ -23,6 +22,5 @@ import org.gradle.api.component.Artifact;
  *
  * @since 2.0
  */
-@Incubating
 public interface JavadocArtifact extends Artifact {
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/artifact/SourcesArtifact.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/artifact/SourcesArtifact.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.language.base.artifact;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.Artifact;
 
 /**
@@ -23,6 +22,5 @@ import org.gradle.api.component.Artifact;
  *
  * @since 2.0
  */
-@Incubating
 public interface SourcesArtifact extends Artifact {
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/JvmLibrary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/JvmLibrary.java
@@ -16,12 +16,10 @@
 
 package org.gradle.jvm;
 
-import org.gradle.api.Incubating;
 import org.gradle.platform.base.Library;
 
 /**
  * A Library component that runs on the Java Virtual Machine.
  */
-@Incubating
 public interface JvmLibrary extends Library {
 }


### PR DESCRIPTION
The 'artifact query' feature is on the list of things to be deprecated in the future. Most use cases can be addressed in a more flexible way by variant-aware dependency resolution. Component metadata rules allow you to add variants for arbitrary variants that Gradle can then resolve to (e.g. variants containing the sources Jars or the metadata files themselves).

However, there are no concrete plans at the moment to make sure artifact queries can be fully replaced by alternative solutions.

In any case, since the feature is around since Gradle 2, it needs to go through a full deprecation cycle. There is no point in having some of the used types still 'Incubating'.

