### PR TITLE
Make workers tests compatible with Spock2

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -315,7 +315,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         assertSameDaemonWasUsed("runInDaemon", "reuseDaemon")
     }
 
-    def "throws if worker used from a thread with no current build operation in #isolationMode"() {
+    def "throws if worker used from a thread with no current build operation in #workerMethod"() {
         given:
         fixture.withWorkActionClassInBuildSrc()
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Spock2 tests fail if the variable reference in unrolled method name can not be resolved.