### PR TITLE
Promote APIs for composite build naming and beforeSettings

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedBuild.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedBuild.java
@@ -17,7 +17,6 @@
 package org.gradle.api.initialization;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.DependencySubstitutions;
 
 /**
@@ -33,7 +32,6 @@ public interface ConfigurableIncludedBuild extends IncludedBuild {
      * @param name the name of the build
      * @since 6.0
      */
-    @Incubating
     void setName(String name);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -179,7 +179,6 @@ public interface Gradle extends PluginAware {
      * @param closure The action to execute.
      * @since 6.0
      */
-    @Incubating
     void beforeSettings(Closure<?> closure);
 
     /**
@@ -188,7 +187,6 @@ public interface Gradle extends PluginAware {
      * @param action The action to execute.
      * @since 6.0
      */
-    @Incubating
     void beforeSettings(Action<? super Settings> action);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -16,7 +16,6 @@
 package org.gradle.api.tasks;
 
 import org.gradle.StartParameter;
-import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.ConventionTask;
@@ -166,7 +165,6 @@ public class GradleBuild extends ConventionTask {
      * @return the build name to use for the nested build (or null if the default is to be used)
      * @since 6.0
      */
-    @Incubating
     @Internal
     public String getBuildName() {
         return buildName;
@@ -178,7 +176,6 @@ public class GradleBuild extends ConventionTask {
      * @param buildName the build name to use for the nested build
      * @since 6.0
      */
-    @Incubating
     public void setBuildName(String buildName) {
         this.buildName = buildName;
     }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -200,6 +200,10 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.workers.WorkerExecutor.processIsolation()
         - org.gradle.workers.WorkerExecutor.processIsolation(Action)
         - org.gradle.workers.WorkerSpec
+    - [Composite Builds](userguide/composite_builds.html)
+        - org.gradle.api.initialization.ConfigurableIncludedBuild.setName(String)
+        - org.gradle.api.tasks.GradleBuild.getBuildName()
+        - org.gradle.api.tasks.GradleBuild.setBuildName(String)
     - Reporting
         - org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroup()
         - org.gradle.api.tasks.diagnostics.TaskReportTask.setDisplayGroup(String)
@@ -213,6 +217,8 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.JavaVersion.isCompatibleWith
         - org.gradle.api.ProjectConfigurationException
         - org.gradle.api.invocation.BuildInvocationDetails
+        - org.gradle.api.invocation.Gradle.beforeSettings(Action)
+        - org.gradle.api.invocation.Gradle.beforeSettings(Closure)
         - org.gradle.api.reflect.TypeOf.getConcreteClass()
         - org.gradle.plugin.management.PluginManagementSpec.getPlugins()
         - org.gradle.plugin.management.PluginManagementSpec.plugins(Action)  


### PR DESCRIPTION
Promotes what has been introduced in #10998 and #10304

### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- ~Deprecate existing API that is replaced by the new one~
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [x] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).