### PR TITLE
Exit early for FileSystemNode.hasDescendants

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNode.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNode.java
@@ -19,7 +19,6 @@ package org.gradle.internal.snapshot;
 import org.gradle.internal.file.FileType;
 
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
 public abstract class AbstractIncompleteFileSystemNode implements FileSystemNode {
@@ -152,27 +151,9 @@ public abstract class AbstractIncompleteFileSystemNode implements FileSystemNode
         return anyChildMatches(children, FileSystemNode::hasDescendants);
     }
 
-    private boolean anyChildMatches(ChildMap<FileSystemNode> children, Predicate<FileSystemNode> predicate) {
-        AnyChildHasPropertyVisitor visitor = new AnyChildHasPropertyVisitor(predicate);
-        children.visitChildren(visitor);
-        return visitor.isAnyChildMatches();
-    }
-
-    public static class AnyChildHasPropertyVisitor implements BiConsumer<String, FileSystemNode> {
-        private final Predicate<FileSystemNode> predicate;
-        private boolean anyChildMatches = false;
-
-        public AnyChildHasPropertyVisitor(Predicate<FileSystemNode> predicate) {
-            this.predicate = predicate;
-        }
-
-        @Override
-        public void accept(String path, FileSystemNode child) {
-            anyChildMatches |= predicate.test(child);
-        }
-
-        public boolean isAnyChildMatches() {
-            return anyChildMatches;
-        }
+    private static boolean anyChildMatches(ChildMap<FileSystemNode> children, Predicate<FileSystemNode> predicate) {
+        return children.entries().stream()
+            .map(ChildMap.Entry::getValue)
+            .anyMatch(predicate);
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
@@ -62,7 +62,7 @@ abstract class AbstractIncompleteFileSystemNodeTest<T extends FileSystemNode> ex
 
         1 * snapshot.asFileSystemNode() >> newGrandChild
         _ * newGrandChild.snapshot >> Optional.of(snapshot)
-        1 * selectedChild.snapshot >> Optional.empty()
+        _ * selectedChild.snapshot >> Optional.empty()
         1 * snapshot.type >> fileType
         interaction { noMoreInteractions() }
 
@@ -94,7 +94,7 @@ abstract class AbstractIncompleteFileSystemNodeTest<T extends FileSystemNode> ex
 
         1 * snapshot.asFileSystemNode() >> newGrandChild
         _ * newGrandChild.snapshot >> Optional.of(snapshot)
-        1 * selectedChild.snapshot >> Optional.empty()
+        _ * selectedChild.snapshot >> Optional.empty()
         1 * snapshot.type >> FileType.Missing
         interaction { noMoreInteractions() }
 


### PR DESCRIPTION
So we don't need to iterate the whole VFS.

Fixes #15919.