### PR TITLE
Avoid scan project directory when publishing artifacts

### DIFF
--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -71,8 +71,6 @@ const val failedTestArtifactDestination = ".teamcity/gradle-logs"
 
 fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, timeout: Int = 30, vcsRoot: String = "Gradle_Branches_GradlePersonalBranches") {
     artifactRules = """
-        **/build/report-* => $failedTestArtifactDestination
-        **/build/tmp/test files/** => $failedTestArtifactDestination/test-files
         build/errorLogs/** => $failedTestArtifactDestination/errorLogs
         subprojects/internal-build-reports/build/reports/incubation/all-incubating.html => incubation-reports
         build/reports/dependency-verification/** => dependency-verification-reports

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
@@ -181,12 +181,12 @@ fun zip(destZip: File, srcDir: File) {
 fun prepareReportForCiPublishing(report: File) {
     if (report.exists()) {
         if (report.isDirectory) {
-            val destFile = layout.buildDirectory.file("report-${project.name}-${report.name}.zip").get().asFile
+            val destFile = rootProject.layout.buildDirectory.file("report-${project.name}-${report.name}.zip").get().asFile
             zip(destFile, report)
         } else {
             copy {
                 from(report)
-                into(layout.buildDirectory)
+                into(rootProject.layout.buildDirectory)
                 rename { "report-${project.name}-${report.parentFile.name}-${report.name}" }
             }
         }


### PR DESCRIPTION
We found that artifacts publishing takes 3~4 min in each build, which
is proved that we're using patterns like `**/build`.
