### PR TITLE
Do not fail the build on invalid declared file inputs

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -742,6 +742,7 @@ afterEvaluate {
 
             task buildOutputs {
                 inputs.files configurations.buildInputs
+                outputs.upToDateWhen { false }
                 doLast {
                     configurations.buildInputs.each { }
                 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -310,8 +310,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
                 - A RegularFile instance.
                 - A URI or URL instance.
                 - A TextResource instance.
-            Consider using Task.dependsOn instead of an input file collection.
-        """.stripIndent())
+            Consider using Task.dependsOn instead of an input file collection.""".stripIndent())
     }
 
     void expectMissingDependencyDeprecation(String producer, String consumer) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -24,7 +24,6 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.reflect.TypeValidationContext;
 
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public interface TaskExecutionContext {
 
@@ -34,7 +33,7 @@ public interface TaskExecutionContext {
 
     WorkValidationContext getValidationContext();
 
-    Consumer<TypeValidationContext> getValidationAction();
+    ValidationAction getValidationAction();
 
     void setTaskExecutionMode(TaskExecutionMode taskExecutionMode);
 
@@ -64,4 +63,8 @@ public interface TaskExecutionContext {
      * by capturing input snapshotting and cache key calculation.
      */
     void setSnapshotTaskInputsBuildOperationContext(BuildOperationContext operation);
+
+    interface ValidationAction {
+        void validate(boolean historyMaintained, TypeValidationContext validationContext);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -21,26 +21,24 @@ import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.execution.plan.LocalTaskNode;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.operations.BuildOperationContext;
-import org.gradle.internal.reflect.TypeValidationContext;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public class DefaultTaskExecutionContext implements TaskExecutionContext {
 
     private final LocalTaskNode localTaskNode;
     private final TaskProperties properties;
     private final WorkValidationContext validationContext;
-    private final Consumer<TypeValidationContext> validationAction;
+    private final ValidationAction validationAction;
     private TaskExecutionMode taskExecutionMode;
     private Long executionTime;
     private BuildOperationContext snapshotTaskInputsBuildOperationContext;
 
     private final Timer executionTimer;
 
-    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode, TaskProperties taskProperties, WorkValidationContext validationContext, Consumer<TypeValidationContext> validationAction) {
+    public DefaultTaskExecutionContext(LocalTaskNode localTaskNode, TaskProperties taskProperties, WorkValidationContext validationContext, ValidationAction validationAction) {
         this.localTaskNode = localTaskNode;
         this.properties = taskProperties;
         this.validationContext = validationContext;
@@ -64,7 +62,7 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     }
 
     @Override
-    public Consumer<TypeValidationContext> getValidationAction() {
+    public ValidationAction getValidationAction() {
         return validationAction;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -431,7 +431,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                 reservedFileSystemLocationRegistry,
                 typeValidationContext
             ));
-            context.getValidationAction().accept(typeValidationContext);
+            context.getValidationAction().validate(context.getTaskExecutionMode().isTaskHistoryMaintained(), typeValidationContext);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.reflect.TypeValidationContext;
+import org.gradle.util.TextUtil;
 
 import java.io.File;
 import java.util.ArrayDeque;
@@ -84,31 +85,41 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         Set<String> taskInputs = new LinkedHashSet<>();
         Set<FilteredTree> filteredFileTreeTaskInputs = new LinkedHashSet<>();
         node.getTaskProperties().getInputFileProperties()
-            .forEach(spec -> spec.getPropertyFiles().visitStructure(new FileCollectionStructureVisitor() {
-                @Override
-                public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
-                    contents.forEach(location -> taskInputs.add(location.getAbsolutePath()));
-                }
+            .forEach(spec -> {
+                try {
+                    spec.getPropertyFiles().visitStructure(new FileCollectionStructureVisitor() {
+                        @Override
+                        public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+                            contents.forEach(location -> taskInputs.add(location.getAbsolutePath()));
+                        }
 
-                @Override
-                public void visitGenericFileTree(FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
-                    fileTree.forEach(location -> taskInputs.add(location.getAbsolutePath()));
-                }
+                        @Override
+                        public void visitGenericFileTree(FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
+                            fileTree.forEach(location -> taskInputs.add(location.getAbsolutePath()));
+                        }
 
-                @Override
-                public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
-                    if (patterns.isEmpty()) {
-                        taskInputs.add(root.getAbsolutePath());
-                    } else {
-                        filteredFileTreeTaskInputs.add(new FilteredTree(root.getAbsolutePath(), patterns));
-                    }
-                }
+                        @Override
+                        public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
+                            if (patterns.isEmpty()) {
+                                taskInputs.add(root.getAbsolutePath());
+                            } else {
+                                filteredFileTreeTaskInputs.add(new FilteredTree(root.getAbsolutePath(), patterns));
+                            }
+                        }
 
-                @Override
-                public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
-                    taskInputs.add(file.getAbsolutePath());
+                        @Override
+                        public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
+                            taskInputs.add(file.getAbsolutePath());
+                        }
+                    });
+                } catch (Exception e) {
+                    validationContext.visitPropertyProblem(
+                        TypeValidationContext.Severity.WARNING,
+                        spec.getPropertyName(),
+                        String.format("cannot be resolved:%n%s%nConsider using Task.dependsOn instead of an input file collection", TextUtil.indent(e.getMessage(), "  "))
+                    );
                 }
-            }));
+            });
         inputHierarchy.recordNodeAccessingLocations(node, taskInputs);
         for (String locationConsumedByThisTask : taskInputs) {
             outputHierarchy.getNodesAccessing(locationConsumedByThisTask).stream()

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -114,7 +114,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
                     });
                 } catch (Exception e) {
                     if (historyMaintained) {
-                        // We would try to snapshots the inputs anyway, no need to suppress the exception
+                        // We would later try to snapshot the inputs anyway, no need to suppress the exception
                         throw e;
                     } else {
                         validationContext.visitPropertyProblem(

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -113,7 +113,8 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
                         }
                     });
                 } catch (Exception e) {
-                    if (historyMaintained) { // We would try to snapshots the inputs anyway, no need to suppress the exception
+                    if (historyMaintained) {
+                        // We would try to snapshots the inputs anyway, no need to suppress the exception
                         throw e;
                     } else {
                         validationContext.visitPropertyProblem(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -80,10 +80,8 @@ import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 import org.gradle.internal.work.AsyncWorkTracker
-
 import spock.lang.Specification
 
-import java.util.function.Consumer
 import java.util.function.Supplier
 
 import static java.util.Collections.emptyList
@@ -203,7 +201,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         executionContext.getTaskExecutionMode() >> TaskExecutionMode.INCREMENTAL
         executionContext.getTaskProperties() >> taskProperties
         executionContext.getValidationContext() >> validationContext
-        executionContext.getValidationAction() >> { { c -> } as Consumer }
+        executionContext.getValidationAction() >> { { historyMaintained, c -> } as TaskExecutionContext.ValidationAction }
         executionHistoryStore.load("task") >> Optional.of(previousState)
         taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -68,7 +68,7 @@ abstract class AbstractProjectBuilderSpec extends Specification {
             null,
             DefaultTaskProperties.resolve(executionServices.get(PropertyWalker), executionServices.get(FileCollectionFactory), task as TaskInternal),
             new DefaultWorkValidationContext(),
-            {}
+            { historyMaintained, context -> }
         )
         executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, taskExecutionContext)
         task.state.rethrowFailure()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -380,6 +380,7 @@ project(":b") {
     dependencies { compile(project(':a')) { artifact { name = 'b'; type = 'jar' } } }
     task test {
         inputs.files configurations.compile
+        outputs.upToDateWhen { false }
         doFirst {
             configurations.compile.files.collect { it.name }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1668,6 +1668,10 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 @Console
                 final Property<String> identifier = project.objects.property(String)
 
+                Resolve() {
+                    outputs.upToDateWhen { false }
+                }
+
                 @Optional
                 @InputFiles
                 FileCollection getArtifactFiles() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -350,6 +350,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                     attributes { it.attribute(artifactType, 'size') }
                 }.artifacts
                 inputs.files(artifacts.artifactFiles)
+                outputs.upToDateWhen { false }
 
                 doLast {
                     println artifacts.artifactFiles.collect { it.name }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.resolve.transform
 
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
@@ -94,6 +93,10 @@ import ${ZipEntry.name}
 class ShowFileCollection extends DefaultTask {
     @InputFiles
     final ConfigurableFileCollection files = project.objects.fileCollection()
+
+    ShowFileCollection() {
+        outputs.upToDateWhen { false }
+    }
 
     @TaskAction
     def go() {

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -30,4 +30,4 @@ Gradle is tested with Kotlin 1.3.21 through 1.4.20.
 Gradle is tested with Groovy 1.5.8 through 2.5.12.
 
 == Android
-Gradle is tested with Android Gradle Plugin 3.4, 3.5, 3.6, 4.0, 4.1 and 4.2. Alpha and beta versions may or may not work.
+Gradle is tested with Android Gradle Plugin 4.0, 4.1, 4.2 and 7.0. Alpha and beta versions may or may not work.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -874,6 +874,10 @@ class GenerateGraphTask extends DefaultTask {
     @Internal
     boolean buildArtifacts
 
+    GenerateGraphTask() {
+        outputs.upToDateWhen { false }
+    }
+
     @TaskAction
     def generateOutput() {
         outputFile.parentFile.mkdirs()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -29,7 +29,7 @@ import org.junit.Rule
 
 class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
 
-    protected static final List<String> TESTED_AGP_VERSIONS = AGP_VERSIONS.getLatestsFromMinorPlusNightly("3.6")
+    protected static final List<String> TESTED_AGP_VERSIONS = AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.0")
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -29,7 +29,7 @@ import org.junit.Rule
 
 class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
 
-    protected static final List<String> TESTED_AGP_VERSIONS = AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.0")
+    protected static final Iterable<String> TESTED_AGP_VERSIONS = TestedVersions.androidGradle.versions
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -48,7 +48,6 @@ abstract class AbstractSmokeTest extends Specification {
 
     protected static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
     protected static final KotlinGradlePluginVersions KOTLIN_VERSIONS = new KotlinGradlePluginVersions()
-    protected static final String AGP_3_ITERATION_MATCHER = ".*agp=3\\..*"
     protected static final String AGP_4_0_ITERATION_MATCHER = ".*agp=4\\.0\\..*"
     protected static final String AGP_4_1_ITERATION_MATCHER = ".*agp=4\\.1\\..*"
     protected static final String AGP_4_2_ITERATION_MATCHER = ".*agp=4\\.2\\..*"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -98,7 +98,7 @@ abstract class AbstractSmokeTest extends Specification {
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "29.0.3"
         // https://developer.android.com/studio/releases/gradle-plugin
-        static androidGradle = Versions.of(*AGP_VERSIONS.latestsPlusNightly)
+        static androidGradle = Versions.of(*AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.0"))
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
         static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -47,7 +47,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_0_ITERATION_MATCHER)
     def "android library and application APK assembly (agp=#agpVersion, ide=#ide)"(
         String agpVersion, boolean ide
     ) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
@@ -35,7 +35,7 @@ class AndroidSantaTrackerJavaCachingSmokeTest extends AbstractAndroidSantaTracke
     }
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_0_ITERATION_MATCHER)
     def "can cache Santa Tracker Java Android application (agp=#agpVersion)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerKotlinCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerKotlinCachingSmokeTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 class AndroidSantaTrackerKotlinCachingSmokeTest extends AbstractAndroidSantaTrackerSmokeTest {
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER, AGP_4_1_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_4_0_ITERATION_MATCHER, AGP_4_1_ITERATION_MATCHER])
     def "can cache Santa Tracker Kotlin Android application (agp=#agpVersion)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.smoketests
 
-
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.util.GradleVersion
-import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -34,8 +32,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         return 150
     }
 
-    @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_0_ITERATION_MATCHER)
     def "check deprecation warnings produced by building Santa Tracker Java (agp=#agpVersion)"() {
 
         given:
@@ -49,17 +46,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         def result = buildLocation(checkoutDir, agpVersion)
 
         then:
-        if (agpVersion.startsWith("3.6")) {
-            expectDeprecationWarnings(
-                    result,
-                    "Internal API constructor DefaultDomainObjectSet(Class<T>) has been deprecated. " +
-                            "This is scheduled to be removed in Gradle 7.0. Please use ObjectFactory.domainObjectSet(Class<T>) instead. " +
-                            "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/custom_gradle_types.html#domainobjectset for more details.",
-                    "The WorkerExecutor.submit() method has been deprecated. " +
-                            "This is scheduled to be removed in Gradle 8.0. Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. " +
-                            "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#method_workerexecutor_submit_is_deprecated for more details."
-            )
-        } else if (agpVersion.startsWith('4.0.2')) {
+        if (agpVersion.startsWith('4.0.2')) {
             expectDeprecationWarnings(
                     result,
                     "The WorkerExecutor.submit() method has been deprecated. " +
@@ -79,8 +66,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         agpVersion << TESTED_AGP_VERSIONS
     }
 
-    @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_0_ITERATION_MATCHER)
     def "incremental Java compilation works for Santa Tracker Java (agp=#agpVersion)"() {
 
         given:
@@ -119,8 +105,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         agpVersion << TESTED_AGP_VERSIONS
     }
 
-    @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_4_2_ITERATION_MATCHER)
+    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_4_0_ITERATION_MATCHER, AGP_4_1_ITERATION_MATCHER, AGP_4_2_ITERATION_MATCHER])
     def "can lint Santa-Tracker #flavour (agp=#agpVersion)"() {
 
         given:
@@ -146,6 +131,6 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         result.output.contains("Lint found errors in the project; aborting build.")
 
         where:
-        [agpVersion, flavour] << [AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.2"), ['Java', 'Kotlin']].combinations()
+        [agpVersion, flavour] << [TESTED_AGP_VERSIONS, ['Java', 'Kotlin']].combinations()
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -34,7 +34,7 @@ class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [KotlinPluginSmokeTest.NO_CONFIGURATION_CACHE_ITERATION_MATCHER, AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = [KotlinPluginSmokeTest.NO_CONFIGURATION_CACHE_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -34,7 +34,7 @@ class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
-    @UnsupportedWithConfigurationCache(iterationMatchers = [KotlinPluginSmokeTest.NO_CONFIGURATION_CACHE_ITERATION_MATCHER, AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = [KotlinPluginSmokeTest.NO_CONFIGURATION_CACHE_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example-kotlin-dsl (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()


### PR DESCRIPTION
Since Gradle 7.0 we evaluate all file inputs of a task, regardless if
we snapshot the inputs. This causes some tasks without output files
to fail now, most prominently the Android Plugin Lint task for
AGP versions < 4.2.

We now catch possible exceptions when evaluating input file properties
and emit a validation warning instead of failing the build. We
can then fail the build for those input file properties in Gradle 8.0.