### PR TITLE
Remove deprecated UsageContext.getUsage()

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
@@ -16,10 +16,7 @@
 
 package org.gradle.api.internal.component;
 
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponentVariant;
 
 public interface UsageContext extends SoftwareComponentVariant {
-    @Deprecated
-    Usage getUsage(); // kept for backwards compatibility of plugins using internal APIs
 }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -143,6 +143,11 @@ If this is causing issues in cases you manually configure the module path, or us
 
 The `ValidateTaskProperties` task has been removed and replaced by the link:{javadocPath}/org/gradle/plugin/devel/tasks/ValidatePlugins.html task.
 
+
+==== Removal of `UsageContext.getUsage()`
+
+The method was kept only for maintaining backward compatibility with older plugins.
+
 === Deprecations
 
 [[missing_dependencies]]

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/AbstractUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/AbstractUsageContext.java
@@ -17,7 +17,6 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.UsageContext;
 
@@ -30,11 +29,6 @@ public abstract class AbstractUsageContext implements UsageContext {
     public AbstractUsageContext(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
         this.attributes = attributes;
         this.artifacts = artifacts;
-    }
-
-    @Override
-    public Usage getUsage() {
-        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -32,8 +32,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         given:
         BuildResult result
         useSample("gmm-example")
-        // TODO Test Kotlin 1.4
-        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.3")
+        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.4")
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.0")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 


### PR DESCRIPTION
### Summary
* org.gradle.api.internal.component.UsageContext.getUsage()

### Checklist
- [x] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [x] Update the upgrade guide
- [x] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 