### PR TITLE
Fix worker classpath vs. module path setup

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -91,7 +91,9 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
         Object requestedSecurityManager = execSpec.getSystemProperties().get("java.security.manager");
         List<File> workerMainClassPath = classPathRegistry.getClassPath("WORKER_MAIN").getAsFiles();
 
-        if (implementationModulePath != null) {
+        boolean runAsModule = !applicationModulePath.isEmpty() && execSpec.getModularity().getInferModulePath().get();
+
+        if (runAsModule) {
             execSpec.getMainModule().set("gradle.worker");
         }
         execSpec.getMainClass().set("worker." + GradleWorkerMain.class.getName());
@@ -100,7 +102,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
         if (useOptionsFile) {
             // Use an options file to pass across application classpath
             File optionsFile = temporaryFileProvider.createTemporaryFile("gradle-worker-classpath", "txt");
-            List<String> jvmArgs = writeOptionsFile(execSpec.getModularity().getInferModulePath().get(), workerMainClassPath, implementationModulePath, applicationClasspath, applicationModulePath, optionsFile);
+            List<String> jvmArgs = writeOptionsFile(runAsModule, workerMainClassPath, implementationModulePath, applicationClasspath, applicationModulePath, optionsFile);
             execSpec.jvmArgs(jvmArgs);
         } else {
             // Use a dummy security manager, which hacks the application classpath into the system ClassLoader
@@ -130,7 +132,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
             }
 
             // Serialize the worker implementation classpath, this is consumed by GradleWorkerMain
-            if (execSpec.getModularity().getInferModulePath().get() || implementationModulePath == null) {
+            if (runAsModule || implementationModulePath == null) {
                 outstr.writeInt(implementationClassPath.size());
                 for (URL entry : implementationClassPath) {
                     outstr.writeUTF(entry.toString());

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayRunIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayRunIntegrationTest.groovy
@@ -20,11 +20,9 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.play.integtest.fixtures.PlayMultiVersionRunApplicationIntegrationTest
 import org.gradle.play.integtest.fixtures.app.BasicPlayApp
-import spock.lang.Ignore
 
 import java.util.concurrent.TimeUnit
 
-@Ignore("https://github.com/gradle/gradle-private/issues/3255")
 class PlayRunIntegrationTest extends PlayMultiVersionRunApplicationIntegrationTest {
     PlayApp playApp = new BasicPlayApp(versionNumber)
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -110,7 +110,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         builder.applicationClasspath(classPath);
         builder.applicationModulePath(modulePath);
         options.copyTo(builder.getJavaCommand());
-        builder.getJavaCommand().getModularity().getInferModulePath().set(modulePath.iterator().hasNext());
         builder.getJavaCommand().jvmArgs("-Dorg.gradle.native=false");
         buildConfigAction.execute(builder);
 


### PR DESCRIPTION
Gradle attempted to run a worker as module in too many cases. Having the 'infer' option enabled is not enough. We also actually need a module to run on the module path. The fix that was done in #15677 is not correct. With this commit, the condition is now as follows:

- Only run the worker itself as module when the application has  a module path
- Only in that case, the implementation module path of the worker itself is taken into account. Otherwise everything is done on the classpath.

The issue was discovered by a test running against the play framework plugins with a very unique worker setup. The issue should have also been revealed by all tests for the JUnit5 test runners, because JUnit5 actually has a specific module path when running as module. However, this was hidden by specifically setting 'inferModulePath=false' in the case of test running under a specific condition. This special handling is now removed.
