### PR TITLE
Make platform-base tests compatible with Spock2

### DIFF
--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LifecycleBasePluginIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LifecycleBasePluginIntegrationTest.groovy
@@ -47,7 +47,7 @@ class LifecycleBasePluginIntegrationTest extends AbstractIntegrationSpec {
         taskName << ["check", "clean", "build", "assemble"]
     }
 
-    def "can attach custom task as dependency to lifecycle task - #task"() {
+    def "can attach custom task as dependency to lifecycle task - #taskName"() {
         when:
         buildFile << """
             task myTask {}


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Spock2 tests fail if the variable reference in unrolled method name can not be resolved.
