### PR TITLE
Fix `GradleBuildConfigurationCacheSmokeTest`

### DIFF
--- a/build-logic-commons/gradle.properties
+++ b/build-logic-commons/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ kotlin.stdlib.default.dependency=false
 gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
+
+# Set the property here so it matches the configuration cache fingerprint of the :build-logic-commons and :build-logic builds
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -33,7 +33,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.experimental.categories.Category
-import spock.lang.Ignore
 
 import java.text.SimpleDateFormat
 
@@ -48,7 +47,6 @@ import java.text.SimpleDateFormat
 })
 class GradleBuildConfigurationCacheSmokeTest extends AbstractSmokeTest {
 
-    @Ignore("wip")
     def "can build gradle with configuration cache enabled"() {
 
         given:


### PR DESCRIPTION
By setting the `o.g.kotlin.dsl.precompiled.accessors.strict` to the same value in all builds. This is due to a current limitation in the configuration cache fingerprinting infrastructure for composite builds, see #15820.