### PR TITLE
Fail on invalid available-at when generating Gradle Module Metadata

### DIFF
--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -119,10 +119,12 @@ Existing metadata must remain compatible and thus tools supporting the Gradle Mo
 
 This value, nested in `variants`, must contain an object with the following values:
 
-- `url`: The location of the metadata file that describes the variant. A string. In version 1.0, this must be a path relative to the module.
+- `url`: The location of the metadata file that describes the variant. A string. In version 1.0 and 1.1, this must be a path relative to the module.
 - `group`: The group of the module. A string
 - `module`: The name of the module. A string
 - `version`: The version of the module. A string
+
+Note that the `group:module` cannot be the same as the `group:module` of the root `component` element.
 
 ### `dependencies` value
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.internal.metadata;
 
 import com.google.common.collect.Sets;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -187,6 +188,9 @@ class ModuleMetadataSpecBuilder {
     }
 
     private ModuleMetadataSpec.AvailableAt availableAt(ModuleVersionIdentifier coordinates, ModuleVersionIdentifier targetCoordinates) {
+        if (coordinates.getModule().equals(targetCoordinates.getModule())) {
+            throw new InvalidUserCodeException("Cannot have a remote variant with coordinates '" + targetCoordinates.getModule() + "' that are the same as the module itself.");
+        }
         return new ModuleMetadataSpec.AvailableAt(
             relativeUrlTo(coordinates, targetCoordinates),
             targetCoordinates


### PR DESCRIPTION
When generating Gradle Module Metadata, it is invalid to have an
external variant that lives at the same coordinates as the source
module.

In addition: 
When resolving external variants, Gradle now detects cycle and prints
a warning instead of failing with a StackOverflowError.