### PR TITLE
Move `FileAlreadyExistsException` handling to `InstrumentingClasspathFileTransformer`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -30,7 +30,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
@@ -52,11 +51,6 @@ public class ClasspathBuilder {
     public void jar(File jarFile, Action action) {
         try {
             buildJar(jarFile, action);
-        } catch (FileAlreadyExistsException e) {
-            // Temporarily ignore this.
-            // We run identical transforms concurrently and we can sometimes
-            // finish two transforms at the same time in a way that Files.move will
-            // see the jarFile created before the move is done.
         } catch (Exception e) {
             throw new GradleException(String.format("Failed to create Jar file %s.", jarFile), e);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.classpath;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.archive.ZipEntry;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 
 class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentingClasspathFileTransformer.class);
@@ -58,16 +60,34 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     @Override
     public File transform(File source, FileSystemLocationSnapshot sourceSnapshot, File cacheDir) {
         String name = sourceSnapshot.getType() == FileType.Directory ? source.getName() + ".jar" : source.getName();
+        HashCode fileHash = hashOf(sourceSnapshot);
+        String destFileName = fileHash.toString() + '/' + name;
+        File transformed = new File(cacheDir, destFileName);
+        if (!transformed.isFile()) {
+            try {
+                transform(source, transformed);
+            } catch (GradleException e) {
+                if (e.getCause() instanceof FileAlreadyExistsException) {
+                    // Mostly harmless race-condition, a concurrent writer has already started writing to the file.
+                    // We run identical transforms concurrently and we can sometimes finish two transforms at the same
+                    // time in a way that Files.move (see [ClasspathBuilder.jar]) will see [transformed] created before
+                    // the move is done.
+                    LOGGER.debug("Instrumented classpath file '{}' already exists.", destFileName, e);
+                } else {
+                    throw e;
+                }
+            }
+        }
+        return transformed;
+    }
+
+    private HashCode hashOf(FileSystemLocationSnapshot sourceSnapshot) {
         Hasher hasher = Hashing.defaultFunction().newHasher();
         hasher.putHash(configHash);
         // TODO - apply runtime classpath normalization?
         hasher.putHash(sourceSnapshot.getHash());
         HashCode fileHash = hasher.hash();
-        File transformed = new File(cacheDir, fileHash.toString() + '/' + name);
-        if (!transformed.isFile()) {
-            transform(source, transformed);
-        }
-        return transformed;
+        return fileHash;
     }
 
     private void transform(File source, File dest) {


### PR DESCRIPTION
Since `InstrumentingClasspathFileTransformer` is the one with the optimistic concurrency model.