### PR TITLE
Promote minor API additions introduced in 5.1 and 5.2

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/ProjectConfigurationException.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ProjectConfigurationException.java
@@ -34,7 +34,6 @@ public class ProjectConfigurationException extends DefaultMultiCauseException {
      * @param causes The causes
      * @since 5.1
      */
-    @Incubating
     public ProjectConfigurationException(String message, Iterable<? extends Throwable> causes) {
         super(message, causes);
     }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -185,6 +185,9 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.JavaVersion.isJava12
         - org.gradle.api.JavaVersion.isJava12Compatible
         - org.gradle.api.JavaVersion.isCompatibleWith
+        - org.gradle.api.ProjectConfigurationException
+        - org.gradle.testkit.runner.GradleRunner.getEnvironment()
+        - org.gradle.testkit.runner.GradleRunner.withEnvironment(Map<String, String>)
 - Dependency management
     - Dependency notations
         - org.gradle.api.artifacts.dsl.DependencyHandler.enforcedPlatform(java.lang.Object)
@@ -279,6 +282,8 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.tooling.events.test.Destination
         - org.gradle.tooling.events.test.TestOutputDescriptor
         - org.gradle.tooling.events.test.TestOutputEvent
+    - Miscellaneous
+        - org.gradle.tooling.events.configuration.ProjectConfigurationProgressEvent
 - Java Ecosystem
     - Java plugins
         - org.gradle.api.plugins.FeatureSpec.withJavadocJar()
@@ -291,6 +296,7 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.SourceSet.getJavadocTaskName()
         - org.gradle.api.tasks.SourceSet.getSourcesElementsConfigurationName()
         - org.gradle.api.tasks.SourceSet.getSourcesJarTaskName()
+        - org.gradle.api.tasks.SourceSetOutput.getGeneratedSourcesDirs()
         - org.gradle.api.plugins.JavaBasePlugin.COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY
       - Java Module System
         - org.gradle.api.jvm.ModularitySpec

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 
 import javax.annotation.Nullable;
@@ -160,6 +159,5 @@ public interface SourceSetOutput extends FileCollection {
      * @return The generated sources directories. Never returns null.
      * @since 5.2
      */
-    @Incubating
     FileCollection getGeneratedSourcesDirs();
 }

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
@@ -16,7 +16,6 @@
 
 package org.gradle.testkit.runner;
 
-import org.gradle.api.Incubating;
 import org.gradle.testkit.runner.internal.DefaultGradleRunner;
 
 import javax.annotation.Nullable;
@@ -313,7 +312,6 @@ public abstract class GradleRunner {
      * @since 5.2
      */
     @Nullable
-    @Incubating
     public abstract Map<String, String> getEnvironment();
 
     /**
@@ -327,8 +325,7 @@ public abstract class GradleRunner {
      * @return this
      * @since 5.2
      */
-    @Incubating
-    public abstract GradleRunner withEnvironment(Map<String, String> environmentVariables);
+    public abstract GradleRunner withEnvironment(@Nullable Map<String, String> environmentVariables);
 
     /**
      * Configures the runner to forward standard output from builds to the given writer.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/ProjectConfigurationProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/ProjectConfigurationProgressEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.configuration;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.ProgressEvent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.ProgressEvent;
  *
  * @since 5.1
  */
-@Incubating
 public interface ProjectConfigurationProgressEvent extends ProgressEvent {
     /**
      * Returns the description of the project configuration operation for which progress is reported.


### PR DESCRIPTION
- org.gradle.api.ProjectConfigurationException
- org.gradle.tooling.events.configuration.ProjectConfigurationProgressEvent
- org.gradle.api.tasks.SourceSetOutput.getGeneratedSourcesDirs()
- org.gradle.testkit.runner.GradleRunner.getEnvironment()
- org.gradle.testkit.runner.GradleRunner.withEnvironment(java.util.Map<java.lang.String, java.lang.String>)

### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
