### PR TITLE
Fix properties normalization when bad unicode sequences are encountered

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -445,6 +445,27 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
+    def "safely handles properties files with bad unicode escape sequences"() {
+        def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
+        project.propertiesFileInDir.backingFile.text = 'propertyWithBadValue=this is a bad unicode sequence \\uxxxx'
+
+        when:
+        succeeds project.customTask
+        then:
+        executedAndNotSkipped(project.customTask)
+
+        when:
+        succeeds project.customTask
+        then:
+        skipped(project.customTask)
+
+        when:
+        project.propertiesFileInDir.backingFile.text = 'propertyWithBadValue=this is also a bad unicode sequence \\uyyyy'
+        succeeds project.customTask
+        then:
+        executedAndNotSkipped(project.customTask)
+    }
+
     static final String IGNORE_ME = 'ignore-me'
     static final String IGNORE_ME_TOO = 'ignore-me-too'
     static final String DONT_IGNORE_ME = 'dont-ignore-me'

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasher.java
@@ -71,7 +71,7 @@ public class PropertiesFileAwareClasspathResourceHasher implements ResourceHashe
         } else {
             try (FileInputStream propertiesFileInputStream = new FileInputStream(snapshotContext.getSnapshot().getAbsolutePath())){
                 return hashProperties(propertiesFileInputStream, resourceEntryFilter);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOGGER.debug("Could not load fingerprint for " + snapshotContext.getSnapshot().getAbsolutePath() + ". Falling back to full entry fingerprinting", e);
                 return delegate.hash(snapshotContext);
             }
@@ -87,7 +87,7 @@ public class PropertiesFileAwareClasspathResourceHasher implements ResourceHashe
         } else {
             try {
                 return hashProperties(zipEntryContext.getEntry().getInputStream(), resourceEntryFilter);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOGGER.debug("Could not load fingerprint for " + zipEntryContext.getRootParentName() + "!" + zipEntryContext.getFullName() + ". Falling back to full entry fingerprinting", e);
                 return delegate.hash(zipEntryContext);
             }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -18,11 +18,21 @@ package org.gradle.api.internal.changedetection.state
 
 import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Maps
+import com.google.common.io.ByteStreams
 import org.gradle.api.internal.file.archive.ZipEntry
+import org.gradle.internal.hash.Hashing
+import org.gradle.internal.hash.HashingOutputStream
+import org.gradle.internal.snapshot.RegularFileSnapshot
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.function.Supplier
+
+@Unroll
 class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
+    @Rule TemporaryFolder tmpdir = new TemporaryFolder()
     Map<String, ResourceEntryFilter> filters = Maps.newHashMap()
     ResourceHasher delegate = new RuntimeClasspathResourceHasher()
     ResourceHasher unfilteredHasher = new PropertiesFileAwareClasspathResourceHasher(delegate, PropertiesFileFilter.FILTER_NOTHING)
@@ -37,10 +47,10 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         ]
     }
 
-    def "properties are case sensitive"() {
+    def "properties are case sensitive (context: #context)"() {
         given:
-        def propertiesEntry1 = zipEntry(["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)"])
-        def propertiesEntry2 = zipEntry(["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry1 = contextFor(context, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry2 = contextFor(context, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -52,12 +62,15 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash2 != hash4
         hash3 != hash4
         hash1 != hash3
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    def "properties are normalized and filtered out"() {
+    def "properties are normalized and filtered out (context: #context)"() {
         given:
-        def propertiesEntry1 = zipEntry(["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "foo": "true"])
-        def propertiesEntry2 = zipEntry(["created-by": "1.8.0_232-b15 (Azul Systems, Inc.)", "foo": "true"])
+        def propertiesEntry1 = contextFor(context, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "foo": "true"])
+        def propertiesEntry2 = contextFor(context, ["created-by": "1.8.0_232-b15 (Azul Systems, Inc.)", "foo": "true"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -71,11 +84,14 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
 
         and:
         hash3 == hash4
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    def "properties can have UTF-8 encoding"() {
-        def propertiesEntry1 = zipEntry(["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "some sanskrit", "तान्यहानि": "more sanskrit"])
-        def propertiesEntry2 = zipEntry(["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "changed sanskrit", "तान्यहानि": "more sanskrit"])
+    def "properties can have UTF-8 encoding (context: #context)"() {
+        def propertiesEntry1 = contextFor(context, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "some sanskrit", "तान्यहानि": "more sanskrit"])
+        def propertiesEntry2 = contextFor(context, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "changed sanskrit", "तान्यहानि": "more sanskrit"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -89,12 +105,15 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
 
         and:
         hash3 == hash4
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    def "properties are order insensitive"() {
+    def "properties are order insensitive (context: #context)"() {
         given:
-        def propertiesEntry1 = zipEntry(["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "foo": "true"])
-        def propertiesEntry2 = zipEntry(["foo": "true", "created-by": "1.8.0_232-b15 (Azul Systems, Inc.)"])
+        def propertiesEntry1 = contextFor(context, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "foo": "true"])
+        def propertiesEntry2 = contextFor(context, ["foo": "true", "created-by": "1.8.0_232-b15 (Azul Systems, Inc.)"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -108,11 +127,14 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
 
         and:
         hash3 == hash4
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    def "comments are always filtered out when filters are applied"() {
-        def propertiesEntry1 = zipEntry(["foo": "true"], "Build information 1.0")
-        def propertiesEntry2 = zipEntry(["foo": "true"], "Build information 1.1")
+    def "comments are always filtered out when filters are applied (context: #context)"() {
+        def propertiesEntry1 = contextFor(context, ["foo": "true"], "Build information 1.0")
+        def propertiesEntry2 = contextFor(context, ["foo": "true"], "Build information 1.1")
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -125,18 +147,20 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         and:
         hash1 != hash2
         hash1 != hash3
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    @Unroll
-    def "can filter files selectively based on pattern (pattern: #fooPattern)"() {
+    def "can filter files selectively based on pattern (pattern: #fooPattern, context: #context)"() {
         given:
         filters = [
             '**/*.properties': ResourceEntryFilter.FILTER_NOTHING,
             (fooPattern): filter("created-by", "पशुपतिरपि")
         ]
 
-        def propertiesEntry1 = zipEntry('some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
-        def propertiesEntry2 = zipEntry('some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry1 = contextFor(context, 'some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry2 = contextFor(context, 'some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -152,20 +176,19 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash1 == hash2
 
         where:
-        fooPattern << ['**/foo.properties', '**/f*.properties', 'some/**/f*.properties', 'some/path/to/foo.properties']
+        [context, fooPattern] << [SnapshotContext.values(), ['**/foo.properties', '**/f*.properties', 'some/**/f*.properties', 'some/path/to/foo.properties']].combinations()*.flatten()
     }
 
-    @Unroll
-    def "can filter multiple files selectively based on pattern (pattern: #fPattern)"() {
+    def "can filter multiple files selectively based on pattern (pattern: #fPattern, context: #context)"() {
         given:
         filters = [
             '**/*.properties': ResourceEntryFilter.FILTER_NOTHING,
             (fPattern.toString()): filter("created-by", "पशुपतिरपि")
         ]
 
-        def propertiesEntry1 = zipEntry('some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
-        def propertiesEntry2 = zipEntry('some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
-        def propertiesEntry3 = zipEntry('some/other/path/to/fuzz.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry1 = contextFor(context, 'some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry2 = contextFor(context, 'some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry3 = contextFor(context, 'some/other/path/to/fuzz.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -184,19 +207,19 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash4 == hash6
 
         where:
-        fPattern << ['**/f*.properties', 'some/**/f*.properties']
+        [context, fPattern] << [SnapshotContext.values(), ['**/f*.properties', 'some/**/f*.properties']].combinations()*.flatten()
     }
 
-    def "multiple filters can be applied to the same file"() {
+    def "multiple filters can be applied to the same file (context: #context)"() {
         given:
         filters = [
             '**/*.properties': filter("created-by"),
             '**/foo.properties': filter("पशुपतिरपि")
         ]
 
-        def propertiesEntry1 = zipEntry('some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "some sanskrit"])
-        def propertiesEntry2 = zipEntry('some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
-        def propertiesEntry3 = zipEntry('some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry1 = contextFor(context, 'some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "पशुपतिरपि": "some sanskrit"])
+        def propertiesEntry2 = contextFor(context, 'some/path/to/bar.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+        def propertiesEntry3 = contextFor(context, 'some/path/to/foo.properties', ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
 
         def hash1 = unfilteredHasher.hash(propertiesEntry1)
         def hash2 = unfilteredHasher.hash(propertiesEntry2)
@@ -213,21 +236,55 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash2 == hash3
         hash4 == hash5
         hash4 == hash6
+
+        where:
+        context << SnapshotContext.values()
     }
 
-    def "delegates to file hasher when bad unicode escape sequences are used"() {
+    def "delegates to file hasher when bad unicode escape sequences are present (error in: #location, context: #context)"() {
         given:
         filters = [ '**/*.properties': ResourceEntryFilter.FILTER_NOTHING ]
-        def properties = zipEntry('some/path/to/foo.properties', bytesFrom(property))
+        def properties = contextFor(context, 'some/path/to/foo.properties', bytesFrom(property))
 
         expect:
         filteredHasher.hash(properties) == delegate.hash(properties)
 
         where:
-        property << [
-            'someKey=a value with bad escape sequence \\uxxxx',
-            'keyWithBadEscapeSequence\\uxxxx=some value'
-        ]
+        context                       | location | property
+        SnapshotContext.ZIP_ENTRY     | "value"  | 'someKey=a value with bad escape sequence \\uxxxx'
+        SnapshotContext.ZIP_ENTRY     | "key"    | 'keyWithBadEscapeSequence\\uxxxx=some value'
+        SnapshotContext.FILE_SNAPSHOT | "value"  | 'someKey=a value with bad escape sequence \\uxxxx'
+        SnapshotContext.FILE_SNAPSHOT | "key"    | 'keyWithBadEscapeSequence\\uxxxx=some value'
+    }
+
+    enum SnapshotContext {
+        ZIP_ENTRY, FILE_SNAPSHOT
+    }
+
+    def contextFor(SnapshotContext context, String path, Map<String, String> attributes, String comments = "") {
+        switch(context) {
+            case SnapshotContext.ZIP_ENTRY:
+                return zipEntry(path, attributes, comments)
+            case SnapshotContext.FILE_SNAPSHOT:
+                return fileSnapshot(path, attributes, comments)
+            default:
+                throw new IllegalAccessException()
+        }
+    }
+
+    def contextFor(SnapshotContext context, String path, ByteArrayOutputStream bos) {
+        switch(context) {
+            case SnapshotContext.ZIP_ENTRY:
+                return zipEntry(path, bos)
+            case SnapshotContext.FILE_SNAPSHOT:
+                return fileSnapshot(path, bos)
+            default:
+                throw new IllegalAccessException()
+        }
+    }
+
+    def contextFor(SnapshotContext context, Map<String, String> attributes, String comments = "") {
+        contextFor(context, "META-INF/build-info.properties", attributes, comments)
     }
 
     static ByteArrayOutputStream bytesFrom(String value) {
@@ -238,10 +295,6 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
 
     static filter(String... properties) {
         return new IgnoringResourceEntryFilter(ImmutableSet.copyOf(properties))
-    }
-
-    ZipEntryContext zipEntry(Map<String, String> attributes, String comments = "") {
-        zipEntry("META-INF/build-info.properties", attributes, comments)
     }
 
     ZipEntryContext zipEntry(String path, Map<String, String> attributes, String comments = "") {
@@ -280,5 +333,36 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
             }
         }
         return new ZipEntryContext(zipEntry, path, "foo.zip")
+    }
+
+    RegularFileSnapshotContext fileSnapshot(String path, Map<String, String> attributes, String comments = "") {
+        Properties properties = new Properties()
+        properties.putAll(attributes)
+        ByteArrayOutputStream bos = new ByteArrayOutputStream()
+        properties.store(bos, comments)
+        return fileSnapshot(path, bos)
+    }
+
+    RegularFileSnapshotContext fileSnapshot(String path, ByteArrayOutputStream bos) {
+        def dir = tmpdir.newFolder()
+        def file = new File(dir, path)
+        file.parentFile.mkdirs()
+        file << bos.toByteArray()
+        return Mock(RegularFileSnapshotContext) {
+            _ * getSnapshot() >> Mock(RegularFileSnapshot) {
+                _ * getAbsolutePath() >> file.absolutePath
+                _ * getHash() >> {
+                    HashingOutputStream hasher = Hashing.primitiveStreamHasher()
+                    ByteStreams.copy(new ByteArrayInputStream(bos.toByteArray()), hasher)
+                    return hasher.hash()
+                }
+            }
+            _ * getRelativePathSegments() >> new Supplier<String[]>() {
+                @Override
+                String[] get() {
+                    return path.split('/')
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #15740 

This also improves the property file hashing tests to be more comprehensive.