### PR TITLE
Update configuration deprecations

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -93,7 +93,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         List<String> alternatives = selectedConfiguration.getConsumptionAlternatives();
         if (alternatives != null) {
             DeprecationLogger.deprecateConfiguration(selectedConfiguration.getName()).forConsumption().replaceWith(alternatives)
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUserManual("java_library_plugin", "sec:java_library_configurations_graph")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationsIntegrationTest.groovy
@@ -64,7 +64,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 8.0. " +
             "Please use the implementation configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
@@ -83,7 +83,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 8.0. " +
             "Please use the implementation configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
@@ -100,7 +100,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 8.0. " +
             "Please use the implementation or compileElements configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
@@ -119,7 +119,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for resolution. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for resolution. This will fail with an error in Gradle 8.0. " +
             "Please resolve the compileClasspath configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
@@ -145,7 +145,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 8.0. " +
             "Please use attributes to consume the compileElements configuration instead. " +
             "See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph for more details.")
 
@@ -173,7 +173,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 8.0. " +
             "Please use attributes to consume the compileElements configuration instead. " +
             "See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph for more details.")
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
@@ -57,7 +57,7 @@ public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<De
         List<String> alternatives = ((DeprecatableConfiguration) clientConfiguration).getDeclarationAlternatives();
         if (alternatives != null) {
             DeprecationLogger.deprecateConfiguration(clientConfiguration.getName()).forDependencyDeclaration().replaceWith(alternatives)
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
@@ -72,7 +72,7 @@ public class DefaultDependencySet extends DelegatingDomainObjectSet<Dependency> 
         List<String> alternatives = ((DeprecatableConfiguration) clientConfiguration).getDeclarationAlternatives();
         if (alternatives != null) {
             DeprecationLogger.deprecateConfiguration(clientConfiguration.getName()).forDependencyDeclaration().replaceWith(alternatives)
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -603,7 +603,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private void warnIfConfigurationIsDeprecatedForResolving() {
         if (resolutionAlternatives != null) {
             DeprecationLogger.deprecateConfiguration(this.name).forResolution().replaceWith(resolutionAlternatives)
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
@@ -66,7 +66,7 @@ public class DefaultArtifactHandler implements ArtifactHandler, MethodMixIn {
         if (configuration.isFullyDeprecated()) {
             DeprecationLogger.deprecateConfiguration(configuration.getName()).forArtifactDeclaration()
                 .replaceWith(GUtil.flattenElements(configuration.getDeclarationAlternatives(), configuration.getConsumptionAlternatives()))
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -168,7 +168,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         List<String> consumptionAlternatives = toConfiguration.getConsumptionAlternatives();
         if (consumptionAlternatives != null) {
             DeprecationLogger.deprecateConfiguration(toConfiguration.getName()).forConsumption().replaceWith(consumptionAlternatives)
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUserManual("java_library_plugin", "sec:java_library_configurations_graph")
                 .nagUser();
         }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
@@ -297,7 +297,7 @@ Secondary variants (*)
         then:
         outputContains("""> Task :outgoingVariants
 There is no variant named 'nope' defined on this project.
-Here are the available outgoing variants: apiElements, archives, compileOnly, default, runtimeElements, testCompileOnly
+Here are the available outgoing variants: apiElements, archives, default, runtimeElements
 """)
         and:
         doesNotHaveLegacyVariantsLegend()
@@ -356,11 +356,6 @@ Artifacts
     - build${File.separator}libs${File.separator}myLib-1.0.jar (artifactType = jar)
 
 --------------------------------------------------
-Variant compileOnly (l)
---------------------------------------------------
-Description = Compile only dependencies for source set 'main'.
-
---------------------------------------------------
 Variant default (l)
 --------------------------------------------------
 Description = Configuration for default artifacts.
@@ -401,11 +396,6 @@ Secondary variants (*)
           - org.gradle.usage               = java-runtime
        - Artifacts
           - build${File.separator}resources${File.separator}main (artifactType = java-resources-directory)
-
---------------------------------------------------
-Variant testCompileOnly (l)
---------------------------------------------------
-Description = Compile only dependencies for source set 'test'.
 """
 
         and:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -126,7 +126,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         where:
         plugin         | configuration                  | alternatives
 
-        'java'         | 'compileOnly'                  | "apiElements"
+        'java'         | 'compileOnly'                  | FORBIDDEN
         'java'         | 'runtimeOnly'                  | FORBIDDEN
         'java'         | 'implementation'               | FORBIDDEN
         'java'         | 'runtimeElements'              | VALID
@@ -137,7 +137,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         'java'         | 'api'                          | DOES_NOT_EXIST
         'java'         | 'compileOnlyApi'               | DOES_NOT_EXIST
 
-        'java-library' | 'compileOnly'                  | "apiElements"
+        'java-library' | 'compileOnly'                  | FORBIDDEN
         'java-library' | 'runtimeOnly'                  | FORBIDDEN
         'java-library' | 'implementation'               | FORBIDDEN
         'java-library' | 'runtimeElements'              | VALID
@@ -180,7 +180,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         where:
         plugin         | configuration                  | alternatives
 
-        'java'         | 'compileOnly'                  | "compileClasspath"
+        'java'         | 'compileOnly'                  | FORBIDDEN
         'java'         | 'runtimeOnly'                  | FORBIDDEN
         'java'         | 'implementation'               | FORBIDDEN
         'java'         | 'runtimeElements'              | FORBIDDEN
@@ -191,7 +191,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         'java'         | 'api'                          | DOES_NOT_EXIST
         'java'         | 'compileOnlyApi'               | DOES_NOT_EXIST
 
-        'java-library' | 'compileOnly'                  | "compileClasspath"
+        'java-library' | 'compileOnly'                  | FORBIDDEN
         'java-library' | 'runtimeOnly'                  | FORBIDDEN
         'java-library' | 'implementation'               | FORBIDDEN
         'java-library' | 'runtimeElements'              | FORBIDDEN

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -62,7 +62,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         }
 
         then:
-        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the $alternatives configuration instead.")
+        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 8.0. Please use the $alternatives configuration instead.")
         !valid(alternatives)        || !output.contains("> Configure project :")
         !doesNotExist(alternatives) || errorOutput.contains("Could not find method $configuration() for arguments [some:module:1.0] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler")
 
@@ -118,7 +118,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         }
 
         then:
-        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. Please use attributes to consume the ${alternatives} configuration instead.")
+        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for consumption. This will fail with an error in Gradle 8.0. Please use attributes to consume the ${alternatives} configuration instead.")
         !valid(alternatives)        || output.contains("> Task :resolve\n\n")
         !forbidden(alternatives)    || errorOutput.contains("Selected configuration '$configuration' on 'project :sub' but it can't be used as a project dependency because it isn't intended for consumption by other components.")
         !doesNotExist(alternatives) || errorOutput.contains("Project : declares a dependency from configuration 'root' to configuration '$configuration' which is not declared in the descriptor for project :sub.")
@@ -172,7 +172,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         }
 
         then:
-        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for resolution. This will fail with an error in Gradle 7.0. Please resolve the ${alternatives} configuration instead.")
+        !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for resolution. This will fail with an error in Gradle 8.0. Please resolve the ${alternatives} configuration instead.")
         !valid(alternatives)        || output.contains("> Task :resolve\n\n")
         !forbidden(alternatives)    || errorOutput.contains("Resolving dependency configuration '$configuration' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends '$configuration' should be resolved.")
         !doesNotExist(alternatives) || errorOutput.contains("Could not get unknown property '$configuration' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.")

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -226,8 +226,6 @@ public class JavaBasePlugin implements Plugin<Project> {
         String compileClasspathConfigurationName = sourceSet.getCompileClasspathConfigurationName();
         String annotationProcessorConfigurationName = sourceSet.getAnnotationProcessorConfigurationName();
         String runtimeClasspathConfigurationName = sourceSet.getRuntimeClasspathConfigurationName();
-        String apiElementsConfigurationName = sourceSet.getApiElementsConfigurationName();
-        String runtimeElementsConfigurationName = sourceSet.getRuntimeElementsConfigurationName();
         String sourceSetName = sourceSet.toString();
 
         Configuration implementationConfiguration = configurations.maybeCreate(implementationConfigurationName);
@@ -238,6 +236,8 @@ public class JavaBasePlugin implements Plugin<Project> {
 
         DeprecatableConfiguration compileOnlyConfiguration = (DeprecatableConfiguration) configurations.maybeCreate(compileOnlyConfigurationName);
         compileOnlyConfiguration.setVisible(false);
+        compileOnlyConfiguration.setCanBeConsumed(false);
+        compileOnlyConfiguration.setCanBeResolved(false);
         compileOnlyConfiguration.setDescription("Compile only dependencies for " + sourceSetName + ".");
 
         ConfigurationInternal compileClasspathConfiguration = (ConfigurationInternal) configurations.maybeCreate(compileClasspathConfigurationName);
@@ -273,9 +273,6 @@ public class JavaBasePlugin implements Plugin<Project> {
         sourceSet.setCompileClasspath(compileClasspathConfiguration);
         sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeClasspathConfiguration));
         sourceSet.setAnnotationProcessorPath(annotationProcessorConfiguration);
-
-        compileOnlyConfiguration.deprecateForConsumption(apiElementsConfigurationName);
-        compileOnlyConfiguration.deprecateForResolution(compileClasspathConfigurationName);
 
         compileClasspathConfiguration.deprecateForDeclaration(implementationConfigurationName, compileOnlyConfigurationName);
         runtimeClasspathConfiguration.deprecateForDeclaration(implementationConfigurationName, compileOnlyConfigurationName, runtimeOnlyConfigurationName);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -145,6 +145,8 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         then:
         testCompileOnly.extendsFrom == toSet(compileOnlyApi)
         !testCompileOnly.visible
+        !testRuntimeOnly.canBeConsumed
+        !testRuntimeOnly.canBeResolved
         testCompileOnly.transitive
 
         when:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -84,6 +84,8 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         then:
         compileOnly.extendsFrom == [] as Set
         !compileOnly.visible
+        !compileOnly.canBeConsumed
+        !compileOnly.canBeResolved
         compileOnly.transitive
 
         when:
@@ -128,6 +130,8 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         then:
         testCompileOnly.extendsFrom == toSet()
         !testCompileOnly.visible
+        !testRuntimeOnly.canBeConsumed
+        !testRuntimeOnly.canBeResolved
         testCompileOnly.transitive
 
         when:


### PR DESCRIPTION
- Target Gradle 8.0 in deprecation warnings for deprecated configurations.
- Turn existing deprecations into errors (compileOnly)
