### PR TITLE
Make testing-jvm tests compatible with Spock2

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/SuiteTimestampIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/SuiteTimestampIntegrationTest.groovy
@@ -18,13 +18,11 @@ package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
-import org.junit.Test
 import spock.lang.Issue
 
 class SuiteTimestampIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("GRADLE-2730")
-    @Test
     void "test logging is included in XML results"() {
         file("build.gradle") << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.junit.Before
 import org.junit.Rule
-import org.junit.Test
 import spock.lang.Issue
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
@@ -33,11 +32,10 @@ class TestOutputListenerIntegrationTest extends JUnitMultiVersionIntegrationSpec
     @Rule public final TestResources resources = new TestResources(temporaryFolder)
 
     @Before
-    public void before() {
+    void before() {
         executer.noExtraLogging()
     }
 
-    @Test
     def "can use standard output listener for tests"() {
         given:
         def test = file("src/test/java/SomeTest.java")
@@ -98,7 +96,6 @@ class RemoveMeListener implements TestOutputListener {
         !failure.output.contains("remove me!")
     }
 
-    @Test
     @UnsupportedWithConfigurationCache
     def "can register output listener at gradle level and using onOutput method"() {
         given:
@@ -142,7 +139,6 @@ class VerboseOutputListener implements TestOutputListener {
         outputContains('second: message from foo')
     }
 
-    @Test
     def "shows standard streams configured via closure"() {
         given:
         def test = file("src/test/java/SomeTest.java")
@@ -174,7 +170,6 @@ test.testLogging {
         outputContains('message from foo')
     }
 
-    @Test
     def "shows standard stream also for testNG"() {
         given:
         ignoreWhenJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
-import org.junit.Test
 import spock.lang.Issue
 
 @TargetCoverage({TestNGCoverage.STANDARD_COVERAGE})
@@ -31,7 +30,6 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
      * https://discuss.gradle.org/t/npe-when-accessing-missing-property-in-usetestng-block-2-11-nightly/13226
      * https://discuss.gradle.org/t/calling-suitexmlbuilder-changes-invocation-context-in-usetestng-block-2-11-nightly/13227
      */
-    @Test
     def "can reference suiteXmlBuilder"() {
         given:
         buildFile << '''


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Remove JUnit Test annotations from Spock tests - those cause JUnit engine to try and execute the test as a JUnit test in addition to executing it as a Spock test which results in a failure.