### PR TITLE
Ignore missing dependency if there is an explicit ordering

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -995,7 +995,6 @@ task generate(type: TransformerTask) {
 """
 
         when:
-        executer.expectDocumentedDeprecationWarning(":transform1 consumes the output of :src2, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
         run "src1", "transform1", "src2", "transform2"
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -22,7 +22,11 @@ import spock.lang.Unroll
 @Unroll
 class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final String DEPRECATION_WARNING = ":consumer consumes the output of :producer, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
+    private static final String DEPRECATION_WARNING = "Task ':consumer' uses the output of task ':producer', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task ':producer' as an input). " +
+        "This will cause correctness issues, depending on what order the tasks are executed. " +
+        "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+        "Execution optimizations are disabled due to the failed validation. " +
+        "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
 
     def "detects missing dependency between two tasks (#description)"() {
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Unroll
 class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String DEPRECATION_WARNING = "Task ':consumer' uses the output of task ':producer', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task ':producer' as an input). " +
-        "This will cause correctness issues, depending on what order the tasks are executed. " +
+        "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
         "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
         "Execution optimizations are disabled due to the failed validation. " +
         "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -142,7 +142,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         TypeValidationContext.Severity severity = TypeValidationContext.Severity.WARNING;
         validationContext.visitPropertyProblem(
             severity,
-            String.format("Task '%s' uses the output of task '%s', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '%s' as an input). This will cause correctness issues, depending on what order the tasks are executed", consumer, producer, producer)
+            String.format("Task '%s' uses the output of task '%s', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '%s' as an input). This can lead to incorrect results being produced, depending on what order the tasks are executed", consumer, producer, producer)
         );
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -142,7 +142,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         TypeValidationContext.Severity severity = TypeValidationContext.Severity.WARNING;
         validationContext.visitPropertyProblem(
             severity,
-            String.format("%s consumes the output of %s, but does not declare a dependency", consumer, producer)
+            String.format("Task '%s' uses the output of task '%s', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '%s' as an input). This will cause correctness issues, depending on what order the tasks are executed", consumer, producer, producer)
         );
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -73,7 +73,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
     private void detectMissingDependencies(LocalTaskNode node, TypeValidationContext validationContext) {
         for (String outputPath : node.getMutationInfo().outputPaths) {
             consumedLocations.getNodesRelatedTo(outputPath).stream()
-                .filter(consumerNode -> missesDependency(node, consumerNode))
+                .filter(consumerNode -> hasNoSpecifiedOrder(node, consumerNode))
                 .forEach(consumerWithoutDependency -> collectValidationProblem(node, consumerWithoutDependency, validationContext));
         }
         Set<String> locationsConsumedByThisTask = new LinkedHashSet<>();
@@ -102,9 +102,18 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         consumedLocations.recordRelatedToNode(node, locationsConsumedByThisTask);
         for (String locationConsumedByThisTask : locationsConsumedByThisTask) {
             producedLocations.getNodesRelatedTo(locationConsumedByThisTask).stream()
-                .filter(producerNode -> missesDependency(producerNode, node))
+                .filter(producerNode -> hasNoSpecifiedOrder(producerNode, node))
                 .forEach(producerWithoutDependency -> collectValidationProblem(producerWithoutDependency, node, validationContext));
         }
+    }
+
+    // In a perfect world, the consumer should depend on the producer.
+    // Though we still don't have a good solution for the code linter and formatter use-case.
+    // And for that case, there will be a cyclic dependency between the analyze and the format task if we only take output/input locations into account.
+    // Therefore, we currently allow these kind of missing dependencies, as long as any order has been specified.
+    // See https://github.com/gradle/gradle/issues/15616.
+    private boolean hasNoSpecifiedOrder(Node producerNode, Node consumerNode) {
+        return missesDependency(producerNode, consumerNode) && missesDependency(consumerNode, producerNode);
     }
 
     private static boolean missesDependency(Node producer, Node consumer) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -290,8 +290,6 @@ class Main {
 installDist.destinationDir = buildDir
 """
         when:
-        executer.expectDocumentedDeprecationWarning(":startScripts consumes the output of :installDist, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":jar consumes the output of :installDist, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
         runAndFail "installDist"
 
         then:

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -735,7 +735,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     void expectMissingDependencyDeprecation(String producer, String consumer) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
-                "This will cause correctness issues, depending on what order the tasks are executed. " +
+                "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +
                 "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -469,8 +469,8 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         }
 
         when:
-        executer.expectDocumentedDeprecationWarning(":backup consumes the output of :restore, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":restore consumes the output of :backup, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":restore", ":backup")
+        expectMissingDependencyDeprecation(":backup", ":restore")
         run 'backup', 'restore'
 
         then:
@@ -487,8 +487,8 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         //
         // If cleaning up stale output files does not invalidate the file system mirror, then the restore task would be up-to-date.
         invalidateBuildOutputCleanupState()
-        executer.expectDocumentedDeprecationWarning(":backup consumes the output of :restore, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":restore consumes the output of :backup, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":restore", ":backup")
+        expectMissingDependencyDeprecation(":backup", ":restore")
         run 'backup', 'restore', '--info'
 
         then:
@@ -732,4 +732,12 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
+    void expectMissingDependencyDeprecation(String producer, String consumer) {
+        executer.expectDocumentedDeprecationWarning(
+            "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "This will cause correctness issues, depending on what order the tasks are executed. " +
+                "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+                "Execution optimizations are disabled due to the failed validation. " +
+                "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -108,8 +108,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         }
         // Generate external jar with entries in alphabetical order
         def externalJar = file('build/libs/external.jar')
-        executer.expectDocumentedDeprecationWarning(":a:compileJava consumes the output of :alphabetic, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":a:javadoc consumes the output of :alphabetic, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":alphabetic", ":a:compileJava")
+        expectMissingDependencyDeprecation(":alphabetic", ":a:javadoc")
         succeeds("alphabetic", ":a:javadoc")
         new ZipTestFixture(externalJar).hasDescendantsInOrder('META-INF/MANIFEST.MF', 'a', 'b', 'c', 'd')
 
@@ -156,8 +156,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             file("external/$it").touch()
         }
         // Generate external jar with entries with a current timestamp
-        executer.expectDocumentedDeprecationWarning(":a:compileJava consumes the output of :currentTime, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":a:javadoc consumes the output of :currentTime, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":currentTime", ":a:compileJava")
+        expectMissingDependencyDeprecation(":currentTime", ":a:javadoc")
         succeeds("currentTime", ":a:javadoc")
         def oldHash = externalJar.md5Hash
         when:
@@ -199,8 +199,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         duplicate.text = "duplicate"
 
         // Generate external jar with entries with a duplicate 'a' file
-        executer.expectDocumentedDeprecationWarning(":a:compileJava consumes the output of :duplicate, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
-        executer.expectDocumentedDeprecationWarning(":a:javadoc consumes the output of :duplicate, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":duplicate", ":a:compileJava")
+        expectMissingDependencyDeprecation(":duplicate", ":a:javadoc")
         succeeds("duplicate", ":a:javadoc")
         def oldHash = externalJar.md5Hash
 
@@ -257,5 +257,14 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped(":a:javadoc")
         file("a/build/docs/javadoc/A.html").isFile()
         !file("a/build/docs/javadoc/AA.html").isFile()
+    }
+
+    void expectMissingDependencyDeprecation(String producer, String consumer) {
+        executer.expectDocumentedDeprecationWarning(
+            "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
+            "This will cause correctness issues, depending on what order the tasks are executed. " +
+            "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+            "Execution optimizations are disabled due to the failed validation. " +
+            "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -262,7 +262,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     void expectMissingDependencyDeprecation(String producer, String consumer) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
-            "This will cause correctness issues, depending on what order the tasks are executed. " +
+            "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
             "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
             "Execution optimizations are disabled due to the failed validation. " +
             "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
@@ -91,7 +91,7 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
     void expectMissingDependencyDeprecation(String producer, String consumer) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
-                "This will cause correctness issues, depending on what order the tasks are executed. " +
+                "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +
                 "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
@@ -78,7 +78,7 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
 
         when:
         // FIXME: Infer dependencies for zipTree(Provider<>)
-        executer.expectDocumentedDeprecationWarning(":unpackJavadocs consumes the output of :javadocJarArchive, but does not declare a dependency. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        expectMissingDependencyDeprecation(":javadocJarArchive", ":unpackJavadocs")
         def result = succeeds('javadocJar', 'unpackJavadocs')
 
         then: "The HTML Javadoc files are unpacked to the 'dist' directory"
@@ -86,6 +86,15 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
 
         where:
         dsl << ['groovy', 'kotlin']
+    }
+
+    void expectMissingDependencyDeprecation(String producer, String consumer) {
+        executer.expectDocumentedDeprecationWarning(
+            "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using dependsOn or mustRunAfter) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "This will cause correctness issues, depending on what order the tasks are executed. " +
+                "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+                "Execution optimizations are disabled due to the failed validation. " +
+                "See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
     }
 
     @Unroll


### PR DESCRIPTION
For some use-cases there are cyclic dependencies with respect to input
and output location of tasks. For example the spotless apply task depends
on the output of the spotless analyze task, but also modifies the inputs
(the sources) of the spotless analyze task. We don't have a better solution
for this use-case, yet, so we don't want to emit a deprecation warning.

So as long as there is an order relation in any direction, we do not emit
a warning about missing dependencies between tasks.

See #15616.