### PR TITLE
Enable file system watching by default

### DIFF
--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.slf4jApi)
     implementation(libs.guava)
 
+    testImplementation(project(":file-watching"))
     testImplementation(testFixtures(project(":dependency-management")))
 
     integTestImplementation(project(":build-option"))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
@@ -39,6 +39,7 @@ import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.BuildScopeServices
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.util.Path
 
@@ -85,7 +86,10 @@ open class ConfigurationCacheIncludedBuildState(
                     settingsPreparer,
                     taskExecutionPreparer,
                     NullConfigurationCache,
-                    BuildOptionBuildOperationProgressEventsEmitter(gradle.serviceOf())
+                    BuildOptionBuildOperationProgressEventsEmitter(
+                        gradle.serviceOf(),
+                        serviceRegistry.get(BuildLifecycleAwareVirtualFileSystem::class.java)
+                    )
                 )
             }
         )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
@@ -39,7 +39,6 @@ import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.BuildScopeServices
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.util.Path
 
@@ -86,10 +85,7 @@ open class ConfigurationCacheIncludedBuildState(
                     settingsPreparer,
                     taskExecutionPreparer,
                     NullConfigurationCache,
-                    BuildOptionBuildOperationProgressEventsEmitter(
-                        gradle.serviceOf(),
-                        serviceRegistry.get(BuildLifecycleAwareVirtualFileSystem::class.java)
-                    )
+                    BuildOptionBuildOperationProgressEventsEmitter(gradle.serviceOf())
                 )
             }
         )

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -30,7 +30,6 @@ import static org.gradle.internal.Cast.uncheckedCast;
 public class StartParameterInternal extends StartParameter {
     private boolean watchFileSystem;
     private boolean watchFileSystemDebugLogging;
-    private boolean watchFileSystemUsingDeprecatedOption;
     private boolean vfsVerboseLogging;
 
     private boolean configurationCache;
@@ -54,7 +53,6 @@ public class StartParameterInternal extends StartParameter {
         StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
         p.watchFileSystem = watchFileSystem;
         p.watchFileSystemDebugLogging = watchFileSystemDebugLogging;
-        p.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
         p.vfsVerboseLogging = vfsVerboseLogging;
         p.configurationCache = configurationCache;
         p.configurationCacheProblems = configurationCacheProblems;
@@ -102,14 +100,6 @@ public class StartParameterInternal extends StartParameter {
 
     public void setWatchFileSystemDebugLogging(boolean watchFileSystemDebugLogging) {
         this.watchFileSystemDebugLogging = watchFileSystemDebugLogging;
-    }
-
-    public boolean isWatchFileSystemUsingDeprecatedOption() {
-        return watchFileSystemUsingDeprecatedOption;
-    }
-
-    public void setWatchFileSystemUsingDeprecatedOption(boolean watchFileSystemUsingDeprecatedOption) {
-        this.watchFileSystemUsingDeprecatedOption = watchFileSystemUsingDeprecatedOption;
     }
 
     public boolean isVfsVerboseLogging() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 
 import java.io.File;
 import java.util.Collection;
@@ -28,7 +29,7 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 import static org.gradle.internal.Cast.uncheckedCast;
 
 public class StartParameterInternal extends StartParameter {
-    private boolean watchFileSystem;
+    private BuildLifecycleAwareVirtualFileSystem.WatchMode watchFileSystemMode = BuildLifecycleAwareVirtualFileSystem.WatchMode.DEFAULT;
     private boolean watchFileSystemDebugLogging;
     private boolean vfsVerboseLogging;
 
@@ -51,7 +52,7 @@ public class StartParameterInternal extends StartParameter {
     @Override
     protected StartParameter prepareNewBuild(StartParameter startParameter) {
         StartParameterInternal p = (StartParameterInternal) super.prepareNewBuild(startParameter);
-        p.watchFileSystem = watchFileSystem;
+        p.watchFileSystemMode = watchFileSystemMode;
         p.watchFileSystemDebugLogging = watchFileSystemDebugLogging;
         p.vfsVerboseLogging = vfsVerboseLogging;
         p.configurationCache = configurationCache;
@@ -86,12 +87,12 @@ public class StartParameterInternal extends StartParameter {
         super.searchUpwards = searchUpwards;
     }
 
-    public boolean isWatchFileSystem() {
-        return watchFileSystem;
+    public BuildLifecycleAwareVirtualFileSystem.WatchMode getWatchFileSystemMode() {
+        return watchFileSystemMode;
     }
 
-    public void setWatchFileSystem(boolean watchFileSystem) {
-        this.watchFileSystem = watchFileSystem;
+    public void setWatchFileSystemMode(BuildLifecycleAwareVirtualFileSystem.WatchMode watchFileSystemMode) {
+        this.watchFileSystemMode = watchFileSystemMode;
     }
 
     public boolean isWatchFileSystemDebugLogging() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
+import org.gradle.internal.watch.vfs.WatchMode;
 
 import java.io.File;
 import java.util.Collection;
@@ -29,7 +29,7 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 import static org.gradle.internal.Cast.uncheckedCast;
 
 public class StartParameterInternal extends StartParameter {
-    private BuildLifecycleAwareVirtualFileSystem.WatchMode watchFileSystemMode = BuildLifecycleAwareVirtualFileSystem.WatchMode.DEFAULT;
+    private WatchMode watchFileSystemMode = WatchMode.DEFAULT;
     private boolean watchFileSystemDebugLogging;
     private boolean vfsVerboseLogging;
 
@@ -87,11 +87,11 @@ public class StartParameterInternal extends StartParameter {
         super.searchUpwards = searchUpwards;
     }
 
-    public BuildLifecycleAwareVirtualFileSystem.WatchMode getWatchFileSystemMode() {
+    public WatchMode getWatchFileSystemMode() {
         return watchFileSystemMode;
     }
 
-    public void setWatchFileSystemMode(BuildLifecycleAwareVirtualFileSystem.WatchMode watchFileSystemMode) {
+    public void setWatchFileSystemMode(WatchMode watchFileSystemMode) {
         this.watchFileSystemMode = watchFileSystemMode;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
@@ -20,16 +20,22 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.configurationcache.options.ConfigurationCacheSettingsFinalizedProgressDetails;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 
 import javax.inject.Inject;
 
 public class BuildOptionBuildOperationProgressEventsEmitter {
 
     private final BuildOperationProgressEventEmitter eventEmitter;
+    private final BuildLifecycleAwareVirtualFileSystem buildLifecycleAwareVirtualFileSystem;
 
     @Inject
-    public BuildOptionBuildOperationProgressEventsEmitter(BuildOperationProgressEventEmitter eventEmitter) {
+    public BuildOptionBuildOperationProgressEventsEmitter(
+        BuildOperationProgressEventEmitter eventEmitter,
+        BuildLifecycleAwareVirtualFileSystem buildLifecycleAwareVirtualFileSystem
+    ) {
         this.eventEmitter = eventEmitter;
+        this.buildLifecycleAwareVirtualFileSystem = buildLifecycleAwareVirtualFileSystem;
     }
 
     @SuppressWarnings({"Anonymous2MethodRef", "Convert2Lambda"})
@@ -43,7 +49,7 @@ public class BuildOptionBuildOperationProgressEventsEmitter {
         eventEmitter.emitNowForCurrent(new FileSystemWatchingSettingsFinalizedProgressDetails() {
             @Override
             public boolean isEnabled() {
-                return startParameterInternal.isWatchFileSystem();
+                return buildLifecycleAwareVirtualFileSystem.isWatchingFileSystem();
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
@@ -19,23 +19,16 @@ package org.gradle.initialization;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.configurationcache.options.ConfigurationCacheSettingsFinalizedProgressDetails;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
-import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 
 import javax.inject.Inject;
 
 public class BuildOptionBuildOperationProgressEventsEmitter {
 
     private final BuildOperationProgressEventEmitter eventEmitter;
-    private final BuildLifecycleAwareVirtualFileSystem buildLifecycleAwareVirtualFileSystem;
 
     @Inject
-    public BuildOptionBuildOperationProgressEventsEmitter(
-        BuildOperationProgressEventEmitter eventEmitter,
-        BuildLifecycleAwareVirtualFileSystem buildLifecycleAwareVirtualFileSystem
-    ) {
+    public BuildOptionBuildOperationProgressEventsEmitter(BuildOperationProgressEventEmitter eventEmitter) {
         this.eventEmitter = eventEmitter;
-        this.buildLifecycleAwareVirtualFileSystem = buildLifecycleAwareVirtualFileSystem;
     }
 
     @SuppressWarnings({"Anonymous2MethodRef", "Convert2Lambda"})
@@ -44,12 +37,6 @@ public class BuildOptionBuildOperationProgressEventsEmitter {
             @Override
             public boolean isEnabled() {
                 return startParameterInternal.isConfigurationCache();
-            }
-        });
-        eventEmitter.emitNowForCurrent(new FileSystemWatchingSettingsFinalizedProgressDetails() {
-            @Override
-            public boolean isEnabled() {
-                return buildLifecycleAwareVirtualFileSystem.isWatchingFileSystem();
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -51,6 +51,7 @@ import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.session.BuildSessionState;
 import org.gradle.internal.session.CrossBuildSessionState;
 import org.gradle.internal.time.Time;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.invocation.DefaultGradle;
 
 import javax.annotation.Nullable;
@@ -190,7 +191,8 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             taskExecutionPreparer,
             gradle.getServices().get(ConfigurationCache.class),
             new BuildOptionBuildOperationProgressEventsEmitter(
-                gradle.getServices().get(BuildOperationProgressEventEmitter.class)
+                gradle.getServices().get(BuildOperationProgressEventEmitter.class),
+                serviceRegistry.get(BuildLifecycleAwareVirtualFileSystem.class)
             )
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -51,7 +51,6 @@ import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.session.BuildSessionState;
 import org.gradle.internal.session.CrossBuildSessionState;
 import org.gradle.internal.time.Time;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.invocation.DefaultGradle;
 
 import javax.annotation.Nullable;
@@ -191,8 +190,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             taskExecutionPreparer,
             gradle.getServices().get(ConfigurationCache.class),
             new BuildOptionBuildOperationProgressEventsEmitter(
-                gradle.getServices().get(BuildOperationProgressEventEmitter.class),
-                serviceRegistry.get(BuildLifecycleAwareVirtualFileSystem.class)
+                gradle.getServices().get(BuildOperationProgressEventEmitter.class)
             )
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -64,7 +64,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         options.add(new BuildCacheDebugLoggingOption());
         options.add(new WatchFileSystemOption());
         options.add(new WatchFileSystemDebugLoggingOption());
-        options.add(new DeprecatedWatchFileSystemOption());
         options.add(new VfsVerboseLoggingOption());
         options.add(new BuildScanOption());
         options.add(new DependencyLockingWriteOption());
@@ -310,21 +309,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
             startParameter.setWatchFileSystem(value);
-        }
-    }
-
-    @Deprecated
-    public static class DeprecatedWatchFileSystemOption extends BooleanBuildOption<StartParameterInternal> {
-        public static final String GRADLE_PROPERTY = "org.gradle.unsafe.watch-fs";
-
-        public DeprecatedWatchFileSystemOption() {
-            super(GRADLE_PROPERTY);
-        }
-
-        @Override
-        public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
-            startParameter.setWatchFileSystem(value);
-            startParameter.setWatchFileSystemUsingDeprecatedOption(true);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -32,6 +32,7 @@ import org.gradle.internal.buildoption.IntegerBuildOption;
 import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -308,7 +309,10 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
-            startParameter.setWatchFileSystem(value);
+            startParameter.setWatchFileSystemMode(value
+                ? BuildLifecycleAwareVirtualFileSystem.WatchMode.ENABLED
+                : BuildLifecycleAwareVirtualFileSystem.WatchMode.DISABLED
+            );
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -32,7 +32,7 @@ import org.gradle.internal.buildoption.IntegerBuildOption;
 import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
+import org.gradle.internal.watch.vfs.WatchMode;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -310,8 +310,8 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal startParameter, Origin origin) {
             startParameter.setWatchFileSystemMode(value
-                ? BuildLifecycleAwareVirtualFileSystem.WatchMode.ENABLED
-                : BuildLifecycleAwareVirtualFileSystem.WatchMode.DISABLED
+                ? WatchMode.ENABLED
+                : WatchMode.DISABLED
             );
         }
     }

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -354,8 +354,8 @@ image::gradle-core-test-build-scan-performance.png[Build Scan performance report
 
 `--watch-fs`, `--no-watch-fs`::
 Toggles <<gradle_daemon.adoc#sec:daemon_watch_fs,watching the file system>>.
-Allows Gradle to re-use information about the file system in the next build.
-_Default is off_.
+When enabled Gradle re-uses information it collects about the file system between builds.
+_Enabled by default on operating systems where Gradle supports this feature._
 
 === Gradle daemon options
 You can manage the <<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> through the following command line options.

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -85,8 +85,8 @@ _Default is off_.
 
 `org.gradle.vfs.watch=(true,false)`::
 Toggles <<gradle_daemon.adoc#sec:daemon_watch_fs,watching the file system>>.
-Allows Gradle to re-use information about the file system in the next build.
-_Default is off_.
+When enabled Gradle re-uses information it collects about the file system between builds.
+_Enabled by default on operating systems where Gradle supports this feature._
 
 `org.gradle.warning.mode=(all,fail,summary,none)`::
 When set to `all`, `summary` or `none`, Gradle will use different warning type display. See <<command_line_interface.adoc#sec:command_line_logging,Command-line logging options>> for details.

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -192,7 +192,7 @@ A significant part of the story for modern JVM performance is runtime code optim
 The Daemon also allows more effective in memory caching across builds. For example, the classes needed by the build (e.g. plugins, build scripts) can be held in memory between builds. Similarly, Gradle can maintain in-memory caches of build data such as the hashes of task inputs and outputs, used for incremental building.
 
 To detect changes on the file system, and to calculate what needs to be rebuilt, Gradle collects a lot of information about the state of the file system during every build.
-When <<sec:daemon_watch_fs,watching the file system>> is enabled, the Daemon can re-use the already collected information from the last build.
+On supported operating systems the Daemon re-uses the already collected information from the last build (see <<sec:daemon_watch_fs,watching the file system>>).
 This can save a significant amount of time for incremental builds, where the number of changes to the file system between two builds is typically low.
 
 [[sec:daemon_watch_fs]]
@@ -204,33 +204,34 @@ Doing so allows the Daemon to save the time to rebuild the Virtual File System f
 For incremental builds, there are typically only a few changes between builds.
 Therefore, incremental builds can re-use most of the Virtual File System from the last build and benefit the most from watching the file system.
 
-Gradle uses operating system features for watching the file system.
+Gradle uses native operating system features for watching the file system.
 It supports the feature on these operating systems and file systems:
 
 - Windows 10 with NTFS,
 - Linux (Ubuntu 16.04 or later, CentOS 8 or later, Red Hat Enterprise Linux 8 or later, Amazon Linux 2) using ext3 and ext4,
 - macOS 10.14 (Mojave) or later on APFS and HFS+.
 
-Network file systems like NFS and SMB are not supported.
-FAT file systems are not supported.
+Provided the operating system is supported by Gradle file system watching is enabled by default.
 
-Watching the file system is an experimental feature and is disabled by default.
-You can enable the feature in a couple of ways:
+=== Limitations
+File system watching currently has the following limitations:
 
-Run with `--watch-fs` on the command line::
-This enables watching the file system for this build only.
-Put `org.gradle.vfs.watch=true` in your `gradle.properties`::
-This enables watching the file system for all builds, unless explicitly disabled with `--no-watch-fs`.
+- If you have symlinks in your build, you won’t get the performance benefits for those locations.
+- Network drives like NFS or SMB are not supported
+- FAT file systems are not supported
 
 [[sec:daemon_watch_fs_troubleshooting]]
 === Troubleshooting file system watching
 
-Limitations::
-File system watching currently has the following limitations:
-- If you have symlinks in your build, you won’t get the performance benefits for those locations.
-- On Windows, we don’t support network drives (they might work, but we don’t test them yet).
+==== Disable file system watching
+Should the need arise, it can be explicitly disabled in the following ways:
 
-Enable verbose logging::
+Run with `--no-watch-fs` on the command line::
+This disables watching the file system for this build only.
+Put `org.gradle.vfs.watch=false` in your `gradle.properties`::
+This disables watching the file system for all builds, unless explicitly enabled with `--watch-fs`.
+
+==== Enable verbose logging
 You can instruct Gradle to some more information about the state of the virtual file system, and the events received from the file system using the `org.gradle.vfs.verbose` flag.
 This produces the following output at the start and end of the build:
 +
@@ -252,6 +253,8 @@ Virtual file system retains information about 3 files, 2 directories and 2 missi
 +
 Note that on Windows and macOS Gradle might report changes received since the last build even if you haven't changed anything.
 These are harmless notifications about changes to Gradle's own caches and can be ignored safely.
+
+==== Common problems
 
 Gradle does not pick up some of my changes::
 _Please https://gradle-community.slack.com/app_redirect?channel=file-system-watching[let us know on the Gradle community Slack] if that happens to you._

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -85,21 +85,15 @@ That’s the end of the quick wins.
 From here on out, improving your build performance will require some elbow grease.
 First, perhaps the most important step: finding out which bits of your build are slow and why.
 
-=== Enable file system watching
+=== File system watching
 
 Gradle talks a lot to the file system, especially when trying to resolve the state of the inputs and outputs of the build.
 To avoid unnecessary I/O an in-memory _virtual file system_ is maintained throughout the build.
-The _file system watching_ feature allows Gradle to keep this in-memory data between builds, further reducing I/O in a significant way.
+The _file system watching_ feature allows Gradle to keep this in-memory data between builds, further reducing I/O significantly.
 The impact depends on a number of factors, but is proportional to how much of the build is up-to-date.
 Thus it is most useful for building small changes incrementally.
 
-The typical way to enable the feature is to add the by adding the following setting to the project's `gradle.properties` file:
-
-.gradle.properties
-[source,properties]
-----
-org.gradle.vfs.watch=true
-----
+Since Gradle 7.0 file system watching is enabled by default on operating systems where the feature is supported by Gradle.
 
 Read more about this feature in the <<gradle_daemon.adoc#sec:daemon_watch_fs,corresponding section>>.
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -78,26 +78,6 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
 
     @Unroll
     @SuppressWarnings('GrDeprecatedAPIUsage')
-    def "deprecation message is shown when using the old property to enable watching the file system (enabled: #enabled)"() {
-        buildFile << """
-            apply plugin: "java"
-        """
-        executer.expectDocumentedDeprecationWarning(
-            "The org.gradle.unsafe.watch-fs system property has been deprecated. " +
-                "This is scheduled to be removed in Gradle 7.0. " +
-                "Please use the org.gradle.vfs.watch system property instead. " +
-                "See https://docs.gradle.org/current/userguide/gradle_daemon.html for more details."
-        )
-
-        expect:
-        succeeds("assemble", "-D${StartParameterBuildOptions.DeprecatedWatchFileSystemOption.GRADLE_PROPERTY}=${enabled}")
-
-        where:
-        enabled << [true, false]
-    }
-
-    @Unroll
-    @SuppressWarnings('GrDeprecatedAPIUsage')
     def "deprecation message is shown when using old VFS retention property to enable watching the file system (enabled: #enabled)"() {
         buildFile << """
             apply plugin: "java"

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -24,6 +24,17 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
     private static final String ENABLED_MESSAGE = "Watching the file system is enabled"
     private static final String DISABLED_MESSAGE = "Watching the file system is disabled"
 
+    def "is enabled by default"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+
+        when:
+        run("assemble", "--info")
+        then:
+        outputContains(ENABLED_MESSAGE)
+    }
+
     @Unroll
     def "can be enabled via gradle.properties (enabled: #enabled)"() {
         buildFile << """

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -35,6 +35,11 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     void afterBuildStarted(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
 
     /**
+     * Returns whether watching the file system is supported on the current operating system, and has successfully been started.
+     */
+    boolean isWatchingFileSystem();
+
+    /**
      * Register a watchable hierarchy.
      *
      * Only locations within watchable hierarchies will be watched for changes.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -53,33 +53,4 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
      */
     void beforeBuildFinished(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
 
-    enum VfsLogging {
-        NORMAL, VERBOSE
-    }
-
-    enum WatchMode {
-        ENABLED(true, "enabled"),
-        DEFAULT(true, "enabled if available"),
-        DISABLED(false, "disabled");
-
-        private final boolean enabled;
-        private final String description;
-
-        WatchMode(boolean enabled, String description) {
-            this.enabled = enabled;
-            this.description = description;
-        }
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-    }
-
-    enum WatchLogging {
-        NORMAL, DEBUG
-    }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -32,7 +32,7 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is started.
      */
-    void afterBuildStarted(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
+    void afterBuildStarted(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
 
     /**
      * Returns whether watching the file system is supported on the current operating system, and has successfully been started.
@@ -51,10 +51,32 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is finished.
      */
-    void beforeBuildFinished(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
+    void beforeBuildFinished(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
 
     enum VfsLogging {
         NORMAL, VERBOSE
+    }
+
+    enum WatchMode {
+        ENABLED(true, "enabled"),
+        DEFAULT(true, "enabled if available"),
+        DISABLED(false, "disabled");
+
+        private final boolean enabled;
+        private final String description;
+
+        WatchMode(boolean enabled, String description) {
+            this.enabled = enabled;
+            this.description = description;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public String getDescription() {
+            return description;
+        }
     }
 
     enum WatchLogging {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -31,15 +31,12 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
 
     /**
      * Called when the build is started.
+     *
+     * @return whether watching the file system is currently enabled. This requires that the feature
+     * is supported on the current operating system, it is enabled for the build, and has been successfully
+     * started.
      */
-    void afterBuildStarted(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
-
-    /**
-     * Returns whether watching the file system is currently enabled. This requires that the feature
-     * is supported on the current operating system, it is enabled for the build, has been successfully
-     * started, and has not been disabled because of a problem.
-     */
-    boolean isWatchingFileSystem();
+    boolean afterBuildStarted(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
 
     /**
      * Register a watchable hierarchy.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -35,7 +35,9 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     void afterBuildStarted(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner);
 
     /**
-     * Returns whether watching the file system is supported on the current operating system, and has successfully been started.
+     * Returns whether watching the file system is currently enabled. This requires that the feature
+     * is supported on the current operating system, it is enabled for the build, has been successfully
+     * started, and has not been disabled because of a problem.
      */
     boolean isWatchingFileSystem();
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -51,6 +51,6 @@ public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem 
     /**
      * Called when the build is finished.
      */
-    void beforeBuildFinished(WatchMode watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
+    void beforeBuildFinished(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies);
 
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/VfsLogging.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/VfsLogging.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.vfs;
+
+public enum VfsLogging {
+    NORMAL, VERBOSE
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchLogging.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchLogging.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.vfs;
+
+public enum WatchLogging {
+    NORMAL, DEBUG
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchMode.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchMode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.vfs;
+
+public enum WatchMode {
+    ENABLED(true, "enabled"),
+    DEFAULT(true, "enabled if available"),
+    DISABLED(false, "disabled");
+
+    private final boolean enabled;
+    private final String description;
+
+    WatchMode(boolean enabled, String description) {
+        this.enabled = enabled;
+        this.description = description;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -47,6 +47,11 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
     }
 
     @Override
+    public boolean isWatchingFileSystem() {
+        return false;
+    }
+
+    @Override
     protected SnapshotHierarchy updateNotifyingListeners(UpdateFunction updateFunction) {
         return updateFunction.update(SnapshotHierarchy.NodeDiffListener.NOOP);
     }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -57,8 +57,8 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
     }
 
     @Override
-    public void afterBuildStarted(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
-        if (watchingEnabled) {
+    public void afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
+        if (watchMode == WatchMode.ENABLED) {
             LOGGER.warn("Watching the file system is not supported on this operating system.");
         }
         rootReference.update(vfsRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
@@ -81,7 +81,7 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
     }
 
     @Override
-    public void beforeBuildFinished(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
+    public void beforeBuildFinished(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
         rootReference.update(vfsRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -27,6 +27,9 @@ import org.gradle.internal.vfs.impl.VfsRootReference;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType;
+import org.gradle.internal.watch.vfs.VfsLogging;
+import org.gradle.internal.watch.vfs.WatchLogging;
+import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -50,17 +50,12 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
     }
 
     @Override
-    public boolean isWatchingFileSystem() {
-        return false;
-    }
-
-    @Override
     protected SnapshotHierarchy updateNotifyingListeners(UpdateFunction updateFunction) {
         return updateFunction.update(SnapshotHierarchy.NodeDiffListener.NOOP);
     }
 
     @Override
-    public void afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
+    public boolean afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
         if (watchMode == WatchMode.ENABLED) {
             LOGGER.warn("Watching the file system is not supported on this operating system.");
         }
@@ -77,6 +72,7 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
                     .details(BuildStartedFileSystemWatchingBuildOperationType.Details.INSTANCE);
             }
         }));
+        return false;
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -72,6 +72,11 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     }
 
     @Override
+    public boolean isWatchingFileSystem() {
+        return watchRegistry != null;
+    }
+
+    @Override
     protected SnapshotHierarchy updateNotifyingListeners(UpdateFunction updateFunction) {
         if (watchRegistry == null) {
             return updateFunction.update(SnapshotHierarchy.NodeDiffListener.NOOP);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -75,11 +75,6 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     }
 
     @Override
-    public boolean isWatchingFileSystem() {
-        return watchRegistry != null;
-    }
-
-    @Override
     protected SnapshotHierarchy updateNotifyingListeners(UpdateFunction updateFunction) {
         if (watchRegistry == null) {
             return updateFunction.update(SnapshotHierarchy.NodeDiffListener.NOOP);
@@ -93,7 +88,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     }
 
     @Override
-    public void afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
+    public boolean afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
         reasonForNotWatchingFiles = null;
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
@@ -158,6 +153,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                     .details(BuildStartedFileSystemWatchingBuildOperationType.Details.INSTANCE);
             }
         }));
+        return watchRegistry != null;
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -35,6 +35,9 @@ import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperati
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.FileSystemWatchingStatistics;
+import org.gradle.internal.watch.vfs.VfsLogging;
+import org.gradle.internal.watch.vfs.WatchLogging;
+import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -90,12 +90,12 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     }
 
     @Override
-    public void afterBuildStarted(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
+    public void afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
         reasonForNotWatchingFiles = null;
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {
-                if (watchingEnabled) {
+                if (watchMode.isEnabled()) {
                     SnapshotHierarchy newRoot;
                     FileSystemWatchingStatistics statisticsSinceLastBuild;
                     if (watchRegistry == null) {
@@ -172,12 +172,12 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     }
 
     @Override
-    public void beforeBuildFinished(boolean watchingEnabled, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
+    public void beforeBuildFinished(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner, int maximumNumberOfWatchedHierarchies) {
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {
                 watchableHierarchies.clear();
-                if (watchingEnabled) {
+                if (watchMode.isEnabled()) {
                     if (reasonForNotWatchingFiles != null) {
                         // Log exception again so it doesn't get lost.
                         logWatchingError(reasonForNotWatchingFiles, FILE_WATCHING_ERROR_MESSAGE_AT_END_OF_BUILD);

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -21,10 +21,13 @@ import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.vfs.impl.VfsRootReference
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging
 import spock.lang.Specification
+import spock.lang.Unroll
 
+@Unroll
 class WatchingNotSupportedVirtualFileSystemTest extends Specification {
     def emptySnapshotHierarchy = DefaultSnapshotHierarchy.empty(CaseSensitivity.CASE_SENSITIVE)
     def nonEmptySnapshotHierarchy = Stub(SnapshotHierarchy) {
@@ -34,19 +37,19 @@ class WatchingNotSupportedVirtualFileSystemTest extends Specification {
     def watchingNotSupportedHandler = new WatchingNotSupportedVirtualFileSystem(rootReference)
     def buildOperationRunner = new TestBuildOperationExecutor()
 
-    def "invalidates the virtual file system before and after the build"() {
+    def "invalidates the virtual file system before and after the build (watch mode: #watchMode.description)"() {
         when:
-        watchingNotSupportedHandler.afterBuildStarted(retentionEnabled, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingNotSupportedHandler.afterBuildStarted(watchMode, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         rootReference.getRoot() == emptySnapshotHierarchy
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingNotSupportedHandler.beforeBuildFinished(retentionEnabled, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
+        watchingNotSupportedHandler.beforeBuildFinished(watchMode, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         rootReference.getRoot() == emptySnapshotHierarchy
 
         where:
-        retentionEnabled << [true, false]
+        watchMode << BuildLifecycleAwareVirtualFileSystem.WatchMode.values().toList()
     }
 }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.vfs.impl.VfsRootReference
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging
+import org.gradle.internal.watch.vfs.VfsLogging
+import org.gradle.internal.watch.vfs.WatchLogging
+import org.gradle.internal.watch.vfs.WatchMode
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -50,6 +50,6 @@ class WatchingNotSupportedVirtualFileSystemTest extends Specification {
         rootReference.getRoot() == emptySnapshotHierarchy
 
         where:
-        watchMode << BuildLifecycleAwareVirtualFileSystem.WatchMode.values().toList()
+        watchMode << WatchMode.values().toList()
     }
 }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -24,9 +24,9 @@ import org.gradle.internal.vfs.impl.VfsRootReference
 import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory
 import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchMode
+import org.gradle.internal.watch.vfs.VfsLogging
+import org.gradle.internal.watch.vfs.WatchLogging
+import org.gradle.internal.watch.vfs.WatchMode
 import spock.lang.Specification
 
 class WatchingVirtualFileSystemTest extends Specification {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.watch.registry.FileWatcherRegistryFactory
 import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchMode
 import spock.lang.Specification
 
 class WatchingVirtualFileSystemTest extends Specification {
@@ -49,7 +50,7 @@ class WatchingVirtualFileSystemTest extends Specification {
     def "invalidates the virtual file system before and after the build when watching is disabled"() {
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(false, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.DISABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         0 * _
 
@@ -57,7 +58,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.beforeBuildFinished(false, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(WatchMode.DISABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         0 * _
 
@@ -66,14 +67,14 @@ class WatchingVirtualFileSystemTest extends Specification {
 
     def "stops the watchers before the build when watching is disabled"() {
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.setDebugLoggingEnabled(false)
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
@@ -81,7 +82,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(false, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.DISABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistry.close()
         0 * _
@@ -91,14 +92,14 @@ class WatchingVirtualFileSystemTest extends Specification {
 
     def "retains the virtual file system when watching is enabled"() {
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.setDebugLoggingEnabled(false)
         0 * _
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()
@@ -106,7 +107,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         when:
         rootReference.update { root -> nonEmptySnapshotHierarchy }
-        watchingVirtualFileSystem.afterBuildStarted(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.setDebugLoggingEnabled(false)
@@ -126,7 +127,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         0 * _
 
         when:
-        watchingVirtualFileSystem.afterBuildStarted(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.setDebugLoggingEnabled(false)
@@ -139,7 +140,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         1 * watcherRegistry.registerWatchableHierarchy(anotherWatchableHierarchy, _)
 
         when:
-        watchingVirtualFileSystem.beforeBuildFinished(true, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
+        watchingVirtualFileSystem.beforeBuildFinished(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.buildFinished(_, Integer.MAX_VALUE) >> rootReference.getRoot()

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -117,7 +117,6 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
             encoder.writeBoolean(startParameter.isWatchFileSystem());
             encoder.writeBoolean(startParameter.isWatchFileSystemDebugLogging());
-            encoder.writeBoolean(startParameter.isWatchFileSystemUsingDeprecatedOption());
             encoder.writeBoolean(startParameter.isVfsVerboseLogging());
             encoder.writeBoolean(startParameter.isConfigurationCache());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
@@ -197,7 +196,6 @@ public class BuildActionSerializer {
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
             startParameter.setWatchFileSystem(decoder.readBoolean());
             startParameter.setWatchFileSystemDebugLogging(decoder.readBoolean());
-            startParameter.setWatchFileSystemUsingDeprecatedOption(decoder.readBoolean());
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -33,6 +33,7 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.ListSerializer;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.internal.serialize.SetSerializer;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -115,7 +116,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isRefreshDependencies());
             encoder.writeBoolean(startParameter.isBuildCacheEnabled());
             encoder.writeBoolean(startParameter.isBuildCacheDebugLogging());
-            encoder.writeBoolean(startParameter.isWatchFileSystem());
+            encoder.writeString(startParameter.getWatchFileSystemMode().name());
             encoder.writeBoolean(startParameter.isWatchFileSystemDebugLogging());
             encoder.writeBoolean(startParameter.isVfsVerboseLogging());
             encoder.writeBoolean(startParameter.isConfigurationCache());
@@ -194,7 +195,7 @@ public class BuildActionSerializer {
             startParameter.setRefreshDependencies(decoder.readBoolean());
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
-            startParameter.setWatchFileSystem(decoder.readBoolean());
+            startParameter.setWatchFileSystemMode(BuildLifecycleAwareVirtualFileSystem.WatchMode.valueOf(decoder.readString()));
             startParameter.setWatchFileSystemDebugLogging(decoder.readBoolean());
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -33,7 +33,7 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.ListSerializer;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.internal.serialize.SetSerializer;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
+import org.gradle.internal.watch.vfs.WatchMode;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -195,7 +195,7 @@ public class BuildActionSerializer {
             startParameter.setRefreshDependencies(decoder.readBoolean());
             startParameter.setBuildCacheEnabled(decoder.readBoolean());
             startParameter.setBuildCacheDebugLogging(decoder.readBoolean());
-            startParameter.setWatchFileSystemMode(BuildLifecycleAwareVirtualFileSystem.WatchMode.valueOf(decoder.readString()));
+            startParameter.setWatchFileSystemMode(WatchMode.valueOf(decoder.readString()));
             startParameter.setWatchFileSystemDebugLogging(decoder.readBoolean());
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(decoder.readBoolean());

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -63,7 +63,6 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
             ? WatchLogging.DEBUG
             : WatchLogging.NORMAL;
 
-        logMessageForDeprecatedWatchFileSystemProperty(startParameter);
         logMessageForDeprecatedVfsRetentionProperty(startParameter);
         LOGGER.info("Watching the file system is {}", watchFileSystem ? "enabled" : "disabled");
         if (watchFileSystem) {
@@ -99,18 +98,6 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
     private static void dropVirtualFileSystemIfRequested(StartParameterInternal startParameter, BuildLifecycleAwareVirtualFileSystem virtualFileSystem) {
         if (VirtualFileSystemServices.isDropVfs(startParameter)) {
             virtualFileSystem.invalidateAll();
-        }
-    }
-
-    private static void logMessageForDeprecatedWatchFileSystemProperty(StartParameterInternal startParameter) {
-        if (startParameter.isWatchFileSystemUsingDeprecatedOption()) {
-            @SuppressWarnings("deprecation")
-            String deprecatedWatchFsProperty = StartParameterBuildOptions.DeprecatedWatchFileSystemOption.GRADLE_PROPERTY;
-            DeprecationLogger.deprecateSystemProperty(deprecatedWatchFsProperty)
-                .replaceWith(StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY)
-                .willBeRemovedInGradle7()
-                .withUserManual("gradle_daemon")
-                .nagUser();
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -30,8 +30,9 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.VirtualFileSystemServices;
 import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging;
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging;
+import org.gradle.internal.watch.vfs.VfsLogging;
+import org.gradle.internal.watch.vfs.WatchLogging;
+import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         DirectorySnapshotterStatistics.Collector directorySnapshotterStatisticsCollector = services.get(DirectorySnapshotterStatistics.Collector.class);
         BuildOperationRunner buildOperationRunner = services.get(BuildOperationRunner.class);
 
-        BuildLifecycleAwareVirtualFileSystem.WatchMode watchFileSystemMode = startParameter.getWatchFileSystemMode();
+        WatchMode watchFileSystemMode = startParameter.getWatchFileSystemMode();
         VfsLogging verboseVfsLogging = startParameter.isVfsVerboseLogging()
             ? VfsLogging.VERBOSE
             : VfsLogging.NORMAL;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -36,6 +36,7 @@ import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
@@ -156,6 +157,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                                           BuildStateRegistry buildStateRegistry,
                                                           PayloadSerializer payloadSerializer,
                                                           BuildOperationNotificationValve buildOperationNotificationValve,
+                                                          BuildOperationProgressEventEmitter eventEmitter,
                                                           BuildCancellationToken buildCancellationToken,
                                                           ConfigurationCacheSupport configurationCacheSupport,
                                                           WorkValidationWarningReporter workValidationWarningReporter
@@ -168,7 +170,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                 configurationCacheSupport,
                 new RunAsBuildOperationBuildActionRunner(
                     new BuildCompletionNotifyingBuildActionRunner(
-                        new FileSystemWatchingBuildActionRunner(
+                        new FileSystemWatchingBuildActionRunner(eventEmitter,
                             new ValidatingBuildActionRunner(
                                 new BuildOutcomeReportingBuildActionRunner(styledTextOutputFactory, workValidationWarningReporter,
                                     new ChainingBuildActionRunner(buildActionRunners)))))));

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -27,9 +27,9 @@ import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.VfsLogging
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchLogging
-import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem.WatchMode
+import org.gradle.internal.watch.vfs.VfsLogging
+import org.gradle.internal.watch.vfs.WatchLogging
+import org.gradle.internal.watch.vfs.WatchMode
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -55,7 +55,9 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
 
     def "watching virtual file system is informed about watching the file system being #watchFsEnabledString (VFS logging: #vfsLogging, watch logging: #watchLogging)"() {
         _ * startParameter.getSystemPropertiesArgs() >> [:]
-        _ * startParameter.isWatchFileSystem() >> watchFsEnabled
+        _ * startParameter.watchFileSystemMode >> watchFsEnabled
+            ? BuildLifecycleAwareVirtualFileSystem.WatchMode.ENABLED
+            : BuildLifecycleAwareVirtualFileSystem.WatchMode.DISABLED
         _ * startParameter.isWatchFileSystemDebugLogging() >> (watchLogging == WatchLogging.DEBUG)
         _ * startParameter.isVfsVerboseLogging() >> (vfsLogging == VfsLogging.VERBOSE)
         _ * startParameter.isVfsDebugLogging() >> false

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -30,6 +30,8 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.classpath.size() == 2
         resolve.classpath.any {it.name ==~ /slf4j-api-.*\.jar/}
+        // If this suddenly fails without an obvious reason, you likely have added some code
+        // that references types that were previously eliminated from gradle-tooling-api.jar.
         resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 2.13 * 1024 * 1024
 
         cleanup:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/15549 (un-deprecate watching properties)
Fixes https://github.com/gradle/gradle/issues/15505 (enable by default)

Related: ~https://github.com/gradle/gradle/issues/15762 (de-incubate)~ (fixed for 6.8.1)
