### PR TITLE
Remove deprecated binResultsDir property from AbstractTestTask

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1511,6 +1511,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.AbstractTestTask",
+            "member": "Method org.gradle.api.tasks.testing.AbstractTestTask.getBinResultsDir()",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.AbstractTestTask",
+            "member": "Method org.gradle.api.tasks.testing.AbstractTestTask.setBinResultsDir(java.io.File)",
+            "acceptation": "Removal of deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.AbstractTestTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.AbstractTestTask.xml
@@ -25,10 +25,6 @@
                 </tr>
             </thead>
             <tr>
-                <td>binResultsDir</td>
-                <td><literal><replaceable>project.testResultsDir</replaceable>/binary/<replaceable>task.name</replaceable></literal></td>
-            </tr>
-            <tr>
                 <td>ignoreFailures</td>
                 <td/>
             </tr>

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -143,6 +143,10 @@ If this is causing issues in cases you manually configure the module path, or us
 
 The `ValidateTaskProperties` task has been removed and replaced by the link:{javadocPath}/org/gradle/plugin/devel/tasks/ValidatePlugins.html task.
 
+==== Removal of `binResultsDir` property from `AbstractTestTask`
+
+The `getBinResultsDir()` and The `setBinResultsDir(File)` have been removed from `AbstractTestTask`. Clients should replace usages with `binaryResultsDirectory` property.
+
 === Deprecations
 
 [[missing_dependencies]]

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -164,7 +164,7 @@ public class ThingTest {
             sourceSets.otherTest.runtimeClasspath = sourceSets.otherTest.compileClasspath + sourceSets.otherTest.output
 
             task otherTests(type: Test) {
-                binResultsDir file("bin")
+                binaryResultsDirectory = file("bin")
                 testClassesDirs = sourceSets.otherTest.output.classesDirs
                 classpath = sourceSets.otherTest.runtimeClasspath
             }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestReportTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestReportTest.groovy
@@ -31,7 +31,7 @@ class TestReportTest extends AbstractProjectBuilderSpec {
         reportTask.reportOn([[test2], test3])
 
         then:
-        reportTask.testResultDirs.files as List == [test1, test2, test3].binResultsDir
+        reportTask.testResultDirs.files as List == [test1, test2, test3].binaryResultsDirectory.asFile.orNull
         reportTask.testResultDirs.buildDependencies.getDependencies(reportTask) == [test1, test2, test3] as Set
     }
 
@@ -47,7 +47,7 @@ class TestReportTest extends AbstractProjectBuilderSpec {
 
     def test(String name) {
         def test = TestUtil.createTask(Test, project, name)
-        test.binResultsDir = temporaryFolder.file(name)
+        test.binaryResultsDirectory = temporaryFolder.file(name)
         return test
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -40,7 +40,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         task = TestUtil.create(temporaryFolder).task(Test)
         task.testExecuter = testExecuter
         task.testReporter = Mock(TestReporter)
-        task.binResultsDir = task.project.file('build/test-results')
+        task.binaryResultsDirectory  = task.project.file('build/test-results')
         task.reports.junitXml.destination = task.project.file('build/test-results')
         task.testClassesDirs = task.project.layout.files()
         completion = task.project.services.get(WorkerLeaseRegistry).getWorkerLease().start()

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -342,7 +342,7 @@ class TestTest extends AbstractConventionTaskTest {
 
         test.setTestClassesDirs(TestFiles.fixed(classesDir))
         test.getReports().getJunitXml().setDestination(resultsDir)
-        test.setBinResultsDir(binResultsDir)
+        test.binaryResultsDirectory = binResultsDir
         test.getReports().getHtml().setDestination(reportDir)
         test.setClasspath(classpathMock)
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -53,7 +53,6 @@ import org.gradle.api.internal.tasks.testing.results.StateTrackingTestResultProc
 import org.gradle.api.internal.tasks.testing.results.TestListenerAdapter;
 import org.gradle.api.internal.tasks.testing.results.TestListenerInternal;
 import org.gradle.api.logging.LogLevel;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Reporting;
 import org.gradle.api.tasks.Internal;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -203,27 +203,6 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     /**
-     * Returns the root folder for the test results in internal binary format.
-     *
-     * @return the test result directory, containing the test results in binary format.
-     */
-    @ReplacedBy("binaryResultsDirectory")
-    @Deprecated
-    public File getBinResultsDir() {
-        return binaryResultsDirectory.getAsFile().getOrNull();
-    }
-
-    /**
-     * Sets the root folder for the test results in internal binary format.
-     *
-     * @param binResultsDir The root folder
-     */
-    @Deprecated
-    public void setBinResultsDir(File binResultsDir) {
-        this.binaryResultsDirectory.set(binResultsDir);
-    }
-
-    /**
      * Returns the root directory property for the test results in internal binary format.
      *
      * @since 4.4
@@ -435,7 +414,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
         TestExecutionSpec executionSpec = createTestExecutionSpec();
 
-        final File binaryResultsDir = getBinResultsDir();
+        final File binaryResultsDir = getBinaryResultsDirectory().getAsFile().getOrNull();
         FileSystemOperations fs = getFileSystemOperations();
         fs.delete(new Action<DeleteSpec>() {
             @Override

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -93,7 +93,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
                 doLast {
                     assert ${testTaskName}.reports.junitXml.destination == file('build/test-results/${testTaskName}')
                     assert ${testTaskName}.reports.html.destination == file('build/reports/tests/${testTaskName}')
-                    assert ${testTaskName}.binResultsDir == file('build/test-results/${testTaskName}/binary')
+                    assert ${testTaskName}.binaryResultsDirectory.asFile.orNull == file('build/test-results/${testTaskName}/binary')
                 }
             }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -205,7 +205,7 @@ public class SubClassTests extends SuperClassTests {
              $junitSetup
 
             task otherTests(type: Test) {
-                binResultsDir file("bin")
+                binaryResultsDirectory = file("bin")
                 testClassesDirs = files("blah")
             }
 
@@ -236,7 +236,7 @@ public class SubClassTests extends SuperClassTests {
              $junitSetup
 
             task testReport(type: TestReport) {
-                testResultDirs = [test.binResultsDir]
+                testResultDirs = [test.binaryResultsDirectory]
                 destinationDir reporting.file("tr")
             }
         """

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -650,7 +650,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     }
 
     private Set<String> getPreviousFailedTestClasses() {
-        TestResultSerializer serializer = new TestResultSerializer(getBinResultsDir());
+        TestResultSerializer serializer = new TestResultSerializer(getBinaryResultsDirectory().getAsFile().getOrNull());
         if (serializer.isHasResults()) {
             final Set<String> previousFailedTestClasses = new HashSet<String>();
             serializer.read(new Action<TestClassResult>() {


### PR DESCRIPTION
### Summary
<!--- List the API methods marked for removal -->

- org.gradle.api.tasks.testing.AbstractTestTask.getBinResultsDir()
- org.gradle.api.tasks.testing.AbstractTestTask.setBinResultsDir(File) 

### Checklist
- [x] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [ ] Update the upgrade guide
- [ ] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 
