### PR TITLE
Fix skipping of unrolled test iterations that are unsupported with config cache

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.ClassInspector
 import org.gradle.test.fixtures.ResettableExpectations
 import org.junit.AssumptionViolatedException
-import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
@@ -31,7 +31,7 @@ import java.util.function.Predicate
 
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.DO_NOT_SKIP
 
-class ToBeFixedForConfigurationCacheExtension extends AbstractAnnotationDrivenExtension<ToBeFixedForConfigurationCache> {
+class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtension<ToBeFixedForConfigurationCache> {
 
     @Override
     void visitFeatureAnnotation(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
@@ -17,8 +17,7 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.junit.AssumptionViolatedException
-import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
@@ -28,7 +27,7 @@ import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExten
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.iterationMatches
 
-class UnsupportedWithConfigurationCacheExtension extends AbstractAnnotationDrivenExtension<UnsupportedWithConfigurationCache> {
+class UnsupportedWithConfigurationCacheExtension implements IAnnotationDrivenExtension<UnsupportedWithConfigurationCache> {
 
     @Override
     void visitSpecAnnotation(UnsupportedWithConfigurationCache annotation, SpecInfo spec) {
@@ -37,7 +36,7 @@ class UnsupportedWithConfigurationCacheExtension extends AbstractAnnotationDrive
                 spec.skipped = true
             } else {
                 spec.features.each { feature ->
-                    feature.iterationInterceptors.add(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                    feature.addIterationInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
                 }
             }
         }
@@ -49,7 +48,7 @@ class UnsupportedWithConfigurationCacheExtension extends AbstractAnnotationDrive
             if (isAllIterations(annotation.iterationMatchers()) && isEnabledBottomSpec(annotation.bottomSpecs(), { feature.parent.bottomSpec.name == it })) {
                 feature.skipped = true
             } else {
-                feature.iterationInterceptors.add(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                feature.addIterationInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
             }
         }
     }
@@ -64,11 +63,10 @@ class UnsupportedWithConfigurationCacheExtension extends AbstractAnnotationDrive
 
         @Override
         void intercept(IMethodInvocation invocation) throws Throwable {
-            if (!iterationMatches(iterationMatchers, invocation.iteration.name)) {
-                invocation.proceed()
-            } else {
-                throw new AssumptionViolatedException("Unsupported with configuration cache")
+            if (iterationMatches(iterationMatchers, invocation.iteration.name)) {
+                return // skip - unsupported with configuration cache
             }
+            invocation.proceed()
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.opentest4j.TestAbortedException
 import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
@@ -36,7 +37,7 @@ class UnsupportedWithConfigurationCacheExtension implements IAnnotationDrivenExt
                 spec.skipped = true
             } else {
                 spec.features.each { feature ->
-                    feature.addIterationInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                    feature.getFeatureMethod().addInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
                 }
             }
         }
@@ -48,7 +49,7 @@ class UnsupportedWithConfigurationCacheExtension implements IAnnotationDrivenExt
             if (isAllIterations(annotation.iterationMatchers()) && isEnabledBottomSpec(annotation.bottomSpecs(), { feature.parent.bottomSpec.name == it })) {
                 feature.skipped = true
             } else {
-                feature.addIterationInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                feature.getFeatureMethod().addInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
             }
         }
     }
@@ -64,7 +65,7 @@ class UnsupportedWithConfigurationCacheExtension implements IAnnotationDrivenExt
         @Override
         void intercept(IMethodInvocation invocation) throws Throwable {
             if (iterationMatches(iterationMatchers, invocation.iteration.name)) {
-                return // skip - unsupported with configuration cache
+                throw new TestAbortedException("Unsupported with configuration cache")
             }
             invocation.proceed()
         }


### PR DESCRIPTION
~With Spock2, throwing from an iteration interceptor aborts all the subsequent iterations.
As a quick fix - skip the iterations without throwing. A side effect of that is that those skipped iterations will be shown as passed tests in the test reports.~
Everything is fine if the interceptor is attached to the feature method instead of the iteration.