### PR TITLE
Remove 'search-upwards', 'use-empty-settings' and 'master' directory support

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1511,6 +1511,63 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Field useEmptySettings",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Field searchUpwards",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.doUseEmptySettings()",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.isSearchUpwards()",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.isUseEmptySettings()",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.setSearchUpwards(boolean)",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.useEmptySettings()",
+            "acceptation": "Deprecated start parameter has been removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -220,15 +220,6 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
                 case SystemPropertySource.GRADLE_PROPERTIES:
                     file('root/gradle.properties').text = "systemProp.greeting=$greeting"
                     return configurationCacheRun('greet')
-                case SystemPropertySource.GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR:
-                    // because the 'master' directory special treatment deprecation message is not emitted when configuration is loaded form config cache
-                    executer.noDeprecationChecks()
-
-                    file('master/gradle.properties').text = "systemProp.greeting=$greeting"
-                    file('master/settings.gradle').text = """
-                        rootProject.projectDir = file('../root')
-                    """
-                    return configurationCacheRun('greet')
             }
             throw new IllegalArgumentException('source')
         }
@@ -259,8 +250,7 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
 
     enum SystemPropertySource {
         COMMAND_LINE,
-        GRADLE_PROPERTIES,
-        GRADLE_PROPERTIES_FROM_MASTER_SETTINGS_DIR;
+        GRADLE_PROPERTIES
 
         @Override
         String toString() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -241,7 +241,7 @@ class ConfigurationCacheHost internal constructor(
                 SettingsLocation(settingsDir(), null),
                 gradle.classLoaderScope,
                 gradle.startParameter.apply {
-                    useEmptySettingsWithoutDeprecationWarning()
+                    useEmptySettings()
                 }
             )
         }

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -35,7 +35,6 @@ import org.gradle.initialization.UserHomeInitScriptFinder;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -76,13 +75,11 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean buildProjectDependencies = true;
     private File currentDir;
     private File projectDir;
-    protected boolean searchUpwards;
     private Map<String, String> projectProperties = new HashMap<>();
     private Map<String, String> systemPropertiesArgs = new HashMap<>();
     private File gradleUserHomeDir;
     protected File gradleHomeDir;
     private File settingsFile;
-    protected boolean useEmptySettings;
     private File buildFile;
     private List<File> initScripts = new ArrayList<>();
     private boolean dryRun;
@@ -193,7 +190,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     public StartParameter() {
         BuildLayoutParameters layoutParameters = new BuildLayoutParameters();
         gradleHomeDir = layoutParameters.getGradleInstallationHomeDir();
-        searchUpwards = layoutParameters.getSearchUpwards();
         currentDir = layoutParameters.getCurrentDir();
         projectDir = layoutParameters.getProjectDir();
         gradleUserHomeDir = layoutParameters.getGradleUserHomeDir();
@@ -214,12 +210,10 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;
-        p.useEmptySettings = useEmptySettings;
         p.taskRequests = new ArrayList<>(taskRequests);
         p.excludedTaskNames = new LinkedHashSet<>(excludedTaskNames);
         p.buildProjectDependencies = buildProjectDependencies;
         p.currentDir = currentDir;
-        p.searchUpwards = searchUpwards;
         p.projectProperties = new HashMap<>(projectProperties);
         p.systemPropertiesArgs = new HashMap<>(systemPropertiesArgs);
         p.initScripts = new ArrayList<>(initScripts);
@@ -296,43 +290,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
             this.buildFile = FileUtils.canonicalize(buildFile);
             setProjectDir(this.buildFile.getParentFile());
         }
-    }
-
-    /**
-     * Specifies that an empty settings script should be used.
-     *
-     * This means that even if a settings file exists in the conventional location, or has been previously specified by {@link #setSettingsFile(File)}, it will not be used.
-     *
-     * If {@link #setSettingsFile(File)} is called after this, it will supersede calling this method.
-     *
-     * @return this
-     */
-    public StartParameter useEmptySettings() {
-        DeprecationLogger.deprecateMethod(StartParameter.class, "useEmptySettings()")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(6, "discontinued_methods")
-            .nagUser();
-        doUseEmptySettings();
-        return this;
-    }
-
-    protected void doUseEmptySettings() {
-        searchUpwards = false;
-        useEmptySettings = true;
-        settingsFile = null;
-    }
-
-    /**
-     * Returns whether an empty settings script will be used regardless of whether one exists in the default location.
-     *
-     * @return Whether to use empty settings or not.
-     */
-    public boolean isUseEmptySettings() {
-        DeprecationLogger.deprecateMethod(StartParameter.class, "isUseEmptySettings()")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(6, "discontinued_methods")
-            .nagUser();
-        return useEmptySettings;
     }
 
     /**
@@ -421,22 +378,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         }
     }
 
-    public boolean isSearchUpwards() {
-        DeprecationLogger.deprecateMethod(StartParameter.class, "isSearchUpwards()")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(5, "search_upwards_related_apis_in_startparameter_have_been_deprecated")
-            .nagUser();
-        return searchUpwards;
-    }
-
-    public void setSearchUpwards(boolean searchUpwards) {
-        DeprecationLogger.deprecateMethod(StartParameter.class, "setSearchUpwards(boolean)")
-            .willBeRemovedInGradle7()
-            .withUpgradeGuideSection(5, "search_upwards_related_apis_in_startparameter_have_been_deprecated")
-            .nagUser();
-        this.searchUpwards = searchUpwards;
-    }
-
     public Map<String, String> getProjectProperties() {
         return projectProperties;
     }
@@ -505,7 +446,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         if (settingsFile == null) {
             this.settingsFile = null;
         } else {
-            this.useEmptySettings = false;
             this.settingsFile = FileUtils.canonicalize(settingsFile);
             currentDir = this.settingsFile.getParentFile();
         }
@@ -514,10 +454,9 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     /**
      * Returns the explicit settings file to use for the build, or null.
      *
-     * Will return null if the default settings file is to be used. However, if {@link #isUseEmptySettings()} returns true, then no settings file at all will be used.
+     * Will return null if the default settings file is to be used.
      *
      * @return The settings file. May be null.
-     * @see #isUseEmptySettings()
      */
     @Nullable
     public File getSettingsFile() {
@@ -750,7 +689,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
             + "taskRequests=" + taskRequests
             + ", excludedTaskNames=" + excludedTaskNames
             + ", currentDir=" + currentDir
-            + ", searchUpwards=" + searchUpwards
             + ", projectProperties=" + projectProperties
             + ", systemPropertiesArgs=" + systemPropertiesArgs
             + ", gradleUserHomeDir=" + gradleUserHomeDir

--- a/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
@@ -29,7 +29,6 @@ public class BuildLayoutParameters {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = "gradle.user.home";
     private static final File DEFAULT_GRADLE_USER_HOME = new File(SystemProperties.getInstance().getUserHome() + "/.gradle");
 
-    private boolean searchUpwards = true;
     private File currentDir = canonicalize(SystemProperties.getInstance().getCurrentDir());
     private File projectDir;
     private File gradleUserHomeDir;
@@ -58,11 +57,6 @@ public class BuildLayoutParameters {
             return gradleInstallation.getGradleHome();
         }
         return null;
-    }
-
-    public BuildLayoutParameters setSearchUpwards(boolean searchUpwards) {
-        this.searchUpwards = searchUpwards;
-        return this;
     }
 
     public BuildLayoutParameters setProjectDir(File projectDir) {
@@ -105,10 +99,6 @@ public class BuildLayoutParameters {
     @Nullable
     public File getGradleInstallationHomeDir() {
         return gradleInstallationHomeDir;
-    }
-
-    public boolean getSearchUpwards() {
-        return searchUpwards;
     }
 
 }

--- a/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -38,7 +38,6 @@ class StartParameterTest extends Specification {
         parameter.taskNames = ['a']
         parameter.buildProjectDependencies = true
         parameter.currentDir = new File('a')
-        parameter.searchUpwards = false
         parameter.projectProperties = [a: 'a']
         parameter.systemPropertiesArgs = [b: 'b']
         parameter.gradleUserHomeDir = new File('b')
@@ -220,18 +219,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.settingsFile == null
-        assertThat(parameter, isSerializable())
-    }
-
-    void "can use empty settings script"() {
-        StartParameter parameter = new StartParameter()
-
-        when:
-        parameter.useEmptySettings()
-
-        then:
-        parameter.settingsFile == null
-        !parameter.searchUpwards
         assertThat(parameter, isSerializable())
     }
 

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
@@ -38,7 +38,6 @@ class BuildLayoutParametersTest extends Specification {
     def "has reasonable defaults"() {
         expect:
         def params = new BuildLayoutParameters()
-        params.searchUpwards
         params.gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
         params.currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         params.projectDir == null

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
-import spock.lang.Unroll
 
 class GradleBuildTaskIntegrationTest extends AbstractIntegrationSpec {
 
@@ -88,35 +87,6 @@ class GradleBuildTaskIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Execution failed for task ':b2'")
         failure.assertHasCause("Included build $testDirectory has build path :bp which is the same as included build $testDirectory")
-    }
-
-    @Unroll
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
-    def "shows deprecation warning when accessing #displayName when configuring GradleBuild task"() {
-        given:
-        settingsFile << "rootProject.name = 'parent'"
-        buildFile << """
-            task buildInBuild(type:GradleBuild) {
-                buildFile = 'other.gradle'
-            }
-
-            ${codeUnderTest}
-        """
-        file('other.gradle') << 'assert true'
-
-        when:
-        executer.expectDeprecationWarning()
-        run 'buildInBuild'
-
-        then:
-        outputContains("${displayName} method has been deprecated. This is scheduled to be removed in Gradle 7.0.")
-
-        where:
-        displayName                                | codeUnderTest
-        "StartParameter.setSearchUpwards(boolean)" | "buildInBuild.startParameter.searchUpwards = true"
-        "StartParameter.isSearchUpwards()"         | "buildInBuild.startParameter.searchUpwards"
-        "StartParameter.useEmptySettings()"        | "buildInBuild.startParameter.useEmptySettings()"
-        "StartParameter.isUseEmptySettings()"      | "buildInBuild.startParameter.useEmptySettings"
     }
 
     @ToBeFixedForConfigurationCache(because = "GradleBuild task")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -35,25 +35,6 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         operation().details.buildPath == ":"
     }
 
-    def "settings with master folder are exposed"() {
-        executer.expectDocumentedDeprecationWarning("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#master_subdirectory_root_build")
-
-        def customSettingsFile = file("master/settings.gradle")
-        customSettingsFile << """
-        includeFlat "a"
-        """
-
-        def projectDirectory = testDirectory.createDir("a")
-
-        when:
-        projectDir(projectDirectory)
-        succeeds('help')
-
-        then:
-        verifySettings(operation(), customSettingsFile)
-        operation().details.buildPath == ":"
-    }
-
     def "settings set via cmdline flag are exposed"() {
         def customSettingsDir = file("custom")
         customSettingsDir.mkdirs()

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import spock.lang.Issue
-import spock.lang.Unroll
 
 @LeaksFileHandles
 class InitScriptIntegrationTest extends AbstractIntegrationSpec {
@@ -168,31 +167,6 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
         then:
         output.contains("order: plugin - settings.gradle - settingsEvaluated")
         output.contains("subprojects: :sub1 - :sub2")
-    }
-
-    @Unroll
-    def "shows deprecation warning when accessing #displayName from init script"() {
-        given:
-        createProject()
-        file("init.gradle") << """
-            ${codeUnderTest}
-        """
-
-        executer.usingInitScript(file('init.gradle'))
-
-        when:
-        executer.expectDeprecationWarning()
-        run 'help'
-
-        then:
-        outputContains("${displayName} method has been deprecated. This is scheduled to be removed in Gradle 7.0.")
-
-        where:
-        displayName                                | codeUnderTest
-        "StartParameter.setSearchUpwards(boolean)" | "gradle.startParameter.searchUpwards = true"
-        "StartParameter.isSearchUpwards()"         | "gradle.startParameter.searchUpwards"
-        "StartParameter.useEmptySettings()"        | "gradle.startParameter.useEmptySettings()"
-        "StartParameter.isUseEmptySettings()"      | "gradle.startParameter.useEmptySettings"
     }
 
     private static String initScript() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -52,36 +52,6 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         verifyProject(project(':a:c:d'), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
     }
 
-    def "settings with master folder are exposed correctly"() {
-        executer.expectDocumentedDeprecationWarning("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#master_subdirectory_root_build")
-
-        def customSettingsFile = file("master/settings.gradle")
-        customSettingsFile << """
-        rootProject.name = "root"
-        rootProject.buildFileName = 'root.gradle'
-
-        includeFlat "a"
-        """
-
-        def projectDirectory = testDirectory.createDir("a")
-
-        when:
-        projectDir(projectDirectory)
-        succeeds('help')
-
-        then:
-        operation().result.buildPath == ":"
-        operation().result.rootProject.name == "root"
-        operation().result.rootProject.path == ":"
-        operation().result.rootProject.projectDir == customSettingsFile.parentFile.absolutePath
-        operation().result.rootProject.buildFile == customSettingsFile.parentFile.file("root.gradle").absolutePath
-
-        opResult.buildPath == ":"
-        opResult.rootProject.path == ":"
-        verifyProject(opResult.rootProject, 'root', ':', [':a'], customSettingsFile.parentFile, 'root.gradle')
-        verifyProject(project(':a'), 'a')
-    }
-
     def "settings set via cmdline flag are exposed correctly"() {
         def customSettingsDir = file("custom")
         customSettingsDir.mkdirs()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
@@ -124,7 +124,7 @@ public class BuildDefinition {
     private static StartParameter startParameterForIncludedBuildFrom(StartParameter startParameter, File buildRootDir) {
         StartParameter includedBuildStartParam = startParameter.newBuild();
         includedBuildStartParam.setCurrentDir(buildRootDir);
-        ((StartParameterInternal) includedBuildStartParam).setSearchUpwardsWithoutDeprecationWarning(false);
+        ((StartParameterInternal) includedBuildStartParam).doNotSearchUpwards();
         includedBuildStartParam.setConfigureOnDemand(false);
         includedBuildStartParam.setInitScripts(startParameter.getInitScripts());
         includedBuildStartParam.setExcludedTaskNames(startParameter.getExcludedTaskNames());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -38,6 +38,8 @@ public class StartParameterInternal extends StartParameter {
     private int configurationCacheMaxProblems = 512;
     private boolean configurationCacheRecreateCache;
     private boolean configurationCacheQuiet;
+    private boolean searchUpwards = true;
+    private boolean useEmptySettings = false;
 
     @Override
     public StartParameter newInstance() {
@@ -60,6 +62,8 @@ public class StartParameterInternal extends StartParameter {
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
         p.configurationCacheRecreateCache = configurationCacheRecreateCache;
         p.configurationCacheQuiet = configurationCacheQuiet;
+        p.searchUpwards = searchUpwards;
+        p.useEmptySettings = useEmptySettings;
         return p;
     }
 
@@ -71,20 +75,20 @@ public class StartParameterInternal extends StartParameter {
         this.gradleHomeDir = gradleHomeDir;
     }
 
-    public void useEmptySettingsWithoutDeprecationWarning() {
-        doUseEmptySettings();
+    public boolean isSearchUpwards() {
+        return searchUpwards;
     }
 
-    public boolean isUseEmptySettingsWithoutDeprecationWarning() {
-        return super.useEmptySettings;
+    public void doNotSearchUpwards() {
+        this.searchUpwards = false;
     }
 
-    public boolean isSearchUpwardsWithoutDeprecationWarning() {
-        return super.searchUpwards;
+    public boolean isUseEmptySettings() {
+        return useEmptySettings;
     }
 
-    public void setSearchUpwardsWithoutDeprecationWarning(boolean searchUpwards) {
-        super.searchUpwards = searchUpwards;
+    public void useEmptySettings() {
+        this.useEmptySettings = true;
     }
 
     public WatchMode getWatchFileSystemMode() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.Path;
 
 /**
@@ -54,12 +53,6 @@ public class DefaultSettingsLoader implements SettingsLoader {
         StartParameter startParameter = gradle.getStartParameter();
 
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
-        if (settingsLocation.isSettingsLoadedFromMasterDirectory()) {
-            DeprecationLogger.deprecateBehaviour("Searching for settings files in a directory named 'master' from a sibling directory has been deprecated.")
-                .willBeRemovedInGradle7()
-                .withUpgradeGuideSection(6, "master_subdirectory_root_build")
-                .nagUser();
-        }
         loadGradlePropertiesFrom(settingsLocation);
 
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter, settingsLocation, gradle.getClassLoaderScope());
@@ -96,8 +89,10 @@ public class DefaultSettingsLoader implements SettingsLoader {
     }
 
     private SettingsInternal createEmptySettings(GradleInternal gradle, StartParameter startParameter, ClassLoaderScope classLoaderScope) {
-        StartParameter noSearchParameter = startParameter.newInstance();
-        ((StartParameterInternal) noSearchParameter).useEmptySettingsWithoutDeprecationWarning();
+        StartParameterInternal noSearchParameter = (StartParameterInternal) startParameter.newInstance();
+        noSearchParameter.setSettingsFile(null);
+        noSearchParameter.useEmptySettings();
+        noSearchParameter.doNotSearchUpwards();
         BuildLayout layout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(noSearchParameter));
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, noSearchParameter, layout, classLoaderScope);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -22,23 +22,12 @@ import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 
-import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
-
 public class LayoutCommandLineConverter extends AbstractCommandLineConverter<BuildLayoutParameters> {
     private final CommandLineConverter<BuildLayoutParameters> converter = new BuildLayoutParametersBuildOptions().commandLineConverter();
 
     @Override
     public BuildLayoutParameters convert(ParsedCommandLine options, BuildLayoutParameters target) throws CommandLineArgumentException {
         converter.convert(options, target);
-
-        if (options.getExtraArguments().contains("init")) {
-            target.setSearchUpwards(false);
-        }
-
-        if (target.getSearchDir().getName().equals(BUILD_SRC)) {
-            target.setSearchUpwards(false);
-        }
-
         return target;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsLocation.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsLocation.java
@@ -24,16 +24,9 @@ public class SettingsLocation {
     @Nullable
     private final File settingsFile;
 
-    private final boolean settingsLoadedFromMasterDirectory;
-
-    public SettingsLocation(File settingsDir, @Nullable File settingsFile, boolean settingsLoadedFromMasterDirectory) {
+    public SettingsLocation(File settingsDir, @Nullable File settingsFile) {
         this.settingsDir = settingsDir;
         this.settingsFile = settingsFile;
-        this.settingsLoadedFromMasterDirectory = settingsLoadedFromMasterDirectory;
-    }
-
-    public SettingsLocation(File settingsDir, @Nullable File settingsFile) {
-        this(settingsDir, settingsFile, false);
     }
 
     /**
@@ -49,10 +42,6 @@ public class SettingsLocation {
     @Nullable
     public File getSettingsFile() {
         return settingsFile;
-    }
-
-    boolean isSettingsLoadedFromMasterDirectory() {
-        return settingsLoadedFromMasterDirectory;
     }
 }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -85,10 +85,10 @@ public class BuildSourceBuilder {
             return ClassPath.EMPTY;
         }
 
-        final StartParameter buildSrcStartParameter = containingBuildParameters.newBuild();
+        final StartParameterInternal buildSrcStartParameter = (StartParameterInternal) containingBuildParameters.newBuild();
         buildSrcStartParameter.setCurrentDir(buildSrcDir);
         buildSrcStartParameter.setProjectProperties(containingBuildParameters.getProjectProperties());
-        ((StartParameterInternal) buildSrcStartParameter).setSearchUpwardsWithoutDeprecationWarning(false);
+        buildSrcStartParameter.doNotSearchUpwards();
         buildSrcStartParameter.setProfile(containingBuildParameters.isProfile());
         final BuildDefinition buildDefinition = BuildDefinition.fromStartParameterForBuild(
             buildSrcStartParameter,

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
@@ -23,11 +23,6 @@ import java.io.File;
 public class BuildLayout extends SettingsLocation {
     private final File rootDirectory;
 
-    BuildLayout(File rootDirectory, File settingsDir, @Nullable File settingsFile, boolean settingsLoadedFromMasterDirectory) {
-        super(settingsDir, settingsFile, settingsLoadedFromMasterDirectory);
-        this.rootDirectory = rootDirectory;
-    }
-
     // Note: `null` for `settingsFile` means explicitly no settings
     //       A non null value can be a non existent file, which is semantically equivalent to an empty file
     public BuildLayout(File rootDirectory, File settingsDir, @Nullable File settingsFile) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -34,9 +34,9 @@ public class BuildLayoutConfiguration {
 
     public BuildLayoutConfiguration(StartParameter startParameter) {
         currentDir = startParameter.getCurrentDir();
-        searchUpwards = ((StartParameterInternal)startParameter).isSearchUpwardsWithoutDeprecationWarning() && !isInitTaskRequested(startParameter);
+        searchUpwards = ((StartParameterInternal)startParameter).isSearchUpwards() && !isInitTaskRequested(startParameter);
         settingsFile = startParameter.getSettingsFile();
-        useEmptySettings = ((StartParameterInternal)startParameter).isUseEmptySettingsWithoutDeprecationWarning();
+        useEmptySettings = ((StartParameterInternal)startParameter).isUseEmptySettings();
     }
 
     private boolean isInitTaskRequested(StartParameter startParameter) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -70,18 +70,10 @@ public class BuildLayoutFactory {
         if (settingsFile != null) {
             return layout(currentDir, settingsFile);
         }
-        settingsFile = findExistingSettingsFileIn(new File(currentDir, "master"));
-        if (settingsFile != null) {
-            return layoutWithDeprecatedMasterDirectoryFlag(currentDir, settingsFile);
-        }
         for (File candidate = currentDir.getParentFile(); candidate != null && !candidate.equals(stopAt); candidate = candidate.getParentFile()) {
             settingsFile = findExistingSettingsFileIn(candidate);
             if (settingsFile != null) {
                 return layout(candidate, settingsFile);
-            }
-            settingsFile = findExistingSettingsFileIn(new File(candidate, "master"));
-            if (settingsFile != null) {
-                return layoutWithDeprecatedMasterDirectoryFlag(candidate, settingsFile);
             }
         }
         return layout(currentDir, new File(currentDir, Settings.DEFAULT_SETTINGS_FILE));
@@ -89,9 +81,5 @@ public class BuildLayoutFactory {
 
     private BuildLayout layout(File rootDir, File settingsFile) {
         return new BuildLayout(rootDir, settingsFile.getParentFile(), FileUtils.canonicalize(settingsFile));
-    }
-
-    private BuildLayout layoutWithDeprecatedMasterDirectoryFlag(File rootDir, File settingsFile) {
-        return new BuildLayout(rootDir, settingsFile.getParentFile(), FileUtils.canonicalize(settingsFile), true);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
@@ -42,23 +42,12 @@ class LayoutCommandLineConverterTest extends Specification {
         convert().currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         convert().projectDir == null
         convert().gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
-        convert().searchUpwards
     }
 
     def "converts"() {
         expect:
         convert("-p", "foo").projectDir.name == "foo"
         convert("-g", "bar").gradleUserHomeDir.name == "bar"
-    }
-
-    def "doesn't search upwards when building buildSrc"() {
-        expect:
-        !convert("-p", "buildSrc").searchUpwards
-    }
-
-    def "doesn't search upwards when running init task"() {
-        expect:
-        !convert("init").searchUpwards
     }
 
     def "converts relatively to the target dir"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -73,86 +73,6 @@ class BuildLayoutFactoryTest extends Specification {
     }
 
     @Unroll
-    def "looks for sibling directory called 'master' that it contains a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def currentDir = tmpDir.createDir("current")
-        def masterDir = tmpDir.createDir("master")
-        def settingsFile = masterDir.createFile(settingsFilename)
-
-        expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == masterDir.parentFile
-        layout.settingsDir == masterDir
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
-    def "looks for child directory called 'master' that it contains a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def masterDir = tmpDir.createDir("master")
-        def settingsFile = masterDir.createFile(settingsFilename)
-
-        expect:
-        def layout = locator.getLayoutFor(tmpDir.testDirectory, true)
-        layout.rootDirectory == masterDir.parentFile
-        layout.settingsDir == masterDir
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
-    def "searches ancestors for a directory called 'master' that contains a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def currentDir = tmpDir.createDir("sub/current")
-        def masterDir = tmpDir.createDir("master")
-        def settingsFile = masterDir.createFile("settings.gradle")
-
-        expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == masterDir.parentFile
-        layout.settingsDir == masterDir
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
-    def "ignores 'master' directory when it does not contain a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def currentDir = tmpDir.createDir("sub/current")
-        def masterDir = tmpDir.createDir("sub/master")
-        masterDir.createFile("gradle.properties")
-        def settingsFile = tmpDir.createFile(settingsFilename)
-
-        expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == tmpDir.testDirectory
-        layout.settingsDir == tmpDir.testDirectory
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
     def "returns closest ancestor directory that contains a #settingsFilename file"() {
         given:
         def locator = buildLayoutFactoryFor()
@@ -188,50 +108,6 @@ class BuildLayoutFactoryTest extends Specification {
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
-    def "prefers the 'master' directory over ancestor directory with a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def currentDir = tmpDir.createDir("sub/current")
-        def masterDir = tmpDir.createDir("sub/master")
-        def settingsFile = masterDir.createFile(settingsFilename)
-        tmpDir.createFile(settingsFilename)
-
-        expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == masterDir.parentFile
-        layout.settingsDir == masterDir
-        refersTo(layout, settingsFile)
-
-        where:
-        settingsFilename << TEST_CASES
-    }
-
-    @Unroll
-    def "prefers the child 'master' directory over an ancestor directory with 'master' or a #settingsFilename file"() {
-        given:
-        def locator = buildLayoutFactoryFor()
-
-        and:
-        def currentDir = tmpDir.createDir("project")
-        def masterDir = currentDir.createDir("master")
-        def settingsFile = masterDir.createFile(settingsFilename)
-        def ancestorMasterDir = tmpDir.createDir("master")
-        ancestorMasterDir.createFile(settingsFilename)
-        tmpDir.createFile(settingsFilename)
-
-        expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == masterDir.parentFile
-        layout.settingsDir == masterDir
         refersTo(layout, settingsFile)
 
         where:
@@ -309,7 +185,7 @@ class BuildLayoutFactoryTest extends Specification {
         currentDir.createFile(settingsFilename)
         def startParameter = new StartParameterInternal()
         startParameter.currentDir = currentDir
-        startParameter.useEmptySettings()
+        startParameter.settingsFile = null
         def config = new BuildLayoutConfiguration(startParameter)
 
         expect:

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -37,7 +37,7 @@ Some plugins will break with this new version of Gradle, for example because the
 == Upgrading from 6.8
 === Changes in the IDE integration
 
-===== Changes in the IDEA model
+==== Changes in the IDEA model
 
 The `getGeneratedSourceDirectories()` and `getGeneratedTestDirectories()` methods are removed from the `IdeaContentRoot` interface.
 Clients should replace these invocations with `getSourceDirectories()` and `getTestDirectories()` and use the `isGenerated()` method on the returned instances.
@@ -129,6 +129,19 @@ You can use link:{javadocPath}/org/gradle/api/DefaultTask.html[DefaultTask] inst
 
 `BuildListener.buildStarted(Gradle)` was deprecated in Gradle 6.0 and is now removed in Gradle 7.0.
 Please use link:{javadocPath}/org/gradle/BuildListener.html#beforeSettings-org.gradle.api.initialization.Settings-[BuildListener.beforeSettings(Settings)] instead.
+
+==== Removal of unused `StartParameter` APIs
+
+The following APIs, which were not usable via command line options anymore since Gradle 5.0, are now removed:
+`StartParameter.useEmptySettings()`, `StartParameter.isUseEmptySettings()`, `StartParameter.setSearchUpwards(boolean)` and `StartParameter.isSearchUpwards()`.
+
+==== Removal of searching for settings files in 'master' directories
+
+Gradle no longer supports discovering the settings file in a directory named `master` in a sibling directory.
+If your build still uses this deprecated feature, consider refactoring the build to have the root directory match the physical root of the project hierarchy.
+You can find more information about <<multi_project_builds.adoc#,how to structure a Gradle build>> or a <<structuring_software_products.adoc#,composition of builds>> in the user manual.
+Alternatively, you can still run tasks in builds like this by invoking the build from the `master` directory only using a
+<<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,fully qualified path to the task>>.
 
 ==== `modularity.inferModulePath` defaults to 'true'
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -97,8 +97,6 @@ public class BuildActionSerializer {
             nullableFileSerializer.write(encoder, startParameter.getGradleHomeDir());
             nullableFileSerializer.write(encoder, startParameter.getProjectCacheDir());
             fileListSerializer.write(encoder, startParameter.getIncludedBuilds());
-            encoder.writeBoolean(startParameter.isUseEmptySettingsWithoutDeprecationWarning());
-            encoder.writeBoolean(startParameter.isSearchUpwardsWithoutDeprecationWarning());
 
             // Other stuff
             NO_NULL_STRING_MAP_SERIALIZER.write(encoder, startParameter.getProjectProperties());
@@ -174,10 +172,6 @@ public class BuildActionSerializer {
             startParameter.setGradleHomeDir(nullableFileSerializer.read(decoder));
             startParameter.setProjectCacheDir(nullableFileSerializer.read(decoder));
             startParameter.setIncludedBuilds(fileListSerializer.read(decoder));
-            if (decoder.readBoolean()) {
-                startParameter.useEmptySettingsWithoutDeprecationWarning();
-            }
-            startParameter.setSearchUpwardsWithoutDeprecationWarning(decoder.readBoolean());
 
             // Other stuff
             startParameter.setProjectProperties(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
@@ -70,7 +70,6 @@ public class BuildLayoutConverter {
         public void applyTo(BuildLayoutParameters buildLayout) {
             buildLayout.setCurrentDir(this.buildLayout.getCurrentDir());
             buildLayout.setProjectDir(this.buildLayout.getProjectDir());
-            buildLayout.setSearchUpwards(this.buildLayout.getSearchUpwards());
             buildLayout.setGradleUserHomeDir(this.buildLayout.getGradleUserHomeDir());
             buildLayout.setGradleInstallationHomeDir(this.buildLayout.getGradleInstallationHomeDir());
         }
@@ -79,7 +78,6 @@ public class BuildLayoutConverter {
         public void applyTo(StartParameterInternal startParameter) {
             startParameter.setProjectDir(buildLayout.getProjectDir());
             startParameter.setCurrentDir(buildLayout.getCurrentDir());
-            startParameter.setSearchUpwardsWithoutDeprecationWarning(buildLayout.getSearchUpwards());
             startParameter.setGradleUserHomeDir(buildLayout.getGradleUserHomeDir());
         }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -65,7 +65,7 @@ public class LayoutToPropertiesConverter {
         layout.applyTo(layoutParameters);
         Map<String, String> properties = new HashMap<>();
         configureFromHomeDir(layoutParameters.getGradleInstallationHomeDir(), properties);
-        configureFromBuildDir(layoutParameters.getSearchDir(), layoutParameters.getSearchUpwards(), properties);
+        configureFromBuildDir(layoutParameters.getSearchDir(), properties);
         configureFromHomeDir(layout.getGradleUserHomeDir(), properties);
         configureFromSystemPropertiesOfThisJvm(Cast.uncheckedNonnullCast(properties));
         properties.putAll(initialProperties.getRequestedSystemProperties());
@@ -86,8 +86,8 @@ public class LayoutToPropertiesConverter {
         maybeConfigureFrom(new File(gradleUserHomeDir, Project.GRADLE_PROPERTIES), result);
     }
 
-    private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, searchUpwards);
+    private void configureFromBuildDir(File currentDir, Map<String, String> result) {
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, true);
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -284,10 +284,6 @@ public class ProviderConnection {
             if (operationParameters.getGradleUserHomeDir() != null) {
                 layout.setGradleUserHomeDir(operationParameters.getGradleUserHomeDir());
             }
-            Boolean searchUpwards = operationParameters.isSearchUpwards();
-            if (searchUpwards != null) {
-                layout.setSearchUpwards(searchUpwards);
-            }
             layout.setProjectDir(operationParameters.getProjectDir());
         });
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
@@ -83,7 +83,9 @@ public interface ProviderOperationParameters {
     /**
      * @return When null, use the provider's default value for search upwards.
      * @since 1.0-milestone-3
+     * @deprecated The ability to change the search upward behavior when calling a build has been removed in Gradle 7.0. This is kept for compatibility with pre 7.0 versions.
      */
+    @Deprecated
     @Nullable
     Boolean isSearchUpwards();
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
@@ -89,13 +89,11 @@ class BuildLayoutConverterTest extends Specification {
         def parameters = convert(["--gradle-user-home", "dir"]) {
             gradleUserHomeDir = new File("ignore-me")
             projectDir = dir
-            searchUpwards = true
         }
 
         then:
         parameters.gradleUserHomeDir == dir
         parameters.projectDir == dir
-        parameters.searchUpwards
     }
 
     BuildLayoutParameters convert(List<String> args, @DelegatesTo(BuildLayoutParameters) Closure overrides = {}) {
@@ -112,7 +110,6 @@ class BuildLayoutConverterTest extends Specification {
         assert startParameters.gradleUserHomeDir == parameters.gradleUserHomeDir
         assert startParameters.currentDir == parameters.currentDir
         assert startParameters.projectDir == parameters.projectDir
-        assert startParameters.searchUpwards == parameters.searchUpwards
 
         return parameters
     }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -51,6 +51,7 @@ class LayoutToPropertiesConverterTest extends Specification {
         when:
         def properties = properties()
         def layout = layout(properties)
+        rootDir.file("settings.gradle") << ''
         gradleDistribution.file("gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m -Dprop=value"
 
         then:
@@ -71,6 +72,7 @@ class LayoutToPropertiesConverterTest extends Specification {
         when:
         def properties = properties()
         def layout = layout(properties)
+        rootDir.file("settings.gradle") << ''
         rootDir.file("gradle.properties") << "$DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY=125"
 
         then:
@@ -101,7 +103,6 @@ class LayoutToPropertiesConverterTest extends Specification {
         def properties = properties()
         def layout = layout(properties) {
             setProjectDir(rootDir.file("foo"))
-            searchUpwards = true
         }
         rootDir.file("settings.gradle") << "include 'foo'"
         rootDir.file("gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx128m"
@@ -114,6 +115,7 @@ class LayoutToPropertiesConverterTest extends Specification {
         when:
         def properties = properties()
         def layout = layout(properties)
+        rootDir.file("settings.gradle") << ''
         rootDir.file("gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m"
         gradleDistribution.file("gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx512m"
 
@@ -193,7 +195,6 @@ class LayoutToPropertiesConverterTest extends Specification {
             it.setGradleInstallationHomeDir(gradleDistribution)
             it.setGradleUserHomeDir(gradleHome)
             it.setProjectDir(rootDir)
-            it.setSearchUpwards(false)
             overrides.delegate = it
             overrides()
         }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -52,7 +52,7 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
 
     @Override
     public PluginRequests getAutoAppliedPlugins(Settings target) {
-        if (((StartParameterInternal) target.getStartParameter()).isUseEmptySettingsWithoutDeprecationWarning()) {
+        if (((StartParameterInternal) target.getStartParameter()).isUseEmptySettings()) {
             return PluginRequests.EMPTY;
         }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
@@ -115,7 +115,8 @@ class PassingCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificatio
     def "can overwrite project dir via build arguments"() {
         given:
         file('otherDir').createDir()
-        file('build.gradle') << "assert projectDir.name.endsWith('otherDir')"
+        file('otherDir/build.gradle') << "assert projectDir.name.endsWith('otherDir')"
+        file('otherDir/settings.gradle') << ''
 
         when:
         withConnection {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r213/ModelsWithGradleProjectCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r213/ModelsWithGradleProjectCrossVersionSpec.groovy
@@ -134,6 +134,7 @@ class ModelsWithGradleProjectCrossVersionSpec extends ToolingApiSpecification {
         assertProject(projectFromEclipseProject, rootMulti, ':x', 'x', ':', [])
     }
 
+    @TargetGradleVersion("<7.0")
     def "ProjectConnection provides GradleProject for subproject of multi-project build with --no-search-upward"() {
         when:
         def rootDir = rootMulti.file("x")

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -201,9 +201,8 @@ project.description = text
         def allProgress = new CopyOnWriteArrayList<String>()
 
         concurrent.start {
-            def connector = toolingApi.connector()
+            def connector = toolingApi.connector(file("build1"))
             distributionOperation(connector, { it.description = "download for 1"; Thread.sleep(500) } )
-            connector.forProjectDirectory(file("build1"))
 
             toolingApi.withConnection(connector) { connection ->
                 def build = connection.newBuild()
@@ -216,9 +215,8 @@ project.description = text
         }
 
         concurrent.start {
-            def connector = toolingApi.connector()
+            def connector = toolingApi.connector(file("build2"))
             distributionOperation(connector, { it.description = "download for 2"; Thread.sleep(500) } )
-            connector.forProjectDirectory(file("build2"))
 
             def connection = connector.connect()
 
@@ -367,8 +365,7 @@ logger.lifecycle 'this is lifecycle: $idx'
     }
 
     def withConnectionInDir(String dir, Closure cl) {
-        GradleConnector connector = toolingApi.connector()
-        connector.forProjectDirectory(file(dir))
+        GradleConnector connector = toolingApi.connector(file(dir))
         toolingApi.withConnection(connector, cl)
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/BuildOperationParametersVersion1.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/BuildOperationParametersVersion1.java
@@ -35,7 +35,9 @@ public interface BuildOperationParametersVersion1 extends LongRunningOperationPa
      * Specifies whether to search for root project, or null to use default.
      *
      * @since 1.0-milestone-3
+     * @deprecated The ability to change the search upward behavior when calling a build has been removed in Gradle 7.0. This is kept for compatibility with pre 7.0 versions.
      */
+    @Deprecated
     Boolean isSearchUpwards();
 
     /**


### PR DESCRIPTION
This removes the ability...
- ...to use a settings file in a 'master' directory outside the build
- ...to ignore an existing settings file from a build script using `StartParameter.useEmptySettings()`
- ...to change the _search upwards_ behaviour from a build script using `StartParameter.setSearchUpwards()`
- ...to change the _search upwards_ behaviour via the Tooling API connection (this is internal API). To keep the cross-version protocol intact, the `ProviderOperationParameters.isSearchUpwards()` method stays, but it's value has no effect when targeting a Gradle 7+ build.

While the functionality to ignore a settings file (e.g. when loading from config cache) and to not search upwards (e.g. for buildSrc and included builds) stay, everything only needed to make this configurable from the launcher side is removed.

The Tooling API tests where actually using `connector.searchUpwards(false)` to test Gradle projects without settings file. These are effectively incomplete projects. So now, if we run the tests with Gradle 6+ Tooling API (as search upwards was deprecated in 6) we add an empty settings file instead of `searchUpwards(false)` option.

### Checklist
- [x] Update the upgrade guide
- [x] Check User Manual for dangling references and outdated documentation
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=2040581133). 
