### PR TITLE
Do not concatenate strings in debug and info log messages

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
@@ -53,7 +53,7 @@ public abstract class AbstractCompositeParticipantBuildState extends AbstractBui
     private void registerProject(Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules, ProjectInternal project) {
         ProjectComponentIdentifier projectIdentifier = new DefaultProjectComponentIdentifier(getBuildIdentifier(), project.getIdentityPath(), project.getProjectPath(), project.getName());
         ModuleVersionIdentifier moduleId = DefaultModuleVersionIdentifier.newId(project.getModule());
-        LOGGER.info("Registering " + project + " in composite build. Will substitute for module '" + moduleId.getModule() + "'.");
+        LOGGER.info("Registering {} in composite build. Will substitute for module '{}'.", project, moduleId.getModule());
         availableModules.add(Pair.of(moduleId, projectIdentifier));
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
@@ -214,7 +214,7 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         if (tasksToExecute.isEmpty()) {
             return;
         }
-        LOGGER.info("Executing " + includedBuild.getName() + " tasks " + tasksToExecute);
+        LOGGER.info("Executing {} tasks {}", includedBuild.getName(), tasksToExecute);
         IncludedBuildExecutionListener listener = new IncludedBuildExecutionListener(tasksToExecute);
         try {
             includedBuild.execute(tasksToExecute, listener);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -70,7 +70,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
         DependencySubstitutionsInternal substitutions = resolveDependencySubstitutions(build);
         if (!substitutions.rulesMayAddProjectDependency()) {
             // Configure the included build to discover available modules
-            LOGGER.info("[composite-build] Configuring build: " + build.getRootDirectory());
+            LOGGER.info("[composite-build] Configuring build: {}", build.getRootDirectory());
             context.addAvailableModules(build.getAvailableModules());
         } else {
             // Register the defined substitutions for included build

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -157,7 +157,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         executionPlan.addEntryTasks(taskSet);
         graphState = GraphState.DIRTY;
 
-        LOGGER.debug("Timing: Creating the DAG took " + clock.getElapsed());
+        LOGGER.debug("Timing: Creating the DAG took {}", clock.getElapsed());
     }
 
     @Override
@@ -173,7 +173,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
             fireWhenReady();
             hasFiredWhenReady = true;
         } else if (!graphListeners.isEmpty()) {
-            LOGGER.info("Ignoring listeners of task graph ready event, as this build (" + gradleInternal.getIdentityPath() + ") has already executed work.");
+            LOGGER.info("Ignoring listeners of task graph ready event, as this build ({}) has already executed work.", gradleInternal.getIdentityPath());
         }
     }
 
@@ -198,7 +198,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
                     new InvokeNodeExecutorsAction(nodeExecutors, projectExecutionServices)
                 )
             );
-            LOGGER.debug("Timing: Executing the DAG took " + clock.getElapsed());
+            LOGGER.debug("Timing: Executing the DAG took {}", clock.getElapsed());
         } finally {
             coordinationService.withStateLock(resourceLockState -> {
                 executionPlan.clear();

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
@@ -136,7 +136,7 @@ public class DaemonClient implements BuildActionExecuter<BuildActionParameters, 
         UUID buildId = idGenerator.generateId();
         List<DaemonInitialConnectException> accumulatedExceptions = Lists.newArrayList();
 
-        LOGGER.debug("Executing build " + buildId + " in daemon client {pid=" + processEnvironment.maybeGetPid() + "}");
+        LOGGER.debug("Executing build {} in daemon client {pid={}}", buildId, processEnvironment.maybeGetPid());
 
         int saneNumberOfAttempts = 100; //is it sane enough?
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowMemoryDaemonExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowMemoryDaemonExpirationStrategy.java
@@ -62,7 +62,7 @@ public class LowMemoryDaemonExpirationStrategy implements DaemonExpirationStrate
             if (memoryStatus != null) {
                 long freeMem = memoryStatus.getFreePhysicalMemory();
                 if (freeMem < memoryThresholdInBytes) {
-                    LOGGER.info("after free system memory (" + NumberUtil.formatBytes(freeMem) + ") fell below threshold of " + NumberUtil.formatBytes(memoryThresholdInBytes));
+                    LOGGER.info("after free system memory ({}) fell below threshold of {}", NumberUtil.formatBytes(freeMem), NumberUtil.formatBytes(memoryThresholdInBytes));
                     return new DaemonExpirationResult(GRACEFUL_EXPIRE, EXPIRATION_REASON);
                 } else if (freeMem < memoryThresholdInBytes * 2) {
                     LOGGER.debug("Nearing low memory threshold - {}", memoryStatus);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectorMonitoringStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectorMonitoringStrategy.java
@@ -100,7 +100,7 @@ public enum GarbageCollectorMonitoringStrategy {
         });
 
         if (gcStrategy == null) {
-            LOGGER.info("Unable to determine a garbage collection monitoring strategy for " + Jvm.current().toString());
+            LOGGER.info("Unable to determine a garbage collection monitoring strategy for {}", Jvm.current());
             return GarbageCollectorMonitoringStrategy.UNKNOWN;
         } else {
             List<String> memoryPools = CollectionUtils.collect(ManagementFactory.getMemoryPoolMXBeans(), new Transformer<String, MemoryPoolMXBean>() {
@@ -110,7 +110,7 @@ public enum GarbageCollectorMonitoringStrategy {
                 }
             });
             if (!memoryPools.contains(gcStrategy.heapPoolName) || !memoryPools.contains(gcStrategy.nonHeapPoolName)) {
-                LOGGER.info("Unable to determine which memory pools to monitor for " + Jvm.current().toString());
+                LOGGER.info("Unable to determine which memory pools to monitor for {}", Jvm.current());
                 return GarbageCollectorMonitoringStrategy.UNKNOWN;
             }
             return gcStrategy;

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -128,7 +128,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
                         }
                         JANSI_BOOT_PATH_CONFIGURER.configure(nativeBaseDir);
                     }
-                    LOGGER.info("Initialized native services in: " + nativeBaseDir);
+                    LOGGER.info("Initialized native services in: {}", nativeBaseDir);
                 }
                 initialized = true;
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/Upload.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/Upload.java
@@ -55,7 +55,7 @@ public class Upload extends ConventionTask {
 
     @TaskAction
     protected void upload() {
-        getLogger().info("Publishing configuration: " + configuration);
+        getLogger().info("Publishing configuration: {}", configuration);
         Module module = ((ConfigurationInternal) configuration).getModule();
 
         ArtifactPublisher artifactPublisher = getPublicationServices().createArtifactPublisher();

--- a/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/RetryHttpInitializerWrapper.java
+++ b/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/RetryHttpInitializerWrapper.java
@@ -85,7 +85,7 @@ final class RetryHttpInitializerWrapper implements HttpRequestInitializer {
                     return true;
                 } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
                     // Otherwise, we defer to the judgement of our internal backoff handler.
-                    LOG.info("Retrying " + request.getUrl().toString());
+                    LOG.info("Retrying {}", request.getUrl());
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
Instead, use `.debug/.info(String format, Object ...args)` methods so that String concatenation only happens if debug log level is enabled.