### PR TITLE
Promote EAR plugin deployment descriptor generation configuration

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -342,6 +342,10 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.scala.ScalaCompile.setScalaCompilerPlugins(FileCollection)
         - org.gradle.api.tasks.scala.ScalaDoc.getMaxMemory()
         - org.gradle.api.tasks.scala.IncrementalCompileOptions.getClassfileBackupDir()
+    - Miscellaneous
+        - org.gradle.plugins.ear.Ear.getGenerateDeploymentDescriptor()
+        - org.gradle.plugins.ear.EarPluginConvention.getGenerateDeploymentDescriptor()
+    
 - [Kotlin DSL](userguide/kotlin_dsl.html)
     - org.gradle.kotlin.dsl.KotlinScript
     - org.gradle.kotlin.dsl.KotlinSettingsScript.plugins(block: PluginDependenciesSpecScope.() -> Unit): Unit

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -18,7 +18,6 @@ package org.gradle.plugins.ear;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DuplicatesStrategy;
@@ -256,7 +255,6 @@ public class Ear extends Jar {
      * @since 6.0
      */
     @Input
-    @Incubating
     public Property<Boolean> getGenerateDeploymentDescriptor() {
         return generateDeploymentDescriptor;
     }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -17,7 +17,6 @@ package org.gradle.plugins.ear;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 
@@ -58,7 +57,6 @@ public abstract class EarPluginConvention {
      *
      * @since 6.0
      */
-    @Incubating
     public abstract Property<Boolean> getGenerateDeploymentDescriptor();
 
     /**


### PR DESCRIPTION
Promotes: https://github.com/gradle/gradle/pull/10129

### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).