### PR TITLE
Do not register root build substitutions by default

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -173,6 +173,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         """
         buildA.settingsFile << """
             rootProject.name = 'theNameOfBuildA'
+            includeBuild '../rootBuild'
         """
 
         when:
@@ -195,6 +196,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
                 }
             """
             settingsFile << """
+                includeBuild '.'
                 includeBuild '../buildA'
                 includeBuild '../buildB'
             """
@@ -210,6 +212,9 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         buildB.buildFile << """
             apply plugin: 'java-library'
             dependencies { api 'org.test:x3' }
+        """
+        buildB.settingsFile << """
+            includeBuild '../rootBuild'
         """
 
         when:

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -63,6 +63,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     private final Map<File, IncludedBuildState> includedBuildsByRootDir = new LinkedHashMap<>();
     private final Map<Path, File> includedBuildDirectoriesByPath = new LinkedHashMap<>();
     private final Deque<IncludedBuildState> pendingIncludedBuilds = new ArrayDeque<>();
+    private boolean registerSubstitutionsForRootBuild = false;
 
     public DefaultIncludedBuildRegistry(BuildTreeState owner, IncludedBuildFactory includedBuildFactory, IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager) {
         this.owner = owner;
@@ -162,7 +163,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public void afterConfigureRootBuild() {
-        if (!includedBuildsByRootDir.isEmpty()) {
+        if (registerSubstitutionsForRootBuild) {
             dependencySubstitutionsBuilder.build((CompositeBuildParticipantBuildState) rootBuild);
         }
     }
@@ -207,6 +208,11 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         // Attach the build only after it has been fully constructed.
         rootOfNestedBuildTree.attach();
         return rootOfNestedBuildTree;
+    }
+
+    @Override
+    public void registerSubstitutionsForRootBuild() {
+        registerSubstitutionsForRootBuild = true;
     }
 
     private void validateNameIsNotBuildSrc(String name, File dir) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -102,4 +102,9 @@ public interface BuildStateRegistry {
      * Creates a new standalone nested build tree.
      */
     NestedRootBuild addNestedBuildTree(BuildDefinition buildDefinition, BuildState owner, @Nullable String buildName);
+
+    /**
+     * Register dependency substitutions for the root build itself. This way, the projects of the root build can be addressed by coordinates as the projects of all other builds.
+     */
+    void registerSubstitutionsForRootBuild();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -61,6 +61,7 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
                     IncludedBuildState includedBuild = addIncludedBuild(includedBuildSpec, gradle);
                     children.add(includedBuild.getModel());
                 } else {
+                    buildRegistry.registerSubstitutionsForRootBuild();
                     children.add(new IncludedRootBuild((CompositeBuildParticipantBuildState) buildRegistry.getRootBuild()));
                 }
             }

--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
@@ -141,6 +141,9 @@ Source dependencies are configured, providing cross-build navigation and refacto
 By default, Gradle will configure each included build in order to determine the dependencies it can provide.
 The algorithm for doing this is very simple: Gradle will inspect the group and name for the projects in the included build, and substitute project dependencies for any external dependency matching `${project.group}:${project.name}`.
 
+NOTE: By default, substitutions are not registered for the _main_ build.
+To make the (sub)projects of the main build addressable by `${project.group}:${project.name}`, you can tell Gradle to treat the main build like an included build by self-including it: `includeBuild(".")`.
+
 There are cases when the default substitutions determined by Gradle are not sufficient, or they are not correct for a particular composite.
 For these cases it is possible to explicitly declare the substitutions for an included build.
 Take for example a single-project build 'anonymous-library', that produces a java utility library but does not declare a value for the group attribute:


### PR DESCRIPTION
This was introduced in #14638 but breaks scenarios where a build uses different versions of a component, that is also a subproject of the root build, in different places.

The root project now has to be explicitly included by an `includeBuild(..)` statement for the substitutions to be applied:

- This will naturally happen if there is a cycle where an included build points back to the root project via `includeBuild("path/to/root")`. So that conceptually the root build is also a nested included build. This is the major use case for #14638 in the first place.
- A user can explicitly decide to get the substitutions by directly including the root build itself --  `includeBuild(".")`. Documentation for this feature is added in this PR.
 

Fixes #15781

