### PR TITLE
Remove "Watching too many directories" from samples output

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -41,6 +41,7 @@ import org.gradle.samples.test.runner.SamplesOutputNormalizers;
     NativeComponentReportOutputNormalizer.class,
     DependencyInsightOutputNormalizer.class,
     ConfigurationCacheOutputNormalizer.class,
+    // Adding FileSystemWatchingOutputNormalizer is a workaround until we remove the directory for the sample after the test
     FileSystemWatchingOutputNormalizer.class
 })
 @SampleModifiers({

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier;
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.FileSystemWatchingOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.GradleWelcomeOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.NativeComponentReportOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.SampleOutputNormalizer;
@@ -39,7 +40,8 @@ import org.gradle.samples.test.runner.SamplesOutputNormalizers;
     ArtifactResolutionOmittingOutputNormalizer.class,
     NativeComponentReportOutputNormalizer.class,
     DependencyInsightOutputNormalizer.class,
-    ConfigurationCacheOutputNormalizer.class
+    ConfigurationCacheOutputNormalizer.class,
+    FileSystemWatchingOutputNormalizer.class
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket1SnippetsTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket1SnippetsTest.java
@@ -16,10 +16,8 @@
 
 package org.gradle.docs.samples;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
-@Ignore
 @RunWith(PartitioningSamplesRunner.SnippetsBucket1.class)
 public class Bucket1SnippetsTest extends BaseSamplesTest {
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket2SnippetsTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket2SnippetsTest.java
@@ -16,10 +16,8 @@
 
 package org.gradle.docs.samples;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
-@Ignore
 @RunWith(PartitioningSamplesRunner.SnippetsBucket2.class)
 public class Bucket2SnippetsTest extends BaseSamplesTest {
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket3SnippetsTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/Bucket3SnippetsTest.java
@@ -16,10 +16,8 @@
 
 package org.gradle.docs.samples;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
-@Ignore
 @RunWith(PartitioningSamplesRunner.SnippetsBucket3.class)
 public class Bucket3SnippetsTest extends BaseSamplesTest {
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/SamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/SamplesTest.java
@@ -16,10 +16,8 @@
 
 package org.gradle.docs.samples;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
-@Ignore
 @RunWith(PartitioningSamplesRunner.SamplesBucket.class)
 public class SamplesTest extends BaseSamplesTest {
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/FileSystemWatchingOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/FileSystemWatchingOutputNormalizer.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.samples.executor.ExecutionMetadata
+import org.gradle.samples.test.normalizer.OutputNormalizer
+
+class FileSystemWatchingOutputNormalizer implements OutputNormalizer {
+    @Override
+    String normalize(String commandOutput, ExecutionMetadata executionMetadata) {
+        List<String> lines = Arrays.asList(commandOutput.split('\\n', -1))
+
+        return lines.findAll {
+            !it.startsWith('Watching too many directories in the file system (watching')
+        }.join('\n')
+    }
+}


### PR DESCRIPTION
Fixes the problem we saw with the samples tests, now that file system watching has been enabled by default.