### PR TITLE
Promote incubating methods in ProjectDependency

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -336,6 +336,16 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.jvm.JvmLibrary
         - org.gradle.language.base.artifact.SourcesArtifact
         - org.gradle.language.java.artifact.JavadocArtifact
+- IDE
+    - Eclipse plugin
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublication()
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublication(FileReference)
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublicationSourcePath()
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublicationSourcePath(FileReference)
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublicationJavadocPath()
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublicationJavadocPath(FileReference)
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.getBuildDependencies()
+      - org.gradle.plugins.ide.eclipse.model.ProjectDependency.buildDependencies(Object...)
 - Tooling API
     - Eclipse models
         - org.gradle.plugins.ide.eclipse.model.UnresolvedLibrary

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
@@ -18,7 +18,6 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import com.google.common.base.Preconditions;
 import groovy.util.Node;
-import org.gradle.api.Incubating;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.tasks.TaskDependency;
 
@@ -54,7 +53,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      *
      * @since 5.6
      */
-    @Incubating
     public FileReference getPublication() {
         return publication;
     }
@@ -64,7 +62,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      *
      * @since 5.6
      */
-    @Incubating
     public void setPublication(FileReference publication) {
         this.publication = publication;
     }
@@ -75,7 +72,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @see #getPublication()
      * @since 5.6
      */
-    @Incubating
     public FileReference getPublicationSourcePath() {
         return publicationSourcePath;
     }
@@ -86,7 +82,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @see #getPublication()
      * @since 5.6
      */
-    @Incubating
     public void setPublicationSourcePath(FileReference publicationSourcePath) {
         this.publicationSourcePath = publicationSourcePath;
     }
@@ -97,7 +92,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @see #getPublication()
      * @since 5.6
      */
-    @Incubating
     public FileReference getPublicationJavadocPath() {
         return publicationJavadocPath;
     }
@@ -108,7 +102,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @see #getPublication()
      * @since 5.6
      */
-    @Incubating
     public void setPublicationJavadocPath(FileReference publicationJavadocPath) {
         this.publicationJavadocPath = publicationJavadocPath;
     }
@@ -122,7 +115,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      *
      * @since 5.6
      */
-    @Incubating
     public TaskDependency getBuildDependencies() {
         return buildDependencies;
     }
@@ -133,7 +125,6 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @see #getBuildDependencies()
      * @since 5.6
      */
-    @Incubating
     public void buildDependencies(Object... buildDependencies) {
         this.buildDependencies.add(buildDependencies);
     }


### PR DESCRIPTION
### Summary
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublication()
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublication(FileReference)
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublicationSourcePath()
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublicationSourcePath(FileReference)
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.getPublicationJavadocPath()
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.setPublicationJavadocPath(FileReference)
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.getBuildDependencies()
- org.gradle.plugins.ide.eclipse.model.ProjectDependency.buildDependencies(Object...)

### Checklist
- [x] Validate whether we should de-incubate the API in the 7.0 release.
    - If the removal is not possible, create a follow-up issue and link it in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit#gid=1195622786)
- [x] Update release notes (add API to promoted features)
- [x] Check User Manual (it might mention that the API is still incubating)
  - Think about updating snippets and samples to use this API
- [x] Deprecate existing API that is replaced by the new one
  - If it's not immediately possible, create a follow-up issue with a milestone (e.g. `7.1 RC1` or `8.0 RC1`)
- [x] Check Incubation Report on TeamCity ([example](https://builds.gradle.org/viewLog.html?buildId=40024670&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_Incubating_APIs_Report)) 
- [ ] Mark the story as done in the [overview spreadsheet](https://docs.google.com/spreadsheets/d/19J1nR_dFKpfKdu5KDFMVZGfjR0ysT9DthsBUPwf8mkM/edit?ts=5fcfefb8#gid=0).  
