### PR TITLE
Update wrapper to the latest nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210126174351+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210127230053+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Contains a fix to https://github.com/gradle/gradle/issues/15185 that will allow selecting tests from abstract classes via command line and the IDE with Spock2.

Also fixes https://github.com/gradle/test-retry-gradle-plugin/issues/91 that relies on this filtering. As a result, tests from abstract classes can now be retried again.