### PR TITLE
Re-enable AGP lint task smoke test

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,3 +1,3 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
 latests=3.4.3,3.5.4,3.6.4,4.0.2,4.1.1,4.2.0-beta03,7.0.0-alpha04
-nightly=4.2.0-20201018014119+0000
+nightly=

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -81,12 +81,12 @@ class AndroidGradlePluginVersions {
         return getVersionList("latests")
     }
 
-    String getNightly() {
-        return getVersion("nightly")
+    List<String> getNightlies() {
+        return getVersionList("nightly")
     }
 
     List<String> getLatestsPlusNightly() {
-        return [latests, [nightly]].flatten() as List<String>
+        return [latests, nightlies].flatten() as List<String>
     }
 
     List<String> getLatestsFromMinor(String lowerBound) {
@@ -100,15 +100,12 @@ class AndroidGradlePluginVersions {
     }
 
     List<String> getLatestsFromMinorPlusNightly(String lowerBound) {
-        return [getLatestsFromMinor(lowerBound), [nightly]].flatten() as List<String>
+        return [getLatestsFromMinor(lowerBound), nightlies].flatten() as List<String>
     }
 
     private List<String> getVersionList(String name) {
-        return loadedProperties().getProperty(name).split(",")
-    }
-
-    private String getVersion(String name) {
-        return loadedProperties().getProperty(name)
+        def versionList = loadedProperties().getProperty(name)
+        return versionList.empty ? [] : versionList.split(",")
     }
 
     private Properties loadedProperties() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
@@ -106,7 +106,6 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
 
     @Unroll
     @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_2_ITERATION_MATCHER)
-    @ToBeFixedForConfigurationCache(iterationMatchers = AGP_7_ITERATION_MATCHER)
     def "can lint Santa-Tracker #flavour (agp=#agpVersion)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -105,7 +105,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
     }
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER, AGP_4_1_ITERATION_MATCHER, AGP_4_2_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_2_ITERATION_MATCHER)
     @ToBeFixedForConfigurationCache(iterationMatchers = AGP_7_ITERATION_MATCHER)
     def "can lint Santa-Tracker #flavour (agp=#agpVersion)"() {
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.util.GradleVersion
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -108,7 +107,6 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
     @Unroll
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER, AGP_4_1_ITERATION_MATCHER, AGP_4_2_ITERATION_MATCHER])
     @ToBeFixedForConfigurationCache(iterationMatchers = AGP_7_ITERATION_MATCHER)
-    @Ignore("Lint does not work right now, see https://github.com/gradle/gradle/issues/15489")
     def "can lint Santa-Tracker #flavour (agp=#agpVersion)"() {
 
         given:
@@ -134,6 +132,6 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         result.output.contains("Lint found errors in the project; aborting build.")
 
         where:
-        [agpVersion, flavour] << [TESTED_AGP_VERSIONS, ['Java', 'Kotlin']].combinations()
+        [agpVersion, flavour] << [AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.2"), ['Java', 'Kotlin']].combinations()
     }
 }


### PR DESCRIPTION
The problem has been fixed in AGP 4.2 beta03.

Fixes #15489