### PR TITLE
Promote changing the priority of the daemon process

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -142,6 +142,10 @@ It is no longer required to activate the functionality using `java.modularity.in
 
 [Dependency verification](userguide/dependency_verification.html) is promoted to a stable feature.
 
+### Changing the priority of the daemon process
+
+Changing the [priority of the daemon process](userguide/command_line_interface.html#sec:command_line_performance) with `--priority` is now a stable feature.
+
 ### Promoted APIs
 In Gradle 7.0 we moved the following classes or methods out of incubation phase.
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -210,7 +210,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         public static final String GRADLE_PROPERTY = "org.gradle.priority";
 
         public PriorityOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("priority", "Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'").incubating());
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("priority", "Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'"));
         }
 
         @Override


### PR DESCRIPTION
This was introduced in Gradle 5.0 (#7403) and no more has been done on it since then.
