### PR TITLE
Attempt at cleaning integration test infra

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -29,7 +29,6 @@ import org.gradle.test.fixtures.server.http.PomHttpArtifact
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TextUtil
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 
 class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
@@ -40,7 +39,7 @@ class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
     @Rule
     public final SetSystemProperties systemProperties = new SetSystemProperties()
 
-//    @Rule
+    @Rule
     public final HttpServer server = new HttpServer()
 
     @Override
@@ -54,11 +53,6 @@ class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
          * */
         m2.generateUserSettingsFile(m2.mavenRepo())
         using m2
-        server.start()
-    }
-
-    def cleanup() {
-        server.after()
     }
 
     @ToBeFixedForConfigurationCache(because = ":projects")
@@ -429,7 +423,6 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @Ignore("Broken by https://github.com/gradle/gradle/pull/15879 - investigating")
     @Issue("GRADLE-2820")
     def "remoteparent"() {
         def dsl = dslFixtureFor(scriptDsl as BuildInitDsl)
@@ -483,7 +476,6 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @Ignore("Broken by https://github.com/gradle/gradle/pull/15879 - investigating")
     @Issue("GRADLE-2819")
     @ToBeFixedForConfigurationCache(because = ":projects")
     def "multiModuleWithRemoteParent"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -701,25 +701,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         return this;
     }
 
-    protected String toJvmArgsString(Iterable<String> jvmArgs) {
-        StringBuilder result = new StringBuilder();
-        for (String jvmArg : jvmArgs) {
-            if (result.length() > 0) {
-                result.append(" ");
-            }
-            if (jvmArg.contains(" ")) {
-                assert !jvmArg.contains("\"") : "jvmArg '" + jvmArg + "' contains '\"'";
-                result.append('"');
-                result.append(jvmArg);
-                result.append('"');
-            } else {
-                result.append(jvmArg);
-            }
-        }
-
-        return result.toString();
-    }
-
     @Override
     public GradleExecuter withTasks(String... names) {
         return withTasks(Arrays.asList(names));

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -58,15 +58,11 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     @Override
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
+
         if(!isQuiet() && isAllowExtraLogging()) {
             if (!containsLoggingArgument(args)) {
                 args.add(0, "-i");
             }
-        }
-
-        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
-        if (getUserHomeDir() != null) {
-            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
         }
 
         return args;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
@@ -118,7 +118,6 @@ class ForkingGradleHandle extends OutputScrapingGradleHandle {
         println(format("    GRADLE_HOME: %s", environment.get("GRADLE_HOME")));
         println(format("    GRADLE_USER_HOME: %s", environment.get("GRADLE_USER_HOME")));
         println(format("    JAVA_OPTS: %s", environment.get("JAVA_OPTS")));
-        println(format("    GRADLE_OPTS: %s", environment.get("GRADLE_OPTS")));
         String roCache = environment.get(ArtifactCachesProvider.READONLY_CACHE_ENV_VAR);
         if (roCache != null) {
             println(format("    %s: %s", ArtifactCachesProvider.READONLY_CACHE_ENV_VAR, roCache));

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -119,6 +119,12 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         List<String> args = new ArrayList<String>();
         args.addAll(super.getAllArgs());
         addPropagatedSystemProperties(args);
+
+        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
+        if (getUserHomeDir() != null) {
+            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
+        }
+
         return args;
     }
 


### PR DESCRIPTION
Removed code behind conditions that are true since
Gradle > 1.0-milestone-5
Removed code dealing with `GRADLE_OPTS` as this is not used by any
forking setup.
