### PR TITLE
Promote BuildInvocationDetails interface

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.invocation;
 
-import org.gradle.api.Incubating;
-
 /**
  * Provides some useful information about the build invocation that triggered this build.
  * <p>
@@ -35,7 +33,6 @@ import org.gradle.api.Incubating;
  * </pre>
  * @since 5.0
  */
-@Incubating
 public interface BuildInvocationDetails {
 
     /**

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -189,6 +189,7 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.JavaVersion.isJava12Compatible
         - org.gradle.api.JavaVersion.isCompatibleWith
         - org.gradle.api.ProjectConfigurationException
+        - org.gradle.api.invocation.BuildInvocationDetails
         - org.gradle.testkit.runner.GradleRunner.getEnvironment()
         - org.gradle.testkit.runner.GradleRunner.withEnvironment(Map<String, String>)
 - Dependency management


### PR DESCRIPTION
### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
