### PR TITLE
Preserve backward compatibility with plugins compiled with Gradle < 5.0

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -27,7 +27,6 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import java.lang.invoke.CallSite;
@@ -42,6 +41,7 @@ import java.util.Properties;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
@@ -150,7 +150,7 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
         public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
             super.visit(version, access, name, signature, superName, interfaces);
             this.className = name;
-            this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
+            this.isInterface = (access & ACC_INTERFACE) != 0;
         }
 
         @Override
@@ -408,7 +408,7 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
         private String fixSyntheticBridgeMethodDescriptor(int access, String descriptor) {
             // Restore compatibility with plugins compiled with an old Groovy version (like org.samples.greeting:1.0 used by the GE build)
             // in which super class getters are accessed via bridge methods.
-            return (ACC_SYNTHETIC & access) != 0 && descriptor.startsWith("()")
+            return (access & ACC_SYNTHETIC) != 0 && descriptor.startsWith("()")
                 ? fixMethodDescriptorForBackwardCompatibility(descriptor)
                 : descriptor;
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GreetingSamplePluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GreetingSamplePluginSmokeTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.util.GradleVersion
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+// https://plugins.gradle.org/plugin/org.samples.greeting
+// Plugin is used by the GE build.
+class GreetingSamplePluginSmokeTest extends AbstractSmokeTest {
+    def 'greeting plugin'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.samples.greeting' version '1.0'
+            }
+        """.stripIndent()
+
+        when:
+        def result = runner('hello').forwardOutput().build()
+
+        then:
+        result.task(':hello').outcome == SUCCESS
+
+        expectDeprecationWarnings(
+            result,
+            "Property 'greeting' is not annotated with an input or output annotation. " +
+                "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
+                "Execution optimizations are disabled due to the failed validation. " +
+                "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
+        )
+    }
+}


### PR DESCRIPTION
After the removal of  the deprecated `org.gradle.logging.LoggingManager` interface in #15767.

More importantly, this PR restores compatibility with `org.samples.greeting:1.0` used by the GE build.