### PR TITLE
Fix Kotlin DSL regression via `-XXLanguage:+DisableCompatibilityModeForNewInference`

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
@@ -37,4 +37,17 @@ class GradleKotlinDslRegressionsTest : AbstractPluginIntegrationTest() {
 
         build("help")
     }
+
+    @Test
+    fun `can configure ext extension`() {
+        withBuildScript(
+            """
+            ext {
+                set("foo", "bar")
+            }
+            """
+        )
+
+        build("help")
+    }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -45,6 +45,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.4",
         "-jvm-target", "1.8",
         "-Xjsr305=strict",
+        "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]
 )
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -65,6 +65,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.4",
         "-jvm-target", "1.8",
         "-Xjsr305=strict",
+        "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]
 )
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -71,6 +71,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.4",
         "-jvm-target", "1.8",
         "-Xjsr305=strict",
+        "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]
 )
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslPluginSupport.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslPluginSupport.kt
@@ -23,5 +23,6 @@ object KotlinDslPluginSupport {
         get() = listOf(
             "-java-parameters",
             "-Xjsr305=strict",
+            "-XXLanguage:+DisableCompatibilityModeForNewInference",
         )
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -51,6 +51,7 @@ import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
 import org.jetbrains.kotlin.config.JvmTarget.JVM_1_8
+import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 
@@ -341,6 +342,9 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     apiVersion = ApiVersion.KOTLIN_1_4,
     analysisFlags = mapOf(
         AnalysisFlags.skipMetadataVersionCheck to true
+    ),
+    specificFeatures = mapOf(
+        LanguageFeature.DisableCompatibilityModeForNewInference to LanguageFeature.State.ENABLED
     )
 )
 


### PR DESCRIPTION
See #15617
See https://youtrack.jetbrains.com/issue/KT-44303
