### PR TITLE
Workaround setup/Before ordering in Spock 2 - file-watching

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
@@ -30,15 +30,17 @@ class ContinuousBuildFileWatchingIntegrationTest extends AbstractContinuousInteg
 
     def setup() {
         executer.requireIsolatedDaemons()
+    }
+
+    def "file system watching picks up changes causing a continuous build to rebuild"() {
+        given:
         // Do not drop the VFS in the first build, since there is only one continuous build invocation.
         // FileSystemWatchingFixture automatically sets the argument for the first build.
         executer.withArgument(FileSystemWatchingHelper.getDropVfsArgument(false))
         executer.beforeExecute {
             withWatchFs()
         }
-    }
 
-    def "file system watching picks up changes causing a continuous build to rebuild"() {
         def numberOfFilesInVfs = 4 // source file, class file, JAR manifest, JAR file
         def vfsLogs = enableVerboseVfsLogs()
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

Spock 2 executes Before annotated JUnit methods after its setup() methods which used to be the other way around.
This breaks the file-watching test that made use of this ordering semantics.
This change rearranges the test configuration so that it is compatible with both Spock 1 and 2.
