### PR TITLE
Fix fluid dependencies resolve test variants

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/FluidDependenciesResolveInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/FluidDependenciesResolveInterceptor.groovy
@@ -29,7 +29,7 @@ class FluidDependenciesResolveInterceptor extends BehindFlagFeatureInterceptor {
     public final static String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies"
 
     FluidDependenciesResolveInterceptor(Class<?> target) {
-        super(target, [ASSUME_FLUID_DEPENDENCIES: booleanFeature("fluid dependencies")], doNotExecuteAllPermutationsForNoDaemonExecuter())
+        super(target, [(ASSUME_FLUID_DEPENDENCIES): booleanFeature("fluid dependencies")], doNotExecuteAllPermutationsForNoDaemonExecuter())
     }
 
     private static boolean doNotExecuteAllPermutationsForNoDaemonExecuter() {


### PR DESCRIPTION
In Groovy, the following:
```
final String CONSTANT = "someConst"
Map<String, String> map = [CONSTANT:CONSTANT]
```
is the same as
```
final String CONSTANT = "someConst"
Map<String, String> map = ["CONSTANT":CONSTANT]
```
while the intention here was always:
```
final String CONSTANT = "someConst"
Map<String, String> groovy = [(CONSTANT): CONSTANT]
```
Which yields the expected map ["someConst":"someConst"]


The result here was that fluid dependencies tests were not setting the right `org.gradle.resolution.assumeFluidDependencies` property and instead, the system property `ASSUME_FLUID_DEPENDENCIES` was being set.