### PR TITLE
Fix tests using isolated home in no daemon

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -29,7 +29,6 @@ import org.gradle.test.fixtures.server.http.PomHttpArtifact
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TextUtil
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 
 class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
@@ -40,7 +39,7 @@ class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
     @Rule
     public final SetSystemProperties systemProperties = new SetSystemProperties()
 
-//    @Rule
+    @Rule
     public final HttpServer server = new HttpServer()
 
     @Override
@@ -54,11 +53,6 @@ class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
          * */
         m2.generateUserSettingsFile(m2.mavenRepo())
         using m2
-        server.start()
-    }
-
-    def cleanup() {
-        server.after()
     }
 
     @ToBeFixedForConfigurationCache(because = ":projects")
@@ -429,7 +423,6 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @Ignore("Broken by https://github.com/gradle/gradle/pull/15879 - investigating")
     @Issue("GRADLE-2820")
     def "remoteparent"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
@@ -483,7 +476,6 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @Ignore("Broken by https://github.com/gradle/gradle/pull/15879 - investigating")
     @Issue("GRADLE-2819")
     @ToBeFixedForConfigurationCache(because = ":projects")
     def "multiModuleWithRemoteParent"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -58,15 +58,11 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     @Override
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
+
         if(!isQuiet() && isAllowExtraLogging()) {
             if (!containsLoggingArgument(args)) {
                 args.add(0, "-i");
             }
-        }
-
-        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
-        if (getUserHomeDir() != null) {
-            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
         }
 
         return args;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -119,6 +119,12 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         List<String> args = new ArrayList<String>();
         args.addAll(super.getAllArgs());
         addPropagatedSystemProperties(args);
+
+        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
+        if (getUserHomeDir() != null) {
+            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
+        }
+
         return args;
     }
 


### PR DESCRIPTION
Fix tests using isolated home in no daemon mode

Previously the user.home was not properly propagated which was a problem
when a single use daemon had to be started anyway.

The change also reverts unnecessary test changes.

The root cause for the issue discovery is the migration to Spock 2 which
caused tests having a `where:` to be unrolled without the need for an 
annotation.