### PR TITLE
Compute precompiled script accessors via nested build

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -59,7 +59,7 @@ tasks.validatePlugins {
 
 val isCiServer = "CI" in System.getenv()
 
-if (isCiServer) {
+if (isCiServer && project.name != "gradle-kotlin-dsl-accessors") {
     gradle.buildFinished {
         failedTasks().forEach { prepareReportForCIPublishing(it.reports["html"].destination) }
     }

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
@@ -43,7 +43,7 @@ val testFilesCleanup = extensions.create<TestFileCleanUpExtension>("testFilesCle
     reportOnly.convention(false)
 }
 
-if (BuildEnvironment.isCiServer) {
+if (BuildEnvironment.isCiServer && project.name != "gradle-kotlin-dsl-accessors") {
     gradle.buildFinished {
         val failedTasks = failedTasks()
         val executedTasks = executedTasks()

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
@@ -34,7 +34,8 @@ configureIde(TestType.CROSSVERSION)
 configureTestFixturesForCrossVersionTests()
 
 fun configureTestFixturesForCrossVersionTests() {
-    if (name != "test") {
+    // do not attempt to find projects when the plugin is applied just to generate accessors
+    if (project.name != "gradle-kotlin-dsl-accessors" && project.name != "test" /* remove once wrapper is updated */) {
         dependencies {
             "crossVersionTestImplementation"(testFixtures(project(":tooling-api")))
         }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
@@ -53,19 +53,19 @@ val testFixturesApiElements by configurations
 // Required due to: https://github.com/gradle/gradle/issues/13278
 testFixturesRuntimeElements.extendsFrom(testFixturesRuntimeOnly)
 
-dependencies {
-    if (project.name != "test") { // do not attempt to find projects during script compilation
+if (project.name != "test") { // do not attempt to find projects during script compilation
+    dependencies {
         testFixturesApi(project(":internal-testing"))
         // platform
         testFixturesImplementation(platform(project(":distributions-dependencies")))
-    }
 
-    // add a set of default dependencies for fixture implementation
-    testFixturesImplementation(libs.junit)
-    testFixturesImplementation(libs.groovy)
-    testFixturesImplementation(libs.spock)
-    testFixturesRuntimeOnly(libs.bytebuddy)
-    testFixturesRuntimeOnly(libs.cglib)
+        // add a set of default dependencies for fixture implementation
+        testFixturesImplementation(libs.junit)
+        testFixturesImplementation(libs.groovy)
+        testFixturesImplementation(libs.spock)
+        testFixturesRuntimeOnly(libs.bytebuddy)
+        testFixturesRuntimeOnly(libs.cglib)
+    }
 }
 
 // Add an outgoing variant allowing to select the exploded resources directory

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
@@ -53,7 +53,8 @@ val testFixturesApiElements by configurations
 // Required due to: https://github.com/gradle/gradle/issues/13278
 testFixturesRuntimeElements.extendsFrom(testFixturesRuntimeOnly)
 
-if (project.name != "test") { // do not attempt to find projects during script compilation
+// do not attempt to find projects when the plugin is applied just to generate accessors
+if (project.name != "gradle-kotlin-dsl-accessors" && project.name != "test" /* remove once wrapper is updated */) {
     dependencies {
         testFixturesApi(project(":internal-testing"))
         // platform

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -77,9 +77,10 @@ fun Project.addDependenciesAndConfigurations(prefix: String) {
         resolver("${prefix}TestSrcDistributionPath", "gradle-src-distribution-zip", srcDistribution)
     }
 
-    dependencies {
-        "${prefix}TestRuntimeOnly"(project.the<ExternalModulesExtension>().junit5Vintage)
-        if (name != "test") { // do not attempt to find projects during script compilation
+    // do not attempt to find projects when the plugin is applied just to generate accessors
+    if (project.name != "gradle-kotlin-dsl-accessors" && project.name != "test" /* remove once wrapper is updated */) {
+        dependencies {
+            "${prefix}TestRuntimeOnly"(project.the<ExternalModulesExtension>().junit5Vintage)
             "${prefix}TestImplementation"(project(":internal-integ-testing"))
             "${prefix}TestFullDistributionRuntimeClasspath"(project(":distributions-full"))
         }

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -51,7 +51,7 @@ tasks.registerEarlyFeedbackRootLifecycleTasks()
  * Print all stacktraces of running JVMs on the machine upon timeout. Helps us diagnose deadlock issues.
  */
 fun setupTimeoutMonitorOnCI() {
-    if (BuildEnvironment.isCiServer) {
+    if (BuildEnvironment.isCiServer && project.name != "gradle-kotlin-dsl-accessors") {
         val timer = Timer(true).apply {
             schedule(
                 timerTask {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210120054716+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-branch-bamboo_fix_GeneratePrecompiledScriptPluginAccessors_leaks_i-20210123130107+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-branch-bamboo_fix_GeneratePrecompiledScriptPluginAccessors_leaks_i-20210123130107+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-branch-bamboo_fix_GeneratePrecompiledScriptPluginAccessors_leaks_i-20210125002805+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
+++ b/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.operations
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.Matchers
 import spock.lang.Issue
 
@@ -76,7 +75,6 @@ class BuildOperationExecutorIntegrationTest extends AbstractIntegrationSpec {
     // We need to make sure that the build operation ids of nested builds started by a GradleBuild task do not overlap.
     // Since we currently have no specific scope for "one build and the builds it started via GradleBuild tasks", we use the global scope.
     @Issue("https://github.com/gradle/gradle/issues/2622")
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def "build operations have unique ids within the global scope"() {
         when:
         settingsFile << ""

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
@@ -15,24 +15,24 @@
  */
 package org.gradle.internal.service;
 
-import org.gradle.internal.Cast;
-
 import java.lang.reflect.Method;
+
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 /**
  * A service method factory that will try to use method handles if available, otherwise fallback on reflection.
  */
 class DefaultServiceMethodFactory implements ServiceMethodFactory {
-    private final ServiceMethodFactory delegate;
+    private final ServiceMethodFactory delegate = getOptimalServiceMethodFactory();
 
-    DefaultServiceMethodFactory() {
-        ServiceMethodFactory factory;
+    private ServiceMethodFactory getOptimalServiceMethodFactory() {
         try {
-            factory = Cast.uncheckedNonnullCast(Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").getConstructor().newInstance());
+            return uncheckedNonnullCast(
+                Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").getConstructor().newInstance()
+            );
         } catch (Exception e) {
-            factory = new ReflectionBasedServiceMethodFactory();
+            return new ReflectionBasedServiceMethodFactory();
         }
-        delegate = factory;
     }
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -36,8 +36,6 @@ import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -59,7 +57,6 @@ import static java.util.Collections.emptyList;
  *
  * <p>You can obtain an instance of a {@code StartParameter} by either creating a new one, or duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
  */
-@ServiceScope(Scopes.BuildSession.class)
 public class StartParameter implements LoggingConfiguration, ParallelismConfiguration, Serializable {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = BuildLayoutParameters.GRADLE_USER_HOME_PROPERTY_KEY;
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
@@ -86,34 +86,6 @@ class GradleBuildTaskIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Included build $testDirectory has build path :bp which is the same as included build $testDirectory")
     }
 
-    @Unroll
-    def "shows deprecation warning when accessing #displayName when configuring GradleBuild task"() {
-        given:
-        settingsFile << "rootProject.name = 'parent'"
-        buildFile << """
-            task buildInBuild(type:GradleBuild) {
-                buildFile = 'other.gradle'
-            }
-
-            ${codeUnderTest}
-        """
-        file('other.gradle') << 'assert true'
-
-        when:
-        executer.expectDeprecationWarning()
-        run 'buildInBuild'
-
-        then:
-        outputContains("${displayName} method has been deprecated. This is scheduled to be removed in Gradle 7.0.")
-
-        where:
-        displayName                                | codeUnderTest
-        "StartParameter.setSearchUpwards(boolean)" | "buildInBuild.startParameter.searchUpwards = true"
-        "StartParameter.isSearchUpwards()"         | "buildInBuild.startParameter.searchUpwards"
-        "StartParameter.useEmptySettings()"        | "buildInBuild.startParameter.useEmptySettings()"
-        "StartParameter.isUseEmptySettings()"      | "buildInBuild.startParameter.useEmptySettings"
-    }
-
     def "nested build can use Gradle home directory that is different to outer build"() {
         given:
         def dir = file("other-home")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -829,7 +829,6 @@ task b(dependsOn: a)
         result.assertTasksSkipped(":a", ":b")
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def "can share artifacts between builds"() {
         writeTransformerTask()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -719,7 +719,6 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         verifyExpectedNumberOfExecuteListenerChildren(projectsLoaded, 0)
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def 'application ids are unique across gradleBuild builds'() {
         given:
         initFile << ""

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/DisallowBuildSrcAsNameIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/DisallowBuildSrcAsNameIntegTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.initialization.buildsrc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class DisallowBuildSrcAsNameIntegTest extends AbstractIntegrationSpec {
 
@@ -87,7 +86,6 @@ class DisallowBuildSrcAsNameIntegTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Included build $b has build name 'buildSrc' which cannot be used as it is a reserved name.")
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "fails when trying to create a buildSrc build with GradleBuild task"() {
         def b = file("b")
         b.file("build.gradle") << ""

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -260,7 +260,6 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         assertNestedTaskOutputTracked()
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def "captures output from GradleBuild task builds"() {
         given:
         configureNestedBuild()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -32,7 +32,6 @@ import org.gradle.initialization.NotifyProjectsEvaluatedBuildOperationType
 import org.gradle.initialization.NotifyProjectsLoadedBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
 
@@ -224,7 +223,6 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.op(RunRootBuildWorkBuildOperationType.Details).parentId == notifications.op(RunBuildBuildOperationType.Details).id
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def "emits for GradleBuild tasks"() {
         when:
         def initScript = file("init.gradle") << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ScopeIdsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ScopeIdsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.scopeids
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.ScopeIdsFixture
 import org.gradle.util.TextUtil
 import org.junit.Rule
@@ -69,7 +68,6 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
         scopeIds.lastBuildPaths() == [":", ":a", ":a:buildSrc", ":b", ":b:buildSrc"]
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "gradle-build builds with different root does not inherit workspace id"() {
         given:
         // GradleBuild launched builds with a different root dir
@@ -91,7 +89,6 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
         ids[":"].workspace != ids[":other"].workspace
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "gradle-build builds with different gradle user home does not inherit user id"() {
         given:
         scopeIds.disableConsistentUserIdCheck = true
@@ -113,7 +110,6 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
         ids[":"].user != ids[buildPaths[1]].user
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "gradle-build with same root and user dir inherits all"() {
         when:
         settingsFile << "rootProject.name = 'root'"

--- a/subprojects/core/src/main/java/org/gradle/internal/build/NestedRootBuildRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/NestedRootBuildRunner.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.StartParameter;
+import org.gradle.api.Transformer;
+import org.gradle.api.internal.BuildDefinition;
+import org.gradle.internal.invocation.BuildController;
+import org.gradle.internal.service.ServiceRegistry;
+
+import javax.annotation.Nullable;
+
+public class NestedRootBuildRunner {
+
+    public static StartParameter createStartParameterForNewBuild(ServiceRegistry services) {
+        return services.get(StartParameter.class).newBuild();
+    }
+
+    public static void runNestedRootBuild(String buildName, StartParameter startParameter, ServiceRegistry services) {
+        createNestedRootBuild(buildName, startParameter, services).run((Transformer<Void, BuildController>) buildController -> {
+            buildController.run();
+            return null;
+        });
+    }
+
+    public static NestedRootBuild createNestedRootBuild(@Nullable String buildName, StartParameter startParameter, ServiceRegistry services) {
+        PublicBuildPath fromBuild = services.get(PublicBuildPath.class);
+        BuildDefinition buildDefinition = BuildDefinition.fromStartParameter(startParameter, fromBuild);
+
+        BuildState currentBuild = services.get(BuildState.class);
+
+        NestedRootBuild nestedBuild;
+
+        // buildStateRegistry is not threadsafe, but this is the only concurrent use currently
+        BuildStateRegistry buildStateRegistry = services.get(BuildStateRegistry.class);
+        synchronized (buildStateRegistry) {
+            nestedBuild = buildStateRegistry.addNestedBuildTree(buildDefinition, currentBuild, buildName);
+        }
+        return nestedBuild;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -76,11 +76,17 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     @Override
     public ClassPath transform(ClassPath classPath, StandardTransform transform) {
+        if (classPath.isEmpty()) {
+            return classPath;
+        }
         return transformFiles(classPath, fileTransformerFor(transform));
     }
 
     @Override
     public ClassPath transform(ClassPath classPath, StandardTransform transform, Transform additional) {
+        if (classPath.isEmpty()) {
+            return classPath;
+        }
         return transformFiles(classPath, new InstrumentingClasspathFileTransformer(classpathWalker, classpathBuilder, new CompositeTransformer(additional, transformerFor(transform))));
     }
 
@@ -105,9 +111,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     }
 
     private ClassPath transformFiles(ClassPath classPath, ClasspathFileTransformer transformer) {
-        if (classPath.isEmpty()) {
-            return classPath;
-        }
+        assert !classPath.isEmpty();
         return cache.useCache(() -> {
             List<File> originalFiles = classPath.getAsFiles();
             List<CacheOperation> operations = new ArrayList<>(originalFiles.size());

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -68,11 +68,9 @@ public class GradleBuildController implements BuildController {
                 @Override
                 public T create() {
                     GradleLauncher launcher = getLauncher();
-                    try {
-                        return build.transform(launcher);
-                    } finally {
-                        launcher.finishBuild();
-                    }
+                    T result = build.transform(launcher);
+                    launcher.finishBuild();
+                    return result;
                 }
             });
         } finally {

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.invocation;
 
-import org.gradle.api.Action;
+import org.gradle.api.Transformer;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.internal.Factory;
@@ -61,17 +61,18 @@ public class GradleBuildController implements BuildController {
         return doBuild(GradleLauncher::getConfiguredBuild);
     }
 
-    private GradleInternal doBuild(final Action<? super GradleLauncher> build) {
+    public <T> T doBuild(final Transformer<T, ? super GradleLauncher> build) {
         try {
             // TODO:pm Move this to RunAsBuildOperationBuildActionRunner when BuildOperationWorkerRegistry scope is changed
-            return workerLeaseService.withLocks(Collections.singleton(workerLeaseService.getWorkerLease()), new Factory<GradleInternal>() {
+            return workerLeaseService.withLocks(Collections.singleton(workerLeaseService.getWorkerLease()), new Factory<T>() {
                 @Override
-                public GradleInternal create() {
-                    GradleInternal gradle = getGradle();
+                public T create() {
                     GradleLauncher launcher = getLauncher();
-                    build.execute(launcher);
-                    launcher.finishBuild();
-                    return gradle;
+                    try {
+                        return build.transform(launcher);
+                    } finally {
+                        launcher.finishBuild();
+                    }
                 }
             });
         } finally {

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -49,7 +49,6 @@ import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.classpath.ClassPath;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -63,7 +62,6 @@ import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.session.BuildSessionState;
 import org.gradle.internal.session.CrossBuildSessionState;
 import org.gradle.internal.time.Time;
-import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.invocation.DefaultGradle;
@@ -72,9 +70,6 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
-
-import static org.gradle.internal.concurrent.CompositeStoppable.NO_OP_STOPPABLE;
-import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
 
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
@@ -99,10 +94,6 @@ public class ProjectBuilderImpl {
     }
 
     public Project createProject(String name, @Nullable File inputProjectDir, File gradleUserHomeDir) {
-        return createProject(name, inputProjectDir, gradleUserHomeDir, false);
-    }
-
-    public ProjectInternal createProject(String name, File inputProjectDir, File gradleUserHomeDir, boolean isolate) {
 
         final File projectDir = prepareProjectDir(inputProjectDir);
         final File homeDir = new File(projectDir, "gradleHome");
@@ -111,7 +102,7 @@ public class ProjectBuilderImpl {
         startParameter.setGradleUserHomeDir(userHomeDir);
         NativeServices.initialize(userHomeDir);
 
-        final ServiceRegistry globalServices = isolate ? createGlobalServices() : getGlobalServices();
+        final ServiceRegistry globalServices = getGlobalServices();
 
         BuildRequestMetaData buildRequestMetaData = new DefaultBuildRequestMetaData(Time.currentTimeMillis());
         CrossBuildSessionState crossBuildSessionState = new CrossBuildSessionState(globalServices, startParameter);
@@ -147,25 +138,7 @@ public class ProjectBuilderImpl {
         WorkerLeaseRegistry.WorkerLease workerLease = workerLeaseService.getWorkerLease();
         coordinationService.withStateLock(DefaultResourceLockCoordinationService.lock(workerLease, project.getMutationState().getAccessLock()));
 
-        project.getExtensions().getExtraProperties().set(
-            "ProjectBuilder.stoppable",
-            stoppable(
-                (Stoppable) workerLeaseService::releaseCurrentProjectLocks,
-                (Stoppable) ((DefaultWorkerLeaseService) workerLeaseService)::releaseCurrentResourceLocks,
-                buildServices,
-                buildTreeState,
-                buildSessionState,
-                crossBuildSessionState,
-                isolate ? userHomeServices : NO_OP_STOPPABLE,
-                isolate ? globalServices : NO_OP_STOPPABLE
-            )
-        );
         return project;
-    }
-
-    public static void stop(Project rootProject) {
-        ((Stoppable) rootProject.getExtensions().getExtraProperties().get("ProjectBuilder.stoppable"))
-            .stop();
     }
 
     private GradleUserHomeScopeServiceRegistry userHomeServicesOf(ServiceRegistry globalServices) {

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.watch
 import com.google.common.collect.ImmutableSet
 import org.apache.commons.io.FileUtils
 import org.gradle.cache.GlobalCacheLocations
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.service.scopes.VirtualFileSystemServices
@@ -119,7 +118,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         executedAndNotSkipped(":includedBuild:jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task is not yet supported")
     def "works with GradleBuild task"() {
         buildTestFixture.withBuildInSubDir()
         def buildInBuild = singleProjectBuild("buildInBuild") {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaNestedBuildIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaNestedBuildIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.plugins.ide.idea
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class IdeaNestedBuildIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForConfigurationCache
     def "can use GradleBuild task to run a build that applies the IDEA plugin"() {
         buildFile << """
             task go(type: GradleBuild) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildAggregationIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildAggregationIntegrationTest.groovy
@@ -16,14 +16,12 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.hamcrest.CoreMatchers
 import spock.lang.Issue
 
 class BuildAggregationIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def canExecuteAnotherBuildFromBuild() {
         when:
         buildFile << '''
@@ -70,7 +68,6 @@ class BuildAggregationIntegrationTest extends AbstractIntegrationSpec {
         succeeds "build"
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def reportsNestedBuildFailure() {
         when:
         file('other/settings.gradle') << "rootProject.name = 'other'"
@@ -106,7 +103,6 @@ class BuildAggregationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://issues.gradle.org//browse/GRADLE-3052")
-    @ToBeFixedForConfigurationCache(because = "GradleBuild task")
     def buildTaskCanHaveInputsAndOutputs() {
         file("input") << "foo"
         settingsFile << "rootProject.name = 'proj'"

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -304,7 +304,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
                     scriptPlugins.map { hashedSchema to it }
                 } catch (error: Throwable) {
                     reportProjectSchemaError(scriptPlugins, error)
-                    emptyList<Pair<HashedProjectSchema, PrecompiledScriptPlugin>>()
+                    emptyList()
                 }
             }.groupBy(
                 { (schema, _) -> schema },

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -405,10 +405,8 @@ class SyntheticProjectSchemaBuilder(
         rootProjectClassPath: Collection<File>
     ): Project {
 
-        val project = ProjectBuilder.builder()
-            .withGradleUserHomeDir(gradleUserHomeDir)
-            .withProjectDir(projectDir)
-            .build()
+        val project = ProjectBuilderImpl()
+            .createProject("root", projectDir, gradleUserHomeDir, true)
             .withEmptyGradleProperties()
 
         addScriptClassPathDependencyTo(project, rootProjectClassPath)

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -328,7 +328,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
                     val rootProjectScope = baseScope.createChild("accessors-root-project")
                     val rootProject = gradle.serviceOf<IProjectFactory>().createProject(
                         gradle,
-                        settings.rootProject.apply { name = "test" },
+                        settings.rootProject.apply { name = "gradle-kotlin-dsl-accessors" },
                         null,
                         rootProjectScope,
                         baseScope

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.launcher.continuous
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class GradleBuildContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def setup() {
@@ -46,7 +45,6 @@ class GradleBuildContinuousIntegrationTest extends AbstractContinuousIntegration
         """
     }
 
-    @ToBeFixedForConfigurationCache
     def "will rebuild on input change for GradleBuild task"() {
         def outputFile = file("gradle-build/build/output.txt")
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGradleBuildGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGradleBuildGroupedTaskFunctionalTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 
 abstract class AbstractConsoleGradleBuildGroupedTaskFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest {
@@ -26,7 +25,6 @@ abstract class AbstractConsoleGradleBuildGroupedTaskFunctionalTest extends Abstr
     private static final String BYE_WORLD_MESSAGE = 'Bye world'
     private static final String AGGREGATE_TASK_NAME = 'all'
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "can group task output from external build invoked executed by GradleBuild in same directory"() {
         given:
         def externalBuildScriptPath = 'other.gradle'
@@ -42,7 +40,6 @@ abstract class AbstractConsoleGradleBuildGroupedTaskFunctionalTest extends Abstr
         result.groupedOutput.task(':byeWorld').output == BYE_WORLD_MESSAGE
     }
 
-    @ToBeFixedForConfigurationCache(because = "GradleBuild")
     def "can group task output from external build invoked executed by GradleBuild in different directory"() {
         given:
         def externalBuildScriptPath = 'external/other.gradle'

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -152,15 +152,18 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     }
 
     private void defineScriptHandlerClassScope(ScriptHandlerInternal scriptHandler, ClassLoaderScope classLoaderScope, Iterable<PluginImplementation<?>> pluginsFromOtherLoaders) {
-        ClassPath classPath = scriptHandler.getScriptClassPath();
-        ClassPath cachedClassPath = cachedClasspathTransformer.transform(classPath, BuildLogic);
-        classLoaderScope.export(cachedClassPath);
+        exportBuildLogicClassPathTo(classLoaderScope, scriptHandler.getScriptClassPath());
 
         for (PluginImplementation<?> pluginImplementation : pluginsFromOtherLoaders) {
             classLoaderScope.export(pluginImplementation.asClass().getClassLoader());
         }
 
         classLoaderScope.lock();
+    }
+
+    private void exportBuildLogicClassPathTo(ClassLoaderScope classLoaderScope, ClassPath classPath) {
+        ClassPath cachedClassPath = cachedClasspathTransformer.transform(classPath, BuildLogic);
+        classLoaderScope.export(cachedClassPath);
     }
 
     private PluginResolver wrapInAlreadyInClasspathResolver(ClassLoaderScope classLoaderScope) {


### PR DESCRIPTION
Instead of via `ProjectBuilder` which was causing a metaspace leak.