### PR TITLE
Do not handle providers special on a PropertyValue level

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.provider.HasConfigurableValueInternal;
 import org.gradle.api.internal.provider.PropertyInternal;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.provider.HasConfigurableValue;
-import org.gradle.api.provider.Provider;
 import org.gradle.internal.state.ModelObject;
 
 import javax.annotation.Nullable;
@@ -68,12 +67,6 @@ public class StaticValue implements PropertyValue {
     @Nullable
     @Override
     public Object call() {
-        // Replace absent Provider with null.
-        // This is required for allowing optional provider properties - all code which unpacks providers calls Provider.get() and would fail if an optional provider is passed.
-        // Returning null from a Callable is ignored, and PropertyValue is a callable.
-        if (value instanceof Provider && !((Provider<?>) value).isPresent()) {
-            return null;
-        }
         return value;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.internal.tasks.TaskValidationContext;
+import org.gradle.api.provider.Provider;
 import org.gradle.util.DeferredUtil;
 
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.ERROR;
@@ -36,7 +37,11 @@ public abstract class AbstractValidatingProperty implements ValidatingProperty {
 
     @Override
     public void validate(TaskValidationContext context) {
-        Object unpacked = DeferredUtil.unpack(value.call());
+        Object rawValue = value.call();
+        if (Provider.class.isInstance(rawValue)) {
+            rawValue = ((Provider) rawValue).getOrNull();
+        }
+        Object unpacked = DeferredUtil.unpack(rawValue);
         if (unpacked == null) {
             if (!optional) {
                 context.visitPropertyProblem(ERROR, String.format("No value has been specified for property '%s'", propertyName));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.internal.tasks.TaskValidationContext;
-import org.gradle.api.provider.Provider;
 import org.gradle.util.DeferredUtil;
 
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.ERROR;
@@ -37,11 +36,7 @@ public abstract class AbstractValidatingProperty implements ValidatingProperty {
 
     @Override
     public void validate(TaskValidationContext context) {
-        Object rawValue = value.call();
-        if (Provider.class.isInstance(rawValue)) {
-            rawValue = ((Provider) rawValue).getOrNull();
-        }
-        Object unpacked = DeferredUtil.unpack(rawValue);
+        Object unpacked = DeferredUtil.unpack(value.call());
         if (unpacked == null) {
             if (!optional) {
                 context.visitPropertyProblem(ERROR, String.format("No value has been specified for property '%s'", propertyName));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
@@ -75,7 +75,7 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
     private static Object unpackProvider(@Nullable Object value) {
         // Only unpack one level of Providers, since Provider<Provider<>> is not supported - we don't need two levels of laziness.
         if (value instanceof Provider) {
-            return ((Provider<?>) value).get();
+            return ((Provider<?>) value).getOrNull();
         }
         return value;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -130,14 +130,7 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
         @Nullable
         @Override
         public Object call() {
-            Object value = valueSupplier.get();
-            // Replace absent Provider with null.
-            // This is required for allowing optional provider properties - all code which unpacks providers calls Provider.get() and would fail if an optional provider is passed.
-            // Returning null from a Callable is ignored, and PropertyValue is a callable.
-            if (value instanceof Provider && !((Provider<?>) value).isPresent()) {
-                return null;
-            }
-            return value;
+            return valueSupplier.get();
         }
 
         @Nullable

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -195,9 +195,9 @@ The following types/formats are supported:
         def baseDir = tmpDir.testDirectory.file("base")
         def file = tmpDir.testDirectory.file("test")
         def provider1 = Stub(Provider)
-        provider1.get() >> file
+        provider1.getOrNull() >> file
         def provider2 = Stub(Provider)
-        provider2.get() >> "value"
+        provider2.getOrNull() >> "value"
 
         expect:
         normalize(provider1, baseDir) == file

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
@@ -785,6 +785,6 @@ class SomeTask extends DefaultTask {
         then:
         failure.assertHasDescription("A problem was found with the configuration of task ':consumer' (type 'ConsumerTask').")
         failure.assertHasCause("No value has been specified for property 'bean.inputFile'.")
-        failure.assertTasksExecuted(':consumer')
+        failure.assertTasksExecuted(':producer', ':consumer')
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -329,7 +329,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
 
         @Override
         public FileTree getAsFileTree() {
-            return fileCollectionFactory.resolving(this).getAsFileTree();
+            return fileCollectionFactory.fileTree().from(this);
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
@@ -21,6 +21,8 @@ import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.file.CompositeFileTree;
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.internal.provider.ValueSupplier;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -156,6 +158,12 @@ public class DefaultConfigurableFileTree extends CompositeFileTree implements Co
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         context.add(buildDependency);
+        if (dir instanceof ProviderInternal<?>) {
+            ValueSupplier.ValueProducer producer = ((ProviderInternal<?>) dir).getProducer();
+            if (producer.isKnown()) {
+                producer.visitProducerTasks(context);
+            }
+        }
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -56,10 +56,7 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
     @Override
     protected void visitChildren(Consumer<FileCollectionInternal> visitor) {
         UnpackingVisitor unpackingVisitor = new UnpackingVisitor(visitor, resolver, patternSetFactory);
-        Object providerValue = provider.getOrNull();
-        if (providerValue != null) {
-            unpackingVisitor.add(providerValue);
-        }
+        unpackingVisitor.add(provider.getOrNull());
     }
 
     public ProviderInternal<?> getProvider() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -56,7 +56,10 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
     @Override
     protected void visitChildren(Consumer<FileCollectionInternal> visitor) {
         UnpackingVisitor unpackingVisitor = new UnpackingVisitor(visitor, resolver, patternSetFactory);
-        unpackingVisitor.add(provider.get());
+        Object providerValue = provider.getOrNull();
+        if (providerValue != null) {
+            unpackingVisitor.add(providerValue);
+        }
     }
 
     public ProviderInternal<?> getProvider() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -261,7 +261,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.getFiles()
 
         then:
-        1 * provider.get() >> { throw exception }
+        1 * provider.getOrNull() >> { throw exception }
         def thrown = thrown(IllegalStateException)
         exception == thrown
     }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -234,8 +234,8 @@ class DefaultFilePropertyFactoryTest extends Specification {
         tree.files
 
         then:
-        // Is that OK?
-        noExceptionThrown()
+        def e5 = thrown(IllegalArgumentException)
+        e5.message == 'Cannot convert path to File. path=\'property(org.gradle.api.file.Directory, undefined)\''
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -234,8 +234,8 @@ class DefaultFilePropertyFactoryTest extends Specification {
         tree.files
 
         then:
-        def e5 = thrown(IllegalStateException)
-        e5.message == 'Cannot query the value of this property because it has no value available.'
+        // Is that OK?
+        noExceptionThrown()
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ProviderBackedFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/ProviderBackedFileCollectionTest.groovy
@@ -60,7 +60,7 @@ class ProviderBackedFileCollectionTest extends Specification {
 
         then:
         1 * provider.producer >> ValueSupplier.ValueProducer.unknown()
-        1 * provider.get() >> 'ignore'
+        1 * provider.getOrNull() >> 'ignore'
         result.empty
     }
 
@@ -79,7 +79,7 @@ class ProviderBackedFileCollectionTest extends Specification {
 
         then:
         1 * provider.producer >> ValueSupplier.ValueProducer.unknown()
-        1 * provider.get() >> value
+        1 * provider.getOrNull() >> value
         1 * value.buildDependencies >> Stub(TaskDependency) {
             _ * getDependencies(_) >> ([task] as Set)
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
@@ -189,5 +189,15 @@ public class CredentialsProviderFactory implements TaskExecutionGraphListener {
                 throw e;
             }
         }
+
+        @Override
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+            try {
+                return super.calculateOwnValue(consumer);
+            } catch (MissingValueException e) {
+                missingProviderErrors.add(e.getMessage());
+                throw e;
+            }
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
@@ -37,7 +37,7 @@ public class DeferredUtil {
         }
         Object value = unpackNestableDeferred(deferred);
         if (value instanceof Provider) {
-            return ((Provider<?>) value).get();
+            return ((Provider<?>) value).getOrNull();
         }
         if (value instanceof Factory) {
             return ((Factory<?>) value).create();


### PR DESCRIPTION
Calling `Provider.isPresent()` at task graph building time caused the resolution of some dependencies. We don't actually need to call `isPresent()` to determine the dependencies.

The PR slightly changes behaviour when a Provider is in a FileCollection: If the Provider is not present, then it is silently ignored, similarly to `Callable`s returning `null`.