### PR TITLE
Promote APIs of Scala plugin introduced in 6.x releases

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -317,6 +317,13 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.testing.TestFilter.getExcludePatterns
         - org.gradle.api.tasks.testing.TestFilter.setExcludePatterns
         - org.gradle.api.tasks.testing.TestFilter.excludeTest
+  - Scala
+        - org.gradle.api.plugins.scala.ScalaBasePlugin.SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME
+        - org.gradle.api.plugins.scala.ScalaPluginExtension
+        - org.gradle.api.tasks.scala.ScalaCompile.getScalaCompilerPlugins()
+        - org.gradle.api.tasks.scala.ScalaCompile.setScalaCompilerPlugins(FileCollection)
+        - org.gradle.api.tasks.scala.ScalaDoc.getMaxMemory()
+        - org.gradle.api.tasks.scala.IncrementalCompileOptions.getClassfileBackupDir()
 - [Kotlin DSL](userguide/kotlin_dsl.html)
     - org.gradle.kotlin.dsl.KotlinScript
     - org.gradle.kotlin.dsl.KotlinSettingsScript.plugins(block: PluginDependenciesSpecScope.() -> Unit): Unit

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -85,9 +84,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
      *
      * @since 6.4
      */
-    @Incubating
     public static final String SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME = "scalaCompilerPlugins";
-
 
     private final ObjectFactory objectFactory;
     private final JvmEcosystemUtilities jvmEcosystemUtilities;

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPluginExtension.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPluginExtension.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins.scala;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.provider.Property;
  *
  * @since 6.0
  */
-@Incubating
 public interface ScalaPluginExtension {
     /**
      * The version of the Zinc compiler to use for compiling Scala code.

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/IncrementalCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/IncrementalCompileOptions.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.scala;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Internal;
@@ -56,7 +55,6 @@ public class IncrementalCompileOptions {
      * @since 6.6
      */
     @LocalState
-    @Incubating
     public RegularFileProperty getClassfileBackupDir() {
         return classfileBackupDir;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -16,7 +16,6 @@
 package org.gradle.api.tasks.scala;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
@@ -76,7 +75,6 @@ public class ScalaCompile extends AbstractScalaCompile {
      * @since 6.4
      */
     @Classpath
-    @Incubating
     public FileCollection getScalaCompilerPlugins() {
         return scalaCompilerPlugins;
     }
@@ -87,7 +85,6 @@ public class ScalaCompile extends AbstractScalaCompile {
      * @param scalaCompilerPlugins Collection of Scala compiler plugins.
      * @since 6.4
      */
-    @Incubating
     public void setScalaCompilerPlugins(FileCollection scalaCompilerPlugins) {
         this.scalaCompilerPlugins = scalaCompilerPlugins;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.scala;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
@@ -156,7 +155,6 @@ public class ScalaDoc extends SourceTask {
      *
      * @since 6.5
      */
-    @Incubating
     @Internal
     public Property<String> getMaxMemory() {
         return maxMemory;


### PR DESCRIPTION
### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
