### PR TITLE
Remove deprecated project field from JacocoPluginExtension

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -55,9 +55,6 @@ public class JacocoPluginExtension {
 
     private static final Logger LOGGER = Logging.getLogger(JacocoPluginExtension.class);
 
-    @Deprecated
-    protected final Project project;
-
     private final ProviderFactory providers;
     private final ObjectFactory objects;
     private final ProjectLayout layout;
@@ -74,7 +71,6 @@ public class JacocoPluginExtension {
      * @param agent the agent JAR to be used by Jacoco
      */
     public JacocoPluginExtension(Project project, JacocoAgentJar agent) {
-        this.project = project;
         this.agent = agent;
         this.providers = project.getProviders();
         this.objects = project.getObjects();

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskCollection;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaForkOptions;
@@ -97,48 +96,6 @@ public class JacocoPluginExtension {
      */
     public DirectoryProperty getReportsDirectory() {
         return reportsDirectory;
-    }
-
-    /**
-     * The directory where reports will be generated.
-     */
-    @Deprecated
-    public File getReportsDir() {
-        nagReportsDirDeprecation();
-        return reportsDirectory.get().getAsFile();
-    }
-
-    /**
-     * Set the provider for calculating the report directory.
-     *
-     * @param reportsDir Reports directory provider
-     * @since 4.0
-     * @deprecated See {@link #getReportsDirectory()}
-     */
-    @Deprecated
-    public void setReportsDir(Provider<File> reportsDir) {
-        nagReportsDirDeprecation();
-        this.reportsDirectory.set(layout.dir(reportsDir));
-    }
-
-    /**
-     * Set the provider for calculating the report directory.
-     *
-     * @param reportsDir Reports directory
-     * @deprecated See {@link #getReportsDirectory()}
-     */
-    @Deprecated
-    public void setReportsDir(File reportsDir) {
-        nagReportsDirDeprecation();
-        this.reportsDirectory.set(reportsDir);
-    }
-
-    private void nagReportsDirDeprecation() {
-        DeprecationLogger.deprecateProperty(JacocoPluginExtension.class, "reportsDir")
-            .replaceWith("reportsDirectory")
-            .willBeRemovedInGradle8()
-            .withDslReference()
-            .nagUser();
     }
 
     /**


### PR DESCRIPTION
### Summary
<!--- List the API methods marked for removal -->

### Checklist
- [ ] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [ ] Update the upgrade guide
- [ ] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 