### PR TITLE
Make dependency-management tests compatible with Spock2

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
@@ -333,7 +333,7 @@ task check(type: Sync) {
      * Dependency graph:
      * a -> b -> c -> d
      */
-    def "when a module is depended on via a single chained path, it is excluded if excluded on any of the links in that path (#name)"() {
+    def "when a module is depended on via a single chained path, it is excluded if excluded on any of the links in that path (#condition)"() {
         given:
         repository {
             'a:a:1.0' {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -259,7 +259,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
     @Unroll
     @ToBeFixedForConfigurationCache
-    void "honors multiple rejections #rejects using dynamic versions using dependency notation #notation"() {
+    void "honors multiple rejections #rejects using dynamic versions using dependency notation #rejects"() {
         given:
         repository {
             (0..5).each {


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Spock2 tests fail if the variable reference in unrolled method name can not be resolved.
