### PR TITLE
Promote Worker API

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -184,6 +184,22 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.file.FileSystemLocationProperty.fileProvider
         - org.gradle.api.file.Directory.files
         - org.gradle.api.file.DirectoryProperty.files
+    - [Worker API](userguide/worker_api.html)
+        - org.gradle.workers.ClassLoaderWorkerSpec
+        - org.gradle.workers.ForkingWorkerSpec
+        - org.gradle.workers.ProcessWorkerSpec
+        - org.gradle.workers.WorkAction
+        - org.gradle.workers.WorkParameters
+        - org.gradle.workers.WorkParameters.None
+        - org.gradle.workers.WorkQueue
+        - org.gradle.workers.WorkerExecutor.submit(Class actionClass, Action);
+        - org.gradle.workers.WorkerExecutor.classLoaderIsolation()
+        - org.gradle.workers.WorkerExecutor.classLoaderIsolation(Action)
+        - org.gradle.workers.WorkerExecutor.noIsolation()
+        - org.gradle.workers.WorkerExecutor.noIsolation(Action)
+        - org.gradle.workers.WorkerExecutor.processIsolation()
+        - org.gradle.workers.WorkerExecutor.processIsolation(Action)
+        - org.gradle.workers.WorkerSpec
     - Reporting
         - org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroup()
         - org.gradle.api.tasks.diagnostics.TaskReportTask.setDisplayGroup(String)
@@ -319,7 +335,7 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.SourceSet.getSourcesJarTaskName()
         - org.gradle.api.tasks.SourceSetOutput.getGeneratedSourcesDirs()
         - org.gradle.api.plugins.JavaBasePlugin.COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY
-      - Java Module System
+    - Java Module System
         - org.gradle.api.jvm.ModularitySpec
         - org.gradle.api.plugins.JavaApplication.getMainModule()
         - org.gradle.api.plugins.JavaPluginExtension.getModularity()
@@ -349,7 +365,7 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.compile.GroovyCompile.getSourceClassesMappingFile()
         - org.gradle.api.tasks.compile.GroovyCompileOptions.isParameters()
         - org.gradle.api.tasks.compile.GroovyCompileOptions.setParameters(boolean)
-  - Scala
+    - Scala
         - org.gradle.api.plugins.scala.ScalaBasePlugin.SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME
         - org.gradle.api.plugins.scala.ScalaPluginExtension
         - org.gradle.api.tasks.scala.ScalaCompile.getScalaCompilerPlugins()

--- a/subprojects/workers/src/main/java/org/gradle/workers/ClassLoaderWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ClassLoaderWorkerSpec.java
@@ -16,7 +16,6 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
  *
  * @since 5.6
  */
-@Incubating
 public interface ClassLoaderWorkerSpec extends WorkerSpec {
     /**
      * Gets the classpath associated with the worker.

--- a/subprojects/workers/src/main/java/org/gradle/workers/ForkingWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ForkingWorkerSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.workers;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.process.JavaForkOptions;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.process.JavaForkOptions;
  *
  * @since 5.6
  */
-@Incubating
 public interface ForkingWorkerSpec extends WorkerSpec {
     /**
      * Executes the provided action against the {@link JavaForkOptions} object associated with this builder.

--- a/subprojects/workers/src/main/java/org/gradle/workers/ProcessWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ProcessWorkerSpec.java
@@ -16,14 +16,11 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Incubating;
-
 /**
  * A worker spec providing the requirements of a forked process with a custom classpath.
  *
  * @since 5.6
  */
-@Incubating
 public interface ProcessWorkerSpec extends ForkingWorkerSpec, ClassLoaderWorkerSpec {
 
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkAction.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkAction.java
@@ -16,8 +16,6 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Incubating;
-
 import javax.inject.Inject;
 
 /**
@@ -56,7 +54,6 @@ import javax.inject.Inject;
  * @param <T> Parameter type for the work action. Should be {@link WorkParameters.None} if the action does not have parameters.
  * @since 5.6
  **/
-@Incubating
 public interface WorkAction<T extends WorkParameters> {
     /**
      * The parameters associated with a concrete work item.

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkParameters.java
@@ -16,8 +16,6 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Incubating;
-
 /**
  * Marker interface for parameter objects to {@link WorkAction}s.
  *
@@ -34,7 +32,6 @@ import org.gradle.api.Incubating;
  *
  * @since 5.6
  */
-@Incubating
 public interface WorkParameters {
     /**
      * Used for work actions without parameters.
@@ -43,7 +40,6 @@ public interface WorkParameters {
      *
      * @since 5.6
      */
-    @Incubating
     final class None implements WorkParameters {
         private None() {}
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
@@ -17,7 +17,6 @@
 package org.gradle.workers;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Represents a queue of work items with a uniform set of worker requirements.
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  *
  * @since 5.6
  */
-@Incubating
 public interface WorkQueue {
     /**
      * Submits a piece of work to be executed asynchronously.

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -17,7 +17,6 @@
 package org.gradle.workers;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -56,7 +55,6 @@ public interface WorkerExecutor {
      * in the {@link WorkerConfiguration}.  If no idle daemons are available, a new daemon will be started.  Any errors
      * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
      */
-    @Deprecated
     void submit(Class<? extends Runnable> actionClass, Action<? super WorkerConfiguration> configAction);
 
     /**
@@ -64,7 +62,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue noIsolation();
 
     /**
@@ -72,7 +69,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue classLoaderIsolation();
 
     /**
@@ -82,7 +78,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue processIsolation();
 
     /**
@@ -90,7 +85,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue noIsolation(Action<? super WorkerSpec> action);
 
     /**
@@ -98,7 +92,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue classLoaderIsolation(Action<? super ClassLoaderWorkerSpec> action);
 
     /**
@@ -108,7 +101,6 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
-    @Incubating
     WorkQueue processIsolation(Action<? super ProcessWorkerSpec> action);
 
     /**

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
@@ -16,7 +16,6 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 5.6
  */
-@Incubating
 @HasInternalProtocol
 public interface WorkerSpec {
 }


### PR DESCRIPTION
Even though we might want to do more in this feature in the future, this has been unchanged since 5.6. And it is already documented as "stable" and widely used (e.g. by Android plugin).

### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  

