### PR TITLE
Reduce Kotlin/AGP version combinations

### DIFF
--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -24,10 +24,14 @@ Java 6 and 7 can still be used for <<building_java_projects.adoc#sec:java_cross_
 Any supported version of Java can be used for compile or test.
 
 == Kotlin
-Gradle is tested with Kotlin 1.3.21 through 1.4.30.
+Gradle is tested with Kotlin 1.3.72 through 1.4.30.
 
 == Groovy
 Gradle is tested with Groovy 1.5.8 through 2.5.12.
 
 == Android
+<<<<<<< HEAD
 Gradle is tested with Android Gradle Plugin 4.0, 4.1, 4.2 and 7.0. Alpha and beta versions may or may not work.
+=======
+Gradle is tested with Android Gradle Plugin 4.0, 4.1 and 4.2. Alpha and beta versions may or may not work.
+>>>>>>> ff9fc9d76b3 (Reduce Kotlin/AGP version combinations)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -23,7 +23,7 @@ class KotlinGradlePluginVersions {
 
     // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
     private static final List<String> LATEST_VERSIONS = [
-        '1.3.21', '1.3.31', '1.3.41', '1.3.50', '1.3.61', '1.3.72',
+        '1.3.72',
         '1.4.0', '1.4.10', '1.4.21', '1.4.30'
     ]
 


### PR DESCRIPTION
With the combinations number increasing the smoke test becomes
slower and slower. Now let's remove some old versions.
