### PR TITLE
Promote all methods of ObjectFactory that are still incubating

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.model;
 
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
@@ -114,7 +113,6 @@ public interface ObjectFactory {
      *
      * @since 6.0
      */
-    @Incubating
     ConfigurableFileTree fileTree();
 
     /**
@@ -133,7 +131,6 @@ public interface ObjectFactory {
      * @return The container. Never returns null.
      * @since 5.5
      */
-    @Incubating
     <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType);
 
     /**
@@ -147,7 +144,6 @@ public interface ObjectFactory {
      * @return The container. Never returns null.
      * @since 5.5
      */
-    @Incubating
     <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory);
 
     /**
@@ -160,7 +156,6 @@ public interface ObjectFactory {
      * @return The container.
      * @since 6.1
      */
-    @Incubating
     <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType);
 
     /**
@@ -171,7 +166,6 @@ public interface ObjectFactory {
      * @return The domain object set. Never returns null.
      * @since 5.5
      */
-    @Incubating
     <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType);
 
     /**
@@ -184,7 +178,6 @@ public interface ObjectFactory {
      * @return The domain object set.
      * @since 6.1
      */
-    @Incubating
     <T> NamedDomainObjectSet<T> namedDomainObjectSet(Class<T> elementType);
 
     /**
@@ -197,7 +190,6 @@ public interface ObjectFactory {
      * @return The domain object list.
      * @since 6.1
      */
-    @Incubating
     <T> NamedDomainObjectList<T> namedDomainObjectList(Class<T> elementType);
 
     /**
@@ -254,7 +246,6 @@ public interface ObjectFactory {
      * @return the property. Never returns null.
      * @since 5.1
      */
-    @Incubating
     <K, V> MapProperty<K, V> mapProperty(Class<K> keyType, Class<V> valueType);
 
     /**

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -147,10 +147,17 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.file.FileSystemOperations
         - org.gradle.process.ExecOperations
     - [Lazy configuration](userguide/lazy_configuration.html)
-        - org.gradle.api.model.ObjectFactory.directoryProperty
-        - org.gradle.api.model.ObjectFactory.fileCollection
-        - org.gradle.api.model.ObjectFactory.fileProperty
-        - org.gradle.api.model.ObjectFactory.sourceDirectorySet
+        - org.gradle.api.model.ObjectFactory.directoryProperty()
+        - org.gradle.api.model.ObjectFactory.domainObjectContainer(Class)
+        - org.gradle.api.model.ObjectFactory.domainObjectContainer(Class, NamedDomainObjectFactory)
+        - org.gradle.api.model.ObjectFactory.domainObjectSet(Class)
+        - org.gradle.api.model.ObjectFactory.fileCollection()
+        - org.gradle.api.model.ObjectFactory.fileProperty()
+        - org.gradle.api.model.ObjectFactory.fileTree()
+        - org.gradle.api.model.ObjectFactory.namedDomainObjectList(Class<T>)
+        - org.gradle.api.model.ObjectFactory.namedDomainObjectSet(Class<T>)
+        - org.gradle.api.model.ObjectFactory.polymorphicDomainObjectContainer(Class<T>)
+        - org.gradle.api.model.ObjectFactory.sourceDirectorySet(String, String)
         - org.gradle.api.file.FileCollection.getElements
         - org.gradle.api.file.FileContents
         - org.gradle.api.provider.ProviderFactory.environmentVariable


### PR DESCRIPTION
### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).