### PR TITLE
Remove no longer needed test workarounds

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
@@ -18,17 +18,10 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 @FluidDependenciesResolveTest
 class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
-
-    @Ignore
-    def "Spock bug workaround - do not remove or the test won't execute" () {
-        expect:
-        true
-    }
 
     @Unroll("cannot resolve a configuration with role #role at execution time")
     def "cannot resolve a configuration which is for publishing only at execution time"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
@@ -38,12 +37,6 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
             }
             apply plugin: 'java-base'
         """
-    }
-
-    @Ignore
-    def "Spock workaround"() {
-        expect:
-        true
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -515,11 +514,5 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
         fixConflict | description
         false       | 'conflict fix not applied'
         true        | 'conflict fix applied'
-    }
-
-    @Ignore
-    def "trust no one"() {
-        expect:
-        true // Spock doesn't like when there are only Unroll tests in a test class
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.ENFORCED_PLATFORM
@@ -484,12 +483,5 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
 
         where:
         platformType << PlatformType.values()
-    }
-
-    @Ignore
-    // Having only Unroll tests breaks something in the combination with GradleMetadataResolveRunner
-    void "dummy"() {
-        expect:
-        true
     }
 }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.nativeplatform
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChainIntegrationSpec {
@@ -55,14 +54,6 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         '''.stripIndent()
 
         helloWorldApp.writeSources(file("src/main"), file("src/hello"), file("src/greetings"))
-    }
-
-    @Ignore
-    def "spock workaround - remove when upgrading to Spock2"() {
-        when:
-        true
-        then:
-        true
     }
 
     @Unroll


### PR DESCRIPTION
With Spock1 we had issues with test classes with only unrolled tests being skipped. A workaround was to add a dummy ignored test to such classes. This workaround is no longer needed with Spock2.