### PR TITLE
Migrate ReproducibleArchivesInterceptor to MultiTestInterceptor

### DIFF
--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -21,14 +21,12 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.hamcrest.CoreMatchers
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 @TestReproducibleArchives
-@Ignore
 class EarPluginIntegrationTest extends AbstractIntegrationSpec {
 
     def "setup"() {
@@ -536,7 +534,7 @@ ear {
     def "using nested descriptor file name is not allowed"() {
         buildScript '''
             apply plugin: 'ear'
-            
+
             ear {
                 deploymentDescriptor {
                     fileName = 'nested/blubb.xml'
@@ -544,7 +542,7 @@ ear {
 
                 }
             }
-            
+
         '''.stripIndent()
 
         when:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/archives/ReproducibleArchivesInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/archives/ReproducibleArchivesInterceptor.groovy
@@ -17,34 +17,44 @@
 package org.gradle.integtests.fixtures.archives
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.spockframework.lang.SpecInternals
-import org.spockframework.mock.runtime.MockController
-import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.gradle.integtests.fixtures.extensions.AbstractMultiTestInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
-import org.spockframework.runtime.model.IterationInfo
-import org.spockframework.runtime.model.NameProvider
 
-class ReproducibleArchivesInterceptor extends AbstractMethodInterceptor {
+class ReproducibleArchivesInterceptor extends AbstractMultiTestInterceptor {
 
-    boolean reproducibleArchives
-
-    @Override
-    void interceptFeatureExecution(IMethodInvocation invocation) throws Throwable {
-        reproducibleArchives = false
-        invocation.proceed()
-        ((MockController)((SpecInternals)invocation.getInstance()).getSpecificationContext().getMockController()).enterScope()
-        reproducibleArchives = true
-        invocation.proceed()
+    protected ReproducibleArchivesInterceptor(Class<?> target) {
+        super(target)
     }
 
     @Override
-    void interceptIterationExecution(IMethodInvocation invocation) throws Throwable {
-        // Allow tests to check at runtime if reproducible archives is switched on or not
-        invocation.instance.metaClass.reproducibleArchives = reproducibleArchives
-        if (reproducibleArchives) {
-            AbstractIntegrationSpec instance = invocation.instance as AbstractIntegrationSpec
-            def initScript = instance.testDirectory.file('reproducible-archives-init.gradle')
-            initScript.text = """
+    protected void createExecutions() {
+        add(new ReproducibleArchivesExecution(false))
+        add(new ReproducibleArchivesExecution(true))
+    }
+
+    private static class ReproducibleArchivesExecution extends AbstractMultiTestInterceptor.Execution {
+
+        private final boolean withReproducibleArchives
+
+        ReproducibleArchivesExecution(boolean withReproducibleArchives) {
+            this.withReproducibleArchives = withReproducibleArchives
+        }
+
+        @Override
+        String toString() {
+            return getDisplayName()
+        }
+
+        @Override
+        protected String getDisplayName() {
+            return withReproducibleArchives ? "with reproducible archives" : "without reproducible archives"
+        }
+
+        protected void before(IMethodInvocation invocation) {
+            if (withReproducibleArchives) {
+                AbstractIntegrationSpec instance = invocation.instance as AbstractIntegrationSpec
+                def initScript = instance.testDirectory.file('reproducible-archives-init.gradle')
+                initScript.text = """
                         rootProject { prj ->
                             allprojects {
                                 tasks.withType(AbstractArchiveTask) {
@@ -54,22 +64,10 @@ class ReproducibleArchivesInterceptor extends AbstractMethodInterceptor {
                             }
                         }
                     """.stripIndent()
-            instance.executer.beforeExecute {
-                usingInitScript(initScript)
+                instance.executer.beforeExecute {
+                    usingInitScript(initScript)
+                }
             }
         }
-
-        invocation.proceed()
-    }
-
-    NameProvider<IterationInfo> nameProvider(final NameProvider<IterationInfo> delegate) {
-        return new NameProvider<IterationInfo>() {
-            @Override
-            String getName(IterationInfo iterationInfo) {
-                return (delegate?.getName(iterationInfo) ?: iterationInfo.parent.name) +
-                    (reproducibleArchives ? ' [reproducible archives]' : '')
-            }
-        }
-
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/archives/ReproducibleArchivesTestExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/archives/ReproducibleArchivesTestExtension.groovy
@@ -17,39 +17,15 @@
 package org.gradle.integtests.fixtures.archives
 
 import groovy.transform.CompileStatic
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension
-import org.spockframework.runtime.model.FeatureInfo
-import org.spockframework.runtime.model.SpecInfo
+import org.gradle.integtests.fixtures.extensions.AbstractMultiTestInterceptor
+import org.gradle.integtests.fixtures.extensions.MultiTestExtension
 
 @CompileStatic
-class ReproducibleArchivesTestExtension implements IAnnotationDrivenExtension<TestReproducibleArchives> {
-    @Override
-    void visitSpecAnnotation(TestReproducibleArchives annotation, SpecInfo spec) {
-        spec.features.each { feature ->
-            runForReproducibleArchives(feature)
-        }
-    }
+class ReproducibleArchivesTestExtension extends MultiTestExtension<TestReproducibleArchives> {
 
     @Override
-    void visitFeatureAnnotation(TestReproducibleArchives annotation, FeatureInfo feature) {
-        runForReproducibleArchives(feature)
-    }
-
-    @Override
-    void visitSpec(SpecInfo spec) {
-        spec.features.each { FeatureInfo feature ->
-            feature.interceptors.find { it instanceof ReproducibleArchivesInterceptor }.each { ReproducibleArchivesInterceptor interceptor ->
-                // Add the name provider as late as possible to capture name providers from other extensions (e.g. @Unroll)
-                feature.iterationNameProvider = interceptor.nameProvider(feature.iterationNameProvider)
-            }
-        }
-    }
-
-    private static void runForReproducibleArchives(FeatureInfo feature) {
-        def interceptor = new ReproducibleArchivesInterceptor()
-        feature.reportIterations = true
-        feature.addInterceptor(interceptor)
-        feature.addIterationInterceptor(interceptor)
+    protected AbstractMultiTestInterceptor makeInterceptor(Class<?> testClass) {
+        return new ReproducibleArchivesInterceptor(testClass);
     }
 }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/CleanupTestDirectoryExtension.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/CleanupTestDirectoryExtension.groovy
@@ -18,14 +18,14 @@ package org.gradle.test.fixtures.file
 
 import org.spockframework.runtime.AbstractRunListener
 import org.spockframework.runtime.GroovyRuntimeUtil
-import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.ErrorInfo
 import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecInfo
 
-class CleanupTestDirectoryExtension extends AbstractAnnotationDrivenExtension<CleanupTestDirectory> {
+class CleanupTestDirectoryExtension implements IAnnotationDrivenExtension<CleanupTestDirectory> {
     @Override
     void visitSpecAnnotation(CleanupTestDirectory annotation, SpecInfo spec) {
         spec.features.each { FeatureInfo feature ->


### PR DESCRIPTION
So that it uses the same underlying infrastructure for rerunning a test with a different setup as the rest of multi-version tests.

This also fixes the unrolled methods that use reproducible archives variant which got broken with Spock 2 upgrade.
