### PR TITLE
Convert RichConsoleStyling trait to a class

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
-class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyResolutionTest implements RichConsoleStyling {
+class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyResolutionTest {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
@@ -121,12 +121,12 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
 
     void outputContainsProgress(GradleHandle build, String taskProgressLine, String... progressOutputLines) {
         def output = LogContent.of(build.standardOutput).ansiCharsToColorText().withNormalizedEol()
-        assert output.contains(workInProgressLine(taskProgressLine)) ||
-            progressOutputLines.any { output.contains(workInProgressLine(taskProgressLine + " " + it)) }
+        assert output.contains(RichConsoleStyling.workInProgressLine(taskProgressLine)) ||
+            progressOutputLines.any { output.contains(RichConsoleStyling.workInProgressLine(taskProgressLine + " " + it)) }
 
         assert progressOutputLines.every {
-            output.contains(workInProgressLine(it)) ||
-                output.contains(workInProgressLine(taskProgressLine + " " + it))
+            output.contains(RichConsoleStyling.workInProgressLine(it)) ||
+                output.contains(RichConsoleStyling.workInProgressLine(taskProgressLine + " " + it))
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -223,8 +224,8 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
         then:
         block.waitForAllPendingCalls()
         poll {
-            assertHasWorkInProgress(build, "> Transforming lib1.jar (project :lib) with Red > Red lib1.jar")
-            assertHasWorkInProgress(build, "> Transforming lib2.jar (project :lib) with Red > Red lib2.jar")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib1.jar (project :lib) with Red > Red lib1.jar")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib2.jar (project :lib) with Red > Red lib2.jar")
         }
 
         block.releaseAll()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RichConsoleStyling.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RichConsoleStyling.groovy
@@ -20,11 +20,11 @@ import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.fixtures.executer.LogContent
 
 /**
- * A trait for testing console behavior.
+ * Assertions for testing console behavior.
  * <p>
  * <b>Note:</b> The console output contains formatting characters.
  */
-trait RichConsoleStyling {
+class RichConsoleStyling {
     static String workInProgressLine(String plainText) {
         return "{bold-on}" + plainText + "{bold-off}"
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/console/AbstractConsoleGroupedTaskFunctionalTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/console/AbstractConsoleGroupedTaskFunctionalTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.fixtures.console
 import org.fusesource.jansi.Ansi
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.ConsoleAttachment
 import org.junit.runner.RunWith
 
@@ -27,7 +26,7 @@ import org.junit.runner.RunWith
  * A base class for testing the console.
  */
 @RunWith(ConsoleAttachmentTestRunner.class)
-abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
     static ConsoleAttachment consoleAttachment
 
     def setup() {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleConfigurationProgressFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleConfigurationProgressFunctionalTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
-abstract class AbstractConsoleConfigurationProgressFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+abstract class AbstractConsoleConfigurationProgressFunctionalTest extends AbstractIntegrationSpec {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
     GradleHandle gradle
@@ -156,7 +156,7 @@ abstract class AbstractConsoleConfigurationProgressFunctionalTest extends Abstra
 
     void assertHasWorkInProgress(String message) {
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(gradle, "> " + message)
+            RichConsoleStyling.assertHasWorkInProgress(gradle, "> " + message)
         }
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.logging.console.jvm
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -26,10 +25,13 @@ import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.*
+import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.JavaTestClass
+import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.containsTestExecutionWorkInProgressLine
+import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.testClass
+import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.testableJavaProject
 
 @IgnoreIf({ GradleContextualExecuter.isParallel() })
-abstract class AbstractConsoleJvmTestWorkerFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+abstract class AbstractConsoleJvmTestWorkerFunctionalTest extends AbstractIntegrationSpec {
 
     private static final int MAX_WORKERS = 2
     private static final String SERVER_RESOURCE_1 = 'test-1'

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleTestNGUnsupportedTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleTestNGUnsupportedTestWorkerFunctionalTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.logging.console.jvm
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
@@ -26,7 +25,7 @@ import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.testC
 import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.testableJavaProject
 import static org.gradle.internal.logging.console.jvm.TestedProjectFixture.useTestNG
 
-class ConsoleTestNGUnsupportedTestWorkerFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+class ConsoleTestNGUnsupportedTestWorkerFunctionalTest extends AbstractIntegrationSpec {
 
     private static final int MAX_WORKERS = 2
     private static final String SERVER_RESOURCE_1 = 'test-1'

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/TestedProjectFixture.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/TestedProjectFixture.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 
-class TestedProjectFixture implements RichConsoleStyling {
+class TestedProjectFixture {
 
     static String testClass(String testAnnotationClassName, String testClassName, String serverResource, BlockingHttpServer server) {
         """
@@ -41,13 +41,13 @@ class TestedProjectFixture implements RichConsoleStyling {
     static String testableJavaProject(String testDependency, int maxWorkers) {
         """
             apply plugin: 'java'
-            
+
             ${RepoScriptBlockUtil.jcenterRepository()}
-            
+
             dependencies {
                 testImplementation '${testDependency}'
             }
-            
+
             tasks.withType(Test) {
                 maxParallelForks = $maxWorkers
             }
@@ -63,7 +63,7 @@ class TestedProjectFixture implements RichConsoleStyling {
     }
 
     static void containsTestExecutionWorkInProgressLine(GradleHandle gradleHandle, String taskPath, String testName) {
-        assertHasWorkInProgress(gradleHandle, "> $taskPath > Executing test $testName")
+        RichConsoleStyling.assertHasWorkInProgress(gradleHandle, "> $taskPath > Executing test $testName")
     }
 
     static class JavaTestClass {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
-class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest implements RichConsoleStyling {
+class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
@@ -87,7 +87,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.jar")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.jar")
         }
 
         when:
@@ -96,7 +96,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.jar.sha1")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.jar.sha1")
         }
 
         when:
@@ -105,7 +105,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.pom")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.pom")
         }
 
         when:
@@ -114,7 +114,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.pom.sha1")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.pom.sha1")
         }
 
         when:
@@ -123,7 +123,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.module > 1.8 KiB/1.8 KiB uploaded")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > test-1.2.module > 1.8 KiB/1.8 KiB uploaded")
         }
 
         when:
@@ -133,7 +133,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
         then:
         ConcurrentTestUtil.poll {
             // TODO - where did this one go?
-//            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > maven-metadata.xml")
+//            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > maven-metadata.xml")
         }
 
         when:
@@ -142,7 +142,7 @@ class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest i
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > maven-metadata.xml")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> :publishMavenPublicationToMavenRepository > maven-metadata.xml")
         }
 
         putMetaData.releaseAll()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JvmBlockingTestClassGenerator.*
 
-abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpec implements RichConsoleStyling {
+abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpec {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
     JvmBlockingTestClassGenerator generator
@@ -158,8 +158,8 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
 
         then:
         ConcurrentTestUtil.poll {
-            assertHasWorkInProgress(gradleHandle, '> :test > Executing test pkg.FailedTest')
-            assertHasWorkInProgress(gradleHandle, '> :test > Executing test pkg.OtherTest')
+            RichConsoleStyling.assertHasWorkInProgress(gradleHandle, '> :test > Executing test pkg.FailedTest')
+            RichConsoleStyling.assertHasWorkInProgress(gradleHandle, '> :test > Executing test pkg.OtherTest')
         }
 
         testExecution.release(FAILED_RESOURCE)


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15567

I don't understand why/how Spock2 triggers this error, but `RichConsoleStyling` trait with its couple of static assertion methods fails the compilation with: https://ge.gradle.org/s/2rwzs52pyu6pm/console-log?task=:internal-integ-testing:compileGroovy
It basically complains that `AbstractConsoleGroupedTaskFunctionalTest` is attempting to override static methods from `RichConsoleStyling` which it does not. Something must be generating those methods somewhere.

This change works around the problem by converting the `RichConsoleStyling` trait to a class. It only contains two static assertion methods that can be referenced from this utility class without users having to implement it as a trait.

