### PR TITLE
Fix invalid project identity in publication

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyPublicationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyPublicationResolver.java
@@ -17,10 +17,16 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.internal.project.ProjectInternal;
 
 public interface ProjectDependencyPublicationResolver {
     /**
      * Determines the coordinates of the given type that should be used to reference the given dependency.
      */
     <T> T resolve(Class<T> coordsType, ProjectDependency dependency);
+
+    /**
+     * Determines the coordinates of the given type that should be used to reference the given dependency.
+     */
+    <T> T resolve(Class<T> coordsType, ProjectInternal projectInternal);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -32,7 +32,6 @@ class DefaultProjectDependencyPublicationResolverTest extends Specification {
     def project = Mock(ProjectInternal)
     def publicationRegistry = Mock(ProjectPublicationRegistry)
     def projectConfigurer = Mock(ProjectConfigurer)
-    def publication = Mock(ProjectPublication)
 
     def setup() {
         project.identityPath >> Path.path(":path")
@@ -43,9 +42,9 @@ class DefaultProjectDependencyPublicationResolverTest extends Specification {
         when:
         dependentProjectHasPublications()
 
-        projectDependency.group >> "dep-group"
+        project.group >> "dep-group"
         project.name >> "project-name"
-        projectDependency.version >> "dep-version"
+        project.version >> "dep-version"
 
         then:
         with (resolve()) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -24,9 +24,12 @@ import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.api.publish.internal.versionmapping.DefaultVariantVersionMappingStrategy;
@@ -46,6 +49,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final ConfigurationContainer configurations;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
+    private final ProjectDependencyPublicationResolver projectResolver;
+    private final ProjectRegistry<ProjectInternal> projectRegistry;
     private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = Lists.newArrayListWithExpectedSize(2);
     private final Map<ImmutableAttributes, String> defaultConfigurations = Maps.newHashMap();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
@@ -54,11 +59,16 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     public DefaultVersionMappingStrategy(ObjectFactory objectFactory,
                                          ConfigurationContainer configurations,
                                          AttributesSchemaInternal schema,
-                                         ImmutableAttributesFactory attributesFactory) {
+                                         ImmutableAttributesFactory attributesFactory,
+                                         ProjectDependencyPublicationResolver projectResolver,
+                                         ProjectRegistry<ProjectInternal> projectRegistry) {
+
         this.objectFactory = objectFactory;
         this.configurations = configurations;
         this.schema = schema;
         this.attributesFactory = attributesFactory;
+        this.projectResolver = projectResolver;
+        this.projectRegistry = projectRegistry;
     }
 
     @Override
@@ -107,7 +117,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     }
 
     private DefaultVariantVersionMappingStrategy createDefaultMappingStrategy(ImmutableAttributes variantAttributes) {
-        DefaultVariantVersionMappingStrategy strategy = new DefaultVariantVersionMappingStrategy(configurations);
+        DefaultVariantVersionMappingStrategy strategy = new DefaultVariantVersionMappingStrategy(configurations, projectResolver, projectRegistry);
         if (!defaultConfigurations.isEmpty()) {
             // First need to populate the default variant version mapping strategy with the default values
             // provided by plugins

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
@@ -20,21 +20,29 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectRegistry;
 
 import java.util.Set;
 
 public class DefaultVariantVersionMappingStrategy implements VariantVersionMappingStrategyInternal {
     private final ConfigurationContainer configurations;
+    private final ProjectDependencyPublicationResolver projectResolver;
+    private final ProjectRegistry<ProjectInternal> projectRegistry;
     private boolean usePublishedVersions;
     private Configuration targetConfiguration;
 
-    public DefaultVariantVersionMappingStrategy(ConfigurationContainer configurations) {
+    public DefaultVariantVersionMappingStrategy(ConfigurationContainer configurations, ProjectDependencyPublicationResolver projectResolver, ProjectRegistry<ProjectInternal> projectRegistry) {
         this.configurations = configurations;
+        this.projectResolver = projectResolver;
+        this.projectRegistry = projectRegistry;
     }
 
     @Override
@@ -74,16 +82,25 @@ public class DefaultVariantVersionMappingStrategy implements VariantVersionMappi
             for (DependencyResult dependencyResult : allDependencies) {
                 if (dependencyResult instanceof ResolvedDependencyResult) {
                     ComponentSelector rcs = dependencyResult.getRequested();
+                    ResolvedComponentResult selected = null;
                     if (rcs instanceof ModuleComponentSelector) {
                         ModuleComponentSelector requested = (ModuleComponentSelector) rcs;
                         if (requested.getGroup().equals(group) && requested.getModule().equals(module)) {
-                            return ((ResolvedDependencyResult) dependencyResult).getSelected().getModuleVersion();
+                            selected = ((ResolvedDependencyResult) dependencyResult).getSelected();
                         }
                     } else if (rcs instanceof ProjectComponentSelector) {
                         ProjectComponentSelector pcs = (ProjectComponentSelector) rcs;
                         if (pcs.getProjectPath().equals(projectPath)) {
-                            return ((ResolvedDependencyResult) dependencyResult).getSelected().getModuleVersion();
+                            selected = ((ResolvedDependencyResult) dependencyResult).getSelected();
                         }
+                    }
+                    // Match found - need to make sure that if the selection is a project, we use its publication identity
+                    if (selected != null) {
+                        if (selected.getId() instanceof ProjectComponentIdentifier) {
+                            ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) selected.getId();
+                            return projectResolver.resolve(ModuleVersionIdentifier.class, projectRegistry.getProject(projectId.getProjectPath()));
+                        }
+                        return selected.getModuleVersion();
                     }
                 }
             }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -24,9 +24,12 @@ import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.internal.component.model.AttributeMatcher;
@@ -43,6 +46,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final ConfigurationContainer configurations;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
+    private final ProjectDependencyPublicationResolver projectResolver;
+    private final ProjectRegistry<ProjectInternal> projectRegistry;
     private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = Lists.newArrayListWithExpectedSize(2);
     private final Map<ImmutableAttributes, String> defaultConfigurations = Maps.newHashMap();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
@@ -51,11 +56,15 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     public DefaultVersionMappingStrategy(ObjectFactory objectFactory,
                                          ConfigurationContainer configurations,
                                          AttributesSchemaInternal schema,
-                                         ImmutableAttributesFactory attributesFactory) {
+                                         ImmutableAttributesFactory attributesFactory,
+                                         ProjectDependencyPublicationResolver projectResolver,
+                                         ProjectRegistry<ProjectInternal> projectRegistry) {
         this.objectFactory = objectFactory;
         this.configurations = configurations;
         this.schema = schema;
         this.attributesFactory = attributesFactory;
+        this.projectResolver = projectResolver;
+        this.projectRegistry = projectRegistry;
     }
 
     @Override
@@ -104,7 +113,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     }
 
     private DefaultVariantVersionMappingStrategy createDefaultMappingStrategy(ImmutableAttributes variantAttributes) {
-        DefaultVariantVersionMappingStrategy strategy = new DefaultVariantVersionMappingStrategy(configurations);
+        DefaultVariantVersionMappingStrategy strategy = new DefaultVariantVersionMappingStrategy(configurations, projectResolver, projectRegistry);
         if (!defaultConfigurations.isEmpty()) {
             // First need to populate the default variant version mapping strategy with the default values
             // provided by plugins


### PR DESCRIPTION
When leveraging the version mapping feature during publication, Gradle
did not properly translate the project identity to its publication
identity when unable to perform a direct match.
