### PR TITLE
Let `GeneratePrecompiledScriptPluginAccessors` fail the build

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 org.gradle.parallel=true
 kotlin.parallel.tasks.in.project=true
 systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
-systemProp.org.gradle.kotlin-dsl.precompiled.accessors.strict=true
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 org.gradle.parallel=true
 kotlin.parallel.tasks.in.project=true
 systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
+systemProp.org.gradle.kotlin-dsl.precompiled.accessors.strict=true

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -634,6 +634,23 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         }
     }
 
+    @Test
+    @ToBeFixedForConfigurationCache
+    fun `plugin application errors can be made to fail the build via system property`() {
+
+        // given:
+        val pluginId = "invalid.plugin"
+        val pluginJar = jarWithInvalidPlugin(pluginId, "InvalidPlugin")
+
+        withPrecompiledScriptApplying(pluginId, pluginJar)
+
+        gradleExecuterFor(arrayOf("classes", "-Dorg.gradle.kotlin-dsl.precompiled.accessors.strict=true")).withStackTraceChecksDisabled().runWithFailure().apply {
+            assertHasFailure("An exception occurred applying plugin request [id: '$pluginId']") {
+                assertHasCause("'InvalidPlugin' is neither a plugin or a rule source and cannot be applied.")
+            }
+        }
+    }
+
     private
     fun withPrecompiledScriptApplying(pluginId: String, pluginJar: File) {
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -644,7 +644,7 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
 
         withPrecompiledScriptApplying(pluginId, pluginJar)
 
-        gradleExecuterFor(arrayOf("classes", "-Dorg.gradle.kotlin-dsl.precompiled.accessors.strict=true")).withStackTraceChecksDisabled().runWithFailure().apply {
+        gradleExecuterFor(arrayOf("classes", "-Dorg.gradle.kotlin.dsl.precompiled.accessors.strict=true")).withStackTraceChecksDisabled().runWithFailure().apply {
             assertHasFailure("An exception occurred applying plugin request [id: '$pluginId']") {
                 assertHasCause("'InvalidPlugin' is neither a plugin or a rule source and cannot be applied.")
             }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -228,7 +228,7 @@ fun Project.enableScriptCompilationOf(
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)
                 strict.set(
                     providers
-                        .systemProperty("org.gradle.kotlin-dsl.precompiled.accessors.strict")
+                        .systemProperty("org.gradle.kotlin.dsl.precompiled.accessors.strict")
                         .map(java.lang.Boolean::parseBoolean)
                         .orElse(false)
                 )

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -226,6 +226,12 @@ fun Project.enableScriptCompilationOf(
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(accessorsMetadata)
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)
+                strict.set(
+                    providers
+                        .systemProperty("org.gradle.kotlin-dsl.precompiled.accessors.strict")
+                        .map(java.lang.Boolean::parseBoolean)
+                        .orElse(false)
+                )
                 plugins = scriptPlugins
             }
 


### PR DESCRIPTION
Upon plugin application errors when the system property `org.gradle.kotlin.dsl.precompiled.accessors.strict` is set to `true`.

Also, set the system property on the `build-logic` build.