### PR TITLE
Do not fail build when tasks with missing dependencies run in parallel

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -17,17 +17,10 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 @Unroll
 class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
-
-    @Rule
-    public final BlockingHttpServer server = new BlockingHttpServer()
 
     private static final String DEPRECATION_WARNING = ":consumer consumes the output of :producer, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
 
@@ -193,50 +186,4 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(DEPRECATION_WARNING)
         succeeds("producer", "consumer")
     }
-
-    @IgnoreIf({ GradleContextualExecuter.parallel })
-    // no point, always runs in parallel
-    def "fails when consumer and producer run in parallel"() {
-        server.start()
-        settingsFile << """
-            include ':a', ':b'
-        """
-        file('a/build.gradle') << """
-            task producer {
-                def outputFile = file("output.txt")
-                outputs.file(outputFile)
-                outputs.upToDateWhen { false }
-                doLast {
-                    ${server.callFromTaskAction("taskAction")}
-                    outputFile.text = "produced"
-                }
-            }
-        """
-        file("b/build.gradle") << """
-            task consumer {
-                def inputFile = file("../a/output.txt")
-                inputs.files(inputFile)
-                doLast {
-                    ${server.callFromTaskAction("taskAction")}
-                    println "Hello " + inputFile.text
-                }
-            }
-        """
-        executer.beforeExecute {
-            withArgument("--max-workers=2")
-        }
-
-        when:
-        // Make sure the input file exists
-        server.expect("taskAction")
-        then:
-        succeeds("producer")
-
-        when:
-        server.expect("taskAction")
-        def result = fails(":b:consumer", ":a:producer")
-        then:
-        result.assertHasCause(":b:consumer consumes the output of :a:producer, but does not declare a dependency.")
-    }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -130,11 +130,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
     }
 
     private void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext) {
-        // If the consumer and producer are running at the same time, then something is very wrong in the current build.
-        // So we fail the build in that case to expose the problem.
-        TypeValidationContext.Severity severity = producer.isExecuting() && consumer.isExecuting()
-            ? TypeValidationContext.Severity.ERROR
-            : TypeValidationContext.Severity.WARNING;
+        TypeValidationContext.Severity severity = TypeValidationContext.Severity.WARNING;
         validationContext.visitPropertyProblem(
             severity,
             String.format("%s consumes the output of %s, but does not declare a dependency", consumer, producer)


### PR DESCRIPTION
We want to fail at some point, though currently we need to figure out how
to solve some use-cases of the gradle/gradle build, and this check would
cause to fail the build right now.

One of the use-cases currently failing is building the source distribution, which has a filtered file tree of the root project dir as an input. So it would need to depend on everything, though actually it doesn't need to depend on anything.