### PR TITLE
Promote destination/classes directory properties used by compile tasks

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -16,7 +16,6 @@
 package org.gradle.api.file;
 
 import org.gradle.api.Describable;
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.api.model.ReplacedBy;
@@ -115,7 +114,6 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @return The destination directory property for this set of sources.
      * @since 6.1
      */
-    @Incubating
     DirectoryProperty getDestinationDirectory();
 
     /**
@@ -124,10 +122,9 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      *
      * Note: To define the path of the output folder use {@link #getDestinationDirectory()}
      *
-     * @return The output directory property for this set of sources.
+     * @return The classes directory property for this set of sources.
      * @since 6.1
      */
-    @Incubating
     Provider<Directory> getClassesDirectory();
 
     /**
@@ -137,7 +134,6 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @param mapping a mapping from the task to the task's output directory (e.g. AbstractCompile::getDestinationDirectory)
      * @since 6.1
      */
-    @Incubating
     <T extends Task> void compiledBy(TaskProvider<T> taskProvider, Function<T, DirectoryProperty> mapping);
 
     /**

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -262,6 +262,10 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.tooling.events.test.TestOutputEvent
 - Java Ecosystem
     - Java plugins
+        - org.gradle.api.file.SourceDirectorySet.getDestinationDirectory()
+        - org.gradle.api.file.SourceDirectorySet.getClassesDirectory()
+        - org.gradle.api.file.SourceDirectorySet.compiledBy(TaskProvider<T>, Function<T, DirectoryProperty>)
+        - org.gradle.api.tasks.compile.AbstractCompile.getDestinationDirectory()
         - org.gradle.api.plugins.FeatureSpec.withJavadocJar()
         - org.gradle.api.plugins.FeatureSpec.withSourcesJar()
         - org.gradle.api.plugins.JavaPluginExtension.withJavadocJar()

--- a/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -221,9 +221,9 @@ The task can also leverage the <<toolchains.adoc#,Java toolchain support>>.
 Can set using anything described in <<working_with_files.adoc#sec:specifying_multiple_files,Specifying Multiple Files>>.
 | `__sourceSet__.groovy`
 
-|  `destinationDir`
+|  `destinationDirectory`
 | `File`.
-| `__sourceSet__.groovy.outputDir`
+| `__sourceSet__.groovy.destinationDirectory`
 
 |  `groovyClasspath`
 | link:{javadocPath}/org/gradle/api/file/FileCollection.html[FileCollection]

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -238,7 +238,7 @@ _Default value_: `src/$name/java`, e.g. _src/main/java_
 +
 The source directories containing the Java source files of this source set.  You can set this to any value that is described in <<working_with_files.adoc#sec:specifying_multiple_files,this section>>.
 
-`java.outputDir` — `File`::
+`java.destinationDirectory` — `DirectoryProperty`::
 _Default value_: `$buildDir/classes/java/$name`, e.g. _build/classes/java/main_
 +
 The directory to generate compiled Java sources into. You can set this to any value that is described in <<working_with_files.adoc#sec:single_file_paths,this section>>.

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.compile;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -70,7 +69,6 @@ public abstract class AbstractCompile extends SourceTask {
      * @return The destination directory property.
      * @since 6.1
      */
-    @Incubating
     @OutputDirectory
     public DirectoryProperty getDestinationDirectory() {
         return destinationDirectory;


### PR DESCRIPTION
De-incubate what was introduced in https://github.com/gradle/gradle/pull/11513


### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- [x] Deprecate existing API that is replaced by the new one
  - If it's not immediately possible, create a follow-up issue with a milestone (e.g. `7.1 RC1` or `8.0 RC1`); list for 7.1: #15681
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
