### PR TITLE
Promote TaskReportTask.displayGroup

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -16,7 +16,6 @@
 package org.gradle.api.tasks.diagnostics;
 
 import com.google.common.base.Strings;
-import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -87,7 +86,6 @@ public class TaskReportTask extends AbstractReportTask {
      *
      * @since 5.1
      */
-    @Incubating
     @Option(option = "group", description = "Show tasks for a specific group.")
     public void setDisplayGroup(String group) {
         this.group = group;
@@ -98,7 +96,6 @@ public class TaskReportTask extends AbstractReportTask {
      *
      * @since 5.1
      */
-    @Incubating
     @Console
     public String getDisplayGroup() {
         return group;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -177,6 +177,9 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.file.FileSystemLocationProperty.fileProvider
         - org.gradle.api.file.Directory.files
         - org.gradle.api.file.DirectoryProperty.files
+    - Reporting
+        - org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroup()
+        - org.gradle.api.tasks.diagnostics.TaskReportTask.setDisplayGroup(String)
     - Miscellaneous
         - org.gradle.buildinit.tasks.InitBuild.getSplitProject()
         - org.gradle.api.JavaVersion.VERSION_15


### PR DESCRIPTION
### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
