### PR TITLE
Remove deprecated methods from GUtil

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -180,24 +180,6 @@ public class GUtil {
         return addToCollection(dest, false, src);
     }
 
-    @Deprecated
-    public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V>... srcs) {
-        for (Iterable<? extends V> src : srcs) {
-            for (V v : src) {
-                if (failOnNull && v == null) {
-                    throw new IllegalArgumentException("Illegal null value provided in this collection: " + src);
-                }
-                dest.add(v);
-            }
-        }
-        return dest;
-    }
-
-    @Deprecated
-    public static <V, T extends Collection<? super V>> T addToCollection(T dest, Iterable<? extends V>... srcs) {
-        return addToCollection(dest, false, srcs);
-    }
-
     public static Comparator<String> caseInsensitive() {
         return new Comparator<String>() {
             @Override

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -162,6 +162,10 @@ The `ImmutableFileCollection` type has been removed.
 Use the link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#files-java.lang.Object...- factory method instead.
 A handle to the project layout can be obtained via link:{javadocPath}/org/gradle/api/Project.html#getLayout--.
 
+=== Removal of `GUtil.addToCollection()` methods
+
+The deprecated, vararg-taking `addToCollections()` methods have been removed and replaced with their non-vararg variants.
+
 === Deprecations
 
 [[missing_dependencies]]

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -32,7 +32,6 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         given:
         BuildResult result
         useSample("gmm-example")
-        // TODO Test Kotlin 1.4
         def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.4")
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.0")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -33,7 +33,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         BuildResult result
         useSample("gmm-example")
         // TODO Test Kotlin 1.4
-        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.3")
+        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.4")
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.0")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
@@ -28,11 +28,11 @@
         {
           "name": "android-kotlin-library-1.0-debug.aar",
           "url": "android-kotlin-library-1.0-debug.aar",
-          "size": 2108,
-          "sha512": "6285c2a221d819ed3d87a3a1652f5f57c9212d74b5fbf8a1f536b041d6734cd1bed47c3d96e13c15d91986db82da3e97e2e4a15926c1c722c69e257b7a207c54",
-          "sha256": "9ecf17ef7d638182768be4ce71a809caa5527e8de8de27d2d525a07030c90065",
-          "sha1": "fb066af3c5b457f7ed79efcf17cf7453aebb6884",
-          "md5": "c8282720dff92465fb2a1fd4347d3d56"
+          "size": 2080,
+          "sha512": "06d1d6c75bb01c41476fd164438f93dd4413a208b478243dd4522f6916faddf79fee14a730c95b4cf249b13c08f05ede5c6d0fdbf4b8c27fc64fb12aa0a16ec4",
+          "sha256": "862b154eb31420f53556d23e93eecbfd4b651d78099b5c6a983c5125b0656e8c",
+          "sha1": "ca1e5eaed518a056d1ee50f2dc67c89a1a1a4c3b",
+          "md5": "3f077b447947a3813eb9ba4f3741e370"
         }
       ]
     },
@@ -50,7 +50,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -58,11 +58,11 @@
         {
           "name": "android-kotlin-library-1.0-debug.aar",
           "url": "android-kotlin-library-1.0-debug.aar",
-          "size": 2108,
-          "sha512": "6285c2a221d819ed3d87a3a1652f5f57c9212d74b5fbf8a1f536b041d6734cd1bed47c3d96e13c15d91986db82da3e97e2e4a15926c1c722c69e257b7a207c54",
-          "sha256": "9ecf17ef7d638182768be4ce71a809caa5527e8de8de27d2d525a07030c90065",
-          "sha1": "fb066af3c5b457f7ed79efcf17cf7453aebb6884",
-          "md5": "c8282720dff92465fb2a1fd4347d3d56"
+          "size": 2080,
+          "sha512": "06d1d6c75bb01c41476fd164438f93dd4413a208b478243dd4522f6916faddf79fee14a730c95b4cf249b13c08f05ede5c6d0fdbf4b8c27fc64fb12aa0a16ec4",
+          "sha256": "862b154eb31420f53556d23e93eecbfd4b651d78099b5c6a983c5125b0656e8c",
+          "sha1": "ca1e5eaed518a056d1ee50f2dc67c89a1a1a4c3b",
+          "md5": "3f077b447947a3813eb9ba4f3741e370"
         }
       ]
     },
@@ -79,11 +79,11 @@
         {
           "name": "android-kotlin-library-1.0-release.aar",
           "url": "android-kotlin-library-1.0-release.aar",
-          "size": 2011,
-          "sha512": "00a9a38504266e38898f44300c06d350a5c4a08bebdf8d316f7212c330699adb7f0837f1187a908b4a0d7818144e846a3f937bd824361261d275d40af26ec690",
-          "sha256": "aa8fd2d336459320754e1ba404782038d9a7fbd499249b897761a21ca037a77a",
-          "sha1": "1c7f39d735f3ce3e4f70643b78bf736cbeb81782",
-          "md5": "42cc48ea3cdf8603fe334692acfdf15b"
+          "size": 1980,
+          "sha512": "1d308cbd564a0428c5c2641d2a62982ddfef6884c24ac2fe79aee81ebeafd66c0224d210ed18373ba00e9ec0aa99fd562a9fc18ffe2cb784b332817c0e95b746",
+          "sha256": "831a2a4e87490afcbb2f73c7352f34985d873c9319fe1c37932cc0ac714039ef",
+          "sha1": "604e2f4ae1d900bfc477b0862aba50b34aad141a",
+          "md5": "701a42ba234131580f57d65439e6a5e0"
         }
       ]
     },
@@ -101,7 +101,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -109,11 +109,11 @@
         {
           "name": "android-kotlin-library-1.0-release.aar",
           "url": "android-kotlin-library-1.0-release.aar",
-          "size": 2011,
-          "sha512": "00a9a38504266e38898f44300c06d350a5c4a08bebdf8d316f7212c330699adb7f0837f1187a908b4a0d7818144e846a3f937bd824361261d275d40af26ec690",
-          "sha256": "aa8fd2d336459320754e1ba404782038d9a7fbd499249b897761a21ca037a77a",
-          "sha1": "1c7f39d735f3ce3e4f70643b78bf736cbeb81782",
-          "md5": "42cc48ea3cdf8603fe334692acfdf15b"
+          "size": 1980,
+          "sha512": "1d308cbd564a0428c5c2641d2a62982ddfef6884c24ac2fe79aee81ebeafd66c0224d210ed18373ba00e9ec0aa99fd562a9fc18ffe2cb784b332817c0e95b746",
+          "sha256": "831a2a4e87490afcbb2f73c7352f34985d873c9319fe1c37932cc0ac714039ef",
+          "sha1": "604e2f4ae1d900bfc477b0862aba50b34aad141a",
+          "md5": "701a42ba234131580f57d65439e6a5e0"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-library-1.0.module
@@ -29,11 +29,11 @@
         {
           "name": "android-library-1.0-demoDebug.aar",
           "url": "android-library-1.0-demoDebug.aar",
-          "size": 1597,
-          "sha512": "25c3244315cb65d34aa14b56cc6ff16d1c2ad1382ac2afe105c02cb7bd24dc4c2b583fd3d474f68c0fb22294317f91a5343648ee6b04ab82b9e62dabf889418c",
-          "sha256": "a88a9c1e7d1f941e2e3df253002a19fff3a1f0aab05614a62d6476fdda505671",
-          "sha1": "516dd8e10c920029d10960be40ffa4b2ad0f03db",
-          "md5": "86cb41e5d705687c26f719fef490d5fb"
+          "size": 1528,
+          "sha512": "3ca0a60b743ae6371eafdfb73c6635e3376d8357e56d076c556223d1ee1cedab56f0e91ee8f27733d800717ce7f942bee24fc9d8e6d11d335d6e0f6a3b50fbad",
+          "sha256": "911efb06c5566e0eed53344d6963a7440d00dd02f976f7e5be9e69eff0c938b5",
+          "sha1": "6d1e395f0bbd2fd54c39c3d14ace373c2d933bb5",
+          "md5": "76e7e67fadbae5b91e19299e20f1291f"
         }
       ]
     },
@@ -51,11 +51,11 @@
         {
           "name": "android-library-1.0-demoDebug.aar",
           "url": "android-library-1.0-demoDebug.aar",
-          "size": 1597,
-          "sha512": "25c3244315cb65d34aa14b56cc6ff16d1c2ad1382ac2afe105c02cb7bd24dc4c2b583fd3d474f68c0fb22294317f91a5343648ee6b04ab82b9e62dabf889418c",
-          "sha256": "a88a9c1e7d1f941e2e3df253002a19fff3a1f0aab05614a62d6476fdda505671",
-          "sha1": "516dd8e10c920029d10960be40ffa4b2ad0f03db",
-          "md5": "86cb41e5d705687c26f719fef490d5fb"
+          "size": 1528,
+          "sha512": "3ca0a60b743ae6371eafdfb73c6635e3376d8357e56d076c556223d1ee1cedab56f0e91ee8f27733d800717ce7f942bee24fc9d8e6d11d335d6e0f6a3b50fbad",
+          "sha256": "911efb06c5566e0eed53344d6963a7440d00dd02f976f7e5be9e69eff0c938b5",
+          "sha1": "6d1e395f0bbd2fd54c39c3d14ace373c2d933bb5",
+          "md5": "76e7e67fadbae5b91e19299e20f1291f"
         }
       ]
     },
@@ -73,11 +73,11 @@
         {
           "name": "android-library-1.0-fullDebug.aar",
           "url": "android-library-1.0-fullDebug.aar",
-          "size": 1595,
-          "sha512": "4b3509d7f20b3a4702086e1c4f3d6384c2c31096d9873ce255383f9554ae8ae3d424112daeb4c48720d78acd426afe8403e5e0f84b64d899c43db050e1bab9f5",
-          "sha256": "ff13a8da75097b23fd4ab152f43b23cd62b487b6027bdf7495839b8bbc0595af",
-          "sha1": "0c6eadf68e341b3a212467eb08692334d2ef4f5f",
-          "md5": "f81420a912e98b1d8034b951744f06f2"
+          "size": 1529,
+          "sha512": "3cafdcb56369c5d0a65a6d768c0907828f9c16d728c4cc3b4effe52ff1a49ef4215a4a964f945b4ca1dde2821286d95b53240ac3f5732957f13cc9900b7ab122",
+          "sha256": "911944a0a11ed6b296250062571cb46267f330d6830f15e32befa26e7d8cf129",
+          "sha1": "f2a9f57970a03f2d6613ea0e3042df172c476d5f",
+          "md5": "bf0884f6207dff732602be6d499566c4"
         }
       ]
     },
@@ -95,11 +95,11 @@
         {
           "name": "android-library-1.0-fullDebug.aar",
           "url": "android-library-1.0-fullDebug.aar",
-          "size": 1595,
-          "sha512": "4b3509d7f20b3a4702086e1c4f3d6384c2c31096d9873ce255383f9554ae8ae3d424112daeb4c48720d78acd426afe8403e5e0f84b64d899c43db050e1bab9f5",
-          "sha256": "ff13a8da75097b23fd4ab152f43b23cd62b487b6027bdf7495839b8bbc0595af",
-          "sha1": "0c6eadf68e341b3a212467eb08692334d2ef4f5f",
-          "md5": "f81420a912e98b1d8034b951744f06f2"
+          "size": 1529,
+          "sha512": "3cafdcb56369c5d0a65a6d768c0907828f9c16d728c4cc3b4effe52ff1a49ef4215a4a964f945b4ca1dde2821286d95b53240ac3f5732957f13cc9900b7ab122",
+          "sha256": "911944a0a11ed6b296250062571cb46267f330d6830f15e32befa26e7d8cf129",
+          "sha1": "f2a9f57970a03f2d6613ea0e3042df172c476d5f",
+          "md5": "bf0884f6207dff732602be6d499566c4"
         }
       ]
     },
@@ -117,11 +117,11 @@
         {
           "name": "android-library-1.0-demoRelease.aar",
           "url": "android-library-1.0-demoRelease.aar",
-          "size": 1504,
-          "sha512": "ebf3d491268135a18e86331dd68c2fa73a0b11b7569fc9d4eabf4ecfb9cbc421cb39154a6d1d32ea4d7135a94f277555ab8d29a4c1df65a7a228f6b8477b1954",
-          "sha256": "caa87b35c4c3275df1d4edca51de2f33b8e8fd70e33c9e04940d1c9a40a11789",
-          "sha1": "230b4be9ce81069ffaec2a7dc414a46c61fc0cf9",
-          "md5": "fbef986e14d586c5e61e2e4cfcbac6c2"
+          "size": 1442,
+          "sha512": "41a2c512c7a6d1da55abf6187d4f7e9e51c0602d26d6c1ed9cc8496b4e02e12b9a1e980d48365d1a6c6f5fcbe64142de33d6342cd129038334dfb0326f9e2540",
+          "sha256": "2cf0e377326830a0a99c92240d07435098439ccf52fa0465cd9c8cef0fff4127",
+          "sha1": "17a7cb2f5b8690107bf2382387cd98c78331eee0",
+          "md5": "5df7ef17e85be1e7446f42b0841cf080"
         }
       ]
     },
@@ -139,11 +139,11 @@
         {
           "name": "android-library-1.0-demoRelease.aar",
           "url": "android-library-1.0-demoRelease.aar",
-          "size": 1504,
-          "sha512": "ebf3d491268135a18e86331dd68c2fa73a0b11b7569fc9d4eabf4ecfb9cbc421cb39154a6d1d32ea4d7135a94f277555ab8d29a4c1df65a7a228f6b8477b1954",
-          "sha256": "caa87b35c4c3275df1d4edca51de2f33b8e8fd70e33c9e04940d1c9a40a11789",
-          "sha1": "230b4be9ce81069ffaec2a7dc414a46c61fc0cf9",
-          "md5": "fbef986e14d586c5e61e2e4cfcbac6c2"
+          "size": 1442,
+          "sha512": "41a2c512c7a6d1da55abf6187d4f7e9e51c0602d26d6c1ed9cc8496b4e02e12b9a1e980d48365d1a6c6f5fcbe64142de33d6342cd129038334dfb0326f9e2540",
+          "sha256": "2cf0e377326830a0a99c92240d07435098439ccf52fa0465cd9c8cef0fff4127",
+          "sha1": "17a7cb2f5b8690107bf2382387cd98c78331eee0",
+          "md5": "5df7ef17e85be1e7446f42b0841cf080"
         }
       ]
     },
@@ -161,11 +161,11 @@
         {
           "name": "android-library-1.0-fullRelease.aar",
           "url": "android-library-1.0-fullRelease.aar",
-          "size": 1507,
-          "sha512": "f5e0642902a7d671667d8792c6d41ca911b309ba9f0308a9be7b891146c42faba184cd65e1846b52382317e7ca8d5a70f5fb73a014253aca31bd759cbef6068c",
-          "sha256": "63f2ad7334719d0a3a35423dc92ff36f5f552882c9c05b9a441c5bfefa3561bc",
-          "sha1": "cec5931b8f4b6c2bfeb5700db11532fb45d584ef",
-          "md5": "3ad07b0e9411b1cd3da3be478957e8eb"
+          "size": 1441,
+          "sha512": "791790c04ff0986f9187bcfe92abd4587f509f9e196c94011e8f4eaaccb788659e1f8d652e3707ce6ade916047bab2f613cb0c18ca7ac837ecc0cff80b445f8d",
+          "sha256": "e3799ecaaf720643900ed50a141b2fc0ef80b3e276cdd3eb6c9bd3d51275355f",
+          "sha1": "b664ccf60842c6d23514dd05ed13d73afcc25b38",
+          "md5": "adcc9c06e6ebe0c2f751be60182f7aa3"
         }
       ]
     },
@@ -183,11 +183,11 @@
         {
           "name": "android-library-1.0-fullRelease.aar",
           "url": "android-library-1.0-fullRelease.aar",
-          "size": 1507,
-          "sha512": "f5e0642902a7d671667d8792c6d41ca911b309ba9f0308a9be7b891146c42faba184cd65e1846b52382317e7ca8d5a70f5fb73a014253aca31bd759cbef6068c",
-          "sha256": "63f2ad7334719d0a3a35423dc92ff36f5f552882c9c05b9a441c5bfefa3561bc",
-          "sha1": "cec5931b8f4b6c2bfeb5700db11532fb45d584ef",
-          "md5": "3ad07b0e9411b1cd3da3be478957e8eb"
+          "size": 1441,
+          "sha512": "791790c04ff0986f9187bcfe92abd4587f509f9e196c94011e8f4eaaccb788659e1f8d652e3707ce6ade916047bab2f613cb0c18ca7ac837ecc0cff80b445f8d",
+          "sha256": "e3799ecaaf720643900ed50a141b2fc0ef80b3e276cdd3eb6c9bd3d51275355f",
+          "sha1": "b664ccf60842c6d23514dd05ed13d73afcc25b38",
+          "md5": "adcc9c06e6ebe0c2f751be60182f7aa3"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-library-single-variant-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-library-single-variant-1.0.module
@@ -27,11 +27,11 @@
         {
           "name": "android-library-single-variant-1.0.aar",
           "url": "android-library-single-variant-1.0.aar",
-          "size": 1557,
-          "sha512": "3e80812373fa26c89307d7743894bae97f7a4e8d225aca6968f03d79a712e3aeb188b9e8a5c5f0cc78d06d5e004fa1e59c08e1c4fdad1931f5507819f19db83d",
-          "sha256": "fcb0980bdd2f4963329771a928527d9f629af5c3449327e24cf1448f79926e40",
-          "sha1": "60d54190b27e46db95ece6803e4ceba4976c5e01",
-          "md5": "b8f3f99367dfd6f6a024395aeb475741"
+          "size": 1485,
+          "sha512": "3f3c9c003eb403c1371f4ff7765c321b99461f3b87aa14dcb01a53d58beb9400a4a787b705d2534c24bffc4293e94f1c02dbf9bb3215fec003efaf202b2c97bf",
+          "sha256": "8992626cbaeaa3d569d1080b01e5c29870a99b9cfc3341e0e80c6b0b5e5f04f1",
+          "sha1": "a2b7a62634b29ba226c7fb8f852b953fc9d03dab",
+          "md5": "5d063fc54606c280fbb0c662e60da0ef"
         }
       ]
     },
@@ -47,11 +47,11 @@
         {
           "name": "android-library-single-variant-1.0.aar",
           "url": "android-library-single-variant-1.0.aar",
-          "size": 1557,
-          "sha512": "3e80812373fa26c89307d7743894bae97f7a4e8d225aca6968f03d79a712e3aeb188b9e8a5c5f0cc78d06d5e004fa1e59c08e1c4fdad1931f5507819f19db83d",
-          "sha256": "fcb0980bdd2f4963329771a928527d9f629af5c3449327e24cf1448f79926e40",
-          "sha1": "60d54190b27e46db95ece6803e4ceba4976c5e01",
-          "md5": "b8f3f99367dfd6f6a024395aeb475741"
+          "size": 1485,
+          "sha512": "3f3c9c003eb403c1371f4ff7765c321b99461f3b87aa14dcb01a53d58beb9400a4a787b705d2534c24bffc4293e94f1c02dbf9bb3215fec003efaf202b2c97bf",
+          "sha256": "8992626cbaeaa3d569d1080b01e5c29870a99b9cfc3341e0e80c6b0b5e5f04f1",
+          "sha1": "a2b7a62634b29ba226c7fb8f852b953fc9d03dab",
+          "md5": "5d063fc54606c280fbb0c662e60da0ef"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/java-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/java-library-1.0.module
@@ -29,10 +29,10 @@
           "name": "java-library-1.0.jar",
           "url": "java-library-1.0.jar",
           "size": 971,
-          "sha512": "b5b0154d601ecc55f81656312fae467fe44813e8d1d8cc4af5025d8dee84497922453b7cbb523774dbbfcb20f61f731d1341b7605c181d528731d40e9f2322f2",
-          "sha256": "c2adfbd62ab9c5b64d18f16dd00140ab1d2289ac5bdd87c9778ff1c20eb632ef",
-          "sha1": "4682dfc6da5339486005bcfcc4e3e9f8f641a748",
-          "md5": "859e71daaf29cafe9ea7aa066a036681"
+          "sha512": "5a7d44937366f96486ed2027b0c4a673347ced949879f55b7aa365adc697d86083a33c72c31785888f5bdc8a6f067dfd02e54642f1c99fe8cc023265f7f685fd",
+          "sha256": "5e854a1db22026274e4c1884d59197415b91fc277b77435ea8263a0b04b90b24",
+          "sha1": "7540539b199e774030077ccde023951f316f0a61",
+          "md5": "ab73e222b2856e44ca45ffdae1d82a88"
         }
       ]
     },
@@ -50,10 +50,10 @@
           "name": "java-library-1.0.jar",
           "url": "java-library-1.0.jar",
           "size": 971,
-          "sha512": "b5b0154d601ecc55f81656312fae467fe44813e8d1d8cc4af5025d8dee84497922453b7cbb523774dbbfcb20f61f731d1341b7605c181d528731d40e9f2322f2",
-          "sha256": "c2adfbd62ab9c5b64d18f16dd00140ab1d2289ac5bdd87c9778ff1c20eb632ef",
-          "sha1": "4682dfc6da5339486005bcfcc4e3e9f8f641a748",
-          "md5": "859e71daaf29cafe9ea7aa066a036681"
+          "sha512": "5a7d44937366f96486ed2027b0c4a673347ced949879f55b7aa365adc697d86083a33c72c31785888f5bdc8a6f067dfd02e54642f1c99fe8cc023265f7f685fd",
+          "sha256": "5e854a1db22026274e4c1884d59197415b91fc277b77435ea8263a0b04b90b24",
+          "sha1": "7540539b199e774030077ccde023951f316f0a61",
+          "md5": "ab73e222b2856e44ca45ffdae1d82a88"
         }
       ]
     },
@@ -70,10 +70,10 @@
           "name": "java-library-1.0-sources.jar",
           "url": "java-library-1.0-sources.jar",
           "size": 750,
-          "sha512": "a81e4d1cc8929ebb2a450e431a34197c986e2fc0735bfcb32ee54021fcc71b66f396b8b46a12e9233e4553dd2d932fbead5267007f21304dbbb39a0f2262ea98",
-          "sha256": "9251a52249aca92a8e40fa01e92308717b972945e5116f6cb406145f0d319212",
-          "sha1": "69c7380ffe5f951de3bceb689b67e820bf93fd6d",
-          "md5": "7d992e31836199ba5c6b94bd3aea8927"
+          "sha512": "85648fe7d940524767a59622d739945d670b26bb79dae28df663242186ea4bf99c400079b5bf5c18ed3dc80622262f8d8e3c12008d160d4e40ed41a84b93edd2",
+          "sha256": "a91f50e17ec902f6065189f9255c31daf78ab9bbdee0aa02b4637522f1362294",
+          "sha1": "3f57e160412feba2c81f110a1989be599031ecf9",
+          "md5": "6a571af6a3e22dd65a9f329e61acac2e"
         }
       ]
     },
@@ -89,11 +89,11 @@
         {
           "name": "java-library-1.0-javadoc.jar",
           "url": "java-library-1.0-javadoc.jar",
-          "size": 397477,
-          "sha512": "7ab0a478f52fd9161429a60c91323e2d33dd94314e68b446ed34634fa62ff101d34ce6f0d88ec12ac47a70c120769d79ab9f5bb8b9ebd45f4c72fcf40bfcb849",
-          "sha256": "d41e3fa38b3928f08c91cc6eaacc96fb8fd271acf92daf9dc7db69af9f12768f",
-          "sha1": "6250b27a1df1a6145a9406498b9bdb7fe6932538",
-          "md5": "781f411859ff8f7481fa0ffb629b8c2c"
+          "size": 393326,
+          "sha512": "a80dc0bb9b30a2a3d9a2dfb89feb8d4e8902dfcf31e9ffe43010cbe90fd3faf5f3952a596cdb1ea50f7a426cd5b9cf508fd127af62cd2d45a6fb868f858fa179",
+          "sha256": "96f038ebb86d37864d68460987536cd515881c33c8aa27dc3d591c7184f8e192",
+          "sha1": "1a076a153b9bdbed7ee0d938ad45d9d7687d1e87",
+          "md5": "1e10a127351ddd0a5ffb8a5b18504b66"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
@@ -30,11 +30,11 @@
         {
           "name": "kotlin-library-1.0.jar",
           "url": "kotlin-library-1.0.jar",
-          "size": 1529,
-          "sha512": "26f2d67f59ac64dfc1b3d72f7e878f5dac37e11d2bb179b9dc593d2cda95504f49ce009955836bf17a8ca5cbb44986abc22ace39bff62a2fa50b8ce855b01886",
-          "sha256": "03482ab9209fb26c3453c24da922bc8900e2f55e4c5bc1192fddee312e29b60d",
-          "sha1": "b6f6ca8d5b8af9386dfd53f7eb880ba09d64d32b",
-          "md5": "4682c4bcd13f4b27ab2ecc1e8a57c985"
+          "size": 1584,
+          "sha512": "9abd8260378dfca0462524cc514b784bfea52564f4ce3396d2d6f9f1e6ab970bb0df0826ca3d9ca43fe2254ce468a11ccc8fe9f292df4583dc6c18544369af33",
+          "sha256": "a950802d066029b7df72ea4a264cb882583dd5a6fbf234b7c4a19691ad9cc696",
+          "sha1": "ed0442c8c972e1af80303948b814fce3b12c8181",
+          "md5": "4bfb79cb585801768642c908af1f299d"
         }
       ]
     },
@@ -54,7 +54,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -62,11 +62,11 @@
         {
           "name": "kotlin-library-1.0.jar",
           "url": "kotlin-library-1.0.jar",
-          "size": 1529,
-          "sha512": "26f2d67f59ac64dfc1b3d72f7e878f5dac37e11d2bb179b9dc593d2cda95504f49ce009955836bf17a8ca5cbb44986abc22ace39bff62a2fa50b8ce855b01886",
-          "sha256": "03482ab9209fb26c3453c24da922bc8900e2f55e4c5bc1192fddee312e29b60d",
-          "sha1": "b6f6ca8d5b8af9386dfd53f7eb880ba09d64d32b",
-          "md5": "4682c4bcd13f4b27ab2ecc1e8a57c985"
+          "size": 1584,
+          "sha512": "9abd8260378dfca0462524cc514b784bfea52564f4ce3396d2d6f9f1e6ab970bb0df0826ca3d9ca43fe2254ce468a11ccc8fe9f292df4583dc6c18544369af33",
+          "sha256": "a950802d066029b7df72ea4a264cb882583dd5a6fbf234b7c4a19691ad9cc696",
+          "sha1": "ed0442c8c972e1af80303948b814fce3b12c8181",
+          "md5": "4bfb79cb585801768642c908af1f299d"
         }
       ]
     },
@@ -83,10 +83,10 @@
           "name": "kotlin-library-1.0-sources.jar",
           "url": "kotlin-library-1.0-sources.jar",
           "size": 722,
-          "sha512": "f9cc9a3851a086534744ac60941231fc209bf170d5562f44c19f22d726746cb6169bd6a2b511101bcfac7f3d3d17fbf5ee935bcd028ef6f5ca6849246a7eb805",
-          "sha256": "c2a0cd71bdfb19d5f2ef5248c55730959b47b1d2bd4b617f1018bd9b93fc9485",
-          "sha1": "748b070f9b82eb77a8e3690f6d3f3bcbdf16b895",
-          "md5": "741e87aafda3ee581708a6d01f56b3c4"
+          "sha512": "bf113b51ae703a3713a1376fb61987cd1219344b0c95115d5ed6bafcb654206bb271c0244930bc048c383e6cb80f329c7e2de414593380954dc7845e083090da",
+          "sha256": "6bf568d00829c8fd544d1d814f4b1eb1e332ef752ed4d24f92a17c59625cd79a",
+          "sha1": "1daa3b956af949574055f00c457f87dc0842e284",
+          "md5": "5ecc166c8471c59de9164f4280cd14b5"
         }
       ]
     },
@@ -103,10 +103,10 @@
           "name": "kotlin-library-1.0-javadoc.jar",
           "url": "kotlin-library-1.0-javadoc.jar",
           "size": 261,
-          "sha512": "56e0622e43f57ef875e1215ea6e19509c25130fbd5752f9d32d21c4e04e9bcab30fe34cdd3c1930e4281fb43128873109ebf2df3d73a6d3e749927566d735253",
-          "sha256": "32088e4485133bc6561e8b7685c0fb37ff22e8ff3dd6020a4930c4dc6dee7109",
-          "sha1": "84269fbcb2aa0e813f1354bef38e0f4fd3e88d0d",
-          "md5": "bf79b9a9abdacd2cca4c4ec707480da1"
+          "sha512": "658a84a837823fd3503d65ed903fa7cb7d859bf15e7807d14681cbeb3f850504c2bde9ffbfedb447f1ae7e4bc79936df12547aa062af7f22dc3f94b3dcac73d1",
+          "sha256": "6249e26cfe9d813f7da17cc29316799ab8d307583b084b61732920b7bfdce261",
+          "sha1": "5b14431441f4c599cc46887b1697e3699993464f",
+          "md5": "332e6ebcee418471b202e1990b915c3c"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.module
@@ -16,137 +16,156 @@
   },
   "variants": [
     {
-      "name": "android-demoDebugApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "demoDebug",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoDebugRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "demoDebug",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullDebugApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "fullDebug",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullDebugRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "fullDebug",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoReleaseApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "demoRelease",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoReleaseRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "demoRelease",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullReleaseApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "fullRelease",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullReleaseRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "fullRelease",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "js-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "files": [
+        {
+          "name": "kotlin-multiplatform-android-library-metadata-1.0.jar",
+          "url": "kotlin-multiplatform-android-library-1.0.jar",
+          "size": 1096,
+          "sha512": "15bbe93c135851c1f6797e02620e28920b169a415568c96af325a217716175d6c2348a9c66f6ab0accc086d6d2a8850fe2b5d7ee84748c080a64f8aa7b530285",
+          "sha256": "6f751b274c45743f3fe4fa5c8198943c68c19cd0426b5f6e89b0ac526ab3a1b9",
+          "sha1": "3921422a7bf6f68e9165763e69445422eb993d77",
+          "md5": "60fe613b928a018306a918320838fcf4"
+        }
+      ]
+    },
+    {
+      "name": "demoDebugApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "demoDebug",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoDebugRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "demoDebug",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullDebugApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "fullDebug",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullDebugRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "fullDebug",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoReleaseApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "demoRelease",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoReleaseRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "demoRelease",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullReleaseApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "fullRelease",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullReleaseRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "fullRelease",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "jsApiElements-published",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -157,9 +176,10 @@
       }
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -170,8 +190,9 @@
       }
     },
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -184,8 +205,9 @@
       }
     },
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -194,19 +216,6 @@
         "url": "../../kotlin-multiplatform-android-library-macosx64/1.0/kotlin-multiplatform-android-library-macosx64-1.0.module",
         "group": "example",
         "module": "kotlin-multiplatform-android-library-macosx64",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "metadata-api",
-      "attributes": {
-        "org.gradle.usage": "kotlin-api",
-        "org.jetbrains.kotlin.platform.type": "common"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-metadata/1.0/kotlin-multiplatform-android-library-metadata-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-metadata",
         "version": "1.0"
       }
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.pom
@@ -10,5 +10,4 @@
   <groupId>example</groupId>
   <artifactId>kotlin-multiplatform-android-library</artifactId>
   <version>1.0</version>
-  <packaging>pom</packaging>
 </project>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "android-demoReleaseApiElements",
+      "name": "demoReleaseApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "demoRelease",
@@ -29,16 +29,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-release.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-1.0.aar",
-          "size": 2100,
-          "sha512": "031fb487590d4f0336bf73f1546ed5faed8790c72ed55c1de6ae3b5c4110805821a8612c3cc037927207361dc53ab3115087867d882ba174825c8aaecabfe03e",
-          "sha256": "ef15d2dd149a3bdcd45545fb947c14869ec3f9af3a8b56c40ccad57e76c696b3",
-          "sha1": "d6b44b28b762d12f38515433b69dca5138da2d0b",
-          "md5": "006ca0248394cade0cf573d20c1b345b"
+          "size": 2084,
+          "sha512": "742078165ba917b3e823b90fb027718d6a08eb600e1acd4bfa9594f3a43b745c56a9cc2a73c1f432aae97fd7a0271159f8fe1aadb75a4432c14f074b5e986c5e",
+          "sha256": "692ab48e93758b3eb33246ae38e49342cb6aabdeb2bcd07c9c657027186ab9d6",
+          "sha1": "a36ba67a16d8b6f522713b9a0ec46bd5a28a8cb4",
+          "md5": "c446ca95c20ceebb7fb553f432ca433a"
         }
       ]
     },
     {
-      "name": "android-demoReleaseRuntimeElements",
+      "name": "demoReleaseRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "demoRelease",
@@ -49,16 +49,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -66,16 +66,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-release.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-1.0.aar",
-          "size": 2100,
-          "sha512": "031fb487590d4f0336bf73f1546ed5faed8790c72ed55c1de6ae3b5c4110805821a8612c3cc037927207361dc53ab3115087867d882ba174825c8aaecabfe03e",
-          "sha256": "ef15d2dd149a3bdcd45545fb947c14869ec3f9af3a8b56c40ccad57e76c696b3",
-          "sha1": "d6b44b28b762d12f38515433b69dca5138da2d0b",
-          "md5": "006ca0248394cade0cf573d20c1b345b"
+          "size": 2084,
+          "sha512": "742078165ba917b3e823b90fb027718d6a08eb600e1acd4bfa9594f3a43b745c56a9cc2a73c1f432aae97fd7a0271159f8fe1aadb75a4432c14f074b5e986c5e",
+          "sha256": "692ab48e93758b3eb33246ae38e49342cb6aabdeb2bcd07c9c657027186ab9d6",
+          "sha1": "a36ba67a16d8b6f522713b9a0ec46bd5a28a8cb4",
+          "md5": "c446ca95c20ceebb7fb553f432ca433a"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "android-demoDebugApiElements",
+      "name": "demoDebugApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "demoDebug",
@@ -29,16 +29,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-debug-1.0.aar",
-          "size": 2196,
-          "sha512": "28f2feaa7ad4df3c1c83d4245473cafdbc9654f784f8eba03781488d408a74a180c52f39d1fd864318fab1e4caa83f614b107bc062b2cafd371f264bb5992643",
-          "sha256": "a17f98ed9bed5e6cd2cb947bf83520eea9e977708b46ba355b4e5e74b2fe3a23",
-          "sha1": "6f46553340b5e4c15209b480f80ff5b9562be1ed",
-          "md5": "9727c05ed9695e7fd1dd23dbe8892e4d"
+          "size": 2179,
+          "sha512": "d09adc3ee9dba4ed713728e1475be62b0e6fe082fbc6f1caeb54acf50fb630a19c41b26dfb428556fffcd1f0d49095915d0880047109fc5c3d5b6d4a02a70949",
+          "sha256": "309504588598e12e4fa3152a18c13e1bac235415fc529c2e1d08b92f2abde752",
+          "sha1": "7071984d40acb1f2e511b1be3aadb031a1113660",
+          "md5": "82bf395e70538757136222e2dc61691f"
         }
       ]
     },
     {
-      "name": "android-demoDebugRuntimeElements",
+      "name": "demoDebugRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "demoDebug",
@@ -49,16 +49,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -66,16 +66,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-debug-1.0.aar",
-          "size": 2196,
-          "sha512": "28f2feaa7ad4df3c1c83d4245473cafdbc9654f784f8eba03781488d408a74a180c52f39d1fd864318fab1e4caa83f614b107bc062b2cafd371f264bb5992643",
-          "sha256": "a17f98ed9bed5e6cd2cb947bf83520eea9e977708b46ba355b4e5e74b2fe3a23",
-          "sha1": "6f46553340b5e4c15209b480f80ff5b9562be1ed",
-          "md5": "9727c05ed9695e7fd1dd23dbe8892e4d"
+          "size": 2179,
+          "sha512": "d09adc3ee9dba4ed713728e1475be62b0e6fe082fbc6f1caeb54acf50fb630a19c41b26dfb428556fffcd1f0d49095915d0880047109fc5c3d5b6d4a02a70949",
+          "sha256": "309504588598e12e4fa3152a18c13e1bac235415fc529c2e1d08b92f2abde752",
+          "sha1": "7071984d40acb1f2e511b1be3aadb031a1113660",
+          "md5": "82bf395e70538757136222e2dc61691f"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "android-fullReleaseApiElements",
+      "name": "fullReleaseApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "fullRelease",
@@ -29,16 +29,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-release.aar",
           "url": "kotlin-multiplatform-android-library-android-full-1.0.aar",
-          "size": 2100,
-          "sha512": "3a1988390706b449d41d9b1c12471ed8fa4cfd876ec72b82991f4dbc6c40859d49f1a1cb3da6ad1e053ca5096b8e430e53a737bdd8d9b65b70b1a70a08751eff",
-          "sha256": "ec40bf4e51487a673886baa48bf31ad4b77df2e1a8961c334638828418e6ee19",
-          "sha1": "0785402e008ed74c66dba20872f16f77d8791b88",
-          "md5": "fcc77bda4c0ee6ff6833e8f468b852a1"
+          "size": 2086,
+          "sha512": "a3a7447da3047b1000410427afb9fd7c3a5ba701c8a104a5449e18bb189080440043eb20e9d7108193d2871aee8672291ebbae33b21b7041a7dccb8da246e18c",
+          "sha256": "853887aecd1d50603b4b9a600e6230a6f0e63f50979e799ba02bde7bdf02c59d",
+          "sha1": "d1f107ea6d98a5295f7329f85c0eaae0cd7c2df3",
+          "md5": "d701446b845813c849b0551ae9594941"
         }
       ]
     },
     {
-      "name": "android-fullReleaseRuntimeElements",
+      "name": "fullReleaseRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "fullRelease",
@@ -49,16 +49,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -66,16 +66,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-release.aar",
           "url": "kotlin-multiplatform-android-library-android-full-1.0.aar",
-          "size": 2100,
-          "sha512": "3a1988390706b449d41d9b1c12471ed8fa4cfd876ec72b82991f4dbc6c40859d49f1a1cb3da6ad1e053ca5096b8e430e53a737bdd8d9b65b70b1a70a08751eff",
-          "sha256": "ec40bf4e51487a673886baa48bf31ad4b77df2e1a8961c334638828418e6ee19",
-          "sha1": "0785402e008ed74c66dba20872f16f77d8791b88",
-          "md5": "fcc77bda4c0ee6ff6833e8f468b852a1"
+          "size": 2086,
+          "sha512": "a3a7447da3047b1000410427afb9fd7c3a5ba701c8a104a5449e18bb189080440043eb20e9d7108193d2871aee8672291ebbae33b21b7041a7dccb8da246e18c",
+          "sha256": "853887aecd1d50603b4b9a600e6230a6f0e63f50979e799ba02bde7bdf02c59d",
+          "sha1": "d1f107ea6d98a5295f7329f85c0eaae0cd7c2df3",
+          "md5": "d701446b845813c849b0551ae9594941"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "android-fullDebugApiElements",
+      "name": "fullDebugApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "fullDebug",
@@ -29,16 +29,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-full-debug-1.0.aar",
-          "size": 2194,
-          "sha512": "5350742ada8d754cc6a2c5d9919e0aaa5b87a39eefee2e76e915b04bfeeb461255d867d932c4efbc0eba75cba21e0cf1a08a2772af8946115a1a244bba3bbf0a",
-          "sha256": "c98095ae96e5d5835b4b032bfc53a26f852d71b7c7475b9249e985e4a5e5eaf5",
-          "sha1": "5a2386911dc426cb5bc123bbb9b2c5067fcaa390",
-          "md5": "5a6bf7331536ebb785dca1249a7c500c"
+          "size": 2179,
+          "sha512": "6e3cdfb4ded110d4e7a08570051a74f1ba50a9cdbe665aa39f122e320d077f944bbe3b4680ddf5aac1e27329dbdfb40cd59aa00ba5e6c14b77c6297fe8e6250a",
+          "sha256": "cbf1ac0434c7450499f7ccc90c09bd4fe997e1d0869ddb2fe5ab8be8320daf3c",
+          "sha1": "3a48502e7f928d426797126ba767fd5ae721aefc",
+          "md5": "002b3404c660e2b25b370a854e003770"
         }
       ]
     },
     {
-      "name": "android-fullDebugRuntimeElements",
+      "name": "fullDebugRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "fullDebug",
@@ -49,16 +49,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -66,16 +66,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-full-debug-1.0.aar",
-          "size": 2194,
-          "sha512": "5350742ada8d754cc6a2c5d9919e0aaa5b87a39eefee2e76e915b04bfeeb461255d867d932c4efbc0eba75cba21e0cf1a08a2772af8946115a1a244bba3bbf0a",
-          "sha256": "c98095ae96e5d5835b4b032bfc53a26f852d71b7c7475b9249e985e4a5e5eaf5",
-          "sha1": "5a2386911dc426cb5bc123bbb9b2c5067fcaa390",
-          "md5": "5a6bf7331536ebb785dca1249a7c500c"
+          "size": 2179,
+          "sha512": "6e3cdfb4ded110d4e7a08570051a74f1ba50a9cdbe665aa39f122e320d077f944bbe3b4680ddf5aac1e27329dbdfb40cd59aa00ba5e6c14b77c6297fe8e6250a",
+          "sha256": "cbf1ac0434c7450499f7ccc90c09bd4fe997e1d0869ddb2fe5ab8be8320daf3c",
+          "sha1": "3a48502e7f928d426797126ba767fd5ae721aefc",
+          "md5": "002b3404c660e2b25b370a854e003770"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
@@ -17,27 +17,29 @@
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "jsApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "files": [
         {
           "name": "kotlin-multiplatform-android-library-js-1.0.jar",
           "url": "kotlin-multiplatform-android-library-js-1.0.jar",
-          "size": 3988,
-          "sha512": "bd1bbf23bdcf7bb7e622b429c068de6d39eab7df7277bd0758e45e3e7baef9d621b4c707a32b2009537f5371b0ce88cf48db2a0f82b9b4064ef5c5edfef1e44c",
-          "sha256": "def48cf63cde9b2bd017e60dc4de5e80520b0333370ab74673d1dba450b261f7",
-          "sha1": "63e84689aeae3d53ae3d4f5f2f244d776470df14",
-          "md5": "24f384b206943d643fdb2badf762deb5"
+          "size": 4002,
+          "sha512": "843d8b60faa61097d94da6e38a022fb5ca115ed06eaebf033bc8d33823bd6b709beca11b6dcb74d2026734415a82e0df8c428cc3b7c6949a159cf8b4c1e0df16",
+          "sha256": "a7de480825f21386cbe83bb9e745d6de9dd9c5bf5f1cdf834943a878d2bccc4e",
+          "sha1": "6befc41cddf1140bb3bd6b671192ead64147bb02",
+          "md5": "0c0e59624a75245d84eb11d3c6cb2cca"
         }
       ]
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "dependencies": [
@@ -45,14 +47,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -60,16 +62,16 @@
         {
           "name": "kotlin-multiplatform-android-library-js-1.0.jar",
           "url": "kotlin-multiplatform-android-library-js-1.0.jar",
-          "size": 3988,
-          "sha512": "bd1bbf23bdcf7bb7e622b429c068de6d39eab7df7277bd0758e45e3e7baef9d621b4c707a32b2009537f5371b0ce88cf48db2a0f82b9b4064ef5c5edfef1e44c",
-          "sha256": "def48cf63cde9b2bd017e60dc4de5e80520b0333370ab74673d1dba450b261f7",
-          "sha1": "63e84689aeae3d53ae3d4f5f2f244d776470df14",
-          "md5": "24f384b206943d643fdb2badf762deb5"
+          "size": 4002,
+          "sha512": "843d8b60faa61097d94da6e38a022fb5ca115ed06eaebf033bc8d33823bd6b709beca11b6dcb74d2026734415a82e0df8c428cc3b7c6949a159cf8b4c1e0df16",
+          "sha256": "a7de480825f21386cbe83bb9e745d6de9dd9c5bf5f1cdf834943a878d2bccc4e",
+          "sha1": "6befc41cddf1140bb3bd6b671192ead64147bb02",
+          "md5": "0c0e59624a75245d84eb11d3c6cb2cca"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
@@ -17,8 +17,9 @@
   },
   "variants": [
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +29,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -36,16 +37,16 @@
         {
           "name": "kotlin-multiplatform-android-library.klib",
           "url": "kotlin-multiplatform-android-library-linuxx64-1.0.klib",
-          "size": 5523,
-          "sha512": "d06545d65fac01c09a030199efa6cf2240f95a13d2b203c5f57e4896344ebb10cb8fa799e67d176e223bd1a859704e88f3259dfe9c688d34a2537bf6a1f57d76",
-          "sha256": "d3984fb54f3215281ce6538c5cdcf7fefbd41949f83a70d442ccb802ee58d7f6",
-          "sha1": "4b1e499ef68e1154ec9db055a441bc0074e4d9b5",
-          "md5": "c5c6a530ac9f68c6b1aff415e4d70567"
+          "size": 5231,
+          "sha512": "2c4a75349de0055684e3b6414b271887d29e7b3ce8607877ecb37e814ebb845c3793e7b4f6d6a467545661448085927d7b31a067d1966b61cdb449ea4d6acf77",
+          "sha256": "4a365b2bb8662f22f8445f09e9ef1a8d0114da7e7c9759594df780aec1604cf6",
+          "sha1": "7c1e660f2025076b7bee2cb4f287a9e3fc6c5143",
+          "md5": "11f289449f6ad238bc0afee3e257d00c"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
@@ -17,8 +17,9 @@
   },
   "variants": [
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +29,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -36,16 +37,16 @@
         {
           "name": "kotlin-multiplatform-android-library.klib",
           "url": "kotlin-multiplatform-android-library-macosx64-1.0.klib",
-          "size": 5523,
-          "sha512": "7529de431f5c410b65c3aaf96bf7ec9e23027d947787a39d580d3c779d9f72e81484bf5482c03f8773e5ca522193182b0ef0ce6737aed0bc5f6e2e90c8df84e6",
-          "sha256": "65669a4fb8aca3e9b4a86da97086f79fd9bdf7dca26994331a840fc51dd78268",
-          "sha1": "57ca2e8adbfbb3430fa6e6c2a63ca2f91b23b7cd",
-          "md5": "c5905bb74cdd1a694bae761d975f5997"
+          "size": 5231,
+          "sha512": "f417c3d0702d9a2c647f51adee843b2898a6e540c2b670bce4637c38b9dff1125dc71d35f704d8edbf7f35a6cdb699228e67b24e1967ae8cd25a0511217e74b1",
+          "sha256": "bdaf2e692c4b9ad13f106067cf4514f216224b7b5620a5d6cbe7a467615b76de",
+          "sha1": "c46d98e130b4ec1db02fc38d171a95e5af931fce",
+          "md5": "fe92765df552814aeba83cc809a181b2"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-metadata-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-metadata-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"
@@ -26,11 +26,11 @@
         {
           "name": "kotlin-multiplatform-android-library-metadata-1.0.jar",
           "url": "kotlin-multiplatform-android-library-metadata-1.0.jar",
-          "size": 1091,
-          "sha512": "8f12d8c41d65ff8b92584890846fdafa4f68a386a0a869057ae7742050f8a545116b0961e0a5e5eb4b41b5c9a99e26bd2fad2a1311c971712f5ba04a5fc898d4",
-          "sha256": "da18462c050f0aa06d360be7b794e34d2d74da4a108a2c47dfad9c71a7ec3a07",
-          "sha1": "af49280392293c96787ef51a37b03c5d025b99de",
-          "md5": "8f64c10e6dc60240a17547e8b71f14b3"
+          "size": 1096,
+          "sha512": "15bbe93c135851c1f6797e02620e28920b169a415568c96af325a217716175d6c2348a9c66f6ab0accc086d6d2a8850fe2b5d7ee84748c080a64f8aa7b530285",
+          "sha256": "6f751b274c45743f3fe4fa5c8198943c68c19cd0426b5f6e89b0ac526ab3a1b9",
+          "sha1": "3921422a7bf6f68e9165763e69445422eb993d77",
+          "md5": "60fe613b928a018306a918320838fcf4"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.module
@@ -16,9 +16,28 @@
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "files": [
+        {
+          "name": "kotlin-multiplatform-library-metadata-1.0.jar",
+          "url": "kotlin-multiplatform-library-1.0.jar",
+          "size": 1031,
+          "sha512": "73537b3b0f94685b252f62be37781700b0157b4ab31c75f7b453c0ac95c757f145375d4d54218b37a74b0cd1ea67c02791361d69ae92e482695c152d9511da02",
+          "sha256": "153aa4903707541a3e62ee9c8c6b4ad029c4146791452963649c90436ebf0230",
+          "sha1": "5fd117ee704ce51cf5b6cd0a08a38ba36cd30e74",
+          "md5": "190f9f1b8f79aa2e68325fc7a500a94a"
+        }
+      ]
+    },
+    {
+      "name": "jsApiElements-published",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -29,9 +48,10 @@
       }
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -42,7 +62,7 @@
       }
     },
     {
-      "name": "jvm-api",
+      "name": "jvmApiElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-api",
@@ -56,7 +76,7 @@
       }
     },
     {
-      "name": "jvm-runtime",
+      "name": "jvmRuntimeElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-runtime",
@@ -70,8 +90,9 @@
       }
     },
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -84,8 +105,9 @@
       }
     },
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -94,19 +116,6 @@
         "url": "../../kotlin-multiplatform-library-macosx64/1.0/kotlin-multiplatform-library-macosx64-1.0.module",
         "group": "example",
         "module": "kotlin-multiplatform-library-macosx64",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "metadata-api",
-      "attributes": {
-        "org.gradle.usage": "kotlin-api",
-        "org.jetbrains.kotlin.platform.type": "common"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-library-metadata/1.0/kotlin-multiplatform-library-metadata-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-library-metadata",
         "version": "1.0"
       }
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.pom
@@ -10,5 +10,4 @@
   <groupId>example</groupId>
   <artifactId>kotlin-multiplatform-library</artifactId>
   <version>1.0</version>
-  <packaging>pom</packaging>
 </project>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
@@ -17,27 +17,29 @@
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "jsApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "files": [
         {
           "name": "kotlin-multiplatform-library-js-1.0.jar",
           "url": "kotlin-multiplatform-library-js-1.0.jar",
-          "size": 3771,
-          "sha512": "ce01625dccb9bbf8f988ac21ece2b4912545dd2d9f2be5f3ebf0d5894d343c150d81b822cc7d02cea83d5b69ac00c379b57429255390d82fced02b315c40cbbd",
-          "sha256": "eb7ba7d5066b14562785942fd66b83bd67566be02c5d638867e505741dc60e4a",
-          "sha1": "06079e5bf82e6af07a871f1be766f14f43d1923f",
-          "md5": "7e574193359cb4f746f1863236ece113"
+          "size": 3783,
+          "sha512": "37f53dcf6c7f05b5f8fec41ed080704dbb451f715749810f8a5bc553bd51af9bc3a9c52d856be954c2e74a9ef0bf7f9df2725b79a524066f890594c3d7fab888",
+          "sha256": "58cef279dee0bea9598d6b1b053eeb342128ff1364c251bc511180c6ecd9a8e3",
+          "sha1": "41a7629341fdf41dc987dd3ffa5b6878cf08e80c",
+          "md5": "41313a3c53883c9fe5399622f75ee58c"
         }
       ]
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "dependencies": [
@@ -45,14 +47,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -60,16 +62,16 @@
         {
           "name": "kotlin-multiplatform-library-js-1.0.jar",
           "url": "kotlin-multiplatform-library-js-1.0.jar",
-          "size": 3771,
-          "sha512": "ce01625dccb9bbf8f988ac21ece2b4912545dd2d9f2be5f3ebf0d5894d343c150d81b822cc7d02cea83d5b69ac00c379b57429255390d82fced02b315c40cbbd",
-          "sha256": "eb7ba7d5066b14562785942fd66b83bd67566be02c5d638867e505741dc60e4a",
-          "sha1": "06079e5bf82e6af07a871f1be766f14f43d1923f",
-          "md5": "7e574193359cb4f746f1863236ece113"
+          "size": 3783,
+          "sha512": "37f53dcf6c7f05b5f8fec41ed080704dbb451f715749810f8a5bc553bd51af9bc3a9c52d856be954c2e74a9ef0bf7f9df2725b79a524066f890594c3d7fab888",
+          "sha256": "58cef279dee0bea9598d6b1b053eeb342128ff1364c251bc511180c6ecd9a8e3",
+          "sha1": "41a7629341fdf41dc987dd3ffa5b6878cf08e80c",
+          "md5": "41313a3c53883c9fe5399622f75ee58c"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "jvm-api",
+      "name": "jvmApiElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-api",
@@ -27,16 +27,16 @@
         {
           "name": "kotlin-multiplatform-library-jvm-1.0.jar",
           "url": "kotlin-multiplatform-library-jvm-1.0.jar",
-          "size": 1614,
-          "sha512": "af0ea7e99721bbf266b2ea1700c893e21ed33ab617d9fd34a4c361ebd8ba140777f8d7a4ff1ba3f77d218fb44889a2a1c6140825adb752d59335a70697fa50d6",
-          "sha256": "fb06a82b1e2117660c4e8cf4248d9f04098b49a5c033491caba18a9d525e4bec",
-          "sha1": "65f4fb4e927a9ffc2c9d05a82e9721ccf4bb7b4d",
-          "md5": "4ee4bc056a9e3837289c37e53d4d00e7"
+          "size": 1670,
+          "sha512": "b59951231a743b2fd5f6af4e77c053cceb9b63ed364cc91d1e18cb3ef04725b097960b24cec5ca6cf86b457e254bcd6d4ef4f7be689f36dd12f6fedca962c265",
+          "sha256": "0f2bcb5379bfa1222621fb2d0bf545df2a3405ec0f3633cdec6d1a6bdc3032ed",
+          "sha1": "72bd3195e935be36db84d7d33e956136c0d3168f",
+          "md5": "ebea79c3297964c067895574a2ff0a2a"
         }
       ]
     },
     {
-      "name": "jvm-runtime",
+      "name": "jvmRuntimeElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-runtime",
@@ -47,14 +47,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -62,16 +62,16 @@
         {
           "name": "kotlin-multiplatform-library-jvm-1.0.jar",
           "url": "kotlin-multiplatform-library-jvm-1.0.jar",
-          "size": 1614,
-          "sha512": "af0ea7e99721bbf266b2ea1700c893e21ed33ab617d9fd34a4c361ebd8ba140777f8d7a4ff1ba3f77d218fb44889a2a1c6140825adb752d59335a70697fa50d6",
-          "sha256": "fb06a82b1e2117660c4e8cf4248d9f04098b49a5c033491caba18a9d525e4bec",
-          "sha1": "65f4fb4e927a9ffc2c9d05a82e9721ccf4bb7b4d",
-          "md5": "4ee4bc056a9e3837289c37e53d4d00e7"
+          "size": 1670,
+          "sha512": "b59951231a743b2fd5f6af4e77c053cceb9b63ed364cc91d1e18cb3ef04725b097960b24cec5ca6cf86b457e254bcd6d4ef4f7be689f36dd12f6fedca962c265",
+          "sha256": "0f2bcb5379bfa1222621fb2d0bf545df2a3405ec0f3633cdec6d1a6bdc3032ed",
+          "sha1": "72bd3195e935be36db84d7d33e956136c0d3168f",
+          "md5": "ebea79c3297964c067895574a2ff0a2a"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
@@ -17,8 +17,9 @@
   },
   "variants": [
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +29,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -36,16 +37,16 @@
         {
           "name": "kotlin-multiplatform-library.klib",
           "url": "kotlin-multiplatform-library-linuxx64-1.0.klib",
-          "size": 5437,
-          "sha512": "3a5c3f67392016bc90735bacc4788b823e155ddf714919d75d1590b0148f5b63d98f53b832c412dcb411fd8f53270c52e2dd83408739be146b550c56c02a9340",
-          "sha256": "7dd6266ed30d631f6c2b95fb92946126ff711b3405a11f6a16ea3cc9b836b3a3",
-          "sha1": "d3c8aa8a265013414bfbb7b457fa5b66d86d062a",
-          "md5": "dd9099c1af5d8dc5b51b42d368d9977d"
+          "size": 5127,
+          "sha512": "756f2eaa622a4d87e08cebbfc5639cd627b3a07c3032dce7be7a3c5c60d2f333e1267f41bdd588decccbab5ae32cd899161814db8a426ce25d1da49bea80036d",
+          "sha256": "9a6e9de35cfe0a896a5f974fa1b18496825248a8a253e431cf171d6ead001ea0",
+          "sha1": "d474aa444d2dac761df4683edba8d6d0a064f0ea",
+          "md5": "1e0ca11151400c48fd41383df633036c"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
@@ -17,8 +17,9 @@
   },
   "variants": [
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +29,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.30-RC"
           }
         }
       ],
@@ -36,16 +37,16 @@
         {
           "name": "kotlin-multiplatform-library.klib",
           "url": "kotlin-multiplatform-library-macosx64-1.0.klib",
-          "size": 5437,
-          "sha512": "cf6097c614c452dbf4933242a80a3339a9361e2d77febb78a4d3543f68d7cc0ec370a392f8813ad4a36d42da6cc1245888ee204fcf327070abff9e08edc5ab3f",
-          "sha256": "842613d67c34a9da15ede4cf465fc8420ac0b7439173086abcf443f72c45fd3f",
-          "sha1": "082370a48c327a8104ba4809470b7eec729a8edc",
-          "md5": "e27f4e03644ad77d47c9b07e0d21d4d3"
+          "size": 5128,
+          "sha512": "c1a013e32e75c88ca8ca5b7315925828222c905a468c79874b9b671d88587897a3690acbb620add8320ff6623385365189b973716ba8b3b928700fa333cfe7bf",
+          "sha256": "b5dc36e47d0449c9dec6efdb96f8e633a5b3866970689f6e2f9da8b4d9f2dd49",
+          "sha1": "29ed7977289d0ce79090a887de443a4b343818f6",
+          "md5": "faf896fc6f615ff66192d1abef14f276"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.30-RC</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-metadata-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-metadata-1.0.module
@@ -17,7 +17,7 @@
   },
   "variants": [
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"
@@ -26,11 +26,11 @@
         {
           "name": "kotlin-multiplatform-library-metadata-1.0.jar",
           "url": "kotlin-multiplatform-library-metadata-1.0.jar",
-          "size": 1026,
-          "sha512": "0528314a4128405d736d9736c2ab17d419318d9ffca4eb821cfb76fc0c8534b9b354db672161c300a799ca15b7b906c161c16cf63ab7d69ce977994ca9732de7",
-          "sha256": "5d8b2e57a1d366beba255299a7ee7df82d06dd838b5a390dfd6ed7c0089dc51c",
-          "sha1": "feab845e50c07d1ddb6c1f1cbd0e96d6133b9959",
-          "md5": "3b2e8efc39ef8e12ce24f4c5d48d982e"
+          "size": 1031,
+          "sha512": "73537b3b0f94685b252f62be37781700b0157b4ab31c75f7b453c0ac95c757f145375d4d54218b37a74b0cd1ea67c02791361d69ae92e482695c152d9511da02",
+          "sha256": "153aa4903707541a3e62ee9c8c6b4ad029c4146791452963649c90436ebf0230",
+          "sha1": "5fd117ee704ce51cf5b6cd0a08a38ba36cd30e74",
+          "md5": "190f9f1b8f79aa2e68325fc7a500a94a"
         }
       ]
     }


### PR DESCRIPTION
### Summary
 - GUtil.addToCollection(T dest, boolean failOnNull, Iterable<? extends V>... srcs)
 - GUtil.addToCollection(T dest, Iterable<? extends V>... srcs)

### Checklist
- [x] Validate whether we should remove the API in the 7.0 release
  - If the removal is not possible then create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=493905624) 
- [x] Update the upgrade guide
- [x] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 
