### PR TITLE
DefaultArtifactCaches: Add info loggin for read-only dependency cache location

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
@@ -59,6 +59,7 @@ public class DefaultArtifactCaches implements ArtifactCachesProvider {
             if (baseDir != null) {
                 readOnlyCacheMetadata = new DefaultArtifactCacheMetadata(cacheScopeMapping, baseDir);
                 readOnlyArtifactCacheLockingManager = new ReadOnlyArtifactCacheLockingManager(cacheRepository, readOnlyCacheMetadata);
+                LOGGER.info("The read-only dependency cache is enabled \nThe {} environment variable was set to {}", READONLY_CACHE_ENV_VAR, baseDir);
             } else {
                 readOnlyCacheMetadata = null;
                 readOnlyArtifactCacheLockingManager = null;


### PR DESCRIPTION
### Context
This is to provide better logging when using [Shared dependency cache](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache)

Today, there's no visibility for a user to know if the shared dependency cache is being used. 

You can set `GRADLE_RO_DEP_CACHE` and if the repository is invalid you will get warnings if the folder does not exist or the layout does not conform with the expected one.

However, there's no way to tal from build output if `GRADLE_RO_DEP_CACHE` was configured properly and where is the folder that it's being used.

The only way I've found so far is to look at the logs and look for things like:

```
Found locally available resource with matching checksum: [https://some-repo/io/zipkin/reporter2/zipkin-reporter-brave/2.15.2/zipkin-reporter-brave-2.15.2.pom, /gradle/shared-dependency-cache/modules-2/files-2.1/io.zipkin.reporter2/zipkin-reporter-brave/2.15.2/77a270dd7c2f7e7729352bc472af731094a36584/zipkin-reporter-brave-2.15.2.pom]
```

This way we could tell if it was located or not.

It would be nice if this information could be surfaced on build scans but for now being able to know that read-only cache was configured and where is it would be really helpful


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
