### PR TITLE
Ignore buildSrc directory that does not contain valid Gradle build

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -247,7 +247,7 @@ initscript {
         executer.requireOwnGradleUserHomeDir()
 
         and:
-        file("buildSrc").mkdir()
+        file("buildSrc/settings.gradle").createFile()
 
         and:
         executer.gradleUserHomeDir.file('init.d/a.gradle') << '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -59,7 +59,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
     def "does not treat buildSrc as undefined build"() {
         given:
         settingsFile.touch()
-        file("buildSrc").mkdir()
+        file("buildSrc/src/main/groovy/Dummy.groovy") << "class Dummy {}"
 
         expect:
         succeeds("help") // without deprecation warning

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ProjectBuildFileIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ProjectBuildFileIntegrationTest.groovy
@@ -42,7 +42,7 @@ class ProjectBuildFileIntegrationTest extends AbstractIntegrationSpec {
     def "buildSrc project.buildFile is non null when does not exist"() {
         given:
         executer.requireOwnGradleUserHomeDir()
-        file("buildSrc").mkdirs()
+        file("buildSrc/settings.gradle").createFile()
 
         expect:
         !buildFile.exists()

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -113,7 +113,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
             includeBuild "b"
         """
 
-        file('buildSrc').mkdir()
+        file("buildSrc/settings.gradle").createFile()
 
         buildFile << """
             apply plugin:'java'

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -39,8 +39,6 @@ import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.plugin.management.internal.PluginRequests;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
@@ -49,7 +47,6 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 @ServiceScope(Scopes.Build.class)
 public class BuildSourceBuilder {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BuildSourceBuilder.class);
     private static final BuildBuildSrcBuildOperationType.Result BUILD_BUILDSRC_RESULT = new BuildBuildSrcBuildOperationType.Result() {
     };
 
@@ -80,8 +77,7 @@ public class BuildSourceBuilder {
     }
 
     private ClassPath createBuildSourceClasspath(File buildSrcDir, final StartParameter containingBuildParameters, ClassLoaderScope parentClassLoaderScope) {
-        if (!buildSrcDir.isDirectory()) {
-            LOGGER.debug("Gradle source dir does not exist. We leave.");
+        if (!BuildSrcDetector.isValidBuildSrcBuild(buildSrcDir)) {
             return ClassPath.EMPTY;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcDetector.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc;
+
+import org.gradle.internal.UncheckedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+class BuildSrcDetector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildSrcDetector.class);
+    private static final String[] GRADLE_BUILD_FILES = new String[] {
+            "settings.gradle", "settings.gradle.kts", "build.gradle", "build.gradle.kts"
+    };
+
+    public static boolean isValidBuildSrcBuild(File buildSrcDir) {
+        if (!buildSrcDir.exists()) {
+            return false;
+        }
+        if (!buildSrcDir.isDirectory()) {
+            LOGGER.info("Ignoring buildSrc: not a directory.");
+            return false;
+        }
+
+        for (String buildFileName : GRADLE_BUILD_FILES) {
+            if (new File(buildSrcDir, buildFileName).exists()) {
+                return true;
+            }
+        }
+        if (containsFiles(new File(buildSrcDir, "src"))) {
+            return true;
+        }
+        LOGGER.info("Ignoring buildSrc directory: does not contain 'settings.gradle[.kts]', 'build.gradle[.kts]', or a 'src' directory.");
+        return false;
+    }
+
+    private static boolean containsFiles(File directory) {
+        if (!directory.exists() || !directory.isDirectory()) {
+            return false;
+        }
+        try {
+            return Files.walk(directory.toPath()).anyMatch(Files::isRegularFile);
+        } catch (IOException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcDetector.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 class BuildSrcDetector {
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildSrcDetector.class);
@@ -55,8 +57,8 @@ class BuildSrcDetector {
         if (!directory.exists() || !directory.isDirectory()) {
             return false;
         }
-        try {
-            return Files.walk(directory.toPath()).anyMatch(Files::isRegularFile);
+        try (Stream<Path> directoryContents = Files.walk(directory.toPath())) {
+            return directoryContents.anyMatch(Files::isRegularFile);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcDetectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcDetectorTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc
+
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static BuildSrcDetector.isValidBuildSrcBuild
+
+class BuildSrcDetectorTest extends Specification {
+
+    @Rule
+    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
+
+    def "ignores buildSrc file that is not a directory"() {
+        expect:
+        !isValidBuildSrcBuild(temp.file("buildSrc"))
+        !isValidBuildSrcBuild(temp.createFile("buildSrc"))
+    }
+
+    def "ignores empty buildSrc directory"() {
+        expect:
+        !isValidBuildSrcBuild(temp.createDir("buildSrc"))
+    }
+
+    def "ignores buildSrc directory without valid Gradle build"() {
+        when:
+        def buildSrcDir = temp.createDir("buildSrc")
+        buildSrcDir.createFile("build/libs/buildSrc.jar")
+        buildSrcDir.createFile(".gitattributes")
+        buildSrcDir.createFile("test.txt")
+
+        then:
+        !isValidBuildSrcBuild(buildSrcDir)
+    }
+
+    def "ignores buildSrc directory with empty src directory"() {
+        when:
+        def buildSrcDir = temp.createDir("buildSrc")
+        buildSrcDir.createDir("src/main/java")
+
+        then:
+        !isValidBuildSrcBuild(buildSrcDir)
+    }
+
+    def "does not ignore buildSrc directory with src directory containing source file"() {
+        when:
+        def buildSrcDir = temp.createDir("buildSrc")
+        buildSrcDir.createFile("src/main/java/Dummy.java")
+
+        then:
+        isValidBuildSrcBuild(buildSrcDir)
+    }
+
+    @Unroll
+    def "does not ignore buildSrc directory with #fileName file"() {
+        when:
+        def buildSrcDir = temp.createDir("buildSrc")
+        buildSrcDir.createFile(fileName)
+
+        then:
+        isValidBuildSrcBuild(buildSrcDir)
+
+        where:
+        fileName << ["build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"]
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -93,6 +93,17 @@ includeBuild("../project-with-plugin-and-library")
 This distinction reflects what Gradle offers for repository declarations - 
 repositories are specified separately for plugin dependencies and for production dependencies.
 
+## General improvements
+
+### Ignore empty `buildSrc` project
+
+In earlier Gradle versions, the mere presence of a `buildSrc` directory was enough to trigger Gradle to execute all `buildSrc` tasks and to add the resulting `buildSrc.jar` to the buildscript class path.
+Gradle will now ignore an empty `buildSrc` directory, and will only generate a `buildSrc.jar` if build files and/or source files are detected.
+
+This has two benefits when an empty `buildSrc` directory is detected:
+- `:buildSrc:*` tasks will not be needlessly executed.
+- The empty `buildSrc.jar` will not be added to the buildscript class path, avoiding cache misses that this can cause.
+
 <!-- 
 
 ================== TEMPLATE ==============================


### PR DESCRIPTION
Without this change, Gradle will execute a `buildSrc` build whenever a `buildSrc`
directory is detected, even if this directory contains no source files. This happens
frequently when migrating a build with `buildSrc` to one using composite builds:
the `buildSrc/build` directory which is normally ignored by git can be retained
resulting in unnecessary build invocation.

What's worse, the empty `buildSrc.jar` that is generated for an empty `buildSrc`
directory will be added to the build script classpath, which can trigger cache
misses for any custom tasks.

This fix addresses the issue by attempting to detect if `buildSrc` is indeed a valid
Gradle build, by checking for `settings.gradle[.kts]`, `build.gradle[.kts]` and for
a non-empty `src` directory. If none of these are found, the `buildSrc` directory
will be ignored, and the `buildSrc.jar` will not be added to the buildscript classpath.

Fixes #13491 
